### PR TITLE
Fixes mismatched case error

### DIFF
--- a/src/profiles/services/service.js
+++ b/src/profiles/services/service.js
@@ -60,7 +60,8 @@ export class Service {
   static getProofUrl(proof: Object) {
     const baseUrls = this.getBaseUrls()
     for (let i = 0; i < baseUrls.length; i++) {
-      if (proof.proof_url.toLowerCase().startsWith(`${baseUrls[i]}${proof.identifier}`)) {
+      const requiredPrefix = `${baseUrls[i]}${proof.identifier}`.toLowerCase()
+      if (proof.proof_url.toLowerCase().startsWith(requiredPrefix)) {
         return proof.proof_url
       }
     }


### PR DESCRIPTION
fix mismatched casing in proof check when there's mixed casing in an identifier --

example:

https://core.blockstack.org/v2/users/ablankstein.id

```
...
"account": [
        {
          "@type": "Account", 
          "identifier": "AaronBlankstein", 
          "proofType": "http", 
          "proofUrl": "https://twitter.com/AaronBlankstein/status/849369534968496129", 
          "service": "twitter"
        },
...
```