### PR TITLE
use crypto randomBytes instead of math.random

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,5 @@
+import { randomBytes } from 'crypto'
+
 /* @flow */
 export const BLOCKSTACK_HANDLER = 'blockstack'
 /**
@@ -55,7 +57,7 @@ export function makeUUID4() {
     d += performance.now() // use high-precision timer if available
   }
   return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
-    const r = (d + Math.random() * 16) % 16 | 0
+    const r = (d + (randomBytes(1).readUInt8() % 16)) % 16
     d = Math.floor(d / 16)
     return (c === 'x' ? r : (r & 0x3 | 0x8)).toString(16)
   })


### PR DESCRIPTION
Math.random isn't a secure way to get random values. We should be using crypto randomBytes instead for the UUID generation here. This is only ever used for the `jti` input of the app authorization, which is in the JWT spec, but unused in our code.