### PR TITLE
get_names_in_namespace ignores count argument

### DIFF
--- a/blockstack_client/proxy.py
+++ b/blockstack_client/proxy.py
@@ -1022,7 +1022,7 @@ def get_names_in_namespace( namespace_id, offset=None, count=None, proxy=None ):
 
         all_names += page
 
-    return all_names
+    return all_names[:count]
 
 
 def get_names_owned_by_address(address, proxy=None):


### PR DESCRIPTION
`blockstack get_names_in_namespace 0 10` ignores the `count` argument (in this example 10) and always returns at least 100 names (unless there are less than 100 remaining names).

