### PR TITLE
Use python2 specific shellbang via /usr/bin/env

### DIFF
--- a/bin/blockstack
+++ b/bin/blockstack
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Blockstack-client

--- a/blockstack_client/__init__.py
+++ b/blockstack_client/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Blockstack-client

--- a/blockstack_client/accounts.py
+++ b/blockstack_client/accounts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Blockstack-client

--- a/blockstack_client/actions.py
+++ b/blockstack_client/actions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Blockstack-client

--- a/blockstack_client/app.py
+++ b/blockstack_client/app.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Blockstack-client

--- a/blockstack_client/b40.py
+++ b/blockstack_client/b40.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Blockstack

--- a/blockstack_client/backend/blockchain.py
+++ b/blockstack_client/backend/blockchain.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Blockstack-client

--- a/blockstack_client/backend/drivers/__init__.py
+++ b/blockstack_client/backend/drivers/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Blockstack-client

--- a/blockstack_client/backend/drivers/blockstack_resolver.py
+++ b/blockstack_client/backend/drivers/blockstack_resolver.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Blockstack-client

--- a/blockstack_client/backend/drivers/blockstack_server.py
+++ b/blockstack_client/backend/drivers/blockstack_server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Blockstack-client

--- a/blockstack_client/backend/drivers/common.py
+++ b/blockstack_client/backend/drivers/common.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Blockstack-client

--- a/blockstack_client/backend/drivers/dht.py
+++ b/blockstack_client/backend/drivers/dht.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Blockstack-client

--- a/blockstack_client/backend/drivers/disk.py
+++ b/blockstack_client/backend/drivers/disk.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Blockstack-client

--- a/blockstack_client/backend/drivers/http.py
+++ b/blockstack_client/backend/drivers/http.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Blockstack-client

--- a/blockstack_client/backend/drivers/s3.py
+++ b/blockstack_client/backend/drivers/s3.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 """
     Blockstack-client
     ~~~~~

--- a/blockstack_client/backend/registrar.py
+++ b/blockstack_client/backend/registrar.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Blockstack-client

--- a/blockstack_client/backend/utxo/__init__.py
+++ b/blockstack_client/backend/utxo/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
 """

--- a/blockstack_client/backend/utxo/blockstack_utxo.py
+++ b/blockstack_client/backend/utxo/blockstack_utxo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Blockstack-client

--- a/blockstack_client/backend/utxo/utxo.py
+++ b/blockstack_client/backend/utxo/utxo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Blockstack-client

--- a/blockstack_client/cli.py
+++ b/blockstack_client/cli.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Blockstack-client

--- a/blockstack_client/client.py
+++ b/blockstack_client/client.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Blockstack-client

--- a/blockstack_client/config.py
+++ b/blockstack_client/config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Blockstack-client

--- a/blockstack_client/data.py
+++ b/blockstack_client/data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Blockstack-client

--- a/blockstack_client/keys.py
+++ b/blockstack_client/keys.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Blockstack-client

--- a/blockstack_client/method_parser.py
+++ b/blockstack_client/method_parser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Blockstack-client

--- a/blockstack_client/operations/__init__.py
+++ b/blockstack_client/operations/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Blockstack-client

--- a/blockstack_client/operations/announce.py
+++ b/blockstack_client/operations/announce.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Blockstack-client

--- a/blockstack_client/operations/nameimport.py
+++ b/blockstack_client/operations/nameimport.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Blockstack-client

--- a/blockstack_client/operations/namespacepreorder.py
+++ b/blockstack_client/operations/namespacepreorder.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Blockstack-client

--- a/blockstack_client/operations/namespaceready.py
+++ b/blockstack_client/operations/namespaceready.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Blockstack-client

--- a/blockstack_client/operations/namespacereveal.py
+++ b/blockstack_client/operations/namespacereveal.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Blockstack-client

--- a/blockstack_client/operations/preorder.py
+++ b/blockstack_client/operations/preorder.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Blockstack-client

--- a/blockstack_client/operations/register.py
+++ b/blockstack_client/operations/register.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Blockstack-client

--- a/blockstack_client/operations/revoke.py
+++ b/blockstack_client/operations/revoke.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Blockstack-client

--- a/blockstack_client/operations/transfer.py
+++ b/blockstack_client/operations/transfer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Blockstack-client

--- a/blockstack_client/operations/update.py
+++ b/blockstack_client/operations/update.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Blockstack-client

--- a/blockstack_client/profile.py
+++ b/blockstack_client/profile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Blockstack-client

--- a/blockstack_client/proxy.py
+++ b/blockstack_client/proxy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Blockstack-client

--- a/blockstack_client/rpc.py
+++ b/blockstack_client/rpc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Blockstack-client

--- a/blockstack_client/rpc_runner.py
+++ b/blockstack_client/rpc_runner.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Blockstack-client

--- a/blockstack_client/scripts.py
+++ b/blockstack_client/scripts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Blockstack-client

--- a/blockstack_client/snv.py
+++ b/blockstack_client/snv.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Blockstack-client

--- a/blockstack_client/storage.py
+++ b/blockstack_client/storage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Blockstack-client

--- a/blockstack_client/tx.py
+++ b/blockstack_client/tx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Blockstack-client

--- a/blockstack_client/user.py
+++ b/blockstack_client/user.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Blockstack-client

--- a/blockstack_client/utils.py
+++ b/blockstack_client/utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Blockstack-client

--- a/blockstack_client/wallet.py
+++ b/blockstack_client/wallet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 """
     Blockstack-client
     ~~~~~

--- a/blockstack_registrar/bin/registrar
+++ b/blockstack_registrar/bin/registrar
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Registrar

--- a/blockstack_registrar/registrar/basic_wallet.py
+++ b/blockstack_registrar/registrar/basic_wallet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Registrar

--- a/blockstack_registrar/registrar/blockchain.py
+++ b/blockstack_registrar/registrar/blockchain.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Registrar

--- a/blockstack_registrar/tools/namespace_import.py
+++ b/blockstack_registrar/tools/namespace_import.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Registrar

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 from setuptools import setup, find_packages
 

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Blockstack-client


### PR DESCRIPTION
Since not all Linux distributions link `/usr/bin/python` to `/usr/bin/python2` it is important to set the python version in the shellbang. Also using `/usr/bin/env` is more portable than `/usr/bin/python`