### PR TITLE
minor fix: 1 BTC = 100,000,000 Satoshi

### DIFF
--- a/blockstack_client/actions.py
+++ b/blockstack_client/actions.py
@@ -427,10 +427,10 @@ def cli_balance( args, config_path=CONFIG_PATH ):
     satoshis, addresses = get_total_balance(wallet_path=wallet_path, config_path=config_path)
 
     # convert to BTC
-    btc = float(Decimal(satoshis / 10e8))
+    btc = float(Decimal(satoshis / 1e8))
 
     for address_info in addresses:
-        address_info['bitcoin'] = float(Decimal(address_info['balance'] / 10e8))
+        address_info['bitcoin'] = float(Decimal(address_info['balance'] / 1e8))
         address_info['satoshis'] = address_info['balance']
         del address_info['balance']
 


### PR DESCRIPTION
Found this issue after setup a blockstack on bitcoin regtest, then send 6.6 btc to it.
Then run blockstack balance/wallet to show a balance, but the bitcoin value is different.
I guess this issue is due to btc is so expensive that developer don't have so much zeros to display. :)