### PR TITLE
Fix Lookup & Update failures

### DIFF
--- a/blockstore_client/client.py
+++ b/blockstore_client/client.py
@@ -313,7 +313,7 @@ def get_name_record(name, create_if_absent=False):
     if 'error' in name_record:
         return name_record
 
-    name_record = name_record[0]
+    name_record = name_record
     if name_record is None:
         # failed to look up
         return {'error': "No such name"}
@@ -873,7 +873,7 @@ def update(name, user_json_or_hash, privatekey, txid=None, proxy=None, tx_only=F
 
         else:
             result = proxy.update(name, user_record_hash, privatekey)
-            result = result[0]
+            result = result
 
         if 'error' in result:
             # failed


### PR DESCRIPTION
`lookup` and `update` methods don't work because blockstore RPC returns a string not an array.

```
root@blockchainid:~# blockstore-cli lookup larry.id
Traceback (most recent call last):
  File "/usr/local/bin/blockstore-cli", line 928, in <module>
    run_cli()
  File "/usr/local/bin/blockstore-cli", line 878, in run_cli
    result = client.lookup(str(args.name))
  File "/usr/local/lib/python2.7/dist-packages/blockstore_client/client.py", line 296, in lookup
    return get_name_record( name )
  File "/usr/local/lib/python2.7/dist-packages/blockstore_client/client.py", line 316, in get_name_record
    name_record = name_record[0]
KeyError: 0
root@blockchainid:~#
```

After making the change in this commit on only line 316, `update` behaves as follows:

```
root@blockchainid:~# blockstore-cli update theblockchain.id "$(cat ~/theblockchain.json)" "$(cat ~/theblockchain.key)"
Traceback (most recent call last):
  File "/usr/local/bin/blockstore-cli", line 928, in <module>
    run_cli()
  File "/usr/local/bin/blockstore-cli", line 713, in run_cli
    txid=txid)
  File "/usr/local/lib/python2.7/dist-packages/blockstore_client/client.py", line 876, in update
    result = result[0]
KeyError: 0
root@blockchainid:~#
```
