### PR TITLE
Direct gaia hub storage operations

### DIFF
--- a/dist/blockstack.js
+++ b/dist/blockstack.js
@@ -201,7 +201,7 @@ function handlePendingSignIn() {
             }
           }
         }
-        var hubUrl = 'https://hub.blockstack.org';
+        var hubUrl = _authConstants.BLOCKSTACK_DEFAULT_GAIA_HUB_URL;
         if ((0, _utils.isLaterVersion)(tokenPayload.version, '1.2.0') && tokenPayload.hubUrl !== null && tokenPayload.hubUrl !== undefined) {
           hubUrl = tokenPayload.hubUrl;
         }
@@ -280,6 +280,7 @@ var BLOCKSTACK_STORAGE_LABEL = exports.BLOCKSTACK_STORAGE_LABEL = 'blockstack';
 var DEFAULT_BLOCKSTACK_HOST = exports.DEFAULT_BLOCKSTACK_HOST = 'https://blockstack.org/auth';
 var DEFAULT_SCOPE = exports.DEFAULT_SCOPE = ['store_write'];
 var BLOCKSTACK_APP_PRIVATE_KEY_LABEL = exports.BLOCKSTACK_APP_PRIVATE_KEY_LABEL = 'blockstack-transit-private-key';
+var BLOCKSTACK_DEFAULT_GAIA_HUB_URL = exports.BLOCKSTACK_DEFAULT_GAIA_HUB_URL = 'https://hub.blockstack.org';
 },{}],3:[function(require,module,exports){
 (function (Buffer){
 'use strict';
@@ -3451,6 +3452,8 @@ var _bigi2 = _interopRequireDefault(_bigi);
 
 var _authApp = require('../auth/authApp');
 
+var _authConstants = require('../auth/authConstants');
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 var BLOCKSTACK_GAIA_HUB_LABEL = exports.BLOCKSTACK_GAIA_HUB_LABEL = 'blockstack-gaia-hub-config';
@@ -3511,6 +3514,15 @@ function connectToGaiaHub(gaiaHubUrl, challengeSignerHex) {
  */
 function setLocalGaiaHubConnection() {
   var userData = (0, _authApp.loadUserData)();
+
+  if (!userData.hubUrl) {
+    userData.hubUrl = _authConstants.BLOCKSTACK_DEFAULT_GAIA_HUB_URL;
+
+    window.localStorage.setItem(_authConstants.BLOCKSTACK_STORAGE_LABEL, JSON.stringify(userData));
+
+    userData = (0, _authApp.loadUserData)();
+  }
+
   return connectToGaiaHub(userData.hubUrl, userData.appPrivateKey).then(function (gaiaConfig) {
     localStorage.setItem(BLOCKSTACK_GAIA_HUB_LABEL, JSON.stringify(gaiaConfig));
     return gaiaConfig;
@@ -3528,7 +3540,7 @@ function getOrSetLocalGaiaHubConnection() {
   }
 }
 }).call(this,require("buffer").Buffer)
-},{"../auth/authApp":1,"bigi":39,"bitcoinjs-lib":78,"buffer":134}],35:[function(require,module,exports){
+},{"../auth/authApp":1,"../auth/authConstants":2,"bigi":39,"bitcoinjs-lib":78,"buffer":134}],35:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {

--- a/dist/blockstack.js
+++ b/dist/blockstack.js
@@ -35,6 +35,8 @@ var _authMessages = require('./authMessages');
 
 var _authConstants = require('./authConstants');
 
+var _storage = require('../storage');
+
 var _profiles = require('../profiles');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
@@ -49,8 +51,7 @@ var DEFAULT_PROFILE = {
    * @return {String} the hex encoded private key
    * @private
    */
-};
-function generateAndStoreTransitKey() {
+};function generateAndStoreTransitKey() {
   var transitKey = (0, _index2.makeECPrivateKey)();
   localStorage.setItem(_authConstants.BLOCKSTACK_APP_PRIVATE_KEY_LABEL, transitKey);
   return transitKey;
@@ -181,7 +182,7 @@ function handlePendingSignIn() {
         // TODO: real version handling
         var appPrivateKey = tokenPayload.private_key;
         var coreSessionToken = tokenPayload.core_token;
-        if ((0, _utils.isLaterVersionString)(tokenPayload.version, '1.1.0')) {
+        if ((0, _utils.isLaterVersion)(tokenPayload.version, '1.1.0')) {
           var transitKey = getTransitKey();
           if (transitKey !== undefined && transitKey != null) {
             if (appPrivateKey !== undefined && appPrivateKey !== null) {
@@ -201,7 +202,7 @@ function handlePendingSignIn() {
           }
         }
         var hubUrl = 'https://hub.blockstack.org';
-        if ((0, _utils.isLaterVersionString)(tokenPayload.version, '1.2.0') && tokenPayload.hubUrl !== null && tokenPayload.hubUrl !== undefined) {
+        if ((0, _utils.isLaterVersion)(tokenPayload.version, '1.2.0') && tokenPayload.hubUrl !== null && tokenPayload.hubUrl !== undefined) {
           hubUrl = tokenPayload.hubUrl;
         }
 
@@ -262,12 +263,13 @@ function signUserOut() {
   var redirectURL = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : null;
 
   window.localStorage.removeItem(_authConstants.BLOCKSTACK_STORAGE_LABEL);
+  window.localStorage.removeItem(_storage.BLOCKSTACK_GAIA_HUB_LABEL);
 
   if (redirectURL !== null) {
     window.location = redirectURL;
   }
 }
-},{"../index":11,"../profiles":13,"../utils":36,"./authConstants":2,"./authMessages":3,"./index":7,"custom-protocol-detection-blockstack":231,"jsontokens":311,"query-string":400}],2:[function(require,module,exports){
+},{"../index":11,"../profiles":13,"../storage":35,"../utils":36,"./authConstants":2,"./authMessages":3,"./index":7,"custom-protocol-detection-blockstack":231,"jsontokens":311,"query-string":400}],2:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -1356,6 +1358,12 @@ Object.defineProperty(exports, 'updateQueryStringParameter', {
   enumerable: true,
   get: function get() {
     return _utils.updateQueryStringParameter;
+  }
+});
+Object.defineProperty(exports, 'isLaterVersion', {
+  enumerable: true,
+  get: function get() {
+    return _utils.isLaterVersion;
   }
 });
 
@@ -3526,7 +3534,7 @@ function getOrSetLocalGaiaHubConnection() {
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.uploadToGaiaHub = exports.connectToGaiaHub = undefined;
+exports.BLOCKSTACK_GAIA_HUB_LABEL = exports.uploadToGaiaHub = exports.connectToGaiaHub = undefined;
 exports.getFile = getFile;
 exports.putFile = putFile;
 exports.deleteFile = deleteFile;
@@ -3608,6 +3616,7 @@ function deleteFile(path) {
 
 exports.connectToGaiaHub = _hub.connectToGaiaHub;
 exports.uploadToGaiaHub = _hub.uploadToGaiaHub;
+exports.BLOCKSTACK_GAIA_HUB_LABEL = _hub.BLOCKSTACK_GAIA_HUB_LABEL;
 },{"../auth":7,"../encryption":9,"../keys":12,"./hub":34}],36:[function(require,module,exports){
 'use strict';
 
@@ -3618,7 +3627,7 @@ exports.nextYear = nextYear;
 exports.nextMonth = nextMonth;
 exports.nextHour = nextHour;
 exports.updateQueryStringParameter = updateQueryStringParameter;
-exports.isLaterVersionString = isLaterVersionString;
+exports.isLaterVersion = isLaterVersion;
 exports.makeUUID4 = makeUUID4;
 var BLOCKSTACK_HANDLER = exports.BLOCKSTACK_HANDLER = 'blockstack';
 /**
@@ -3658,9 +3667,8 @@ function updateQueryStringParameter(uri, key, value) {
  * @param {string} v1 - the left half of the version inequality
  * @param {string} v2 - right half of the version inequality
  * @returns {bool} iff v1 >= v2
- * @private
  */
-function isLaterVersionString(v1, v2) {
+function isLaterVersion(v1, v2) {
   var v1tuple = v1.split('.').map(function (x) {
     return parseInt(x, 10);
   });

--- a/dist/blockstack.js
+++ b/dist/blockstack.js
@@ -3574,7 +3574,12 @@ function getFile(path) {
     return fetch((0, _hub.getFullReadUrl)(path, gaiaHubConfig));
   }).then(function (response) {
     if (response.status !== 200) {
-      throw new Error('getFile ' + path + ' failed with HTTP status ' + response.status);
+      if (response.status === 404) {
+        console.log('getFile ' + path + ' returned 404, returning null');
+        return null;
+      } else {
+        throw new Error('getFile ' + path + ' failed with HTTP status ' + response.status);
+      }
     }
     var contentType = response.headers.get('Content-Type');
     if (contentType === null || decrypt || contentType.startsWith('text') || contentType === 'application/json') {

--- a/dist/blockstack.js
+++ b/dist/blockstack.js
@@ -3534,7 +3534,7 @@ function getOrSetLocalGaiaHubConnection() {
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.BLOCKSTACK_GAIA_HUB_LABEL = exports.uploadToGaiaHub = exports.connectToGaiaHub = undefined;
+exports.GaiaHubConfig = exports.BLOCKSTACK_GAIA_HUB_LABEL = exports.uploadToGaiaHub = exports.connectToGaiaHub = undefined;
 exports.getFile = getFile;
 exports.putFile = putFile;
 exports.deleteFile = deleteFile;
@@ -3617,6 +3617,7 @@ function deleteFile(path) {
 exports.connectToGaiaHub = _hub.connectToGaiaHub;
 exports.uploadToGaiaHub = _hub.uploadToGaiaHub;
 exports.BLOCKSTACK_GAIA_HUB_LABEL = _hub.BLOCKSTACK_GAIA_HUB_LABEL;
+exports.GaiaHubConfig = _hub.GaiaHubConfig;
 },{"../auth":7,"../encryption":9,"../keys":12,"./hub":34}],36:[function(require,module,exports){
 'use strict';
 

--- a/dist/blockstack.js
+++ b/dist/blockstack.js
@@ -303,7 +303,7 @@ var _encryption = require('../encryption');
 
 require('isomorphic-fetch');
 
-var VERSION = '1.2.0';
+var VERSION = '1.1.0';
 
 /**
  * Generates an authentication request that can be sent to the Blockstack
@@ -337,6 +337,7 @@ function makeAuthRequest() {
     redirect_uri: redirectURI,
     version: VERSION,
     do_not_include_profile: true,
+    suppports_hub_url: true,
     scopes: scopes
   };
 

--- a/dist/blockstack.js
+++ b/dist/blockstack.js
@@ -181,7 +181,7 @@ function handlePendingSignIn() {
         // TODO: real version handling
         var appPrivateKey = tokenPayload.private_key;
         var coreSessionToken = tokenPayload.core_token;
-        if (tokenPayload.version === '1.1.0') {
+        if ((0, _utils.isLaterVersionString)(tokenPayload.version, '1.1.0')) {
           var transitKey = getTransitKey();
           if (transitKey !== undefined && transitKey != null) {
             if (appPrivateKey !== undefined && appPrivateKey !== null) {
@@ -192,13 +192,18 @@ function handlePendingSignIn() {
             }
           }
         }
+        var hubUrl = 'https://hub.blockstack.org';
+        if ((0, _utils.isLaterVersionString)(tokenPayload.version, '1.2.0') && tokenPayload.hubUrl !== null) {
+          hubUrl = tokenPayload.hubUrl;
+        }
 
         var userData = {
           username: tokenPayload.username,
           profile: tokenPayload.profile,
           appPrivateKey: appPrivateKey,
           coreSessionToken: coreSessionToken,
-          authResponseToken: authResponseToken
+          authResponseToken: authResponseToken,
+          hubUrl: hubUrl
         };
         var profileURL = tokenPayload.profile_url;
         if ((userData.profile === null || userData.profile === undefined) && profileURL !== undefined && profileURL !== null) {
@@ -254,7 +259,7 @@ function signUserOut() {
     window.location = redirectURL;
   }
 }
-},{"../index":11,"../profiles":13,"../utils":35,"./authConstants":2,"./authMessages":3,"./index":7,"custom-protocol-detection-blockstack":298,"jsontokens":381,"query-string":478}],2:[function(require,module,exports){
+},{"../index":11,"../profiles":13,"../utils":36,"./authConstants":2,"./authMessages":3,"./index":7,"custom-protocol-detection-blockstack":231,"jsontokens":311,"query-string":400}],2:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -287,7 +292,7 @@ var _encryption = require('../encryption');
 
 require('isomorphic-fetch');
 
-var VERSION = '1.1.0';
+var VERSION = '1.2.0';
 
 /**
  * Generates an authentication request that can be sent to the Blockstack
@@ -359,6 +364,7 @@ function makeAuthResponse(privateKey) {
   var appPrivateKey = arguments.length > 5 && arguments[5] !== undefined ? arguments[5] : null;
   var expiresAt = arguments.length > 6 && arguments[6] !== undefined ? arguments[6] : (0, _index.nextMonth)().getTime();
   var transitPublicKey = arguments.length > 7 && arguments[7] !== undefined ? arguments[7] : null;
+  var hubUrl = arguments.length > 8 && arguments[8] !== undefined ? arguments[8] : null;
 
   /* Convert the private key to a public key to an issuer */
   var publicKey = _jsontokens.SECP256K1Client.derivePublicKey(privateKey);
@@ -379,6 +385,7 @@ function makeAuthResponse(privateKey) {
     additionalProperties = {
       email: metadata.email ? metadata.email : null,
       profile_url: metadata.profileUrl ? metadata.profileUrl : null,
+      hubUrl: hubUrl,
       version: VERSION
     };
   } else {
@@ -403,7 +410,7 @@ function makeAuthResponse(privateKey) {
   return tokenSigner.sign(payload);
 }
 }).call(this,require("buffer").Buffer)
-},{"../encryption":9,"../index":11,"./authConstants":2,"buffer":188,"isomorphic-fetch":371,"jsontokens":381}],4:[function(require,module,exports){
+},{"../encryption":9,"../index":11,"./authConstants":2,"buffer":134,"isomorphic-fetch":304,"jsontokens":311}],4:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -471,7 +478,7 @@ function redirectUserToApp(authRequest, authResponse) {
   }
   window.location = redirectURI;
 }
-},{"../index":11,"../utils":35,"jsontokens":381,"query-string":478}],5:[function(require,module,exports){
+},{"../index":11,"../utils":36,"jsontokens":311,"query-string":400}],5:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -628,7 +635,7 @@ function getCoreSession(coreHost, corePort, apiPassword, appPrivateKey) {
 
   return sendCoreSessionRequest(coreHost, corePort, coreAuthRequest, apiPassword);
 }
-},{"isomorphic-fetch":371,"jsontokens":381}],6:[function(require,module,exports){
+},{"isomorphic-fetch":304,"jsontokens":311}],6:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -795,7 +802,7 @@ function verifyAuthResponse(token, nameLookupURL) {
     });
   });
 }
-},{"../index":11,"jsontokens":381}],7:[function(require,module,exports){
+},{"../index":11,"jsontokens":311}],7:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -1164,7 +1171,7 @@ function decryptECIES(privateKey, cipherObject) {
   }
 }
 }).call(this,require("buffer").Buffer)
-},{"buffer":188,"crypto":198,"elliptic":317}],10:[function(require,module,exports){
+},{"buffer":134,"crypto":143,"elliptic":250}],10:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -1352,7 +1359,7 @@ Object.defineProperty(exports, 'decodeToken', {
     return _jsontokens.decodeToken;
   }
 });
-},{"./auth":7,"./dids":8,"./keys":12,"./profiles":13,"./storage":34,"./utils":35,"jsontokens":381}],12:[function(require,module,exports){
+},{"./auth":7,"./dids":8,"./keys":12,"./profiles":13,"./storage":35,"./utils":36,"jsontokens":311}],12:[function(require,module,exports){
 (function (Buffer){
 'use strict';
 
@@ -1397,7 +1404,7 @@ function getPublicKeyFromPrivate(privateKey) {
   return keyPair.getPublicKeyBuffer().toString('hex');
 }
 }).call(this,require("buffer").Buffer)
-},{"bigi":86,"bitcoinjs-lib":125,"buffer":188,"crypto":198}],13:[function(require,module,exports){
+},{"bigi":39,"bitcoinjs-lib":78,"buffer":134,"crypto":143}],13:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -1594,7 +1601,7 @@ var Profile = exports.Profile = function () {
 
   return Profile;
 }();
-},{"./profileProofs":15,"./profileTokens":23,"./profileZoneFiles":24,"schema-inspector":482}],15:[function(require,module,exports){
+},{"./profileProofs":15,"./profileTokens":23,"./profileZoneFiles":24,"schema-inspector":404}],15:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -1726,7 +1733,7 @@ var CreativeWork = exports.CreativeWork = function (_Profile) {
 
   return CreativeWork;
 }(_profile.Profile);
-},{"../profile":14,"../profileTokens":23,"schema-inspector":482}],17:[function(require,module,exports){
+},{"../profile":14,"../profileTokens":23,"schema-inspector":404}],17:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -1848,7 +1855,7 @@ var Organization = exports.Organization = function (_Profile) {
 
   return Organization;
 }(_profile.Profile);
-},{"../profile":14,"../profileTokens":23,"schema-inspector":482}],19:[function(require,module,exports){
+},{"../profile":14,"../profileTokens":23,"schema-inspector":404}],19:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -2080,7 +2087,7 @@ var Person = exports.Person = function (_Profile) {
 
   return Person;
 }(_profile.Profile);
-},{"../profile":14,"../profileTokens":23,"./personLegacy":20,"./personUtils":21,"schema-inspector":482}],20:[function(require,module,exports){
+},{"../profile":14,"../profileTokens":23,"./personLegacy":20,"./personUtils":21,"schema-inspector":404}],20:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -2199,7 +2206,7 @@ function getPersonFromLegacyFormat(profile) {
 
   return profileData;
 }
-},{"hasprop":361}],21:[function(require,module,exports){
+},{"hasprop":294}],21:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -2472,7 +2479,7 @@ function resolveZoneFileToPerson(zoneFile, publicKeyOrAddress, callback) {
     return;
   }
 }
-},{"../profileTokens":23,"../profileZoneFiles":24,"./person":19,"zone-file":553}],23:[function(require,module,exports){
+},{"../profileTokens":23,"../profileZoneFiles":24,"./person":19,"zone-file":472}],23:[function(require,module,exports){
 (function (Buffer){
 'use strict';
 
@@ -2653,7 +2660,7 @@ function extractProfile(token) {
   return profile;
 }
 }).call(this,require("buffer").Buffer)
-},{"../utils":35,"bitcoinjs-lib":125,"buffer":188,"ecurve":314,"jsontokens":381}],24:[function(require,module,exports){
+},{"../utils":36,"bitcoinjs-lib":78,"buffer":134,"ecurve":247,"jsontokens":311}],24:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -2717,7 +2724,7 @@ function getTokenFileUrl(zoneFileJson) {
 
   return tokenFileUrl;
 }
-},{"zone-file":553}],25:[function(require,module,exports){
+},{"zone-file":472}],25:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -2794,7 +2801,7 @@ var Facebook = function (_Service) {
 }(_service.Service);
 
 exports.Facebook = Facebook;
-},{"./service":31,"cheerio":279}],26:[function(require,module,exports){
+},{"./service":31,"cheerio":212}],26:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -2939,7 +2946,7 @@ var HackerNews = function (_Service) {
 }(_service.Service);
 
 exports.HackerNews = HackerNews;
-},{"./service":31,"cheerio":279}],28:[function(require,module,exports){
+},{"./service":31,"cheerio":212}],28:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -3082,7 +3089,7 @@ var Instagram = function (_Service) {
 }(_service.Service);
 
 exports.Instagram = Instagram;
-},{"./service":31,"cheerio":279}],30:[function(require,module,exports){
+},{"./service":31,"cheerio":212}],30:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -3177,7 +3184,7 @@ var LinkedIn = function (_Service) {
 }(_service.Service);
 
 exports.LinkedIn = LinkedIn;
-},{"./service":31,"cheerio":279}],31:[function(require,module,exports){
+},{"./service":31,"cheerio":212}],31:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -3287,7 +3294,7 @@ var Service = exports.Service = function () {
 
   return Service;
 }();
-},{"./serviceUtils":32,"isomorphic-fetch":371}],32:[function(require,module,exports){
+},{"./serviceUtils":32,"isomorphic-fetch":304}],32:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -3404,17 +3411,114 @@ var Twitter = function (_Service) {
 }(_service.Service);
 
 exports.Twitter = Twitter;
-},{"./service":31,"cheerio":279}],34:[function(require,module,exports){
+},{"./service":31,"cheerio":212}],34:[function(require,module,exports){
+(function (Buffer){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+exports.BLOCKSTACK_GAIA_HUB_LABEL = undefined;
+exports.uploadToGaiaHub = uploadToGaiaHub;
+exports.connectToGaiaHub = connectToGaiaHub;
+exports.setLocalGaiaHubConnection = setLocalGaiaHubConnection;
+exports.getOrSetLocalGaiaHubConnection = getOrSetLocalGaiaHubConnection;
+
+var _bitcoinjsLib = require('bitcoinjs-lib');
+
+var _bitcoinjsLib2 = _interopRequireDefault(_bitcoinjsLib);
+
+var _bigi = require('bigi');
+
+var _bigi2 = _interopRequireDefault(_bigi);
+
+var _authApp = require('../auth/authApp');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var BLOCKSTACK_GAIA_HUB_LABEL = exports.BLOCKSTACK_GAIA_HUB_LABEL = 'blockstack-gaia-hub-config';
+
+function uploadToGaiaHub(filename, contents, hubConfig) {
+  var contentType = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : 'application/octet-stream';
+
+  return new Promise(function (resolve) {
+    console.log('uploadToGaiaHub: uploading ' + filename + ' to ' + hubConfig.server);
+    return fetch(hubConfig.server + '/store/' + hubConfig.address + '/' + filename, { method: 'POST',
+      headers: {
+        'Content-Type': contentType,
+        Authorization: 'bearer ' + hubConfig.token
+      },
+      body: contents }).then(function (response) {
+      return response.text();
+    }).then(function (responseText) {
+      return JSON.parse(responseText);
+    }).then(function (responseJSON) {
+      resolve(responseJSON.publicURL);
+    });
+  });
+}
+
+function connectToGaiaHub(gaiaHubUrl, challengeSignerHex) {
+  console.log('connectToGaiaHub: ' + gaiaHubUrl + '/hub_info');
+  var challengeSigner = new _bitcoinjsLib2.default.ECPair(_bigi2.default.fromHex(challengeSignerHex));
+  return new Promise(function (resolve) {
+    fetch(gaiaHubUrl + '/hub_info').then(function (response) {
+      return response.text();
+    }).then(function (responseText) {
+      return JSON.parse(responseText);
+    }).then(function (responseJSON) {
+      var readURL = responseJSON.read_url_prefix;
+      var challenge = responseJSON.challenge_text;
+      var digest = _bitcoinjsLib2.default.crypto.sha256(challenge);
+      var signature = challengeSigner.sign(digest).toDER().toString('hex');
+      var publickey = challengeSigner.getPublicKeyBuffer().toString('hex');
+      var token = new Buffer(JSON.stringify({ publickey: publickey, signature: signature })).toString('base64');
+      var address = challengeSigner.getAddress();
+      resolve({ url_prefix: readURL,
+        address: address,
+        token: token,
+        server: gaiaHubUrl });
+    });
+  });
+}
+
+/**
+ * These two functions are app-specific connections to gaia hub,
+ *   they read the user data object for information on setting up
+ *   a hub connection, and store the hub config to localstorage
+ * @returns {Promise} that resolves to the new gaia hub connection
+ */
+function setLocalGaiaHubConnection() {
+  var userData = (0, _authApp.loadUserData)();
+  return connectToGaiaHub(userData.gaiaHubUrl, userData.appPrivateKey).then(function (gaiaConfig) {
+    localStorage.setItem(BLOCKSTACK_GAIA_HUB_LABEL, gaiaConfig);
+    return gaiaConfig;
+  });
+}
+
+function getOrSetLocalGaiaHubConnection() {
+  var hubConfig = localStorage.getItem(BLOCKSTACK_GAIA_HUB_LABEL);
+  if (hubConfig !== null) {
+    return new Promise(function (resolve) {
+      return resolve(hubConfig);
+    });
+  } else {
+    return setLocalGaiaHubConnection();
+  }
+}
+}).call(this,require("buffer").Buffer)
+},{"../auth/authApp":1,"bigi":39,"bitcoinjs-lib":78,"buffer":134}],35:[function(require,module,exports){
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.uploadToGaiaHub = exports.connectToGaiaHub = undefined;
 exports.getFile = getFile;
 exports.putFile = putFile;
 exports.deleteFile = deleteFile;
 
-var _blockstackStorage = require('blockstack-storage');
+var _hub = require('./hub');
 
 var _encryption = require('../encryption');
 
@@ -3432,7 +3536,9 @@ var _keys = require('../keys');
 function getFile(path) {
   var decrypt = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
 
-  return (0, _blockstackStorage.getFile)(path).then(function (storedContents) {
+  return (0, _hub.getOrSetLocalGaiaHubConnection)().then(function (gaiaHubConfig) {
+    return fetch('' + gaiaHubConfig.url_prefix + path);
+  }).then(function (storedContents) {
     if (decrypt) {
       var privateKey = (0, _auth.loadUserData)().appPrivateKey;
       var cipherObject = JSON.parse(storedContents);
@@ -3460,7 +3566,9 @@ function putFile(path, content) {
     var cipherObject = (0, _encryption.encryptECIES)(publicKey, content);
     content = JSON.stringify(cipherObject);
   }
-  return (0, _blockstackStorage.putFile)(path, content);
+  return (0, _hub.getOrSetLocalGaiaHubConnection)().then(function (gaiaHubConfig) {
+    return (0, _hub.uploadToGaiaHub)(path, content, gaiaHubConfig);
+  });
 }
 
 /**
@@ -3470,9 +3578,12 @@ function putFile(path, content) {
  * or rejects with an error
  */
 function deleteFile(path) {
-  return (0, _blockstackStorage.deleteFile)(path);
+  throw new Error('Delete of ' + path + ' not supported by gaia hubs');
 }
-},{"../auth":7,"../encryption":9,"../keys":12,"blockstack-storage":136}],35:[function(require,module,exports){
+
+exports.connectToGaiaHub = _hub.connectToGaiaHub;
+exports.uploadToGaiaHub = _hub.uploadToGaiaHub;
+},{"../auth":7,"../encryption":9,"../keys":12,"./hub":34}],36:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -3482,6 +3593,7 @@ exports.nextYear = nextYear;
 exports.nextMonth = nextMonth;
 exports.nextHour = nextHour;
 exports.updateQueryStringParameter = updateQueryStringParameter;
+exports.isLaterVersionString = isLaterVersionString;
 exports.makeUUID4 = makeUUID4;
 var BLOCKSTACK_HANDLER = exports.BLOCKSTACK_HANDLER = 'blockstack';
 /**
@@ -3517,6 +3629,32 @@ function updateQueryStringParameter(uri, key, value) {
 }
 
 /**
+ * Versioning
+ * @param {string} v1 - the left half of the version inequality
+ * @param {string} v2 - right half of the version inequality
+ * @returns {bool} iff v1 >= v2
+ * @private
+ */
+function isLaterVersionString(v1, v2) {
+  var v1tuple = v1.split('.').map(function (x) {
+    return parseInt(x, 10);
+  });
+  var v2tuple = v2.split('.').map(function (x) {
+    return parseInt(x, 10);
+  });
+
+  for (var index = 0; index < v2.length; index++) {
+    if (index >= v1.length) {
+      v2tuple.push(0);
+    }
+    if (v1tuple[index] < v2tuple[index]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
  * UUIDs
  * @private
  */
@@ -3532,6855 +3670,7 @@ function makeUUID4() {
     return (c === 'x' ? r : r & 0x3 | 0x8).toString(16);
   });
 }
-},{}],36:[function(require,module,exports){
-'use strict';
-
-var compileSchema = require('./compile')
-  , resolve = require('./compile/resolve')
-  , Cache = require('./cache')
-  , SchemaObject = require('./compile/schema_obj')
-  , stableStringify = require('json-stable-stringify')
-  , formats = require('./compile/formats')
-  , rules = require('./compile/rules')
-  , v5 = require('./v5')
-  , util = require('./compile/util')
-  , async = require('./async')
-  , co = require('co');
-
-module.exports = Ajv;
-
-Ajv.prototype.compileAsync = async.compile;
-
-var customKeyword = require('./keyword');
-Ajv.prototype.addKeyword = customKeyword.add;
-Ajv.prototype.getKeyword = customKeyword.get;
-Ajv.prototype.removeKeyword = customKeyword.remove;
-Ajv.ValidationError = require('./compile/validation_error');
-
-var META_SCHEMA_ID = 'http://json-schema.org/draft-04/schema';
-var SCHEMA_URI_FORMAT = /^(?:(?:[a-z][a-z0-9+-.]*:)?\/\/)?[^\s]*$/i;
-function SCHEMA_URI_FORMAT_FUNC(str) {
-  return SCHEMA_URI_FORMAT.test(str);
-}
-
-var META_IGNORE_OPTIONS = [ 'removeAdditional', 'useDefaults', 'coerceTypes' ];
-
-/**
- * Creates validator instance.
- * Usage: `Ajv(opts)`
- * @param {Object} opts optional options
- * @return {Object} ajv instance
- */
-function Ajv(opts) {
-  if (!(this instanceof Ajv)) return new Ajv(opts);
-  var self = this;
-
-  opts = this._opts = util.copy(opts) || {};
-  this._schemas = {};
-  this._refs = {};
-  this._fragments = {};
-  this._formats = formats(opts.format);
-  this._cache = opts.cache || new Cache;
-  this._loadingSchemas = {};
-  this._compilations = [];
-  this.RULES = rules();
-
-  // this is done on purpose, so that methods are bound to the instance
-  // (without using bind) so that they can be used without the instance
-  this.validate = validate;
-  this.compile = compile;
-  this.addSchema = addSchema;
-  this.addMetaSchema = addMetaSchema;
-  this.validateSchema = validateSchema;
-  this.getSchema = getSchema;
-  this.removeSchema = removeSchema;
-  this.addFormat = addFormat;
-  this.errorsText = errorsText;
-
-  this._addSchema = _addSchema;
-  this._compile = _compile;
-
-  opts.loopRequired = opts.loopRequired || Infinity;
-  if (opts.async || opts.transpile) async.setup(opts);
-  if (opts.beautify === true) opts.beautify = { indent_size: 2 };
-  if (opts.errorDataPath == 'property') opts._errorDataPathProperty = true;
-  this._metaOpts = getMetaSchemaOptions();
-
-  if (opts.formats) addInitialFormats();
-  addDraft4MetaSchema();
-  if (opts.v5) v5.enable(this);
-  if (typeof opts.meta == 'object') addMetaSchema(opts.meta);
-  addInitialSchemas();
-
-
-  /**
-   * Validate data using schema
-   * Schema will be compiled and cached (using serialized JSON as key. [json-stable-stringify](https://github.com/substack/json-stable-stringify) is used to serialize.
-   * @param  {String|Object} schemaKeyRef key, ref or schema object
-   * @param  {Any} data to be validated
-   * @return {Boolean} validation result. Errors from the last validation will be available in `ajv.errors` (and also in compiled schema: `schema.errors`).
-   */
-  function validate(schemaKeyRef, data) {
-    var v;
-    if (typeof schemaKeyRef == 'string') {
-      v = getSchema(schemaKeyRef);
-      if (!v) throw new Error('no schema with key or ref "' + schemaKeyRef + '"');
-    } else {
-      var schemaObj = _addSchema(schemaKeyRef);
-      v = schemaObj.validate || _compile(schemaObj);
-    }
-
-    var valid = v(data);
-    if (v.$async === true)
-      return self._opts.async == '*' ? co(valid) : valid;
-    self.errors = v.errors;
-    return valid;
-  }
-
-
-  /**
-   * Create validating function for passed schema.
-   * @param  {Object} schema schema object
-   * @param  {Boolean} _meta true if schema is a meta-schema. Used internally to compile meta schemas of custom keywords.
-   * @return {Function} validating function
-   */
-  function compile(schema, _meta) {
-    var schemaObj = _addSchema(schema, undefined, _meta);
-    return schemaObj.validate || _compile(schemaObj);
-  }
-
-
-  /**
-   * Adds schema to the instance.
-   * @param {Object|Array} schema schema or array of schemas. If array is passed, `key` and other parameters will be ignored.
-   * @param {String} key Optional schema key. Can be passed to `validate` method instead of schema object or id/ref. One schema per instance can have empty `id` and `key`.
-   * @param {Boolean} _skipValidation true to skip schema validation. Used internally, option validateSchema should be used instead.
-   * @param {Boolean} _meta true if schema is a meta-schema. Used internally, addMetaSchema should be used instead.
-   */
-  function addSchema(schema, key, _skipValidation, _meta) {
-    if (Array.isArray(schema)){
-      for (var i=0; i<schema.length; i++) addSchema(schema[i], undefined, _skipValidation, _meta);
-      return;
-    }
-    // can key/id have # inside?
-    key = resolve.normalizeId(key || schema.id);
-    checkUnique(key);
-    self._schemas[key] = _addSchema(schema, _skipValidation, _meta, true);
-  }
-
-
-  /**
-   * Add schema that will be used to validate other schemas
-   * options in META_IGNORE_OPTIONS are alway set to false
-   * @param {Object} schema schema object
-   * @param {String} key optional schema key
-   * @param {Boolean} skipValidation true to skip schema validation, can be used to override validateSchema option for meta-schema
-   */
-  function addMetaSchema(schema, key, skipValidation) {
-    addSchema(schema, key, skipValidation, true);
-  }
-
-
-  /**
-   * Validate schema
-   * @param {Object} schema schema to validate
-   * @param {Boolean} throwOrLogError pass true to throw (or log) an error if invalid
-   * @return {Boolean} true if schema is valid
-   */
-  function validateSchema(schema, throwOrLogError) {
-    var $schema = schema.$schema || self._opts.defaultMeta || defaultMeta();
-    var currentUriFormat = self._formats.uri;
-    self._formats.uri = typeof currentUriFormat == 'function'
-                        ? SCHEMA_URI_FORMAT_FUNC
-                        : SCHEMA_URI_FORMAT;
-    var valid;
-    try { valid = validate($schema, schema); }
-    finally { self._formats.uri = currentUriFormat; }
-    if (!valid && throwOrLogError) {
-      var message = 'schema is invalid: ' + errorsText();
-      if (self._opts.validateSchema == 'log') console.error(message);
-      else throw new Error(message);
-    }
-    return valid;
-  }
-
-
-  function defaultMeta() {
-    var meta = self._opts.meta;
-    self._opts.defaultMeta = typeof meta == 'object'
-                              ? meta.id || meta
-                              : self._opts.v5
-                                ? v5.META_SCHEMA_ID
-                                : META_SCHEMA_ID;
-    return self._opts.defaultMeta;
-  }
-
-
-  /**
-   * Get compiled schema from the instance by `key` or `ref`.
-   * @param  {String} keyRef `key` that was passed to `addSchema` or full schema reference (`schema.id` or resolved id).
-   * @return {Function} schema validating function (with property `schema`).
-   */
-  function getSchema(keyRef) {
-    var schemaObj = _getSchemaObj(keyRef);
-    switch (typeof schemaObj) {
-      case 'object': return schemaObj.validate || _compile(schemaObj);
-      case 'string': return getSchema(schemaObj);
-      case 'undefined': return _getSchemaFragment(keyRef);
-    }
-  }
-
-
-  function _getSchemaFragment(ref) {
-    var res = resolve.schema.call(self, { schema: {} }, ref);
-    if (res) {
-      var schema = res.schema
-        , root = res.root
-        , baseId = res.baseId;
-      var v = compileSchema.call(self, schema, root, undefined, baseId);
-      self._fragments[ref] = new SchemaObject({
-        ref: ref,
-        fragment: true,
-        schema: schema,
-        root: root,
-        baseId: baseId,
-        validate: v
-      });
-      return v;
-    }
-  }
-
-
-  function _getSchemaObj(keyRef) {
-    keyRef = resolve.normalizeId(keyRef);
-    return self._schemas[keyRef] || self._refs[keyRef] || self._fragments[keyRef];
-  }
-
-
-  /**
-   * Remove cached schema(s).
-   * If no parameter is passed all schemas but meta-schemas are removed.
-   * If RegExp is passed all schemas with key/id matching pattern but meta-schemas are removed.
-   * Even if schema is referenced by other schemas it still can be removed as other schemas have local references.
-   * @param  {String|Object|RegExp} schemaKeyRef key, ref, pattern to match key/ref or schema object
-   */
-  function removeSchema(schemaKeyRef) {
-    if (schemaKeyRef instanceof RegExp) {
-      _removeAllSchemas(self._schemas, schemaKeyRef);
-      _removeAllSchemas(self._refs, schemaKeyRef);
-      return;
-    }
-    switch (typeof schemaKeyRef) {
-      case 'undefined':
-        _removeAllSchemas(self._schemas);
-        _removeAllSchemas(self._refs);
-        self._cache.clear();
-        return;
-      case 'string':
-        var schemaObj = _getSchemaObj(schemaKeyRef);
-        if (schemaObj) self._cache.del(schemaObj.jsonStr);
-        delete self._schemas[schemaKeyRef];
-        delete self._refs[schemaKeyRef];
-        return;
-      case 'object':
-        var jsonStr = stableStringify(schemaKeyRef);
-        self._cache.del(jsonStr);
-        var id = schemaKeyRef.id;
-        if (id) {
-          id = resolve.normalizeId(id);
-          delete self._schemas[id];
-          delete self._refs[id];
-        }
-    }
-  }
-
-
-  function _removeAllSchemas(schemas, regex) {
-    for (var keyRef in schemas) {
-      var schemaObj = schemas[keyRef];
-      if (!schemaObj.meta && (!regex || regex.test(keyRef))) {
-        self._cache.del(schemaObj.jsonStr);
-        delete schemas[keyRef];
-      }
-    }
-  }
-
-
-  function _addSchema(schema, skipValidation, meta, shouldAddSchema) {
-    if (typeof schema != 'object') throw new Error('schema should be object');
-    var jsonStr = stableStringify(schema);
-    var cached = self._cache.get(jsonStr);
-    if (cached) return cached;
-
-    shouldAddSchema = shouldAddSchema || self._opts.addUsedSchema !== false;
-
-    var id = resolve.normalizeId(schema.id);
-    if (id && shouldAddSchema) checkUnique(id);
-
-    var willValidate = self._opts.validateSchema !== false && !skipValidation;
-    var recursiveMeta;
-    if (willValidate && !(recursiveMeta = schema.id && schema.id == schema.$schema))
-      validateSchema(schema, true);
-
-    var localRefs = resolve.ids.call(self, schema);
-
-    var schemaObj = new SchemaObject({
-      id: id,
-      schema: schema,
-      localRefs: localRefs,
-      jsonStr: jsonStr,
-      meta: meta
-    });
-
-    if (id[0] != '#' && shouldAddSchema) self._refs[id] = schemaObj;
-    self._cache.put(jsonStr, schemaObj);
-
-    if (willValidate && recursiveMeta) validateSchema(schema, true);
-
-    return schemaObj;
-  }
-
-
-  function _compile(schemaObj, root) {
-    if (schemaObj.compiling) {
-      schemaObj.validate = callValidate;
-      callValidate.schema = schemaObj.schema;
-      callValidate.errors = null;
-      callValidate.root = root ? root : callValidate;
-      if (schemaObj.schema.$async === true)
-        callValidate.$async = true;
-      return callValidate;
-    }
-    schemaObj.compiling = true;
-
-    var currentOpts;
-    if (schemaObj.meta) {
-      currentOpts = self._opts;
-      self._opts = self._metaOpts;
-    }
-
-    var v;
-    try { v = compileSchema.call(self, schemaObj.schema, root, schemaObj.localRefs); }
-    finally {
-      schemaObj.compiling = false;
-      if (schemaObj.meta) self._opts = currentOpts;
-    }
-
-    schemaObj.validate = v;
-    schemaObj.refs = v.refs;
-    schemaObj.refVal = v.refVal;
-    schemaObj.root = v.root;
-    return v;
-
-
-    function callValidate() {
-      var _validate = schemaObj.validate;
-      var result = _validate.apply(null, arguments);
-      callValidate.errors = _validate.errors;
-      return result;
-    }
-  }
-
-
-  /**
-   * Convert array of error message objects to string
-   * @param  {Array<Object>} errors optional array of validation errors, if not passed errors from the instance are used.
-   * @param  {Object} options optional options with properties `separator` and `dataVar`.
-   * @return {String} human readable string with all errors descriptions
-   */
-  function errorsText(errors, options) {
-    errors = errors || self.errors;
-    if (!errors) return 'No errors';
-    options = options || {};
-    var separator = options.separator === undefined ? ', ' : options.separator;
-    var dataVar = options.dataVar === undefined ? 'data' : options.dataVar;
-
-    var text = '';
-    for (var i=0; i<errors.length; i++) {
-      var e = errors[i];
-      if (e) text += dataVar + e.dataPath + ' ' + e.message + separator;
-    }
-    return text.slice(0, -separator.length);
-  }
-
-
-  /**
-   * Add custom format
-   * @param {String} name format name
-   * @param {String|RegExp|Function} format string is converted to RegExp; function should return boolean (true when valid)
-   */
-  function addFormat(name, format) {
-    if (typeof format == 'string') format = new RegExp(format);
-    self._formats[name] = format;
-  }
-
-
-  function addDraft4MetaSchema() {
-    if (self._opts.meta !== false) {
-      var metaSchema = require('./refs/json-schema-draft-04.json');
-      addMetaSchema(metaSchema, META_SCHEMA_ID, true);
-      self._refs['http://json-schema.org/schema'] = META_SCHEMA_ID;
-    }
-  }
-
-
-  function addInitialSchemas() {
-    var optsSchemas = self._opts.schemas;
-    if (!optsSchemas) return;
-    if (Array.isArray(optsSchemas)) addSchema(optsSchemas);
-    else for (var key in optsSchemas) addSchema(optsSchemas[key], key);
-  }
-
-
-  function addInitialFormats() {
-    for (var name in self._opts.formats) {
-      var format = self._opts.formats[name];
-      addFormat(name, format);
-    }
-  }
-
-
-  function checkUnique(id) {
-    if (self._schemas[id] || self._refs[id])
-      throw new Error('schema with key or id "' + id + '" already exists');
-  }
-
-
-  function getMetaSchemaOptions() {
-    var metaOpts = util.copy(self._opts);
-    for (var i=0; i<META_IGNORE_OPTIONS.length; i++)
-      delete metaOpts[META_IGNORE_OPTIONS[i]];
-    return metaOpts;
-  }
-}
-
-},{"./async":37,"./cache":38,"./compile":42,"./compile/formats":41,"./compile/resolve":43,"./compile/rules":44,"./compile/schema_obj":45,"./compile/util":47,"./compile/validation_error":48,"./keyword":73,"./refs/json-schema-draft-04.json":74,"./v5":76,"co":77,"json-stable-stringify":78}],37:[function(require,module,exports){
-'use strict';
-
-module.exports = {
-  setup: setupAsync,
-  compile: compileAsync
-};
-
-
-var util = require('./compile/util');
-
-var ASYNC = {
-  '*': checkGenerators,
-  'co*': checkGenerators,
-  'es7': checkAsyncFunction
-};
-
-var TRANSPILE = {
-  'nodent': getNodent,
-  'regenerator': getRegenerator
-};
-
-var MODES = [
-  { async: 'co*' },
-  { async: 'es7', transpile: 'nodent' },
-  { async: 'co*', transpile: 'regenerator' }
-];
-
-
-var regenerator, nodent;
-
-
-function setupAsync(opts, required) {
-  if (required !== false) required = true;
-  var async = opts.async
-    , transpile = opts.transpile
-    , check;
-
-  switch (typeof transpile) {
-    case 'string':
-      var get = TRANSPILE[transpile];
-      if (!get) throw new Error('bad transpiler: ' + transpile);
-      return (opts._transpileFunc = get(opts, required));
-    case 'undefined':
-    case 'boolean':
-      if (typeof async == 'string') {
-        check = ASYNC[async];
-        if (!check) throw new Error('bad async mode: ' + async);
-        return (opts.transpile = check(opts, required));
-      }
-
-      for (var i=0; i<MODES.length; i++) {
-        var _opts = MODES[i];
-        if (setupAsync(_opts, false)) {
-          util.copy(_opts, opts);
-          return opts.transpile;
-        }
-      }
-      /* istanbul ignore next */
-      throw new Error('generators, nodent and regenerator are not available');
-    case 'function':
-      return (opts._transpileFunc = opts.transpile);
-    default:
-      throw new Error('bad transpiler: ' + transpile);
-  }
-}
-
-
-function checkGenerators(opts, required) {
-  /* jshint evil: true */
-  try {
-    (new Function('(function*(){})()'))();
-    return true;
-  } catch(e) {
-    /* istanbul ignore next */
-    if (required) throw new Error('generators not supported');
-  }
-}
-
-
-function checkAsyncFunction(opts, required) {
-  /* jshint evil: true */
-  try {
-    (new Function('(async function(){})()'))();
-    /* istanbul ignore next */
-    return true;
-  } catch(e) {
-    if (required) throw new Error('es7 async functions not supported');
-  }
-}
-
-
-function getRegenerator(opts, required) {
-  try {
-    if (!regenerator) {
-      var name = 'regenerator';
-      regenerator = require(name);
-      regenerator.runtime();
-    }
-    if (!opts.async || opts.async === true)
-      opts.async = 'es7';
-    return regeneratorTranspile;
-  } catch(e) {
-    /* istanbul ignore next */
-    if (required) throw new Error('regenerator not available');
-  }
-}
-
-
-function regeneratorTranspile(code) {
-  return regenerator.compile(code).code;
-}
-
-
-function getNodent(opts, required) {
-  /* jshint evil: true */
-  try {
-    if (!nodent) {
-      var name = 'nodent';
-      nodent = require(name)({ log: false, dontInstallRequireHook: true });
-    }
-    if (opts.async != 'es7') {
-      if (opts.async && opts.async !== true) console.warn('nodent transpiles only es7 async functions');
-      opts.async = 'es7';
-    }
-    return nodentTranspile;
-  } catch(e) {
-    /* istanbul ignore next */
-    if (required) throw new Error('nodent not available');
-  }
-}
-
-
-function nodentTranspile(code) {
-  return nodent.compile(code, '', { promises: true, sourcemap: false }).code;
-}
-
-
-/**
- * Creates validating function for passed schema with asynchronous loading of missing schemas.
- * `loadSchema` option should be a function that accepts schema uri and node-style callback.
- * @this  Ajv
- * @param {Object}   schema schema object
- * @param {Function} callback node-style callback, it is always called with 2 parameters: error (or null) and validating function.
- */
-function compileAsync(schema, callback) {
-  /* eslint no-shadow: 0 */
-  /* jshint validthis: true */
-  var schemaObj;
-  var self = this;
-  try {
-    schemaObj = this._addSchema(schema);
-  } catch(e) {
-    setTimeout(function() { callback(e); });
-    return;
-  }
-  if (schemaObj.validate) {
-    setTimeout(function() { callback(null, schemaObj.validate); });
-  } else {
-    if (typeof this._opts.loadSchema != 'function')
-      throw new Error('options.loadSchema should be a function');
-    _compileAsync(schema, callback, true);
-  }
-
-
-  function _compileAsync(schema, callback, firstCall) {
-    var validate;
-    try { validate = self.compile(schema); }
-    catch(e) {
-      if (e.missingSchema) loadMissingSchema(e);
-      else deferCallback(e);
-      return;
-    }
-    deferCallback(null, validate);
-
-    function loadMissingSchema(e) {
-      var ref = e.missingSchema;
-      if (self._refs[ref] || self._schemas[ref])
-        return callback(new Error('Schema ' + ref + ' is loaded but ' + e.missingRef + ' cannot be resolved'));
-      var _callbacks = self._loadingSchemas[ref];
-      if (_callbacks) {
-        if (typeof _callbacks == 'function')
-          self._loadingSchemas[ref] = [_callbacks, schemaLoaded];
-        else
-          _callbacks[_callbacks.length] = schemaLoaded;
-      } else {
-        self._loadingSchemas[ref] = schemaLoaded;
-        self._opts.loadSchema(ref, function (err, sch) {
-          var _callbacks = self._loadingSchemas[ref];
-          delete self._loadingSchemas[ref];
-          if (typeof _callbacks == 'function') {
-            _callbacks(err, sch);
-          } else {
-            for (var i=0; i<_callbacks.length; i++)
-              _callbacks[i](err, sch);
-          }
-        });
-      }
-
-      function schemaLoaded(err, sch) {
-        if (err) return callback(err);
-        if (!(self._refs[ref] || self._schemas[ref])) {
-          try {
-            self.addSchema(sch, ref);
-          } catch(e) {
-            callback(e);
-            return;
-          }
-        }
-        _compileAsync(schema, callback);
-      }
-    }
-
-    function deferCallback(err, validate) {
-      if (firstCall) setTimeout(function() { callback(err, validate); });
-      else return callback(err, validate);
-    }
-  }
-}
-
-},{"./compile/util":47}],38:[function(require,module,exports){
-'use strict';
-
-
-var Cache = module.exports = function Cache() {
-  this._cache = {};
-};
-
-
-Cache.prototype.put = function Cache_put(key, value) {
-  this._cache[key] = value;
-};
-
-
-Cache.prototype.get = function Cache_get(key) {
-  return this._cache[key];
-};
-
-
-Cache.prototype.del = function Cache_del(key) {
-  delete this._cache[key];
-};
-
-
-Cache.prototype.clear = function Cache_clear() {
-  this._cache = {};
-};
-
-},{}],39:[function(require,module,exports){
-'use strict';
-
-//all requires must be explicit because browserify won't work with dynamic requires
-module.exports = {
-  '$ref': require('../dotjs/ref'),
-  allOf: require('../dotjs/allOf'),
-  anyOf: require('../dotjs/anyOf'),
-  dependencies: require('../dotjs/dependencies'),
-  'enum': require('../dotjs/enum'),
-  format: require('../dotjs/format'),
-  items: require('../dotjs/items'),
-  maximum: require('../dotjs/_limit'),
-  minimum: require('../dotjs/_limit'),
-  maxItems: require('../dotjs/_limitItems'),
-  minItems: require('../dotjs/_limitItems'),
-  maxLength: require('../dotjs/_limitLength'),
-  minLength: require('../dotjs/_limitLength'),
-  maxProperties: require('../dotjs/_limitProperties'),
-  minProperties: require('../dotjs/_limitProperties'),
-  multipleOf: require('../dotjs/multipleOf'),
-  not: require('../dotjs/not'),
-  oneOf: require('../dotjs/oneOf'),
-  pattern: require('../dotjs/pattern'),
-  properties: require('../dotjs/properties'),
-  required: require('../dotjs/required'),
-  uniqueItems: require('../dotjs/uniqueItems'),
-  validate: require('../dotjs/validate')
-};
-
-},{"../dotjs/_limit":50,"../dotjs/_limitItems":51,"../dotjs/_limitLength":52,"../dotjs/_limitProperties":53,"../dotjs/allOf":54,"../dotjs/anyOf":55,"../dotjs/dependencies":58,"../dotjs/enum":59,"../dotjs/format":60,"../dotjs/items":61,"../dotjs/multipleOf":62,"../dotjs/not":63,"../dotjs/oneOf":64,"../dotjs/pattern":65,"../dotjs/properties":67,"../dotjs/ref":68,"../dotjs/required":69,"../dotjs/uniqueItems":71,"../dotjs/validate":72}],40:[function(require,module,exports){
-'use strict';
-
-/*eslint complexity: 0*/
-
-module.exports = function equal(a, b) {
-  if (a === b) return true;
-
-  var arrA = Array.isArray(a)
-    , arrB = Array.isArray(b)
-    , i;
-
-  if (arrA && arrB) {
-    if (a.length != b.length) return false;
-    for (i = 0; i < a.length; i++)
-      if (!equal(a[i], b[i])) return false;
-    return true;
-  }
-
-  if (arrA != arrB) return false;
-
-  if (a && b && typeof a === 'object' && typeof b === 'object') {
-    var keys = Object.keys(a);
-    if (keys.length !== Object.keys(b).length) return false;
-
-    var dateA = a instanceof Date
-      , dateB = b instanceof Date;
-    if (dateA && dateB) return a.getTime() == b.getTime();
-    if (dateA != dateB) return false;
-
-    var regexpA = a instanceof RegExp
-      , regexpB = b instanceof RegExp;
-    if (regexpA && regexpB) return a.toString() == b.toString();
-    if (regexpA != regexpB) return false;
-
-    for (i = 0; i < keys.length; i++)
-      if (!Object.prototype.hasOwnProperty.call(b, keys[i])) return false;
-
-    for (i = 0; i < keys.length; i++)
-      if(!equal(a[keys[i]], b[keys[i]])) return false;
-
-    return true;
-  }
-
-  return false;
-};
-
-},{}],41:[function(require,module,exports){
-'use strict';
-
-var util = require('./util');
-
-var DATE = /^\d\d\d\d-(\d\d)-(\d\d)$/;
-var DAYS = [0,31,29,31,30,31,30,31,31,30,31,30,31];
-var TIME = /^(\d\d):(\d\d):(\d\d)(\.\d+)?(z|[+-]\d\d:\d\d)?$/i;
-var HOSTNAME = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[-0-9a-z]{0,61}[0-9a-z])?)*$/i;
-var URI = /^(?:[a-z][a-z0-9+\-.]*:)?(?:\/?\/(?:(?:[a-z0-9\-._~!$&'()*+,;=:]|%[0-9a-f]{2})*@)?(?:\[(?:(?:(?:(?:[0-9a-f]{1,4}:){6}|::(?:[0-9a-f]{1,4}:){5}|(?:[0-9a-f]{1,4})?::(?:[0-9a-f]{1,4}:){4}|(?:(?:[0-9a-f]{1,4}:){0,1}[0-9a-f]{1,4})?::(?:[0-9a-f]{1,4}:){3}|(?:(?:[0-9a-f]{1,4}:){0,2}[0-9a-f]{1,4})?::(?:[0-9a-f]{1,4}:){2}|(?:(?:[0-9a-f]{1,4}:){0,3}[0-9a-f]{1,4})?::[0-9a-f]{1,4}:|(?:(?:[0-9a-f]{1,4}:){0,4}[0-9a-f]{1,4})?::)(?:[0-9a-f]{1,4}:[0-9a-f]{1,4}|(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?))|(?:(?:[0-9a-f]{1,4}:){0,5}[0-9a-f]{1,4})?::[0-9a-f]{1,4}|(?:(?:[0-9a-f]{1,4}:){0,6}[0-9a-f]{1,4})?::)|[Vv][0-9a-f]+\.[a-z0-9\-._~!$&'()*+,;=:]+)\]|(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)|(?:[a-z0-9\-._~!$&'()*+,;=]|%[0-9a-f]{2})*)(?::\d*)?(?:\/(?:[a-z0-9\-._~!$&'()*+,;=:@]|%[0-9a-f]{2})*)*|\/(?:(?:[a-z0-9\-._~!$&'()*+,;=:@]|%[0-9a-f]{2})+(?:\/(?:[a-z0-9\-._~!$&'()*+,;=:@]|%[0-9a-f]{2})*)*)?|(?:[a-z0-9\-._~!$&'()*+,;=:@]|%[0-9a-f]{2})+(?:\/(?:[a-z0-9\-._~!$&'()*+,;=:@]|%[0-9a-f]{2})*)*)(?:\?(?:[a-z0-9\-._~!$&'()*+,;=:@\/?]|%[0-9a-f]{2})*)?(?:\#(?:[a-z0-9\-._~!$&'()*+,;=:@\/?]|%[0-9a-f]{2})*)?$/i;
-var UUID = /^(?:urn\:uuid\:)?[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/i;
-var JSON_POINTER = /^(?:\/(?:[^~\/]|~0|~1)*)*$|^\#(?:\/(?:[a-z0-9_\-\.!$&'()*+,;:=@]|%[0-9a-f]{2}|~0|~1)*)*$/i;
-var RELATIVE_JSON_POINTER = /^(?:0|[1-9][0-9]*)(?:\#|(?:\/(?:[^~\/]|~0|~1)*)*)$/;
-
-
-module.exports = formats;
-
-function formats(mode) {
-  mode = mode == 'full' ? 'full' : 'fast';
-  var formatDefs = util.copy(formats[mode]);
-  for (var fName in formats.compare) {
-    formatDefs[fName] = {
-      validate: formatDefs[fName],
-      compare: formats.compare[fName]
-    };
-  }
-  return formatDefs;
-}
-
-
-formats.fast = {
-  // date: http://tools.ietf.org/html/rfc3339#section-5.6
-  date: /^\d\d\d\d-[0-1]\d-[0-3]\d$/,
-  // date-time: http://tools.ietf.org/html/rfc3339#section-5.6
-  time: /^[0-2]\d:[0-5]\d:[0-5]\d(?:\.\d+)?(?:z|[+-]\d\d:\d\d)?$/i,
-  'date-time': /^\d\d\d\d-[0-1]\d-[0-3]\d[t\s][0-2]\d:[0-5]\d:[0-5]\d(?:\.\d+)?(?:z|[+-]\d\d:\d\d)$/i,
-  // uri: https://github.com/mafintosh/is-my-json-valid/blob/master/formats.js
-  uri: /^(?:[a-z][a-z0-9+-.]*)?(?:\:|\/)\/?[^\s]*$/i,
-  // email (sources from jsen validator):
-  // http://stackoverflow.com/questions/201323/using-a-regular-expression-to-validate-an-email-address#answer-8829363
-  // http://www.w3.org/TR/html5/forms.html#valid-e-mail-address (search for 'willful violation')
-  email: /^[a-z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*$/i,
-  hostname: HOSTNAME,
-  // optimized https://www.safaribooksonline.com/library/view/regular-expressions-cookbook/9780596802837/ch07s16.html
-  ipv4: /^(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)$/,
-  // optimized http://stackoverflow.com/questions/53497/regular-expression-that-matches-valid-ipv6-addresses
-  ipv6: /^\s*(?:(?:(?:[0-9a-f]{1,4}:){7}(?:[0-9a-f]{1,4}|:))|(?:(?:[0-9a-f]{1,4}:){6}(?::[0-9a-f]{1,4}|(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(?:(?:[0-9a-f]{1,4}:){5}(?:(?:(?::[0-9a-f]{1,4}){1,2})|:(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(?:(?:[0-9a-f]{1,4}:){4}(?:(?:(?::[0-9a-f]{1,4}){1,3})|(?:(?::[0-9a-f]{1,4})?:(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(?:(?:[0-9a-f]{1,4}:){3}(?:(?:(?::[0-9a-f]{1,4}){1,4})|(?:(?::[0-9a-f]{1,4}){0,2}:(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(?:(?:[0-9a-f]{1,4}:){2}(?:(?:(?::[0-9a-f]{1,4}){1,5})|(?:(?::[0-9a-f]{1,4}){0,3}:(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(?:(?:[0-9a-f]{1,4}:){1}(?:(?:(?::[0-9a-f]{1,4}){1,6})|(?:(?::[0-9a-f]{1,4}){0,4}:(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(?::(?:(?:(?::[0-9a-f]{1,4}){1,7})|(?:(?::[0-9a-f]{1,4}){0,5}:(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))(?:%.+)?\s*$/i,
-  regex: regex,
-  // uuid: http://tools.ietf.org/html/rfc4122
-  uuid: UUID,
-  // JSON-pointer: https://tools.ietf.org/html/rfc6901
-  // uri fragment: https://tools.ietf.org/html/rfc3986#appendix-A
-  'json-pointer': JSON_POINTER,
-  // relative JSON-pointer: http://tools.ietf.org/html/draft-luff-relative-json-pointer-00
-  'relative-json-pointer': RELATIVE_JSON_POINTER
-};
-
-
-formats.full = {
-  date: date,
-  time: time,
-  'date-time': date_time,
-  uri: uri,
-  email: /^[a-z0-9!#$%&'*+\/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&''*+\/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/i,
-  hostname: hostname,
-  ipv4: /^(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)$/,
-  ipv6: /^\s*(?:(?:(?:[0-9a-f]{1,4}:){7}(?:[0-9a-f]{1,4}|:))|(?:(?:[0-9a-f]{1,4}:){6}(?::[0-9a-f]{1,4}|(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(?:(?:[0-9a-f]{1,4}:){5}(?:(?:(?::[0-9a-f]{1,4}){1,2})|:(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(?:(?:[0-9a-f]{1,4}:){4}(?:(?:(?::[0-9a-f]{1,4}){1,3})|(?:(?::[0-9a-f]{1,4})?:(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(?:(?:[0-9a-f]{1,4}:){3}(?:(?:(?::[0-9a-f]{1,4}){1,4})|(?:(?::[0-9a-f]{1,4}){0,2}:(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(?:(?:[0-9a-f]{1,4}:){2}(?:(?:(?::[0-9a-f]{1,4}){1,5})|(?:(?::[0-9a-f]{1,4}){0,3}:(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(?:(?:[0-9a-f]{1,4}:){1}(?:(?:(?::[0-9a-f]{1,4}){1,6})|(?:(?::[0-9a-f]{1,4}){0,4}:(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(?::(?:(?:(?::[0-9a-f]{1,4}){1,7})|(?:(?::[0-9a-f]{1,4}){0,5}:(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))(?:%.+)?\s*$/i,
-  regex: regex,
-  uuid: UUID,
-  'json-pointer': JSON_POINTER,
-  'relative-json-pointer': RELATIVE_JSON_POINTER
-};
-
-
-formats.compare = {
-  date: compareDate,
-  time: compareTime,
-  'date-time': compareDateTime
-};
-
-
-function date(str) {
-  // full-date from http://tools.ietf.org/html/rfc3339#section-5.6
-  var matches = str.match(DATE);
-  if (!matches) return false;
-
-  var month = +matches[1];
-  var day = +matches[2];
-  return month >= 1 && month <= 12 && day >= 1 && day <= DAYS[month];
-}
-
-
-function time(str, full) {
-  var matches = str.match(TIME);
-  if (!matches) return false;
-
-  var hour = matches[1];
-  var minute = matches[2];
-  var second = matches[3];
-  var timeZone = matches[5];
-  return hour <= 23 && minute <= 59 && second <= 59 && (!full || timeZone);
-}
-
-
-var DATE_TIME_SEPARATOR = /t|\s/i;
-function date_time(str) {
-  // http://tools.ietf.org/html/rfc3339#section-5.6
-  var dateTime = str.split(DATE_TIME_SEPARATOR);
-  return dateTime.length == 2 && date(dateTime[0]) && time(dateTime[1], true);
-}
-
-
-function hostname(str) {
-  // https://tools.ietf.org/html/rfc1034#section-3.5
-  // https://tools.ietf.org/html/rfc1123#section-2
-  return str.length <= 255 && HOSTNAME.test(str);
-}
-
-
-var NOT_URI_FRAGMENT = /\/|\:/;
-function uri(str) {
-  // http://jmrware.com/articles/2009/uri_regexp/URI_regex.html + optional protocol + required "."
-  return NOT_URI_FRAGMENT.test(str) && URI.test(str);
-}
-
-
-function regex(str) {
-  try {
-    new RegExp(str);
-    return true;
-  } catch(e) {
-    return false;
-  }
-}
-
-
-function compareDate(d1, d2) {
-  if (!(d1 && d2)) return;
-  if (d1 > d2) return 1;
-  if (d1 < d2) return -1;
-  if (d1 === d2) return 0;
-}
-
-
-function compareTime(t1, t2) {
-  if (!(t1 && t2)) return;
-  t1 = t1.match(TIME);
-  t2 = t2.match(TIME);
-  if (!(t1 && t2)) return;
-  t1 = t1[1] + t1[2] + t1[3] + (t1[4]||'');
-  t2 = t2[1] + t2[2] + t2[3] + (t2[4]||'');
-  if (t1 > t2) return 1;
-  if (t1 < t2) return -1;
-  if (t1 === t2) return 0;
-}
-
-
-function compareDateTime(dt1, dt2) {
-  if (!(dt1 && dt2)) return;
-  dt1 = dt1.split(DATE_TIME_SEPARATOR);
-  dt2 = dt2.split(DATE_TIME_SEPARATOR);
-  var res = compareDate(dt1[0], dt2[0]);
-  if (res === undefined) return;
-  return res || compareTime(dt1[1], dt2[1]);
-}
-
-},{"./util":47}],42:[function(require,module,exports){
-'use strict';
-
-var resolve = require('./resolve')
-  , util = require('./util')
-  , stableStringify = require('json-stable-stringify')
-  , async = require('../async');
-
-var beautify;
-
-function loadBeautify(){
-  if (beautify === undefined) {
-    var name = 'js-beautify';
-    try { beautify = require(name).js_beautify; }
-    catch(e) { beautify = false; }
-  }
-}
-
-var validateGenerator = require('../dotjs/validate');
-
-/**
- * Functions below are used inside compiled validations function
- */
-
-var co = require('co');
-var ucs2length = util.ucs2length;
-var equal = require('./equal');
-
-// this error is thrown by async schemas to return validation errors via exception
-var ValidationError = require('./validation_error');
-
-module.exports = compile;
-
-
-/**
- * Compiles schema to validation function
- * @this   Ajv
- * @param  {Object} schema schema object
- * @param  {Object} root object with information about the root schema for this schema
- * @param  {Object} localRefs the hash of local references inside the schema (created by resolve.id), used for inline resolution
- * @param  {String} baseId base ID for IDs in the schema
- * @return {Function} validation function
- */
-function compile(schema, root, localRefs, baseId) {
-  /* jshint validthis: true, evil: true */
-  /* eslint no-shadow: 0 */
-  var self = this
-    , opts = this._opts
-    , refVal = [ undefined ]
-    , refs = {}
-    , patterns = []
-    , patternsHash = {}
-    , defaults = []
-    , defaultsHash = {}
-    , customRules = []
-    , keepSourceCode = opts.sourceCode !== false;
-
-  root = root || { schema: schema, refVal: refVal, refs: refs };
-
-  var c = checkCompiling.call(this, schema, root, baseId);
-  var compilation = this._compilations[c.index];
-  if (c.compiling) return (compilation.callValidate = callValidate);
-
-  var formats = this._formats;
-  var RULES = this.RULES;
-
-  try {
-    var v = localCompile(schema, root, localRefs, baseId);
-    compilation.validate = v;
-    var cv = compilation.callValidate;
-    if (cv) {
-      cv.schema = v.schema;
-      cv.errors = null;
-      cv.refs = v.refs;
-      cv.refVal = v.refVal;
-      cv.root = v.root;
-      cv.$async = v.$async;
-      if (keepSourceCode) cv.sourceCode = v.sourceCode;
-    }
-    return v;
-  } finally {
-    endCompiling.call(this, schema, root, baseId);
-  }
-
-  function callValidate() {
-    var validate = compilation.validate;
-    var result = validate.apply(null, arguments);
-    callValidate.errors = validate.errors;
-    return result;
-  }
-
-  function localCompile(_schema, _root, localRefs, baseId) {
-    var isRoot = !_root || (_root && _root.schema == _schema);
-    if (_root.schema != root.schema)
-      return compile.call(self, _schema, _root, localRefs, baseId);
-
-    var $async = _schema.$async === true;
-    if ($async && !opts.transpile) async.setup(opts);
-
-    var sourceCode = validateGenerator({
-      isTop: true,
-      schema: _schema,
-      isRoot: isRoot,
-      baseId: baseId,
-      root: _root,
-      schemaPath: '',
-      errSchemaPath: '#',
-      errorPath: '""',
-      RULES: RULES,
-      validate: validateGenerator,
-      util: util,
-      resolve: resolve,
-      resolveRef: resolveRef,
-      usePattern: usePattern,
-      useDefault: useDefault,
-      useCustomRule: useCustomRule,
-      opts: opts,
-      formats: formats,
-      self: self
-    });
-
-    sourceCode = vars(refVal, refValCode) + vars(patterns, patternCode)
-                   + vars(defaults, defaultCode) + vars(customRules, customRuleCode)
-                   + sourceCode;
-
-    if (opts.beautify) {
-      loadBeautify();
-      /* istanbul ignore else */
-      if (beautify) sourceCode = beautify(sourceCode, opts.beautify);
-      else console.error('"npm install js-beautify" to use beautify option');
-    }
-    // console.log('\n\n\n *** \n', sourceCode);
-    var validate, validateCode
-      , transpile = opts._transpileFunc;
-    try {
-      validateCode = $async && transpile
-                      ? transpile(sourceCode)
-                      : sourceCode;
-
-      var makeValidate = new Function(
-        'self',
-        'RULES',
-        'formats',
-        'root',
-        'refVal',
-        'defaults',
-        'customRules',
-        'co',
-        'equal',
-        'ucs2length',
-        'ValidationError',
-        validateCode
-      );
-
-      validate = makeValidate(
-        self,
-        RULES,
-        formats,
-        root,
-        refVal,
-        defaults,
-        customRules,
-        co,
-        equal,
-        ucs2length,
-        ValidationError
-      );
-
-      refVal[0] = validate;
-    } catch(e) {
-      console.error('Error compiling schema, function code:', validateCode);
-      throw e;
-    }
-
-    validate.schema = _schema;
-    validate.errors = null;
-    validate.refs = refs;
-    validate.refVal = refVal;
-    validate.root = isRoot ? validate : _root;
-    if ($async) validate.$async = true;
-    if (keepSourceCode) validate.sourceCode = sourceCode;
-    if (opts.sourceCode === true) {
-      validate.source = {
-        patterns: patterns,
-        defaults: defaults
-      };
-    }
-
-    return validate;
-  }
-
-  function resolveRef(baseId, ref, isRoot) {
-    ref = resolve.url(baseId, ref);
-    var refIndex = refs[ref];
-    var _refVal, refCode;
-    if (refIndex !== undefined) {
-      _refVal = refVal[refIndex];
-      refCode = 'refVal[' + refIndex + ']';
-      return resolvedRef(_refVal, refCode);
-    }
-    if (!isRoot && root.refs) {
-      var rootRefId = root.refs[ref];
-      if (rootRefId !== undefined) {
-        _refVal = root.refVal[rootRefId];
-        refCode = addLocalRef(ref, _refVal);
-        return resolvedRef(_refVal, refCode);
-      }
-    }
-
-    refCode = addLocalRef(ref);
-    var v = resolve.call(self, localCompile, root, ref);
-    if (!v) {
-      var localSchema = localRefs && localRefs[ref];
-      if (localSchema) {
-        v = resolve.inlineRef(localSchema, opts.inlineRefs)
-            ? localSchema
-            : compile.call(self, localSchema, root, localRefs, baseId);
-      }
-    }
-
-    if (v) {
-      replaceLocalRef(ref, v);
-      return resolvedRef(v, refCode);
-    }
-  }
-
-  function addLocalRef(ref, v) {
-    var refId = refVal.length;
-    refVal[refId] = v;
-    refs[ref] = refId;
-    return 'refVal' + refId;
-  }
-
-  function replaceLocalRef(ref, v) {
-    var refId = refs[ref];
-    refVal[refId] = v;
-  }
-
-  function resolvedRef(refVal, code) {
-    return typeof refVal == 'object'
-            ? { code: code, schema: refVal, inline: true }
-            : { code: code, $async: refVal && refVal.$async };
-  }
-
-  function usePattern(regexStr) {
-    var index = patternsHash[regexStr];
-    if (index === undefined) {
-      index = patternsHash[regexStr] = patterns.length;
-      patterns[index] = regexStr;
-    }
-    return 'pattern' + index;
-  }
-
-  function useDefault(value) {
-    switch (typeof value) {
-      case 'boolean':
-      case 'number':
-        return '' + value;
-      case 'string':
-        return util.toQuotedString(value);
-      case 'object':
-        if (value === null) return 'null';
-        var valueStr = stableStringify(value);
-        var index = defaultsHash[valueStr];
-        if (index === undefined) {
-          index = defaultsHash[valueStr] = defaults.length;
-          defaults[index] = value;
-        }
-        return 'default' + index;
-    }
-  }
-
-  function useCustomRule(rule, schema, parentSchema, it) {
-    var validateSchema = rule.definition.validateSchema;
-    if (validateSchema && self._opts.validateSchema !== false) {
-      var valid = validateSchema(schema);
-      if (!valid) {
-        var message = 'keyword schema is invalid: ' + self.errorsText(validateSchema.errors);
-        if (self._opts.validateSchema == 'log') console.error(message);
-        else throw new Error(message);
-      }
-    }
-
-    var compile = rule.definition.compile
-      , inline = rule.definition.inline
-      , macro = rule.definition.macro;
-
-    var validate;
-    if (compile) {
-      validate = compile.call(self, schema, parentSchema, it);
-    } else if (macro) {
-      validate = macro.call(self, schema, parentSchema, it);
-      if (opts.validateSchema !== false) self.validateSchema(validate, true);
-    } else if (inline) {
-      validate = inline.call(self, it, rule.keyword, schema, parentSchema);
-    } else {
-      validate = rule.definition.validate;
-    }
-
-    var index = customRules.length;
-    customRules[index] = validate;
-
-    return {
-      code: 'customRule' + index,
-      validate: validate
-    };
-  }
-}
-
-
-/**
- * Checks if the schema is currently compiled
- * @this   Ajv
- * @param  {Object} schema schema to compile
- * @param  {Object} root root object
- * @param  {String} baseId base schema ID
- * @return {Object} object with properties "index" (compilation index) and "compiling" (boolean)
- */
-function checkCompiling(schema, root, baseId) {
-  /* jshint validthis: true */
-  var index = compIndex.call(this, schema, root, baseId);
-  if (index >= 0) return { index: index, compiling: true };
-  index = this._compilations.length;
-  this._compilations[index] = {
-    schema: schema,
-    root: root,
-    baseId: baseId
-  };
-  return { index: index, compiling: false };
-}
-
-
-/**
- * Removes the schema from the currently compiled list
- * @this   Ajv
- * @param  {Object} schema schema to compile
- * @param  {Object} root root object
- * @param  {String} baseId base schema ID
- */
-function endCompiling(schema, root, baseId) {
-  /* jshint validthis: true */
-  var i = compIndex.call(this, schema, root, baseId);
-  if (i >= 0) this._compilations.splice(i, 1);
-}
-
-
-/**
- * Index of schema compilation in the currently compiled list
- * @this   Ajv
- * @param  {Object} schema schema to compile
- * @param  {Object} root root object
- * @param  {String} baseId base schema ID
- * @return {Integer} compilation index
- */
-function compIndex(schema, root, baseId) {
-  /* jshint validthis: true */
-  for (var i=0; i<this._compilations.length; i++) {
-    var c = this._compilations[i];
-    if (c.schema == schema && c.root == root && c.baseId == baseId) return i;
-  }
-  return -1;
-}
-
-
-function patternCode(i, patterns) {
-  return 'var pattern' + i + ' = new RegExp(' + util.toQuotedString(patterns[i]) + ');';
-}
-
-
-function defaultCode(i) {
-  return 'var default' + i + ' = defaults[' + i + '];';
-}
-
-
-function refValCode(i, refVal) {
-  return refVal[i] ? 'var refVal' + i + ' = refVal[' + i + '];' : '';
-}
-
-
-function customRuleCode(i) {
-  return 'var customRule' + i + ' = customRules[' + i + '];';
-}
-
-
-function vars(arr, statement) {
-  if (!arr.length) return '';
-  var code = '';
-  for (var i=0; i<arr.length; i++)
-    code += statement(i, arr);
-  return code;
-}
-
-},{"../async":37,"../dotjs/validate":72,"./equal":40,"./resolve":43,"./util":47,"./validation_error":48,"co":77,"json-stable-stringify":78}],43:[function(require,module,exports){
-'use strict';
-
-var url = require('url')
-  , equal = require('./equal')
-  , util = require('./util')
-  , SchemaObject = require('./schema_obj');
-
-module.exports = resolve;
-
-resolve.normalizeId = normalizeId;
-resolve.fullPath = getFullPath;
-resolve.url = resolveUrl;
-resolve.ids = resolveIds;
-resolve.inlineRef = inlineRef;
-resolve.schema = resolveSchema;
-
-/**
- * [resolve and compile the references ($ref)]
- * @this   Ajv
- * @param  {Function} compile reference to schema compilation funciton (localCompile)
- * @param  {Object} root object with information about the root schema for the current schema
- * @param  {String} ref reference to resolve
- * @return {Object|Function} schema object (if the schema can be inlined) or validation function
- */
-function resolve(compile, root, ref) {
-  /* jshint validthis: true */
-  var refVal = this._refs[ref];
-  if (typeof refVal == 'string') {
-    if (this._refs[refVal]) refVal = this._refs[refVal];
-    else return resolve.call(this, compile, root, refVal);
-  }
-
-  refVal = refVal || this._schemas[ref];
-  if (refVal instanceof SchemaObject) {
-    return inlineRef(refVal.schema, this._opts.inlineRefs)
-            ? refVal.schema
-            : refVal.validate || this._compile(refVal);
-  }
-
-  var res = resolveSchema.call(this, root, ref);
-  var schema, v, baseId;
-  if (res) {
-    schema = res.schema;
-    root = res.root;
-    baseId = res.baseId;
-  }
-
-  if (schema instanceof SchemaObject) {
-    v = schema.validate || compile.call(this, schema.schema, root, undefined, baseId);
-  } else if (schema) {
-    v = inlineRef(schema, this._opts.inlineRefs)
-        ? schema
-        : compile.call(this, schema, root, undefined, baseId);
-  }
-
-  return v;
-}
-
-
-/**
- * Resolve schema, its root and baseId
- * @this Ajv
- * @param  {Object} root root object with properties schema, refVal, refs
- * @param  {String} ref  reference to resolve
- * @return {Object} object with properties schema, root, baseId
- */
-function resolveSchema(root, ref) {
-  /* jshint validthis: true */
-  var p = url.parse(ref, false, true)
-    , refPath = _getFullPath(p)
-    , baseId = getFullPath(root.schema.id);
-  if (refPath !== baseId) {
-    var id = normalizeId(refPath);
-    var refVal = this._refs[id];
-    if (typeof refVal == 'string') {
-      return resolveRecursive.call(this, root, refVal, p);
-    } else if (refVal instanceof SchemaObject) {
-      if (!refVal.validate) this._compile(refVal);
-      root = refVal;
-    } else {
-      refVal = this._schemas[id];
-      if (refVal instanceof SchemaObject) {
-        if (!refVal.validate) this._compile(refVal);
-        if (id == normalizeId(ref))
-          return { schema: refVal, root: root, baseId: baseId };
-        root = refVal;
-      } else {
-        return;
-      }
-    }
-    if (!root.schema) return;
-    baseId = getFullPath(root.schema.id);
-  }
-  return getJsonPointer.call(this, p, baseId, root.schema, root);
-}
-
-
-/* @this Ajv */
-function resolveRecursive(root, ref, parsedRef) {
-  /* jshint validthis: true */
-  var res = resolveSchema.call(this, root, ref);
-  if (res) {
-    var schema = res.schema;
-    var baseId = res.baseId;
-    root = res.root;
-    if (schema.id) baseId = resolveUrl(baseId, schema.id);
-    return getJsonPointer.call(this, parsedRef, baseId, schema, root);
-  }
-}
-
-
-var PREVENT_SCOPE_CHANGE = util.toHash(['properties', 'patternProperties', 'enum', 'dependencies', 'definitions']);
-/* @this Ajv */
-function getJsonPointer(parsedRef, baseId, schema, root) {
-  /* jshint validthis: true */
-  parsedRef.hash = parsedRef.hash || '';
-  if (parsedRef.hash.slice(0,2) != '#/') return;
-  var parts = parsedRef.hash.split('/');
-
-  for (var i = 1; i < parts.length; i++) {
-    var part = parts[i];
-    if (part) {
-      part = util.unescapeFragment(part);
-      schema = schema[part];
-      if (!schema) break;
-      if (schema.id && !PREVENT_SCOPE_CHANGE[part]) baseId = resolveUrl(baseId, schema.id);
-      if (schema.$ref) {
-        var $ref = resolveUrl(baseId, schema.$ref);
-        var res = resolveSchema.call(this, root, $ref);
-        if (res) {
-          schema = res.schema;
-          root = res.root;
-          baseId = res.baseId;
-        }
-      }
-    }
-  }
-  if (schema && schema != root.schema)
-    return { schema: schema, root: root, baseId: baseId };
-}
-
-
-var SIMPLE_INLINED = util.toHash([
-  'type', 'format', 'pattern',
-  'maxLength', 'minLength',
-  'maxProperties', 'minProperties',
-  'maxItems', 'minItems',
-  'maximum', 'minimum',
-  'uniqueItems', 'multipleOf',
-  'required', 'enum'
-]);
-function inlineRef(schema, limit) {
-  if (limit === false) return false;
-  if (limit === undefined || limit === true) return checkNoRef(schema);
-  else if (limit) return countKeys(schema) <= limit;
-}
-
-
-function checkNoRef(schema) {
-  var item;
-  if (Array.isArray(schema)) {
-    for (var i=0; i<schema.length; i++) {
-      item = schema[i];
-      if (typeof item == 'object' && !checkNoRef(item)) return false;
-    }
-  } else {
-    for (var key in schema) {
-      if (key == '$ref') return false;
-      item = schema[key];
-      if (typeof item == 'object' && !checkNoRef(item)) return false;
-    }
-  }
-  return true;
-}
-
-
-function countKeys(schema) {
-  var count = 0, item;
-  if (Array.isArray(schema)) {
-    for (var i=0; i<schema.length; i++) {
-      item = schema[i];
-      if (typeof item == 'object') count += countKeys(item);
-      if (count == Infinity) return Infinity;
-    }
-  } else {
-    for (var key in schema) {
-      if (key == '$ref') return Infinity;
-      if (SIMPLE_INLINED[key]) {
-        count++;
-      } else {
-        item = schema[key];
-        if (typeof item == 'object') count += countKeys(item) + 1;
-        if (count == Infinity) return Infinity;
-      }
-    }
-  }
-  return count;
-}
-
-
-function getFullPath(id, normalize) {
-  if (normalize !== false) id = normalizeId(id);
-  var p = url.parse(id, false, true);
-  return _getFullPath(p);
-}
-
-
-function _getFullPath(p) {
-  var protocolSeparator = p.protocol || p.href.slice(0,2) == '//' ? '//' : '';
-  return (p.protocol||'') + protocolSeparator + (p.host||'') + (p.path||'')  + '#';
-}
-
-
-var TRAILING_SLASH_HASH = /#\/?$/;
-function normalizeId(id) {
-  return id ? id.replace(TRAILING_SLASH_HASH, '') : '';
-}
-
-
-function resolveUrl(baseId, id) {
-  id = normalizeId(id);
-  return url.resolve(baseId, id);
-}
-
-
-/* @this Ajv */
-function resolveIds(schema) {
-  /* eslint no-shadow: 0 */
-  /* jshint validthis: true */
-  var id = normalizeId(schema.id);
-  var localRefs = {};
-  _resolveIds.call(this, schema, getFullPath(id, false), id);
-  return localRefs;
-
-  /* @this Ajv */
-  function _resolveIds(schema, fullPath, baseId) {
-    /* jshint validthis: true */
-    if (Array.isArray(schema)) {
-      for (var i=0; i<schema.length; i++)
-        _resolveIds.call(this, schema[i], fullPath+'/'+i, baseId);
-    } else if (schema && typeof schema == 'object') {
-      if (typeof schema.id == 'string') {
-        var id = baseId = baseId
-                          ? url.resolve(baseId, schema.id)
-                          : schema.id;
-        id = normalizeId(id);
-
-        var refVal = this._refs[id];
-        if (typeof refVal == 'string') refVal = this._refs[refVal];
-        if (refVal && refVal.schema) {
-          if (!equal(schema, refVal.schema))
-            throw new Error('id "' + id + '" resolves to more than one schema');
-        } else if (id != normalizeId(fullPath)) {
-          if (id[0] == '#') {
-            if (localRefs[id] && !equal(schema, localRefs[id]))
-              throw new Error('id "' + id + '" resolves to more than one schema');
-            localRefs[id] = schema;
-          } else {
-            this._refs[id] = fullPath;
-          }
-        }
-      }
-      for (var key in schema)
-        _resolveIds.call(this, schema[key], fullPath+'/'+util.escapeFragment(key), baseId);
-    }
-  }
-}
-
-},{"./equal":40,"./schema_obj":45,"./util":47,"url":271}],44:[function(require,module,exports){
-'use strict';
-
-var ruleModules = require('./_rules')
-  , toHash = require('./util').toHash;
-
-module.exports = function rules() {
-  var RULES = [
-    { type: 'number',
-      rules: [ 'maximum', 'minimum', 'multipleOf'] },
-    { type: 'string',
-      rules: [ 'maxLength', 'minLength', 'pattern', 'format' ] },
-    { type: 'array',
-      rules: [ 'maxItems', 'minItems', 'uniqueItems', 'items' ] },
-    { type: 'object',
-      rules: [ 'maxProperties', 'minProperties', 'required', 'dependencies', 'properties' ] },
-    { rules: [ '$ref', 'enum', 'not', 'anyOf', 'oneOf', 'allOf' ] }
-  ];
-
-  var ALL = [ 'type', 'additionalProperties', 'patternProperties' ];
-  var KEYWORDS = [ 'additionalItems', '$schema', 'id', 'title', 'description', 'default' ];
-  var TYPES = [ 'number', 'integer', 'string', 'array', 'object', 'boolean', 'null' ];
-  RULES.all = toHash(ALL);
-
-  RULES.forEach(function (group) {
-    group.rules = group.rules.map(function (keyword) {
-      ALL.push(keyword);
-      var rule = RULES.all[keyword] = {
-        keyword: keyword,
-        code: ruleModules[keyword]
-      };
-      return rule;
-    });
-  });
-
-  RULES.keywords = toHash(ALL.concat(KEYWORDS));
-  RULES.types = toHash(TYPES);
-  RULES.custom = {};
-
-  return RULES;
-};
-
-},{"./_rules":39,"./util":47}],45:[function(require,module,exports){
-'use strict';
-
-var util = require('./util');
-
-module.exports = SchemaObject;
-
-function SchemaObject(obj) {
-  util.copy(obj, this);
-}
-
-},{"./util":47}],46:[function(require,module,exports){
-'use strict';
-
-// https://mathiasbynens.be/notes/javascript-encoding
-// https://github.com/bestiejs/punycode.js - punycode.ucs2.decode
-module.exports = function ucs2length(str) {
-  var length = 0
-    , len = str.length
-    , pos = 0
-    , value;
-  while (pos < len) {
-    length++;
-    value = str.charCodeAt(pos++);
-    if (value >= 0xD800 && value <= 0xDBFF && pos < len) {
-      // high surrogate, and there is a next character
-      value = str.charCodeAt(pos);
-      if ((value & 0xFC00) == 0xDC00) pos++; // low surrogate
-    }
-  }
-  return length;
-};
-
-},{}],47:[function(require,module,exports){
-'use strict';
-
-
-module.exports = {
-  copy: copy,
-  checkDataType: checkDataType,
-  checkDataTypes: checkDataTypes,
-  coerceToTypes: coerceToTypes,
-  toHash: toHash,
-  getProperty: getProperty,
-  escapeQuotes: escapeQuotes,
-  ucs2length: require('./ucs2length'),
-  varOccurences: varOccurences,
-  varReplace: varReplace,
-  cleanUpCode: cleanUpCode,
-  cleanUpVarErrors: cleanUpVarErrors,
-  schemaHasRules: schemaHasRules,
-  schemaHasRulesExcept: schemaHasRulesExcept,
-  stableStringify: require('json-stable-stringify'),
-  toQuotedString: toQuotedString,
-  getPathExpr: getPathExpr,
-  getPath: getPath,
-  getData: getData,
-  unescapeFragment: unescapeFragment,
-  escapeFragment: escapeFragment,
-  escapeJsonPointer: escapeJsonPointer
-};
-
-
-function copy(o, to) {
-  to = to || {};
-  for (var key in o) to[key] = o[key];
-  return to;
-}
-
-
-function checkDataType(dataType, data, negate) {
-  var EQUAL = negate ? ' !== ' : ' === '
-    , AND = negate ? ' || ' : ' && '
-    , OK = negate ? '!' : ''
-    , NOT = negate ? '' : '!';
-  switch (dataType) {
-    case 'null': return data + EQUAL + 'null';
-    case 'array': return OK + 'Array.isArray(' + data + ')';
-    case 'object': return '(' + OK + data + AND +
-                          'typeof ' + data + EQUAL + '"object"' + AND +
-                          NOT + 'Array.isArray(' + data + '))';
-    case 'integer': return '(typeof ' + data + EQUAL + '"number"' + AND +
-                           NOT + '(' + data + ' % 1)' +
-                           AND + data + EQUAL + data + ')';
-    default: return 'typeof ' + data + EQUAL + '"' + dataType + '"';
-  }
-}
-
-
-function checkDataTypes(dataTypes, data) {
-  switch (dataTypes.length) {
-    case 1: return checkDataType(dataTypes[0], data, true);
-    default:
-      var code = '';
-      var types = toHash(dataTypes);
-      if (types.array && types.object) {
-        code = types.null ? '(': '(!' + data + ' || ';
-        code += 'typeof ' + data + ' !== "object")';
-        delete types.null;
-        delete types.array;
-        delete types.object;
-      }
-      if (types.number) delete types.integer;
-      for (var t in types)
-        code += (code ? ' && ' : '' ) + checkDataType(t, data, true);
-
-      return code;
-  }
-}
-
-
-var COERCE_TO_TYPES = toHash([ 'string', 'number', 'integer', 'boolean', 'null' ]);
-function coerceToTypes(optionCoerceTypes, dataTypes) {
-  if (Array.isArray(dataTypes)) {
-    var types = [];
-    for (var i=0; i<dataTypes.length; i++) {
-      var t = dataTypes[i];
-      if (COERCE_TO_TYPES[t]) types[types.length] = t;
-      else if (optionCoerceTypes === 'array' && t === 'array') types[types.length] = t;
-    }
-    if (types.length) return types;
-  } else if (COERCE_TO_TYPES[dataTypes]) {
-    return [dataTypes];
-  } else if (optionCoerceTypes === 'array' && dataTypes === 'array') {
-    return ['array'];
-  }
-}
-
-
-function toHash(arr) {
-  var hash = {};
-  for (var i=0; i<arr.length; i++) hash[arr[i]] = true;
-  return hash;
-}
-
-
-var IDENTIFIER = /^[a-z$_][a-z$_0-9]*$/i;
-var SINGLE_QUOTE = /'|\\/g;
-function getProperty(key) {
-  return typeof key == 'number'
-          ? '[' + key + ']'
-          : IDENTIFIER.test(key)
-            ? '.' + key
-            : "['" + escapeQuotes(key) + "']";
-}
-
-
-function escapeQuotes(str) {
-  return str.replace(SINGLE_QUOTE, '\\$&')
-            .replace(/\n/g, '\\n')
-            .replace(/\r/g, '\\r')
-            .replace(/\f/g, '\\f')
-            .replace(/\t/g, '\\t');
-}
-
-
-function varOccurences(str, dataVar) {
-  dataVar += '[^0-9]';
-  var matches = str.match(new RegExp(dataVar, 'g'));
-  return matches ? matches.length : 0;
-}
-
-
-function varReplace(str, dataVar, expr) {
-  dataVar += '([^0-9])';
-  expr = expr.replace(/\$/g, '$$$$');
-  return str.replace(new RegExp(dataVar, 'g'), expr + '$1');
-}
-
-
-var EMPTY_ELSE = /else\s*{\s*}/g
-  , EMPTY_IF_NO_ELSE = /if\s*\([^)]+\)\s*\{\s*\}(?!\s*else)/g
-  , EMPTY_IF_WITH_ELSE = /if\s*\(([^)]+)\)\s*\{\s*\}\s*else(?!\s*if)/g;
-function cleanUpCode(out) {
-  return out.replace(EMPTY_ELSE, '')
-            .replace(EMPTY_IF_NO_ELSE, '')
-            .replace(EMPTY_IF_WITH_ELSE, 'if (!($1))');
-}
-
-
-var ERRORS_REGEXP = /[^v\.]errors/g
-  , REMOVE_ERRORS = /var errors = 0;|var vErrors = null;|validate.errors = vErrors;/g
-  , REMOVE_ERRORS_ASYNC = /var errors = 0;|var vErrors = null;/g
-  , RETURN_VALID = 'return errors === 0;'
-  , RETURN_TRUE = 'validate.errors = null; return true;'
-  , RETURN_ASYNC = /if \(errors === 0\) return true;\s*else throw new ValidationError\(vErrors\);/
-  , RETURN_TRUE_ASYNC = 'return true;';
-
-function cleanUpVarErrors(out, async) {
-  var matches = out.match(ERRORS_REGEXP);
-  if (!matches || matches.length !== 2) return out;
-  return async
-          ? out.replace(REMOVE_ERRORS_ASYNC, '')
-               .replace(RETURN_ASYNC, RETURN_TRUE_ASYNC)
-          : out.replace(REMOVE_ERRORS, '')
-               .replace(RETURN_VALID, RETURN_TRUE);
-}
-
-
-function schemaHasRules(schema, rules) {
-  for (var key in schema) if (rules[key]) return true;
-}
-
-
-function schemaHasRulesExcept(schema, rules, exceptKeyword) {
-  for (var key in schema) if (key != exceptKeyword && rules[key]) return true;
-}
-
-
-function toQuotedString(str) {
-  return '\'' + escapeQuotes(str) + '\'';
-}
-
-
-function getPathExpr(currentPath, expr, jsonPointers, isNumber) {
-  var path = jsonPointers // false by default
-              ? '\'/\' + ' + expr + (isNumber ? '' : '.replace(/~/g, \'~0\').replace(/\\//g, \'~1\')')
-              : (isNumber ? '\'[\' + ' + expr + ' + \']\'' : '\'[\\\'\' + ' + expr + ' + \'\\\']\'');
-  return joinPaths(currentPath, path);
-}
-
-
-function getPath(currentPath, prop, jsonPointers) {
-  var path = jsonPointers // false by default
-              ? toQuotedString('/' + escapeJsonPointer(prop))
-              : toQuotedString(getProperty(prop));
-  return joinPaths(currentPath, path);
-}
-
-
-var JSON_POINTER = /^\/(?:[^~]|~0|~1)*$/;
-var RELATIVE_JSON_POINTER = /^([0-9]+)(#|\/(?:[^~]|~0|~1)*)?$/;
-function getData($data, lvl, paths) {
-  var up, jsonPointer, data, matches;
-  if ($data === '') return 'rootData';
-  if ($data[0] == '/') {
-    if (!JSON_POINTER.test($data)) throw new Error('Invalid JSON-pointer: ' + $data);
-    jsonPointer = $data;
-    data = 'rootData';
-  } else {
-    matches = $data.match(RELATIVE_JSON_POINTER);
-    if (!matches) throw new Error('Invalid JSON-pointer: ' + $data);
-    up = +matches[1];
-    jsonPointer = matches[2];
-    if (jsonPointer == '#') {
-      if (up >= lvl) throw new Error('Cannot access property/index ' + up + ' levels up, current level is ' + lvl);
-      return paths[lvl - up];
-    }
-
-    if (up > lvl) throw new Error('Cannot access data ' + up + ' levels up, current level is ' + lvl);
-    data = 'data' + ((lvl - up) || '');
-    if (!jsonPointer) return data;
-  }
-
-  var expr = data;
-  var segments = jsonPointer.split('/');
-  for (var i=0; i<segments.length; i++) {
-    var segment = segments[i];
-    if (segment) {
-      data += getProperty(unescapeJsonPointer(segment));
-      expr += ' && ' + data;
-    }
-  }
-  return expr;
-}
-
-
-function joinPaths (a, b) {
-  if (a == '""') return b;
-  return (a + ' + ' + b).replace(/' \+ '/g, '');
-}
-
-
-function unescapeFragment(str) {
-  return unescapeJsonPointer(decodeURIComponent(str));
-}
-
-
-function escapeFragment(str) {
-  return encodeURIComponent(escapeJsonPointer(str));
-}
-
-
-function escapeJsonPointer(str) {
-  return str.replace(/~/g, '~0').replace(/\//g, '~1');
-}
-
-
-function unescapeJsonPointer(str) {
-  return str.replace(/~1/g, '/').replace(/~0/g, '~');
-}
-
-},{"./ucs2length":46,"json-stable-stringify":78}],48:[function(require,module,exports){
-'use strict';
-
-module.exports = ValidationError;
-
-
-function ValidationError(errors) {
-  this.message = 'validation failed';
-  this.errors = errors;
-  this.ajv = this.validation = true;
-}
-
-
-ValidationError.prototype = Object.create(Error.prototype);
-ValidationError.prototype.constructor = ValidationError;
-
-},{}],49:[function(require,module,exports){
-'use strict';
-module.exports = function generate__formatLimit(it, $keyword) {
-  var out = ' ';
-  var $lvl = it.level;
-  var $dataLvl = it.dataLevel;
-  var $schema = it.schema[$keyword];
-  var $schemaPath = it.schemaPath + it.util.getProperty($keyword);
-  var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
-  var $breakOnError = !it.opts.allErrors;
-  var $errorKeyword;
-  var $data = 'data' + ($dataLvl || '');
-  var $valid = 'valid' + $lvl;
-  out += 'var ' + ($valid) + ' = undefined;';
-  if (it.opts.format === false) {
-    out += ' ' + ($valid) + ' = true; ';
-    return out;
-  }
-  var $schemaFormat = it.schema.format,
-    $isDataFormat = it.opts.v5 && $schemaFormat.$data,
-    $closingBraces = '';
-  if ($isDataFormat) {
-    var $schemaValueFormat = it.util.getData($schemaFormat.$data, $dataLvl, it.dataPathArr),
-      $format = 'format' + $lvl,
-      $compare = 'compare' + $lvl;
-    out += ' var ' + ($format) + ' = formats[' + ($schemaValueFormat) + '] , ' + ($compare) + ' = ' + ($format) + ' && ' + ($format) + '.compare;';
-  } else {
-    var $format = it.formats[$schemaFormat];
-    if (!($format && $format.compare)) {
-      out += '  ' + ($valid) + ' = true; ';
-      return out;
-    }
-    var $compare = 'formats' + it.util.getProperty($schemaFormat) + '.compare';
-  }
-  var $isMax = $keyword == 'formatMaximum',
-    $exclusiveKeyword = 'formatExclusive' + ($isMax ? 'Maximum' : 'Minimum'),
-    $schemaExcl = it.schema[$exclusiveKeyword],
-    $isDataExcl = it.opts.v5 && $schemaExcl && $schemaExcl.$data,
-    $op = $isMax ? '<' : '>',
-    $result = 'result' + $lvl;
-  var $isData = it.opts.v5 && $schema && $schema.$data,
-    $schemaValue;
-  if ($isData) {
-    out += ' var schema' + ($lvl) + ' = ' + (it.util.getData($schema.$data, $dataLvl, it.dataPathArr)) + '; ';
-    $schemaValue = 'schema' + $lvl;
-  } else {
-    $schemaValue = $schema;
-  }
-  if ($isDataExcl) {
-    var $schemaValueExcl = it.util.getData($schemaExcl.$data, $dataLvl, it.dataPathArr),
-      $exclusive = 'exclusive' + $lvl,
-      $opExpr = 'op' + $lvl,
-      $opStr = '\' + ' + $opExpr + ' + \'';
-    out += ' var schemaExcl' + ($lvl) + ' = ' + ($schemaValueExcl) + '; ';
-    $schemaValueExcl = 'schemaExcl' + $lvl;
-    out += ' if (typeof ' + ($schemaValueExcl) + ' != \'boolean\' && ' + ($schemaValueExcl) + ' !== undefined) { ' + ($valid) + ' = false; ';
-    var $errorKeyword = $exclusiveKeyword;
-    var $$outStack = $$outStack || [];
-    $$outStack.push(out);
-    out = ''; /* istanbul ignore else */
-    if (it.createErrors !== false) {
-      out += ' { keyword: \'' + ($errorKeyword || '_formatExclusiveLimit') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: {} ';
-      if (it.opts.messages !== false) {
-        out += ' , message: \'' + ($exclusiveKeyword) + ' should be boolean\' ';
-      }
-      if (it.opts.verbose) {
-        out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
-      }
-      out += ' } ';
-    } else {
-      out += ' {} ';
-    }
-    var __err = out;
-    out = $$outStack.pop();
-    if (!it.compositeRule && $breakOnError) { /* istanbul ignore if */
-      if (it.async) {
-        out += ' throw new ValidationError([' + (__err) + ']); ';
-      } else {
-        out += ' validate.errors = [' + (__err) + ']; return false; ';
-      }
-    } else {
-      out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
-    }
-    out += ' }  ';
-    if ($breakOnError) {
-      $closingBraces += '}';
-      out += ' else { ';
-    }
-    if ($isData) {
-      out += ' if (' + ($schemaValue) + ' === undefined) ' + ($valid) + ' = true; else if (typeof ' + ($schemaValue) + ' != \'string\') ' + ($valid) + ' = false; else { ';
-      $closingBraces += '}';
-    }
-    if ($isDataFormat) {
-      out += ' if (!' + ($compare) + ') ' + ($valid) + ' = true; else { ';
-      $closingBraces += '}';
-    }
-    out += ' var ' + ($result) + ' = ' + ($compare) + '(' + ($data) + ',  ';
-    if ($isData) {
-      out += '' + ($schemaValue);
-    } else {
-      out += '' + (it.util.toQuotedString($schema));
-    }
-    out += ' ); if (' + ($result) + ' === undefined) ' + ($valid) + ' = false; var ' + ($exclusive) + ' = ' + ($schemaValueExcl) + ' === true; if (' + ($valid) + ' === undefined) { ' + ($valid) + ' = ' + ($exclusive) + ' ? ' + ($result) + ' ' + ($op) + ' 0 : ' + ($result) + ' ' + ($op) + '= 0; } if (!' + ($valid) + ') var op' + ($lvl) + ' = ' + ($exclusive) + ' ? \'' + ($op) + '\' : \'' + ($op) + '=\';';
-  } else {
-    var $exclusive = $schemaExcl === true,
-      $opStr = $op;
-    if (!$exclusive) $opStr += '=';
-    var $opExpr = '\'' + $opStr + '\'';
-    if ($isData) {
-      out += ' if (' + ($schemaValue) + ' === undefined) ' + ($valid) + ' = true; else if (typeof ' + ($schemaValue) + ' != \'string\') ' + ($valid) + ' = false; else { ';
-      $closingBraces += '}';
-    }
-    if ($isDataFormat) {
-      out += ' if (!' + ($compare) + ') ' + ($valid) + ' = true; else { ';
-      $closingBraces += '}';
-    }
-    out += ' var ' + ($result) + ' = ' + ($compare) + '(' + ($data) + ',  ';
-    if ($isData) {
-      out += '' + ($schemaValue);
-    } else {
-      out += '' + (it.util.toQuotedString($schema));
-    }
-    out += ' ); if (' + ($result) + ' === undefined) ' + ($valid) + ' = false; if (' + ($valid) + ' === undefined) ' + ($valid) + ' = ' + ($result) + ' ' + ($op);
-    if (!$exclusive) {
-      out += '=';
-    }
-    out += ' 0;';
-  }
-  out += '' + ($closingBraces) + 'if (!' + ($valid) + ') { ';
-  var $errorKeyword = $keyword;
-  var $$outStack = $$outStack || [];
-  $$outStack.push(out);
-  out = ''; /* istanbul ignore else */
-  if (it.createErrors !== false) {
-    out += ' { keyword: \'' + ($errorKeyword || '_formatLimit') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { comparison: ' + ($opExpr) + ', limit:  ';
-    if ($isData) {
-      out += '' + ($schemaValue);
-    } else {
-      out += '' + (it.util.toQuotedString($schema));
-    }
-    out += ' , exclusive: ' + ($exclusive) + ' } ';
-    if (it.opts.messages !== false) {
-      out += ' , message: \'should be ' + ($opStr) + ' "';
-      if ($isData) {
-        out += '\' + ' + ($schemaValue) + ' + \'';
-      } else {
-        out += '' + (it.util.escapeQuotes($schema));
-      }
-      out += '"\' ';
-    }
-    if (it.opts.verbose) {
-      out += ' , schema:  ';
-      if ($isData) {
-        out += 'validate.schema' + ($schemaPath);
-      } else {
-        out += '' + (it.util.toQuotedString($schema));
-      }
-      out += '         , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
-    }
-    out += ' } ';
-  } else {
-    out += ' {} ';
-  }
-  var __err = out;
-  out = $$outStack.pop();
-  if (!it.compositeRule && $breakOnError) { /* istanbul ignore if */
-    if (it.async) {
-      out += ' throw new ValidationError([' + (__err) + ']); ';
-    } else {
-      out += ' validate.errors = [' + (__err) + ']; return false; ';
-    }
-  } else {
-    out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
-  }
-  out += '}';
-  return out;
-}
-
-},{}],50:[function(require,module,exports){
-'use strict';
-module.exports = function generate__limit(it, $keyword) {
-  var out = ' ';
-  var $lvl = it.level;
-  var $dataLvl = it.dataLevel;
-  var $schema = it.schema[$keyword];
-  var $schemaPath = it.schemaPath + it.util.getProperty($keyword);
-  var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
-  var $breakOnError = !it.opts.allErrors;
-  var $errorKeyword;
-  var $data = 'data' + ($dataLvl || '');
-  var $isData = it.opts.v5 && $schema && $schema.$data,
-    $schemaValue;
-  if ($isData) {
-    out += ' var schema' + ($lvl) + ' = ' + (it.util.getData($schema.$data, $dataLvl, it.dataPathArr)) + '; ';
-    $schemaValue = 'schema' + $lvl;
-  } else {
-    $schemaValue = $schema;
-  }
-  var $isMax = $keyword == 'maximum',
-    $exclusiveKeyword = $isMax ? 'exclusiveMaximum' : 'exclusiveMinimum',
-    $schemaExcl = it.schema[$exclusiveKeyword],
-    $isDataExcl = it.opts.v5 && $schemaExcl && $schemaExcl.$data,
-    $op = $isMax ? '<' : '>',
-    $notOp = $isMax ? '>' : '<';
-  if ($isDataExcl) {
-    var $schemaValueExcl = it.util.getData($schemaExcl.$data, $dataLvl, it.dataPathArr),
-      $exclusive = 'exclusive' + $lvl,
-      $opExpr = 'op' + $lvl,
-      $opStr = '\' + ' + $opExpr + ' + \'';
-    out += ' var schemaExcl' + ($lvl) + ' = ' + ($schemaValueExcl) + '; ';
-    $schemaValueExcl = 'schemaExcl' + $lvl;
-    out += ' var exclusive' + ($lvl) + '; if (typeof ' + ($schemaValueExcl) + ' != \'boolean\' && typeof ' + ($schemaValueExcl) + ' != \'undefined\') { ';
-    var $errorKeyword = $exclusiveKeyword;
-    var $$outStack = $$outStack || [];
-    $$outStack.push(out);
-    out = ''; /* istanbul ignore else */
-    if (it.createErrors !== false) {
-      out += ' { keyword: \'' + ($errorKeyword || '_exclusiveLimit') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: {} ';
-      if (it.opts.messages !== false) {
-        out += ' , message: \'' + ($exclusiveKeyword) + ' should be boolean\' ';
-      }
-      if (it.opts.verbose) {
-        out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
-      }
-      out += ' } ';
-    } else {
-      out += ' {} ';
-    }
-    var __err = out;
-    out = $$outStack.pop();
-    if (!it.compositeRule && $breakOnError) { /* istanbul ignore if */
-      if (it.async) {
-        out += ' throw new ValidationError([' + (__err) + ']); ';
-      } else {
-        out += ' validate.errors = [' + (__err) + ']; return false; ';
-      }
-    } else {
-      out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
-    }
-    out += ' } else if( ';
-    if ($isData) {
-      out += ' (' + ($schemaValue) + ' !== undefined && typeof ' + ($schemaValue) + ' != \'number\') || ';
-    }
-    out += ' ((exclusive' + ($lvl) + ' = ' + ($schemaValueExcl) + ' === true) ? ' + ($data) + ' ' + ($notOp) + '= ' + ($schemaValue) + ' : ' + ($data) + ' ' + ($notOp) + ' ' + ($schemaValue) + ') || ' + ($data) + ' !== ' + ($data) + ') { var op' + ($lvl) + ' = exclusive' + ($lvl) + ' ? \'' + ($op) + '\' : \'' + ($op) + '=\';';
-  } else {
-    var $exclusive = $schemaExcl === true,
-      $opStr = $op;
-    if (!$exclusive) $opStr += '=';
-    var $opExpr = '\'' + $opStr + '\'';
-    out += ' if ( ';
-    if ($isData) {
-      out += ' (' + ($schemaValue) + ' !== undefined && typeof ' + ($schemaValue) + ' != \'number\') || ';
-    }
-    out += ' ' + ($data) + ' ' + ($notOp);
-    if ($exclusive) {
-      out += '=';
-    }
-    out += ' ' + ($schemaValue) + ' || ' + ($data) + ' !== ' + ($data) + ') {';
-  }
-  var $errorKeyword = $keyword;
-  var $$outStack = $$outStack || [];
-  $$outStack.push(out);
-  out = ''; /* istanbul ignore else */
-  if (it.createErrors !== false) {
-    out += ' { keyword: \'' + ($errorKeyword || '_limit') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { comparison: ' + ($opExpr) + ', limit: ' + ($schemaValue) + ', exclusive: ' + ($exclusive) + ' } ';
-    if (it.opts.messages !== false) {
-      out += ' , message: \'should be ' + ($opStr) + ' ';
-      if ($isData) {
-        out += '\' + ' + ($schemaValue);
-      } else {
-        out += '' + ($schema) + '\'';
-      }
-    }
-    if (it.opts.verbose) {
-      out += ' , schema:  ';
-      if ($isData) {
-        out += 'validate.schema' + ($schemaPath);
-      } else {
-        out += '' + ($schema);
-      }
-      out += '         , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
-    }
-    out += ' } ';
-  } else {
-    out += ' {} ';
-  }
-  var __err = out;
-  out = $$outStack.pop();
-  if (!it.compositeRule && $breakOnError) { /* istanbul ignore if */
-    if (it.async) {
-      out += ' throw new ValidationError([' + (__err) + ']); ';
-    } else {
-      out += ' validate.errors = [' + (__err) + ']; return false; ';
-    }
-  } else {
-    out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
-  }
-  out += ' } ';
-  if ($breakOnError) {
-    out += ' else { ';
-  }
-  return out;
-}
-
-},{}],51:[function(require,module,exports){
-'use strict';
-module.exports = function generate__limitItems(it, $keyword) {
-  var out = ' ';
-  var $lvl = it.level;
-  var $dataLvl = it.dataLevel;
-  var $schema = it.schema[$keyword];
-  var $schemaPath = it.schemaPath + it.util.getProperty($keyword);
-  var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
-  var $breakOnError = !it.opts.allErrors;
-  var $errorKeyword;
-  var $data = 'data' + ($dataLvl || '');
-  var $isData = it.opts.v5 && $schema && $schema.$data,
-    $schemaValue;
-  if ($isData) {
-    out += ' var schema' + ($lvl) + ' = ' + (it.util.getData($schema.$data, $dataLvl, it.dataPathArr)) + '; ';
-    $schemaValue = 'schema' + $lvl;
-  } else {
-    $schemaValue = $schema;
-  }
-  var $op = $keyword == 'maxItems' ? '>' : '<';
-  out += 'if ( ';
-  if ($isData) {
-    out += ' (' + ($schemaValue) + ' !== undefined && typeof ' + ($schemaValue) + ' != \'number\') || ';
-  }
-  out += ' ' + ($data) + '.length ' + ($op) + ' ' + ($schemaValue) + ') { ';
-  var $errorKeyword = $keyword;
-  var $$outStack = $$outStack || [];
-  $$outStack.push(out);
-  out = ''; /* istanbul ignore else */
-  if (it.createErrors !== false) {
-    out += ' { keyword: \'' + ($errorKeyword || '_limitItems') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { limit: ' + ($schemaValue) + ' } ';
-    if (it.opts.messages !== false) {
-      out += ' , message: \'should NOT have ';
-      if ($keyword == 'maxItems') {
-        out += 'more';
-      } else {
-        out += 'less';
-      }
-      out += ' than ';
-      if ($isData) {
-        out += '\' + ' + ($schemaValue) + ' + \'';
-      } else {
-        out += '' + ($schema);
-      }
-      out += ' items\' ';
-    }
-    if (it.opts.verbose) {
-      out += ' , schema:  ';
-      if ($isData) {
-        out += 'validate.schema' + ($schemaPath);
-      } else {
-        out += '' + ($schema);
-      }
-      out += '         , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
-    }
-    out += ' } ';
-  } else {
-    out += ' {} ';
-  }
-  var __err = out;
-  out = $$outStack.pop();
-  if (!it.compositeRule && $breakOnError) { /* istanbul ignore if */
-    if (it.async) {
-      out += ' throw new ValidationError([' + (__err) + ']); ';
-    } else {
-      out += ' validate.errors = [' + (__err) + ']; return false; ';
-    }
-  } else {
-    out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
-  }
-  out += '} ';
-  if ($breakOnError) {
-    out += ' else { ';
-  }
-  return out;
-}
-
-},{}],52:[function(require,module,exports){
-'use strict';
-module.exports = function generate__limitLength(it, $keyword) {
-  var out = ' ';
-  var $lvl = it.level;
-  var $dataLvl = it.dataLevel;
-  var $schema = it.schema[$keyword];
-  var $schemaPath = it.schemaPath + it.util.getProperty($keyword);
-  var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
-  var $breakOnError = !it.opts.allErrors;
-  var $errorKeyword;
-  var $data = 'data' + ($dataLvl || '');
-  var $isData = it.opts.v5 && $schema && $schema.$data,
-    $schemaValue;
-  if ($isData) {
-    out += ' var schema' + ($lvl) + ' = ' + (it.util.getData($schema.$data, $dataLvl, it.dataPathArr)) + '; ';
-    $schemaValue = 'schema' + $lvl;
-  } else {
-    $schemaValue = $schema;
-  }
-  var $op = $keyword == 'maxLength' ? '>' : '<';
-  out += 'if ( ';
-  if ($isData) {
-    out += ' (' + ($schemaValue) + ' !== undefined && typeof ' + ($schemaValue) + ' != \'number\') || ';
-  }
-  if (it.opts.unicode === false) {
-    out += ' ' + ($data) + '.length ';
-  } else {
-    out += ' ucs2length(' + ($data) + ') ';
-  }
-  out += ' ' + ($op) + ' ' + ($schemaValue) + ') { ';
-  var $errorKeyword = $keyword;
-  var $$outStack = $$outStack || [];
-  $$outStack.push(out);
-  out = ''; /* istanbul ignore else */
-  if (it.createErrors !== false) {
-    out += ' { keyword: \'' + ($errorKeyword || '_limitLength') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { limit: ' + ($schemaValue) + ' } ';
-    if (it.opts.messages !== false) {
-      out += ' , message: \'should NOT be ';
-      if ($keyword == 'maxLength') {
-        out += 'longer';
-      } else {
-        out += 'shorter';
-      }
-      out += ' than ';
-      if ($isData) {
-        out += '\' + ' + ($schemaValue) + ' + \'';
-      } else {
-        out += '' + ($schema);
-      }
-      out += ' characters\' ';
-    }
-    if (it.opts.verbose) {
-      out += ' , schema:  ';
-      if ($isData) {
-        out += 'validate.schema' + ($schemaPath);
-      } else {
-        out += '' + ($schema);
-      }
-      out += '         , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
-    }
-    out += ' } ';
-  } else {
-    out += ' {} ';
-  }
-  var __err = out;
-  out = $$outStack.pop();
-  if (!it.compositeRule && $breakOnError) { /* istanbul ignore if */
-    if (it.async) {
-      out += ' throw new ValidationError([' + (__err) + ']); ';
-    } else {
-      out += ' validate.errors = [' + (__err) + ']; return false; ';
-    }
-  } else {
-    out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
-  }
-  out += '} ';
-  if ($breakOnError) {
-    out += ' else { ';
-  }
-  return out;
-}
-
-},{}],53:[function(require,module,exports){
-'use strict';
-module.exports = function generate__limitProperties(it, $keyword) {
-  var out = ' ';
-  var $lvl = it.level;
-  var $dataLvl = it.dataLevel;
-  var $schema = it.schema[$keyword];
-  var $schemaPath = it.schemaPath + it.util.getProperty($keyword);
-  var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
-  var $breakOnError = !it.opts.allErrors;
-  var $errorKeyword;
-  var $data = 'data' + ($dataLvl || '');
-  var $isData = it.opts.v5 && $schema && $schema.$data,
-    $schemaValue;
-  if ($isData) {
-    out += ' var schema' + ($lvl) + ' = ' + (it.util.getData($schema.$data, $dataLvl, it.dataPathArr)) + '; ';
-    $schemaValue = 'schema' + $lvl;
-  } else {
-    $schemaValue = $schema;
-  }
-  var $op = $keyword == 'maxProperties' ? '>' : '<';
-  out += 'if ( ';
-  if ($isData) {
-    out += ' (' + ($schemaValue) + ' !== undefined && typeof ' + ($schemaValue) + ' != \'number\') || ';
-  }
-  out += ' Object.keys(' + ($data) + ').length ' + ($op) + ' ' + ($schemaValue) + ') { ';
-  var $errorKeyword = $keyword;
-  var $$outStack = $$outStack || [];
-  $$outStack.push(out);
-  out = ''; /* istanbul ignore else */
-  if (it.createErrors !== false) {
-    out += ' { keyword: \'' + ($errorKeyword || '_limitProperties') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { limit: ' + ($schemaValue) + ' } ';
-    if (it.opts.messages !== false) {
-      out += ' , message: \'should NOT have ';
-      if ($keyword == 'maxProperties') {
-        out += 'more';
-      } else {
-        out += 'less';
-      }
-      out += ' than ';
-      if ($isData) {
-        out += '\' + ' + ($schemaValue) + ' + \'';
-      } else {
-        out += '' + ($schema);
-      }
-      out += ' properties\' ';
-    }
-    if (it.opts.verbose) {
-      out += ' , schema:  ';
-      if ($isData) {
-        out += 'validate.schema' + ($schemaPath);
-      } else {
-        out += '' + ($schema);
-      }
-      out += '         , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
-    }
-    out += ' } ';
-  } else {
-    out += ' {} ';
-  }
-  var __err = out;
-  out = $$outStack.pop();
-  if (!it.compositeRule && $breakOnError) { /* istanbul ignore if */
-    if (it.async) {
-      out += ' throw new ValidationError([' + (__err) + ']); ';
-    } else {
-      out += ' validate.errors = [' + (__err) + ']; return false; ';
-    }
-  } else {
-    out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
-  }
-  out += '} ';
-  if ($breakOnError) {
-    out += ' else { ';
-  }
-  return out;
-}
-
-},{}],54:[function(require,module,exports){
-'use strict';
-module.exports = function generate_allOf(it, $keyword) {
-  var out = ' ';
-  var $schema = it.schema[$keyword];
-  var $schemaPath = it.schemaPath + it.util.getProperty($keyword);
-  var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
-  var $breakOnError = !it.opts.allErrors;
-  var $it = it.util.copy(it);
-  var $closingBraces = '';
-  $it.level++;
-  var $nextValid = 'valid' + $it.level;
-  var $currentBaseId = $it.baseId,
-    $allSchemasEmpty = true;
-  var arr1 = $schema;
-  if (arr1) {
-    var $sch, $i = -1,
-      l1 = arr1.length - 1;
-    while ($i < l1) {
-      $sch = arr1[$i += 1];
-      if (it.util.schemaHasRules($sch, it.RULES.all)) {
-        $allSchemasEmpty = false;
-        $it.schema = $sch;
-        $it.schemaPath = $schemaPath + '[' + $i + ']';
-        $it.errSchemaPath = $errSchemaPath + '/' + $i;
-        out += '  ' + (it.validate($it)) + ' ';
-        $it.baseId = $currentBaseId;
-        if ($breakOnError) {
-          out += ' if (' + ($nextValid) + ') { ';
-          $closingBraces += '}';
-        }
-      }
-    }
-  }
-  if ($breakOnError) {
-    if ($allSchemasEmpty) {
-      out += ' if (true) { ';
-    } else {
-      out += ' ' + ($closingBraces.slice(0, -1)) + ' ';
-    }
-  }
-  out = it.util.cleanUpCode(out);
-  return out;
-}
-
-},{}],55:[function(require,module,exports){
-'use strict';
-module.exports = function generate_anyOf(it, $keyword) {
-  var out = ' ';
-  var $lvl = it.level;
-  var $dataLvl = it.dataLevel;
-  var $schema = it.schema[$keyword];
-  var $schemaPath = it.schemaPath + it.util.getProperty($keyword);
-  var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
-  var $breakOnError = !it.opts.allErrors;
-  var $data = 'data' + ($dataLvl || '');
-  var $valid = 'valid' + $lvl;
-  var $errs = 'errs__' + $lvl;
-  var $it = it.util.copy(it);
-  var $closingBraces = '';
-  $it.level++;
-  var $nextValid = 'valid' + $it.level;
-  var $noEmptySchema = $schema.every(function($sch) {
-    return it.util.schemaHasRules($sch, it.RULES.all);
-  });
-  if ($noEmptySchema) {
-    var $currentBaseId = $it.baseId;
-    out += ' var ' + ($errs) + ' = errors; var ' + ($valid) + ' = false;  ';
-    var $wasComposite = it.compositeRule;
-    it.compositeRule = $it.compositeRule = true;
-    var arr1 = $schema;
-    if (arr1) {
-      var $sch, $i = -1,
-        l1 = arr1.length - 1;
-      while ($i < l1) {
-        $sch = arr1[$i += 1];
-        $it.schema = $sch;
-        $it.schemaPath = $schemaPath + '[' + $i + ']';
-        $it.errSchemaPath = $errSchemaPath + '/' + $i;
-        out += '  ' + (it.validate($it)) + ' ';
-        $it.baseId = $currentBaseId;
-        out += ' ' + ($valid) + ' = ' + ($valid) + ' || ' + ($nextValid) + '; if (!' + ($valid) + ') { ';
-        $closingBraces += '}';
-      }
-    }
-    it.compositeRule = $it.compositeRule = $wasComposite;
-    out += ' ' + ($closingBraces) + ' if (!' + ($valid) + ') {  var err =   '; /* istanbul ignore else */
-    if (it.createErrors !== false) {
-      out += ' { keyword: \'' + ('anyOf') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: {} ';
-      if (it.opts.messages !== false) {
-        out += ' , message: \'should match some schema in anyOf\' ';
-      }
-      if (it.opts.verbose) {
-        out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
-      }
-      out += ' } ';
-    } else {
-      out += ' {} ';
-    }
-    out += ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; } else {  errors = ' + ($errs) + '; if (vErrors !== null) { if (' + ($errs) + ') vErrors.length = ' + ($errs) + '; else vErrors = null; } ';
-    if (it.opts.allErrors) {
-      out += ' } ';
-    }
-    out = it.util.cleanUpCode(out);
-  } else {
-    if ($breakOnError) {
-      out += ' if (true) { ';
-    }
-  }
-  return out;
-}
-
-},{}],56:[function(require,module,exports){
-'use strict';
-module.exports = function generate_constant(it, $keyword) {
-  var out = ' ';
-  var $lvl = it.level;
-  var $dataLvl = it.dataLevel;
-  var $schema = it.schema[$keyword];
-  var $schemaPath = it.schemaPath + it.util.getProperty($keyword);
-  var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
-  var $breakOnError = !it.opts.allErrors;
-  var $data = 'data' + ($dataLvl || '');
-  var $valid = 'valid' + $lvl;
-  var $isData = it.opts.v5 && $schema && $schema.$data,
-    $schemaValue;
-  if ($isData) {
-    out += ' var schema' + ($lvl) + ' = ' + (it.util.getData($schema.$data, $dataLvl, it.dataPathArr)) + '; ';
-    $schemaValue = 'schema' + $lvl;
-  } else {
-    $schemaValue = $schema;
-  }
-  if (!$isData) {
-    out += ' var schema' + ($lvl) + ' = validate.schema' + ($schemaPath) + ';';
-  }
-  out += 'var ' + ($valid) + ' = equal(' + ($data) + ', schema' + ($lvl) + '); if (!' + ($valid) + ') {   ';
-  var $$outStack = $$outStack || [];
-  $$outStack.push(out);
-  out = ''; /* istanbul ignore else */
-  if (it.createErrors !== false) {
-    out += ' { keyword: \'' + ('constant') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: {} ';
-    if (it.opts.messages !== false) {
-      out += ' , message: \'should be equal to constant\' ';
-    }
-    if (it.opts.verbose) {
-      out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
-    }
-    out += ' } ';
-  } else {
-    out += ' {} ';
-  }
-  var __err = out;
-  out = $$outStack.pop();
-  if (!it.compositeRule && $breakOnError) { /* istanbul ignore if */
-    if (it.async) {
-      out += ' throw new ValidationError([' + (__err) + ']); ';
-    } else {
-      out += ' validate.errors = [' + (__err) + ']; return false; ';
-    }
-  } else {
-    out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
-  }
-  out += ' }';
-  return out;
-}
-
-},{}],57:[function(require,module,exports){
-'use strict';
-module.exports = function generate_custom(it, $keyword) {
-  var out = ' ';
-  var $lvl = it.level;
-  var $dataLvl = it.dataLevel;
-  var $schema = it.schema[$keyword];
-  var $schemaPath = it.schemaPath + it.util.getProperty($keyword);
-  var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
-  var $breakOnError = !it.opts.allErrors;
-  var $errorKeyword;
-  var $data = 'data' + ($dataLvl || '');
-  var $valid = 'valid' + $lvl;
-  var $errs = 'errs__' + $lvl;
-  var $isData = it.opts.v5 && $schema && $schema.$data,
-    $schemaValue;
-  if ($isData) {
-    out += ' var schema' + ($lvl) + ' = ' + (it.util.getData($schema.$data, $dataLvl, it.dataPathArr)) + '; ';
-    $schemaValue = 'schema' + $lvl;
-  } else {
-    $schemaValue = $schema;
-  }
-  var $rule = this,
-    $definition = 'definition' + $lvl,
-    $rDef = $rule.definition;
-  var $compile, $inline, $macro, $ruleValidate, $validateCode;
-  if ($isData && $rDef.$data) {
-    $validateCode = 'keywordValidate' + $lvl;
-    var $validateSchema = $rDef.validateSchema;
-    out += ' var ' + ($definition) + ' = RULES.custom[\'' + ($keyword) + '\'].definition; var ' + ($validateCode) + ' = ' + ($definition) + '.validate;';
-  } else {
-    $ruleValidate = it.useCustomRule($rule, $schema, it.schema, it);
-    $schemaValue = 'validate.schema' + $schemaPath;
-    $validateCode = $ruleValidate.code;
-    $compile = $rDef.compile;
-    $inline = $rDef.inline;
-    $macro = $rDef.macro;
-  }
-  var $ruleErrs = $validateCode + '.errors',
-    $i = 'i' + $lvl,
-    $ruleErr = 'ruleErr' + $lvl,
-    $asyncKeyword = $rDef.async;
-  if ($asyncKeyword && !it.async) throw new Error('async keyword in sync schema');
-  if (!($inline || $macro)) {
-    out += '' + ($ruleErrs) + ' = null;';
-  }
-  out += 'var ' + ($errs) + ' = errors;var ' + ($valid) + ';';
-  if ($validateSchema) {
-    out += ' ' + ($valid) + ' = ' + ($definition) + '.validateSchema(' + ($schemaValue) + '); if (' + ($valid) + ') {';
-  }
-  if ($inline) {
-    if ($rDef.statements) {
-      out += ' ' + ($ruleValidate.validate) + ' ';
-    } else {
-      out += ' ' + ($valid) + ' = ' + ($ruleValidate.validate) + '; ';
-    }
-  } else if ($macro) {
-    var $it = it.util.copy(it);
-    $it.level++;
-    var $nextValid = 'valid' + $it.level;
-    $it.schema = $ruleValidate.validate;
-    $it.schemaPath = '';
-    var $wasComposite = it.compositeRule;
-    it.compositeRule = $it.compositeRule = true;
-    var $code = it.validate($it).replace(/validate\.schema/g, $validateCode);
-    it.compositeRule = $it.compositeRule = $wasComposite;
-    out += ' ' + ($code);
-  } else {
-    var $$outStack = $$outStack || [];
-    $$outStack.push(out);
-    out = '';
-    out += '  ' + ($validateCode) + '.call( ';
-    if (it.opts.passContext) {
-      out += 'this';
-    } else {
-      out += 'self';
-    }
-    if ($compile || $rDef.schema === false) {
-      out += ' , ' + ($data) + ' ';
-    } else {
-      out += ' , ' + ($schemaValue) + ' , ' + ($data) + ' , validate.schema' + (it.schemaPath) + ' ';
-    }
-    out += ' , (dataPath || \'\')';
-    if (it.errorPath != '""') {
-      out += ' + ' + (it.errorPath);
-    }
-    var $parentData = $dataLvl ? 'data' + (($dataLvl - 1) || '') : 'parentData',
-      $parentDataProperty = $dataLvl ? it.dataPathArr[$dataLvl] : 'parentDataProperty';
-    out += ' , ' + ($parentData) + ' , ' + ($parentDataProperty) + ' , rootData )  ';
-    var def_callRuleValidate = out;
-    out = $$outStack.pop();
-    if ($rDef.errors === false) {
-      out += ' ' + ($valid) + ' = ';
-      if ($asyncKeyword) {
-        out += '' + (it.yieldAwait);
-      }
-      out += '' + (def_callRuleValidate) + '; ';
-    } else {
-      if ($asyncKeyword) {
-        $ruleErrs = 'customErrors' + $lvl;
-        out += ' var ' + ($ruleErrs) + ' = null; try { ' + ($valid) + ' = ' + (it.yieldAwait) + (def_callRuleValidate) + '; } catch (e) { ' + ($valid) + ' = false; if (e instanceof ValidationError) ' + ($ruleErrs) + ' = e.errors; else throw e; } ';
-      } else {
-        out += ' ' + ($ruleErrs) + ' = null; ' + ($valid) + ' = ' + (def_callRuleValidate) + '; ';
-      }
-    }
-  }
-  if ($rDef.modifying) {
-    out += ' ' + ($data) + ' = ' + ($parentData) + '[' + ($parentDataProperty) + '];';
-  }
-  if ($validateSchema) {
-    out += ' }';
-  }
-  if ($rDef.valid) {
-    if ($breakOnError) {
-      out += ' if (true) { ';
-    }
-  } else {
-    out += ' if ( ';
-    if ($rDef.valid === undefined) {
-      out += ' !';
-      if ($macro) {
-        out += '' + ($nextValid);
-      } else {
-        out += '' + ($valid);
-      }
-    } else {
-      out += ' ' + (!$rDef.valid) + ' ';
-    }
-    out += ') { ';
-    $errorKeyword = $rule.keyword;
-    var $$outStack = $$outStack || [];
-    $$outStack.push(out);
-    out = '';
-    var $$outStack = $$outStack || [];
-    $$outStack.push(out);
-    out = ''; /* istanbul ignore else */
-    if (it.createErrors !== false) {
-      out += ' { keyword: \'' + ($errorKeyword || 'custom') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { keyword: \'' + ($rule.keyword) + '\' } ';
-      if (it.opts.messages !== false) {
-        out += ' , message: \'should pass "' + ($rule.keyword) + '" keyword validation\' ';
-      }
-      if (it.opts.verbose) {
-        out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
-      }
-      out += ' } ';
-    } else {
-      out += ' {} ';
-    }
-    var __err = out;
-    out = $$outStack.pop();
-    if (!it.compositeRule && $breakOnError) { /* istanbul ignore if */
-      if (it.async) {
-        out += ' throw new ValidationError([' + (__err) + ']); ';
-      } else {
-        out += ' validate.errors = [' + (__err) + ']; return false; ';
-      }
-    } else {
-      out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
-    }
-    var def_customError = out;
-    out = $$outStack.pop();
-    if ($inline) {
-      if ($rDef.errors) {
-        if ($rDef.errors != 'full') {
-          out += '  for (var ' + ($i) + '=' + ($errs) + '; ' + ($i) + '<errors; ' + ($i) + '++) { var ' + ($ruleErr) + ' = vErrors[' + ($i) + ']; if (' + ($ruleErr) + '.dataPath === undefined) ' + ($ruleErr) + '.dataPath = (dataPath || \'\') + ' + (it.errorPath) + '; if (' + ($ruleErr) + '.schemaPath === undefined) { ' + ($ruleErr) + '.schemaPath = "' + ($errSchemaPath) + '"; } ';
-          if (it.opts.verbose) {
-            out += ' ' + ($ruleErr) + '.schema = ' + ($schemaValue) + '; ' + ($ruleErr) + '.data = ' + ($data) + '; ';
-          }
-          out += ' } ';
-        }
-      } else {
-        if ($rDef.errors === false) {
-          out += ' ' + (def_customError) + ' ';
-        } else {
-          out += ' if (' + ($errs) + ' == errors) { ' + (def_customError) + ' } else {  for (var ' + ($i) + '=' + ($errs) + '; ' + ($i) + '<errors; ' + ($i) + '++) { var ' + ($ruleErr) + ' = vErrors[' + ($i) + ']; if (' + ($ruleErr) + '.dataPath === undefined) ' + ($ruleErr) + '.dataPath = (dataPath || \'\') + ' + (it.errorPath) + '; if (' + ($ruleErr) + '.schemaPath === undefined) { ' + ($ruleErr) + '.schemaPath = "' + ($errSchemaPath) + '"; } ';
-          if (it.opts.verbose) {
-            out += ' ' + ($ruleErr) + '.schema = ' + ($schemaValue) + '; ' + ($ruleErr) + '.data = ' + ($data) + '; ';
-          }
-          out += ' } } ';
-        }
-      }
-    } else if ($macro) {
-      out += '   var err =   '; /* istanbul ignore else */
-      if (it.createErrors !== false) {
-        out += ' { keyword: \'' + ($errorKeyword || 'custom') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { keyword: \'' + ($rule.keyword) + '\' } ';
-        if (it.opts.messages !== false) {
-          out += ' , message: \'should pass "' + ($rule.keyword) + '" keyword validation\' ';
-        }
-        if (it.opts.verbose) {
-          out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
-        }
-        out += ' } ';
-      } else {
-        out += ' {} ';
-      }
-      out += ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
-      if (!it.compositeRule && $breakOnError) { /* istanbul ignore if */
-        if (it.async) {
-          out += ' throw new ValidationError(vErrors); ';
-        } else {
-          out += ' validate.errors = vErrors; return false; ';
-        }
-      }
-    } else {
-      if ($rDef.errors === false) {
-        out += ' ' + (def_customError) + ' ';
-      } else {
-        out += ' if (Array.isArray(' + ($ruleErrs) + ')) { if (vErrors === null) vErrors = ' + ($ruleErrs) + '; else vErrors = vErrors.concat(' + ($ruleErrs) + '); errors = vErrors.length;  for (var ' + ($i) + '=' + ($errs) + '; ' + ($i) + '<errors; ' + ($i) + '++) { var ' + ($ruleErr) + ' = vErrors[' + ($i) + ']; if (' + ($ruleErr) + '.dataPath === undefined) ' + ($ruleErr) + '.dataPath = (dataPath || \'\') + ' + (it.errorPath) + ';  ' + ($ruleErr) + '.schemaPath = "' + ($errSchemaPath) + '";  ';
-        if (it.opts.verbose) {
-          out += ' ' + ($ruleErr) + '.schema = ' + ($schemaValue) + '; ' + ($ruleErr) + '.data = ' + ($data) + '; ';
-        }
-        out += ' } } else { ' + (def_customError) + ' } ';
-      }
-    }
-    out += ' } ';
-    if ($breakOnError) {
-      out += ' else { ';
-    }
-  }
-  return out;
-}
-
-},{}],58:[function(require,module,exports){
-'use strict';
-module.exports = function generate_dependencies(it, $keyword) {
-  var out = ' ';
-  var $lvl = it.level;
-  var $dataLvl = it.dataLevel;
-  var $schema = it.schema[$keyword];
-  var $schemaPath = it.schemaPath + it.util.getProperty($keyword);
-  var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
-  var $breakOnError = !it.opts.allErrors;
-  var $data = 'data' + ($dataLvl || '');
-  var $errs = 'errs__' + $lvl;
-  var $it = it.util.copy(it);
-  var $closingBraces = '';
-  $it.level++;
-  var $nextValid = 'valid' + $it.level;
-  var $schemaDeps = {},
-    $propertyDeps = {};
-  for ($property in $schema) {
-    var $sch = $schema[$property];
-    var $deps = Array.isArray($sch) ? $propertyDeps : $schemaDeps;
-    $deps[$property] = $sch;
-  }
-  out += 'var ' + ($errs) + ' = errors;';
-  var $currentErrorPath = it.errorPath;
-  out += 'var missing' + ($lvl) + ';';
-  for (var $property in $propertyDeps) {
-    $deps = $propertyDeps[$property];
-    out += ' if (' + ($data) + (it.util.getProperty($property)) + ' !== undefined ';
-    if ($breakOnError) {
-      out += ' && ( ';
-      var arr1 = $deps;
-      if (arr1) {
-        var _$property, $i = -1,
-          l1 = arr1.length - 1;
-        while ($i < l1) {
-          _$property = arr1[$i += 1];
-          if ($i) {
-            out += ' || ';
-          }
-          var $prop = it.util.getProperty(_$property);
-          out += ' ( ' + ($data) + ($prop) + ' === undefined && (missing' + ($lvl) + ' = ' + (it.util.toQuotedString(it.opts.jsonPointers ? _$property : $prop)) + ') ) ';
-        }
-      }
-      out += ')) {  ';
-      var $propertyPath = 'missing' + $lvl,
-        $missingProperty = '\' + ' + $propertyPath + ' + \'';
-      if (it.opts._errorDataPathProperty) {
-        it.errorPath = it.opts.jsonPointers ? it.util.getPathExpr($currentErrorPath, $propertyPath, true) : $currentErrorPath + ' + ' + $propertyPath;
-      }
-      var $$outStack = $$outStack || [];
-      $$outStack.push(out);
-      out = ''; /* istanbul ignore else */
-      if (it.createErrors !== false) {
-        out += ' { keyword: \'' + ('dependencies') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { property: \'' + (it.util.escapeQuotes($property)) + '\', missingProperty: \'' + ($missingProperty) + '\', depsCount: ' + ($deps.length) + ', deps: \'' + (it.util.escapeQuotes($deps.length == 1 ? $deps[0] : $deps.join(", "))) + '\' } ';
-        if (it.opts.messages !== false) {
-          out += ' , message: \'should have ';
-          if ($deps.length == 1) {
-            out += 'property ' + (it.util.escapeQuotes($deps[0]));
-          } else {
-            out += 'properties ' + (it.util.escapeQuotes($deps.join(", ")));
-          }
-          out += ' when property ' + (it.util.escapeQuotes($property)) + ' is present\' ';
-        }
-        if (it.opts.verbose) {
-          out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
-        }
-        out += ' } ';
-      } else {
-        out += ' {} ';
-      }
-      var __err = out;
-      out = $$outStack.pop();
-      if (!it.compositeRule && $breakOnError) { /* istanbul ignore if */
-        if (it.async) {
-          out += ' throw new ValidationError([' + (__err) + ']); ';
-        } else {
-          out += ' validate.errors = [' + (__err) + ']; return false; ';
-        }
-      } else {
-        out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
-      }
-    } else {
-      out += ' ) { ';
-      var arr2 = $deps;
-      if (arr2) {
-        var $reqProperty, i2 = -1,
-          l2 = arr2.length - 1;
-        while (i2 < l2) {
-          $reqProperty = arr2[i2 += 1];
-          var $prop = it.util.getProperty($reqProperty),
-            $missingProperty = it.util.escapeQuotes($reqProperty);
-          if (it.opts._errorDataPathProperty) {
-            it.errorPath = it.util.getPath($currentErrorPath, $reqProperty, it.opts.jsonPointers);
-          }
-          out += ' if (' + ($data) + ($prop) + ' === undefined) {  var err =   '; /* istanbul ignore else */
-          if (it.createErrors !== false) {
-            out += ' { keyword: \'' + ('dependencies') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { property: \'' + (it.util.escapeQuotes($property)) + '\', missingProperty: \'' + ($missingProperty) + '\', depsCount: ' + ($deps.length) + ', deps: \'' + (it.util.escapeQuotes($deps.length == 1 ? $deps[0] : $deps.join(", "))) + '\' } ';
-            if (it.opts.messages !== false) {
-              out += ' , message: \'should have ';
-              if ($deps.length == 1) {
-                out += 'property ' + (it.util.escapeQuotes($deps[0]));
-              } else {
-                out += 'properties ' + (it.util.escapeQuotes($deps.join(", ")));
-              }
-              out += ' when property ' + (it.util.escapeQuotes($property)) + ' is present\' ';
-            }
-            if (it.opts.verbose) {
-              out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
-            }
-            out += ' } ';
-          } else {
-            out += ' {} ';
-          }
-          out += ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; } ';
-        }
-      }
-    }
-    out += ' }   ';
-    if ($breakOnError) {
-      $closingBraces += '}';
-      out += ' else { ';
-    }
-  }
-  it.errorPath = $currentErrorPath;
-  var $currentBaseId = $it.baseId;
-  for (var $property in $schemaDeps) {
-    var $sch = $schemaDeps[$property];
-    if (it.util.schemaHasRules($sch, it.RULES.all)) {
-      out += ' ' + ($nextValid) + ' = true; if (' + ($data) + (it.util.getProperty($property)) + ' !== undefined) { ';
-      $it.schema = $sch;
-      $it.schemaPath = $schemaPath + it.util.getProperty($property);
-      $it.errSchemaPath = $errSchemaPath + '/' + it.util.escapeFragment($property);
-      out += '  ' + (it.validate($it)) + ' ';
-      $it.baseId = $currentBaseId;
-      out += ' }  ';
-      if ($breakOnError) {
-        out += ' if (' + ($nextValid) + ') { ';
-        $closingBraces += '}';
-      }
-    }
-  }
-  if ($breakOnError) {
-    out += '   ' + ($closingBraces) + ' if (' + ($errs) + ' == errors) {';
-  }
-  out = it.util.cleanUpCode(out);
-  return out;
-}
-
-},{}],59:[function(require,module,exports){
-'use strict';
-module.exports = function generate_enum(it, $keyword) {
-  var out = ' ';
-  var $lvl = it.level;
-  var $dataLvl = it.dataLevel;
-  var $schema = it.schema[$keyword];
-  var $schemaPath = it.schemaPath + it.util.getProperty($keyword);
-  var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
-  var $breakOnError = !it.opts.allErrors;
-  var $data = 'data' + ($dataLvl || '');
-  var $valid = 'valid' + $lvl;
-  var $isData = it.opts.v5 && $schema && $schema.$data,
-    $schemaValue;
-  if ($isData) {
-    out += ' var schema' + ($lvl) + ' = ' + (it.util.getData($schema.$data, $dataLvl, it.dataPathArr)) + '; ';
-    $schemaValue = 'schema' + $lvl;
-  } else {
-    $schemaValue = $schema;
-  }
-  var $i = 'i' + $lvl,
-    $vSchema = 'schema' + $lvl;
-  if (!$isData) {
-    out += ' var ' + ($vSchema) + ' = validate.schema' + ($schemaPath) + ';';
-  }
-  out += 'var ' + ($valid) + ';';
-  if ($isData) {
-    out += ' if (schema' + ($lvl) + ' === undefined) ' + ($valid) + ' = true; else if (!Array.isArray(schema' + ($lvl) + ')) ' + ($valid) + ' = false; else {';
-  }
-  out += '' + ($valid) + ' = false;for (var ' + ($i) + '=0; ' + ($i) + '<' + ($vSchema) + '.length; ' + ($i) + '++) if (equal(' + ($data) + ', ' + ($vSchema) + '[' + ($i) + '])) { ' + ($valid) + ' = true; break; }';
-  if ($isData) {
-    out += '  }  ';
-  }
-  out += ' if (!' + ($valid) + ') {   ';
-  var $$outStack = $$outStack || [];
-  $$outStack.push(out);
-  out = ''; /* istanbul ignore else */
-  if (it.createErrors !== false) {
-    out += ' { keyword: \'' + ('enum') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { allowedValues: schema' + ($lvl) + ' } ';
-    if (it.opts.messages !== false) {
-      out += ' , message: \'should be equal to one of the allowed values\' ';
-    }
-    if (it.opts.verbose) {
-      out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
-    }
-    out += ' } ';
-  } else {
-    out += ' {} ';
-  }
-  var __err = out;
-  out = $$outStack.pop();
-  if (!it.compositeRule && $breakOnError) { /* istanbul ignore if */
-    if (it.async) {
-      out += ' throw new ValidationError([' + (__err) + ']); ';
-    } else {
-      out += ' validate.errors = [' + (__err) + ']; return false; ';
-    }
-  } else {
-    out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
-  }
-  out += ' }';
-  if ($breakOnError) {
-    out += ' else { ';
-  }
-  return out;
-}
-
-},{}],60:[function(require,module,exports){
-'use strict';
-module.exports = function generate_format(it, $keyword) {
-  var out = ' ';
-  var $lvl = it.level;
-  var $dataLvl = it.dataLevel;
-  var $schema = it.schema[$keyword];
-  var $schemaPath = it.schemaPath + it.util.getProperty($keyword);
-  var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
-  var $breakOnError = !it.opts.allErrors;
-  var $data = 'data' + ($dataLvl || '');
-  if (it.opts.format === false) {
-    if ($breakOnError) {
-      out += ' if (true) { ';
-    }
-    return out;
-  }
-  var $isData = it.opts.v5 && $schema && $schema.$data,
-    $schemaValue;
-  if ($isData) {
-    out += ' var schema' + ($lvl) + ' = ' + (it.util.getData($schema.$data, $dataLvl, it.dataPathArr)) + '; ';
-    $schemaValue = 'schema' + $lvl;
-  } else {
-    $schemaValue = $schema;
-  }
-  var $unknownFormats = it.opts.unknownFormats,
-    $allowUnknown = Array.isArray($unknownFormats);
-  if ($isData) {
-    var $format = 'format' + $lvl;
-    out += ' var ' + ($format) + ' = formats[' + ($schemaValue) + ']; var isObject' + ($lvl) + ' = typeof ' + ($format) + ' == \'object\' && !(' + ($format) + ' instanceof RegExp) && ' + ($format) + '.validate; if (isObject' + ($lvl) + ') { ';
-    if (it.async) {
-      out += ' var async' + ($lvl) + ' = ' + ($format) + '.async; ';
-    }
-    out += ' ' + ($format) + ' = ' + ($format) + '.validate; } if (  ';
-    if ($isData) {
-      out += ' (' + ($schemaValue) + ' !== undefined && typeof ' + ($schemaValue) + ' != \'string\') || ';
-    }
-    out += ' (';
-    if ($unknownFormats === true || $allowUnknown) {
-      out += ' (' + ($schemaValue) + ' && !' + ($format) + ' ';
-      if ($allowUnknown) {
-        out += ' && self._opts.unknownFormats.indexOf(' + ($schemaValue) + ') == -1 ';
-      }
-      out += ') || ';
-    }
-    out += ' (' + ($format) + ' && !(typeof ' + ($format) + ' == \'function\' ? ';
-    if (it.async) {
-      out += ' (async' + ($lvl) + ' ? ' + (it.yieldAwait) + ' ' + ($format) + '(' + ($data) + ') : ' + ($format) + '(' + ($data) + ')) ';
-    } else {
-      out += ' ' + ($format) + '(' + ($data) + ') ';
-    }
-    out += ' : ' + ($format) + '.test(' + ($data) + '))))) {';
-  } else {
-    var $format = it.formats[$schema];
-    if (!$format) {
-      if ($unknownFormats === true || ($allowUnknown && $unknownFormats.indexOf($schema) == -1)) {
-        throw new Error('unknown format "' + $schema + '" is used in schema at path "' + it.errSchemaPath + '"');
-      } else {
-        if (!$allowUnknown) {
-          console.warn('unknown format "' + $schema + '" ignored in schema at path "' + it.errSchemaPath + '"');
-          if ($unknownFormats !== 'ignore') console.warn('In the next major version it will throw exception. See option unknownFormats for more information');
-        }
-        if ($breakOnError) {
-          out += ' if (true) { ';
-        }
-        return out;
-      }
-    }
-    var $isObject = typeof $format == 'object' && !($format instanceof RegExp) && $format.validate;
-    if ($isObject) {
-      var $async = $format.async === true;
-      $format = $format.validate;
-    }
-    if ($async) {
-      if (!it.async) throw new Error('async format in sync schema');
-      var $formatRef = 'formats' + it.util.getProperty($schema) + '.validate';
-      out += ' if (!(' + (it.yieldAwait) + ' ' + ($formatRef) + '(' + ($data) + '))) { ';
-    } else {
-      out += ' if (! ';
-      var $formatRef = 'formats' + it.util.getProperty($schema);
-      if ($isObject) $formatRef += '.validate';
-      if (typeof $format == 'function') {
-        out += ' ' + ($formatRef) + '(' + ($data) + ') ';
-      } else {
-        out += ' ' + ($formatRef) + '.test(' + ($data) + ') ';
-      }
-      out += ') { ';
-    }
-  }
-  var $$outStack = $$outStack || [];
-  $$outStack.push(out);
-  out = ''; /* istanbul ignore else */
-  if (it.createErrors !== false) {
-    out += ' { keyword: \'' + ('format') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { format:  ';
-    if ($isData) {
-      out += '' + ($schemaValue);
-    } else {
-      out += '' + (it.util.toQuotedString($schema));
-    }
-    out += '  } ';
-    if (it.opts.messages !== false) {
-      out += ' , message: \'should match format "';
-      if ($isData) {
-        out += '\' + ' + ($schemaValue) + ' + \'';
-      } else {
-        out += '' + (it.util.escapeQuotes($schema));
-      }
-      out += '"\' ';
-    }
-    if (it.opts.verbose) {
-      out += ' , schema:  ';
-      if ($isData) {
-        out += 'validate.schema' + ($schemaPath);
-      } else {
-        out += '' + (it.util.toQuotedString($schema));
-      }
-      out += '         , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
-    }
-    out += ' } ';
-  } else {
-    out += ' {} ';
-  }
-  var __err = out;
-  out = $$outStack.pop();
-  if (!it.compositeRule && $breakOnError) { /* istanbul ignore if */
-    if (it.async) {
-      out += ' throw new ValidationError([' + (__err) + ']); ';
-    } else {
-      out += ' validate.errors = [' + (__err) + ']; return false; ';
-    }
-  } else {
-    out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
-  }
-  out += ' } ';
-  if ($breakOnError) {
-    out += ' else { ';
-  }
-  return out;
-}
-
-},{}],61:[function(require,module,exports){
-'use strict';
-module.exports = function generate_items(it, $keyword) {
-  var out = ' ';
-  var $lvl = it.level;
-  var $dataLvl = it.dataLevel;
-  var $schema = it.schema[$keyword];
-  var $schemaPath = it.schemaPath + it.util.getProperty($keyword);
-  var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
-  var $breakOnError = !it.opts.allErrors;
-  var $data = 'data' + ($dataLvl || '');
-  var $valid = 'valid' + $lvl;
-  var $errs = 'errs__' + $lvl;
-  var $it = it.util.copy(it);
-  var $closingBraces = '';
-  $it.level++;
-  var $nextValid = 'valid' + $it.level;
-  var $idx = 'i' + $lvl,
-    $dataNxt = $it.dataLevel = it.dataLevel + 1,
-    $nextData = 'data' + $dataNxt,
-    $currentBaseId = it.baseId;
-  out += 'var ' + ($errs) + ' = errors;var ' + ($valid) + ';';
-  if (Array.isArray($schema)) {
-    var $additionalItems = it.schema.additionalItems;
-    if ($additionalItems === false) {
-      out += ' ' + ($valid) + ' = ' + ($data) + '.length <= ' + ($schema.length) + '; ';
-      var $currErrSchemaPath = $errSchemaPath;
-      $errSchemaPath = it.errSchemaPath + '/additionalItems';
-      out += '  if (!' + ($valid) + ') {   ';
-      var $$outStack = $$outStack || [];
-      $$outStack.push(out);
-      out = ''; /* istanbul ignore else */
-      if (it.createErrors !== false) {
-        out += ' { keyword: \'' + ('additionalItems') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { limit: ' + ($schema.length) + ' } ';
-        if (it.opts.messages !== false) {
-          out += ' , message: \'should NOT have more than ' + ($schema.length) + ' items\' ';
-        }
-        if (it.opts.verbose) {
-          out += ' , schema: false , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
-        }
-        out += ' } ';
-      } else {
-        out += ' {} ';
-      }
-      var __err = out;
-      out = $$outStack.pop();
-      if (!it.compositeRule && $breakOnError) { /* istanbul ignore if */
-        if (it.async) {
-          out += ' throw new ValidationError([' + (__err) + ']); ';
-        } else {
-          out += ' validate.errors = [' + (__err) + ']; return false; ';
-        }
-      } else {
-        out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
-      }
-      out += ' } ';
-      $errSchemaPath = $currErrSchemaPath;
-      if ($breakOnError) {
-        $closingBraces += '}';
-        out += ' else { ';
-      }
-    }
-    var arr1 = $schema;
-    if (arr1) {
-      var $sch, $i = -1,
-        l1 = arr1.length - 1;
-      while ($i < l1) {
-        $sch = arr1[$i += 1];
-        if (it.util.schemaHasRules($sch, it.RULES.all)) {
-          out += ' ' + ($nextValid) + ' = true; if (' + ($data) + '.length > ' + ($i) + ') { ';
-          var $passData = $data + '[' + $i + ']';
-          $it.schema = $sch;
-          $it.schemaPath = $schemaPath + '[' + $i + ']';
-          $it.errSchemaPath = $errSchemaPath + '/' + $i;
-          $it.errorPath = it.util.getPathExpr(it.errorPath, $i, it.opts.jsonPointers, true);
-          $it.dataPathArr[$dataNxt] = $i;
-          var $code = it.validate($it);
-          $it.baseId = $currentBaseId;
-          if (it.util.varOccurences($code, $nextData) < 2) {
-            out += ' ' + (it.util.varReplace($code, $nextData, $passData)) + ' ';
-          } else {
-            out += ' var ' + ($nextData) + ' = ' + ($passData) + '; ' + ($code) + ' ';
-          }
-          out += ' }  ';
-          if ($breakOnError) {
-            out += ' if (' + ($nextValid) + ') { ';
-            $closingBraces += '}';
-          }
-        }
-      }
-    }
-    if (typeof $additionalItems == 'object' && it.util.schemaHasRules($additionalItems, it.RULES.all)) {
-      $it.schema = $additionalItems;
-      $it.schemaPath = it.schemaPath + '.additionalItems';
-      $it.errSchemaPath = it.errSchemaPath + '/additionalItems';
-      out += ' ' + ($nextValid) + ' = true; if (' + ($data) + '.length > ' + ($schema.length) + ') {  for (var ' + ($idx) + ' = ' + ($schema.length) + '; ' + ($idx) + ' < ' + ($data) + '.length; ' + ($idx) + '++) { ';
-      $it.errorPath = it.util.getPathExpr(it.errorPath, $idx, it.opts.jsonPointers, true);
-      var $passData = $data + '[' + $idx + ']';
-      $it.dataPathArr[$dataNxt] = $idx;
-      var $code = it.validate($it);
-      $it.baseId = $currentBaseId;
-      if (it.util.varOccurences($code, $nextData) < 2) {
-        out += ' ' + (it.util.varReplace($code, $nextData, $passData)) + ' ';
-      } else {
-        out += ' var ' + ($nextData) + ' = ' + ($passData) + '; ' + ($code) + ' ';
-      }
-      if ($breakOnError) {
-        out += ' if (!' + ($nextValid) + ') break; ';
-      }
-      out += ' } }  ';
-      if ($breakOnError) {
-        out += ' if (' + ($nextValid) + ') { ';
-        $closingBraces += '}';
-      }
-    }
-  } else if (it.util.schemaHasRules($schema, it.RULES.all)) {
-    $it.schema = $schema;
-    $it.schemaPath = $schemaPath;
-    $it.errSchemaPath = $errSchemaPath;
-    out += '  for (var ' + ($idx) + ' = ' + (0) + '; ' + ($idx) + ' < ' + ($data) + '.length; ' + ($idx) + '++) { ';
-    $it.errorPath = it.util.getPathExpr(it.errorPath, $idx, it.opts.jsonPointers, true);
-    var $passData = $data + '[' + $idx + ']';
-    $it.dataPathArr[$dataNxt] = $idx;
-    var $code = it.validate($it);
-    $it.baseId = $currentBaseId;
-    if (it.util.varOccurences($code, $nextData) < 2) {
-      out += ' ' + (it.util.varReplace($code, $nextData, $passData)) + ' ';
-    } else {
-      out += ' var ' + ($nextData) + ' = ' + ($passData) + '; ' + ($code) + ' ';
-    }
-    if ($breakOnError) {
-      out += ' if (!' + ($nextValid) + ') break; ';
-    }
-    out += ' }  ';
-    if ($breakOnError) {
-      out += ' if (' + ($nextValid) + ') { ';
-      $closingBraces += '}';
-    }
-  }
-  if ($breakOnError) {
-    out += ' ' + ($closingBraces) + ' if (' + ($errs) + ' == errors) {';
-  }
-  out = it.util.cleanUpCode(out);
-  return out;
-}
-
-},{}],62:[function(require,module,exports){
-'use strict';
-module.exports = function generate_multipleOf(it, $keyword) {
-  var out = ' ';
-  var $lvl = it.level;
-  var $dataLvl = it.dataLevel;
-  var $schema = it.schema[$keyword];
-  var $schemaPath = it.schemaPath + it.util.getProperty($keyword);
-  var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
-  var $breakOnError = !it.opts.allErrors;
-  var $data = 'data' + ($dataLvl || '');
-  var $isData = it.opts.v5 && $schema && $schema.$data,
-    $schemaValue;
-  if ($isData) {
-    out += ' var schema' + ($lvl) + ' = ' + (it.util.getData($schema.$data, $dataLvl, it.dataPathArr)) + '; ';
-    $schemaValue = 'schema' + $lvl;
-  } else {
-    $schemaValue = $schema;
-  }
-  out += 'var division' + ($lvl) + ';if (';
-  if ($isData) {
-    out += ' ' + ($schemaValue) + ' !== undefined && ( typeof ' + ($schemaValue) + ' != \'number\' || ';
-  }
-  out += ' (division' + ($lvl) + ' = ' + ($data) + ' / ' + ($schemaValue) + ', ';
-  if (it.opts.multipleOfPrecision) {
-    out += ' Math.abs(Math.round(division' + ($lvl) + ') - division' + ($lvl) + ') > 1e-' + (it.opts.multipleOfPrecision) + ' ';
-  } else {
-    out += ' division' + ($lvl) + ' !== parseInt(division' + ($lvl) + ') ';
-  }
-  out += ' ) ';
-  if ($isData) {
-    out += '  )  ';
-  }
-  out += ' ) {   ';
-  var $$outStack = $$outStack || [];
-  $$outStack.push(out);
-  out = ''; /* istanbul ignore else */
-  if (it.createErrors !== false) {
-    out += ' { keyword: \'' + ('multipleOf') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { multipleOf: ' + ($schemaValue) + ' } ';
-    if (it.opts.messages !== false) {
-      out += ' , message: \'should be multiple of ';
-      if ($isData) {
-        out += '\' + ' + ($schemaValue);
-      } else {
-        out += '' + ($schema) + '\'';
-      }
-    }
-    if (it.opts.verbose) {
-      out += ' , schema:  ';
-      if ($isData) {
-        out += 'validate.schema' + ($schemaPath);
-      } else {
-        out += '' + ($schema);
-      }
-      out += '         , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
-    }
-    out += ' } ';
-  } else {
-    out += ' {} ';
-  }
-  var __err = out;
-  out = $$outStack.pop();
-  if (!it.compositeRule && $breakOnError) { /* istanbul ignore if */
-    if (it.async) {
-      out += ' throw new ValidationError([' + (__err) + ']); ';
-    } else {
-      out += ' validate.errors = [' + (__err) + ']; return false; ';
-    }
-  } else {
-    out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
-  }
-  out += '} ';
-  if ($breakOnError) {
-    out += ' else { ';
-  }
-  return out;
-}
-
-},{}],63:[function(require,module,exports){
-'use strict';
-module.exports = function generate_not(it, $keyword) {
-  var out = ' ';
-  var $lvl = it.level;
-  var $dataLvl = it.dataLevel;
-  var $schema = it.schema[$keyword];
-  var $schemaPath = it.schemaPath + it.util.getProperty($keyword);
-  var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
-  var $breakOnError = !it.opts.allErrors;
-  var $data = 'data' + ($dataLvl || '');
-  var $errs = 'errs__' + $lvl;
-  var $it = it.util.copy(it);
-  $it.level++;
-  var $nextValid = 'valid' + $it.level;
-  if (it.util.schemaHasRules($schema, it.RULES.all)) {
-    $it.schema = $schema;
-    $it.schemaPath = $schemaPath;
-    $it.errSchemaPath = $errSchemaPath;
-    out += ' var ' + ($errs) + ' = errors;  ';
-    var $wasComposite = it.compositeRule;
-    it.compositeRule = $it.compositeRule = true;
-    $it.createErrors = false;
-    var $allErrorsOption;
-    if ($it.opts.allErrors) {
-      $allErrorsOption = $it.opts.allErrors;
-      $it.opts.allErrors = false;
-    }
-    out += ' ' + (it.validate($it)) + ' ';
-    $it.createErrors = true;
-    if ($allErrorsOption) $it.opts.allErrors = $allErrorsOption;
-    it.compositeRule = $it.compositeRule = $wasComposite;
-    out += ' if (' + ($nextValid) + ') {   ';
-    var $$outStack = $$outStack || [];
-    $$outStack.push(out);
-    out = ''; /* istanbul ignore else */
-    if (it.createErrors !== false) {
-      out += ' { keyword: \'' + ('not') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: {} ';
-      if (it.opts.messages !== false) {
-        out += ' , message: \'should NOT be valid\' ';
-      }
-      if (it.opts.verbose) {
-        out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
-      }
-      out += ' } ';
-    } else {
-      out += ' {} ';
-    }
-    var __err = out;
-    out = $$outStack.pop();
-    if (!it.compositeRule && $breakOnError) { /* istanbul ignore if */
-      if (it.async) {
-        out += ' throw new ValidationError([' + (__err) + ']); ';
-      } else {
-        out += ' validate.errors = [' + (__err) + ']; return false; ';
-      }
-    } else {
-      out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
-    }
-    out += ' } else {  errors = ' + ($errs) + '; if (vErrors !== null) { if (' + ($errs) + ') vErrors.length = ' + ($errs) + '; else vErrors = null; } ';
-    if (it.opts.allErrors) {
-      out += ' } ';
-    }
-  } else {
-    out += '  var err =   '; /* istanbul ignore else */
-    if (it.createErrors !== false) {
-      out += ' { keyword: \'' + ('not') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: {} ';
-      if (it.opts.messages !== false) {
-        out += ' , message: \'should NOT be valid\' ';
-      }
-      if (it.opts.verbose) {
-        out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
-      }
-      out += ' } ';
-    } else {
-      out += ' {} ';
-    }
-    out += ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
-    if ($breakOnError) {
-      out += ' if (false) { ';
-    }
-  }
-  return out;
-}
-
-},{}],64:[function(require,module,exports){
-'use strict';
-module.exports = function generate_oneOf(it, $keyword) {
-  var out = ' ';
-  var $lvl = it.level;
-  var $dataLvl = it.dataLevel;
-  var $schema = it.schema[$keyword];
-  var $schemaPath = it.schemaPath + it.util.getProperty($keyword);
-  var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
-  var $breakOnError = !it.opts.allErrors;
-  var $data = 'data' + ($dataLvl || '');
-  var $valid = 'valid' + $lvl;
-  var $errs = 'errs__' + $lvl;
-  var $it = it.util.copy(it);
-  var $closingBraces = '';
-  $it.level++;
-  var $nextValid = 'valid' + $it.level;
-  out += 'var ' + ($errs) + ' = errors;var prevValid' + ($lvl) + ' = false;var ' + ($valid) + ' = false;';
-  var $currentBaseId = $it.baseId;
-  var $wasComposite = it.compositeRule;
-  it.compositeRule = $it.compositeRule = true;
-  var arr1 = $schema;
-  if (arr1) {
-    var $sch, $i = -1,
-      l1 = arr1.length - 1;
-    while ($i < l1) {
-      $sch = arr1[$i += 1];
-      if (it.util.schemaHasRules($sch, it.RULES.all)) {
-        $it.schema = $sch;
-        $it.schemaPath = $schemaPath + '[' + $i + ']';
-        $it.errSchemaPath = $errSchemaPath + '/' + $i;
-        out += '  ' + (it.validate($it)) + ' ';
-        $it.baseId = $currentBaseId;
-      } else {
-        out += ' var ' + ($nextValid) + ' = true; ';
-      }
-      if ($i) {
-        out += ' if (' + ($nextValid) + ' && prevValid' + ($lvl) + ') ' + ($valid) + ' = false; else { ';
-        $closingBraces += '}';
-      }
-      out += ' if (' + ($nextValid) + ') ' + ($valid) + ' = prevValid' + ($lvl) + ' = true;';
-    }
-  }
-  it.compositeRule = $it.compositeRule = $wasComposite;
-  out += '' + ($closingBraces) + 'if (!' + ($valid) + ') {   ';
-  var $$outStack = $$outStack || [];
-  $$outStack.push(out);
-  out = ''; /* istanbul ignore else */
-  if (it.createErrors !== false) {
-    out += ' { keyword: \'' + ('oneOf') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: {} ';
-    if (it.opts.messages !== false) {
-      out += ' , message: \'should match exactly one schema in oneOf\' ';
-    }
-    if (it.opts.verbose) {
-      out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
-    }
-    out += ' } ';
-  } else {
-    out += ' {} ';
-  }
-  var __err = out;
-  out = $$outStack.pop();
-  if (!it.compositeRule && $breakOnError) { /* istanbul ignore if */
-    if (it.async) {
-      out += ' throw new ValidationError([' + (__err) + ']); ';
-    } else {
-      out += ' validate.errors = [' + (__err) + ']; return false; ';
-    }
-  } else {
-    out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
-  }
-  out += '} else {  errors = ' + ($errs) + '; if (vErrors !== null) { if (' + ($errs) + ') vErrors.length = ' + ($errs) + '; else vErrors = null; }';
-  if (it.opts.allErrors) {
-    out += ' } ';
-  }
-  return out;
-}
-
-},{}],65:[function(require,module,exports){
-'use strict';
-module.exports = function generate_pattern(it, $keyword) {
-  var out = ' ';
-  var $lvl = it.level;
-  var $dataLvl = it.dataLevel;
-  var $schema = it.schema[$keyword];
-  var $schemaPath = it.schemaPath + it.util.getProperty($keyword);
-  var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
-  var $breakOnError = !it.opts.allErrors;
-  var $data = 'data' + ($dataLvl || '');
-  var $isData = it.opts.v5 && $schema && $schema.$data,
-    $schemaValue;
-  if ($isData) {
-    out += ' var schema' + ($lvl) + ' = ' + (it.util.getData($schema.$data, $dataLvl, it.dataPathArr)) + '; ';
-    $schemaValue = 'schema' + $lvl;
-  } else {
-    $schemaValue = $schema;
-  }
-  var $regexp = $isData ? '(new RegExp(' + $schemaValue + '))' : it.usePattern($schema);
-  out += 'if ( ';
-  if ($isData) {
-    out += ' (' + ($schemaValue) + ' !== undefined && typeof ' + ($schemaValue) + ' != \'string\') || ';
-  }
-  out += ' !' + ($regexp) + '.test(' + ($data) + ') ) {   ';
-  var $$outStack = $$outStack || [];
-  $$outStack.push(out);
-  out = ''; /* istanbul ignore else */
-  if (it.createErrors !== false) {
-    out += ' { keyword: \'' + ('pattern') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { pattern:  ';
-    if ($isData) {
-      out += '' + ($schemaValue);
-    } else {
-      out += '' + (it.util.toQuotedString($schema));
-    }
-    out += '  } ';
-    if (it.opts.messages !== false) {
-      out += ' , message: \'should match pattern "';
-      if ($isData) {
-        out += '\' + ' + ($schemaValue) + ' + \'';
-      } else {
-        out += '' + (it.util.escapeQuotes($schema));
-      }
-      out += '"\' ';
-    }
-    if (it.opts.verbose) {
-      out += ' , schema:  ';
-      if ($isData) {
-        out += 'validate.schema' + ($schemaPath);
-      } else {
-        out += '' + (it.util.toQuotedString($schema));
-      }
-      out += '         , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
-    }
-    out += ' } ';
-  } else {
-    out += ' {} ';
-  }
-  var __err = out;
-  out = $$outStack.pop();
-  if (!it.compositeRule && $breakOnError) { /* istanbul ignore if */
-    if (it.async) {
-      out += ' throw new ValidationError([' + (__err) + ']); ';
-    } else {
-      out += ' validate.errors = [' + (__err) + ']; return false; ';
-    }
-  } else {
-    out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
-  }
-  out += '} ';
-  if ($breakOnError) {
-    out += ' else { ';
-  }
-  return out;
-}
-
-},{}],66:[function(require,module,exports){
-'use strict';
-module.exports = function generate_patternRequired(it, $keyword) {
-  var out = ' ';
-  var $lvl = it.level;
-  var $dataLvl = it.dataLevel;
-  var $schema = it.schema[$keyword];
-  var $schemaPath = it.schemaPath + it.util.getProperty($keyword);
-  var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
-  var $breakOnError = !it.opts.allErrors;
-  var $data = 'data' + ($dataLvl || '');
-  var $valid = 'valid' + $lvl;
-  var $key = 'key' + $lvl,
-    $matched = 'patternMatched' + $lvl,
-    $closingBraces = '',
-    $ownProperties = it.opts.ownProperties;
-  out += 'var ' + ($valid) + ' = true;';
-  var arr1 = $schema;
-  if (arr1) {
-    var $pProperty, i1 = -1,
-      l1 = arr1.length - 1;
-    while (i1 < l1) {
-      $pProperty = arr1[i1 += 1];
-      out += ' var ' + ($matched) + ' = false; for (var ' + ($key) + ' in ' + ($data) + ') {  ';
-      if ($ownProperties) {
-        out += ' if (!Object.prototype.hasOwnProperty.call(' + ($data) + ', ' + ($key) + ')) continue; ';
-      }
-      out += ' ' + ($matched) + ' = ' + (it.usePattern($pProperty)) + '.test(' + ($key) + '); if (' + ($matched) + ') break; } ';
-      var $missingPattern = it.util.escapeQuotes($pProperty);
-      out += ' if (!' + ($matched) + ') { ' + ($valid) + ' = false;  var err =   '; /* istanbul ignore else */
-      if (it.createErrors !== false) {
-        out += ' { keyword: \'' + ('patternRequired') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { missingPattern: \'' + ($missingPattern) + '\' } ';
-        if (it.opts.messages !== false) {
-          out += ' , message: \'should have property matching pattern \\\'' + ($missingPattern) + '\\\'\' ';
-        }
-        if (it.opts.verbose) {
-          out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
-        }
-        out += ' } ';
-      } else {
-        out += ' {} ';
-      }
-      out += ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; }   ';
-      if ($breakOnError) {
-        $closingBraces += '}';
-        out += ' else { ';
-      }
-    }
-  }
-  out += '' + ($closingBraces);
-  return out;
-}
-
-},{}],67:[function(require,module,exports){
-'use strict';
-module.exports = function generate_properties(it, $keyword) {
-  var out = ' ';
-  var $lvl = it.level;
-  var $dataLvl = it.dataLevel;
-  var $schema = it.schema[$keyword];
-  var $schemaPath = it.schemaPath + it.util.getProperty($keyword);
-  var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
-  var $breakOnError = !it.opts.allErrors;
-  var $data = 'data' + ($dataLvl || '');
-  var $valid = 'valid' + $lvl;
-  var $errs = 'errs__' + $lvl;
-  var $it = it.util.copy(it);
-  var $closingBraces = '';
-  $it.level++;
-  var $nextValid = 'valid' + $it.level;
-  var $key = 'key' + $lvl,
-    $dataNxt = $it.dataLevel = it.dataLevel + 1,
-    $nextData = 'data' + $dataNxt;
-  var $schemaKeys = Object.keys($schema || {}),
-    $pProperties = it.schema.patternProperties || {},
-    $pPropertyKeys = Object.keys($pProperties),
-    $aProperties = it.schema.additionalProperties,
-    $someProperties = $schemaKeys.length || $pPropertyKeys.length,
-    $noAdditional = $aProperties === false,
-    $additionalIsSchema = typeof $aProperties == 'object' && Object.keys($aProperties).length,
-    $removeAdditional = it.opts.removeAdditional,
-    $checkAdditional = $noAdditional || $additionalIsSchema || $removeAdditional,
-    $ownProperties = it.opts.ownProperties,
-    $currentBaseId = it.baseId;
-  var $required = it.schema.required;
-  if ($required && !(it.opts.v5 && $required.$data) && $required.length < it.opts.loopRequired) var $requiredHash = it.util.toHash($required);
-  if (it.opts.v5) {
-    var $pgProperties = it.schema.patternGroups || {},
-      $pgPropertyKeys = Object.keys($pgProperties);
-  }
-  out += 'var ' + ($errs) + ' = errors;var ' + ($nextValid) + ' = true;';
-  if ($checkAdditional) {
-    out += ' for (var ' + ($key) + ' in ' + ($data) + ') {  ';
-    if ($ownProperties) {
-      out += ' if (!Object.prototype.hasOwnProperty.call(' + ($data) + ', ' + ($key) + ')) continue; ';
-    }
-    if ($someProperties) {
-      out += ' var isAdditional' + ($lvl) + ' = !(false ';
-      if ($schemaKeys.length) {
-        if ($schemaKeys.length > 5) {
-          out += ' || validate.schema' + ($schemaPath) + '[' + ($key) + '] ';
-        } else {
-          var arr1 = $schemaKeys;
-          if (arr1) {
-            var $propertyKey, i1 = -1,
-              l1 = arr1.length - 1;
-            while (i1 < l1) {
-              $propertyKey = arr1[i1 += 1];
-              out += ' || ' + ($key) + ' == ' + (it.util.toQuotedString($propertyKey)) + ' ';
-            }
-          }
-        }
-      }
-      if ($pPropertyKeys.length) {
-        var arr2 = $pPropertyKeys;
-        if (arr2) {
-          var $pProperty, $i = -1,
-            l2 = arr2.length - 1;
-          while ($i < l2) {
-            $pProperty = arr2[$i += 1];
-            out += ' || ' + (it.usePattern($pProperty)) + '.test(' + ($key) + ') ';
-          }
-        }
-      }
-      if (it.opts.v5 && $pgPropertyKeys && $pgPropertyKeys.length) {
-        var arr3 = $pgPropertyKeys;
-        if (arr3) {
-          var $pgProperty, $i = -1,
-            l3 = arr3.length - 1;
-          while ($i < l3) {
-            $pgProperty = arr3[$i += 1];
-            out += ' || ' + (it.usePattern($pgProperty)) + '.test(' + ($key) + ') ';
-          }
-        }
-      }
-      out += ' ); if (isAdditional' + ($lvl) + ') { ';
-    }
-    if ($removeAdditional == 'all') {
-      out += ' delete ' + ($data) + '[' + ($key) + ']; ';
-    } else {
-      var $currentErrorPath = it.errorPath;
-      var $additionalProperty = '\' + ' + $key + ' + \'';
-      if (it.opts._errorDataPathProperty) {
-        it.errorPath = it.util.getPathExpr(it.errorPath, $key, it.opts.jsonPointers);
-      }
-      if ($noAdditional) {
-        if ($removeAdditional) {
-          out += ' delete ' + ($data) + '[' + ($key) + ']; ';
-        } else {
-          out += ' ' + ($nextValid) + ' = false; ';
-          var $currErrSchemaPath = $errSchemaPath;
-          $errSchemaPath = it.errSchemaPath + '/additionalProperties';
-          var $$outStack = $$outStack || [];
-          $$outStack.push(out);
-          out = ''; /* istanbul ignore else */
-          if (it.createErrors !== false) {
-            out += ' { keyword: \'' + ('additionalProperties') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { additionalProperty: \'' + ($additionalProperty) + '\' } ';
-            if (it.opts.messages !== false) {
-              out += ' , message: \'should NOT have additional properties\' ';
-            }
-            if (it.opts.verbose) {
-              out += ' , schema: false , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
-            }
-            out += ' } ';
-          } else {
-            out += ' {} ';
-          }
-          var __err = out;
-          out = $$outStack.pop();
-          if (!it.compositeRule && $breakOnError) { /* istanbul ignore if */
-            if (it.async) {
-              out += ' throw new ValidationError([' + (__err) + ']); ';
-            } else {
-              out += ' validate.errors = [' + (__err) + ']; return false; ';
-            }
-          } else {
-            out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
-          }
-          $errSchemaPath = $currErrSchemaPath;
-          if ($breakOnError) {
-            out += ' break; ';
-          }
-        }
-      } else if ($additionalIsSchema) {
-        if ($removeAdditional == 'failing') {
-          out += ' var ' + ($errs) + ' = errors;  ';
-          var $wasComposite = it.compositeRule;
-          it.compositeRule = $it.compositeRule = true;
-          $it.schema = $aProperties;
-          $it.schemaPath = it.schemaPath + '.additionalProperties';
-          $it.errSchemaPath = it.errSchemaPath + '/additionalProperties';
-          $it.errorPath = it.opts._errorDataPathProperty ? it.errorPath : it.util.getPathExpr(it.errorPath, $key, it.opts.jsonPointers);
-          var $passData = $data + '[' + $key + ']';
-          $it.dataPathArr[$dataNxt] = $key;
-          var $code = it.validate($it);
-          $it.baseId = $currentBaseId;
-          if (it.util.varOccurences($code, $nextData) < 2) {
-            out += ' ' + (it.util.varReplace($code, $nextData, $passData)) + ' ';
-          } else {
-            out += ' var ' + ($nextData) + ' = ' + ($passData) + '; ' + ($code) + ' ';
-          }
-          out += ' if (!' + ($nextValid) + ') { errors = ' + ($errs) + '; if (validate.errors !== null) { if (errors) validate.errors.length = errors; else validate.errors = null; } delete ' + ($data) + '[' + ($key) + ']; }  ';
-          it.compositeRule = $it.compositeRule = $wasComposite;
-        } else {
-          $it.schema = $aProperties;
-          $it.schemaPath = it.schemaPath + '.additionalProperties';
-          $it.errSchemaPath = it.errSchemaPath + '/additionalProperties';
-          $it.errorPath = it.opts._errorDataPathProperty ? it.errorPath : it.util.getPathExpr(it.errorPath, $key, it.opts.jsonPointers);
-          var $passData = $data + '[' + $key + ']';
-          $it.dataPathArr[$dataNxt] = $key;
-          var $code = it.validate($it);
-          $it.baseId = $currentBaseId;
-          if (it.util.varOccurences($code, $nextData) < 2) {
-            out += ' ' + (it.util.varReplace($code, $nextData, $passData)) + ' ';
-          } else {
-            out += ' var ' + ($nextData) + ' = ' + ($passData) + '; ' + ($code) + ' ';
-          }
-          if ($breakOnError) {
-            out += ' if (!' + ($nextValid) + ') break; ';
-          }
-        }
-      }
-      it.errorPath = $currentErrorPath;
-    }
-    if ($someProperties) {
-      out += ' } ';
-    }
-    out += ' }  ';
-    if ($breakOnError) {
-      out += ' if (' + ($nextValid) + ') { ';
-      $closingBraces += '}';
-    }
-  }
-  var $useDefaults = it.opts.useDefaults && !it.compositeRule;
-  if ($schemaKeys.length) {
-    var arr4 = $schemaKeys;
-    if (arr4) {
-      var $propertyKey, i4 = -1,
-        l4 = arr4.length - 1;
-      while (i4 < l4) {
-        $propertyKey = arr4[i4 += 1];
-        var $sch = $schema[$propertyKey];
-        if (it.util.schemaHasRules($sch, it.RULES.all)) {
-          var $prop = it.util.getProperty($propertyKey),
-            $passData = $data + $prop,
-            $hasDefault = $useDefaults && $sch.default !== undefined;
-          $it.schema = $sch;
-          $it.schemaPath = $schemaPath + $prop;
-          $it.errSchemaPath = $errSchemaPath + '/' + it.util.escapeFragment($propertyKey);
-          $it.errorPath = it.util.getPath(it.errorPath, $propertyKey, it.opts.jsonPointers);
-          $it.dataPathArr[$dataNxt] = it.util.toQuotedString($propertyKey);
-          var $code = it.validate($it);
-          $it.baseId = $currentBaseId;
-          if (it.util.varOccurences($code, $nextData) < 2) {
-            $code = it.util.varReplace($code, $nextData, $passData);
-            var $useData = $passData;
-          } else {
-            var $useData = $nextData;
-            out += ' var ' + ($nextData) + ' = ' + ($passData) + '; ';
-          }
-          if ($hasDefault) {
-            out += ' ' + ($code) + ' ';
-          } else {
-            if ($requiredHash && $requiredHash[$propertyKey]) {
-              out += ' if (' + ($useData) + ' === undefined) { ' + ($nextValid) + ' = false; ';
-              var $currentErrorPath = it.errorPath,
-                $currErrSchemaPath = $errSchemaPath,
-                $missingProperty = it.util.escapeQuotes($propertyKey);
-              if (it.opts._errorDataPathProperty) {
-                it.errorPath = it.util.getPath($currentErrorPath, $propertyKey, it.opts.jsonPointers);
-              }
-              $errSchemaPath = it.errSchemaPath + '/required';
-              var $$outStack = $$outStack || [];
-              $$outStack.push(out);
-              out = ''; /* istanbul ignore else */
-              if (it.createErrors !== false) {
-                out += ' { keyword: \'' + ('required') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { missingProperty: \'' + ($missingProperty) + '\' } ';
-                if (it.opts.messages !== false) {
-                  out += ' , message: \'';
-                  if (it.opts._errorDataPathProperty) {
-                    out += 'is a required property';
-                  } else {
-                    out += 'should have required property \\\'' + ($missingProperty) + '\\\'';
-                  }
-                  out += '\' ';
-                }
-                if (it.opts.verbose) {
-                  out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
-                }
-                out += ' } ';
-              } else {
-                out += ' {} ';
-              }
-              var __err = out;
-              out = $$outStack.pop();
-              if (!it.compositeRule && $breakOnError) { /* istanbul ignore if */
-                if (it.async) {
-                  out += ' throw new ValidationError([' + (__err) + ']); ';
-                } else {
-                  out += ' validate.errors = [' + (__err) + ']; return false; ';
-                }
-              } else {
-                out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
-              }
-              $errSchemaPath = $currErrSchemaPath;
-              it.errorPath = $currentErrorPath;
-              out += ' } else { ';
-            } else {
-              if ($breakOnError) {
-                out += ' if (' + ($useData) + ' === undefined) { ' + ($nextValid) + ' = true; } else { ';
-              } else {
-                out += ' if (' + ($useData) + ' !== undefined) { ';
-              }
-            }
-            out += ' ' + ($code) + ' } ';
-          }
-        }
-        if ($breakOnError) {
-          out += ' if (' + ($nextValid) + ') { ';
-          $closingBraces += '}';
-        }
-      }
-    }
-  }
-  var arr5 = $pPropertyKeys;
-  if (arr5) {
-    var $pProperty, i5 = -1,
-      l5 = arr5.length - 1;
-    while (i5 < l5) {
-      $pProperty = arr5[i5 += 1];
-      var $sch = $pProperties[$pProperty];
-      if (it.util.schemaHasRules($sch, it.RULES.all)) {
-        $it.schema = $sch;
-        $it.schemaPath = it.schemaPath + '.patternProperties' + it.util.getProperty($pProperty);
-        $it.errSchemaPath = it.errSchemaPath + '/patternProperties/' + it.util.escapeFragment($pProperty);
-        out += ' for (var ' + ($key) + ' in ' + ($data) + ') {  ';
-        if ($ownProperties) {
-          out += ' if (!Object.prototype.hasOwnProperty.call(' + ($data) + ', ' + ($key) + ')) continue; ';
-        }
-        out += ' if (' + (it.usePattern($pProperty)) + '.test(' + ($key) + ')) { ';
-        $it.errorPath = it.util.getPathExpr(it.errorPath, $key, it.opts.jsonPointers);
-        var $passData = $data + '[' + $key + ']';
-        $it.dataPathArr[$dataNxt] = $key;
-        var $code = it.validate($it);
-        $it.baseId = $currentBaseId;
-        if (it.util.varOccurences($code, $nextData) < 2) {
-          out += ' ' + (it.util.varReplace($code, $nextData, $passData)) + ' ';
-        } else {
-          out += ' var ' + ($nextData) + ' = ' + ($passData) + '; ' + ($code) + ' ';
-        }
-        if ($breakOnError) {
-          out += ' if (!' + ($nextValid) + ') break; ';
-        }
-        out += ' } ';
-        if ($breakOnError) {
-          out += ' else ' + ($nextValid) + ' = true; ';
-        }
-        out += ' }  ';
-        if ($breakOnError) {
-          out += ' if (' + ($nextValid) + ') { ';
-          $closingBraces += '}';
-        }
-      }
-    }
-  }
-  if (it.opts.v5) {
-    var arr6 = $pgPropertyKeys;
-    if (arr6) {
-      var $pgProperty, i6 = -1,
-        l6 = arr6.length - 1;
-      while (i6 < l6) {
-        $pgProperty = arr6[i6 += 1];
-        var $pgSchema = $pgProperties[$pgProperty],
-          $sch = $pgSchema.schema;
-        if (it.util.schemaHasRules($sch, it.RULES.all)) {
-          $it.schema = $sch;
-          $it.schemaPath = it.schemaPath + '.patternGroups' + it.util.getProperty($pgProperty) + '.schema';
-          $it.errSchemaPath = it.errSchemaPath + '/patternGroups/' + it.util.escapeFragment($pgProperty) + '/schema';
-          out += ' var pgPropCount' + ($lvl) + ' = 0; for (var ' + ($key) + ' in ' + ($data) + ') {  ';
-          if ($ownProperties) {
-            out += ' if (!Object.prototype.hasOwnProperty.call(' + ($data) + ', ' + ($key) + ')) continue; ';
-          }
-          out += ' if (' + (it.usePattern($pgProperty)) + '.test(' + ($key) + ')) { pgPropCount' + ($lvl) + '++; ';
-          $it.errorPath = it.util.getPathExpr(it.errorPath, $key, it.opts.jsonPointers);
-          var $passData = $data + '[' + $key + ']';
-          $it.dataPathArr[$dataNxt] = $key;
-          var $code = it.validate($it);
-          $it.baseId = $currentBaseId;
-          if (it.util.varOccurences($code, $nextData) < 2) {
-            out += ' ' + (it.util.varReplace($code, $nextData, $passData)) + ' ';
-          } else {
-            out += ' var ' + ($nextData) + ' = ' + ($passData) + '; ' + ($code) + ' ';
-          }
-          if ($breakOnError) {
-            out += ' if (!' + ($nextValid) + ') break; ';
-          }
-          out += ' } ';
-          if ($breakOnError) {
-            out += ' else ' + ($nextValid) + ' = true; ';
-          }
-          out += ' }  ';
-          if ($breakOnError) {
-            out += ' if (' + ($nextValid) + ') { ';
-            $closingBraces += '}';
-          }
-          var $pgMin = $pgSchema.minimum,
-            $pgMax = $pgSchema.maximum;
-          if ($pgMin !== undefined || $pgMax !== undefined) {
-            out += ' var ' + ($valid) + ' = true; ';
-            var $currErrSchemaPath = $errSchemaPath;
-            if ($pgMin !== undefined) {
-              var $limit = $pgMin,
-                $reason = 'minimum',
-                $moreOrLess = 'less';
-              out += ' ' + ($valid) + ' = pgPropCount' + ($lvl) + ' >= ' + ($pgMin) + '; ';
-              $errSchemaPath = it.errSchemaPath + '/patternGroups/minimum';
-              out += '  if (!' + ($valid) + ') {   ';
-              var $$outStack = $$outStack || [];
-              $$outStack.push(out);
-              out = ''; /* istanbul ignore else */
-              if (it.createErrors !== false) {
-                out += ' { keyword: \'' + ('patternGroups') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { reason: \'' + ($reason) + '\', limit: ' + ($limit) + ', pattern: \'' + (it.util.escapeQuotes($pgProperty)) + '\' } ';
-                if (it.opts.messages !== false) {
-                  out += ' , message: \'should NOT have ' + ($moreOrLess) + ' than ' + ($limit) + ' properties matching pattern "' + (it.util.escapeQuotes($pgProperty)) + '"\' ';
-                }
-                if (it.opts.verbose) {
-                  out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
-                }
-                out += ' } ';
-              } else {
-                out += ' {} ';
-              }
-              var __err = out;
-              out = $$outStack.pop();
-              if (!it.compositeRule && $breakOnError) { /* istanbul ignore if */
-                if (it.async) {
-                  out += ' throw new ValidationError([' + (__err) + ']); ';
-                } else {
-                  out += ' validate.errors = [' + (__err) + ']; return false; ';
-                }
-              } else {
-                out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
-              }
-              out += ' } ';
-              if ($pgMax !== undefined) {
-                out += ' else ';
-              }
-            }
-            if ($pgMax !== undefined) {
-              var $limit = $pgMax,
-                $reason = 'maximum',
-                $moreOrLess = 'more';
-              out += ' ' + ($valid) + ' = pgPropCount' + ($lvl) + ' <= ' + ($pgMax) + '; ';
-              $errSchemaPath = it.errSchemaPath + '/patternGroups/maximum';
-              out += '  if (!' + ($valid) + ') {   ';
-              var $$outStack = $$outStack || [];
-              $$outStack.push(out);
-              out = ''; /* istanbul ignore else */
-              if (it.createErrors !== false) {
-                out += ' { keyword: \'' + ('patternGroups') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { reason: \'' + ($reason) + '\', limit: ' + ($limit) + ', pattern: \'' + (it.util.escapeQuotes($pgProperty)) + '\' } ';
-                if (it.opts.messages !== false) {
-                  out += ' , message: \'should NOT have ' + ($moreOrLess) + ' than ' + ($limit) + ' properties matching pattern "' + (it.util.escapeQuotes($pgProperty)) + '"\' ';
-                }
-                if (it.opts.verbose) {
-                  out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
-                }
-                out += ' } ';
-              } else {
-                out += ' {} ';
-              }
-              var __err = out;
-              out = $$outStack.pop();
-              if (!it.compositeRule && $breakOnError) { /* istanbul ignore if */
-                if (it.async) {
-                  out += ' throw new ValidationError([' + (__err) + ']); ';
-                } else {
-                  out += ' validate.errors = [' + (__err) + ']; return false; ';
-                }
-              } else {
-                out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
-              }
-              out += ' } ';
-            }
-            $errSchemaPath = $currErrSchemaPath;
-            if ($breakOnError) {
-              out += ' if (' + ($valid) + ') { ';
-              $closingBraces += '}';
-            }
-          }
-        }
-      }
-    }
-  }
-  if ($breakOnError) {
-    out += ' ' + ($closingBraces) + ' if (' + ($errs) + ' == errors) {';
-  }
-  out = it.util.cleanUpCode(out);
-  return out;
-}
-
-},{}],68:[function(require,module,exports){
-'use strict';
-module.exports = function generate_ref(it, $keyword) {
-  var out = ' ';
-  var $lvl = it.level;
-  var $dataLvl = it.dataLevel;
-  var $schema = it.schema[$keyword];
-  var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
-  var $breakOnError = !it.opts.allErrors;
-  var $data = 'data' + ($dataLvl || '');
-  var $valid = 'valid' + $lvl;
-  var $async, $refCode;
-  if ($schema == '#' || $schema == '#/') {
-    if (it.isRoot) {
-      $async = it.async;
-      $refCode = 'validate';
-    } else {
-      $async = it.root.schema.$async === true;
-      $refCode = 'root.refVal[0]';
-    }
-  } else {
-    var $refVal = it.resolveRef(it.baseId, $schema, it.isRoot);
-    if ($refVal === undefined) {
-      var $message = 'can\'t resolve reference ' + $schema + ' from id ' + it.baseId;
-      if (it.opts.missingRefs == 'fail') {
-        console.log($message);
-        var $$outStack = $$outStack || [];
-        $$outStack.push(out);
-        out = ''; /* istanbul ignore else */
-        if (it.createErrors !== false) {
-          out += ' { keyword: \'' + ('$ref') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { ref: \'' + (it.util.escapeQuotes($schema)) + '\' } ';
-          if (it.opts.messages !== false) {
-            out += ' , message: \'can\\\'t resolve reference ' + (it.util.escapeQuotes($schema)) + '\' ';
-          }
-          if (it.opts.verbose) {
-            out += ' , schema: ' + (it.util.toQuotedString($schema)) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
-          }
-          out += ' } ';
-        } else {
-          out += ' {} ';
-        }
-        var __err = out;
-        out = $$outStack.pop();
-        if (!it.compositeRule && $breakOnError) { /* istanbul ignore if */
-          if (it.async) {
-            out += ' throw new ValidationError([' + (__err) + ']); ';
-          } else {
-            out += ' validate.errors = [' + (__err) + ']; return false; ';
-          }
-        } else {
-          out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
-        }
-        if ($breakOnError) {
-          out += ' if (false) { ';
-        }
-      } else if (it.opts.missingRefs == 'ignore') {
-        console.log($message);
-        if ($breakOnError) {
-          out += ' if (true) { ';
-        }
-      } else {
-        var $error = new Error($message);
-        $error.missingRef = it.resolve.url(it.baseId, $schema);
-        $error.missingSchema = it.resolve.normalizeId(it.resolve.fullPath($error.missingRef));
-        throw $error;
-      }
-    } else if ($refVal.inline) {
-      var $it = it.util.copy(it);
-      $it.level++;
-      var $nextValid = 'valid' + $it.level;
-      $it.schema = $refVal.schema;
-      $it.schemaPath = '';
-      $it.errSchemaPath = $schema;
-      var $code = it.validate($it).replace(/validate\.schema/g, $refVal.code);
-      out += ' ' + ($code) + ' ';
-      if ($breakOnError) {
-        out += ' if (' + ($nextValid) + ') { ';
-      }
-    } else {
-      $async = $refVal.$async === true;
-      $refCode = $refVal.code;
-    }
-  }
-  if ($refCode) {
-    var $$outStack = $$outStack || [];
-    $$outStack.push(out);
-    out = '';
-    if (it.opts.passContext) {
-      out += ' ' + ($refCode) + '.call(this, ';
-    } else {
-      out += ' ' + ($refCode) + '( ';
-    }
-    out += ' ' + ($data) + ', (dataPath || \'\')';
-    if (it.errorPath != '""') {
-      out += ' + ' + (it.errorPath);
-    }
-    var $parentData = $dataLvl ? 'data' + (($dataLvl - 1) || '') : 'parentData',
-      $parentDataProperty = $dataLvl ? it.dataPathArr[$dataLvl] : 'parentDataProperty';
-    out += ' , ' + ($parentData) + ' , ' + ($parentDataProperty) + ', rootData)  ';
-    var __callValidate = out;
-    out = $$outStack.pop();
-    if ($async) {
-      if (!it.async) throw new Error('async schema referenced by sync schema');
-      out += ' try { ';
-      if ($breakOnError) {
-        out += 'var ' + ($valid) + ' =';
-      }
-      out += ' ' + (it.yieldAwait) + ' ' + (__callValidate) + '; } catch (e) { if (!(e instanceof ValidationError)) throw e; if (vErrors === null) vErrors = e.errors; else vErrors = vErrors.concat(e.errors); errors = vErrors.length; } ';
-      if ($breakOnError) {
-        out += ' if (' + ($valid) + ') { ';
-      }
-    } else {
-      out += ' if (!' + (__callValidate) + ') { if (vErrors === null) vErrors = ' + ($refCode) + '.errors; else vErrors = vErrors.concat(' + ($refCode) + '.errors); errors = vErrors.length; } ';
-      if ($breakOnError) {
-        out += ' else { ';
-      }
-    }
-  }
-  return out;
-}
-
-},{}],69:[function(require,module,exports){
-'use strict';
-module.exports = function generate_required(it, $keyword) {
-  var out = ' ';
-  var $lvl = it.level;
-  var $dataLvl = it.dataLevel;
-  var $schema = it.schema[$keyword];
-  var $schemaPath = it.schemaPath + it.util.getProperty($keyword);
-  var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
-  var $breakOnError = !it.opts.allErrors;
-  var $data = 'data' + ($dataLvl || '');
-  var $valid = 'valid' + $lvl;
-  var $isData = it.opts.v5 && $schema && $schema.$data,
-    $schemaValue;
-  if ($isData) {
-    out += ' var schema' + ($lvl) + ' = ' + (it.util.getData($schema.$data, $dataLvl, it.dataPathArr)) + '; ';
-    $schemaValue = 'schema' + $lvl;
-  } else {
-    $schemaValue = $schema;
-  }
-  var $vSchema = 'schema' + $lvl;
-  if (!$isData) {
-    if ($schema.length < it.opts.loopRequired && it.schema.properties && Object.keys(it.schema.properties).length) {
-      var $required = [];
-      var arr1 = $schema;
-      if (arr1) {
-        var $property, i1 = -1,
-          l1 = arr1.length - 1;
-        while (i1 < l1) {
-          $property = arr1[i1 += 1];
-          var $propertySch = it.schema.properties[$property];
-          if (!($propertySch && it.util.schemaHasRules($propertySch, it.RULES.all))) {
-            $required[$required.length] = $property;
-          }
-        }
-      }
-    } else {
-      var $required = $schema;
-    }
-  }
-  if ($isData || $required.length) {
-    var $currentErrorPath = it.errorPath,
-      $loopRequired = $isData || $required.length >= it.opts.loopRequired;
-    if ($breakOnError) {
-      out += ' var missing' + ($lvl) + '; ';
-      if ($loopRequired) {
-        if (!$isData) {
-          out += ' var ' + ($vSchema) + ' = validate.schema' + ($schemaPath) + '; ';
-        }
-        var $i = 'i' + $lvl,
-          $propertyPath = 'schema' + $lvl + '[' + $i + ']',
-          $missingProperty = '\' + ' + $propertyPath + ' + \'';
-        if (it.opts._errorDataPathProperty) {
-          it.errorPath = it.util.getPathExpr($currentErrorPath, $propertyPath, it.opts.jsonPointers);
-        }
-        out += ' var ' + ($valid) + ' = true; ';
-        if ($isData) {
-          out += ' if (schema' + ($lvl) + ' === undefined) ' + ($valid) + ' = true; else if (!Array.isArray(schema' + ($lvl) + ')) ' + ($valid) + ' = false; else {';
-        }
-        out += ' for (var ' + ($i) + ' = 0; ' + ($i) + ' < ' + ($vSchema) + '.length; ' + ($i) + '++) { ' + ($valid) + ' = ' + ($data) + '[' + ($vSchema) + '[' + ($i) + ']] !== undefined; if (!' + ($valid) + ') break; } ';
-        if ($isData) {
-          out += '  }  ';
-        }
-        out += '  if (!' + ($valid) + ') {   ';
-        var $$outStack = $$outStack || [];
-        $$outStack.push(out);
-        out = ''; /* istanbul ignore else */
-        if (it.createErrors !== false) {
-          out += ' { keyword: \'' + ('required') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { missingProperty: \'' + ($missingProperty) + '\' } ';
-          if (it.opts.messages !== false) {
-            out += ' , message: \'';
-            if (it.opts._errorDataPathProperty) {
-              out += 'is a required property';
-            } else {
-              out += 'should have required property \\\'' + ($missingProperty) + '\\\'';
-            }
-            out += '\' ';
-          }
-          if (it.opts.verbose) {
-            out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
-          }
-          out += ' } ';
-        } else {
-          out += ' {} ';
-        }
-        var __err = out;
-        out = $$outStack.pop();
-        if (!it.compositeRule && $breakOnError) { /* istanbul ignore if */
-          if (it.async) {
-            out += ' throw new ValidationError([' + (__err) + ']); ';
-          } else {
-            out += ' validate.errors = [' + (__err) + ']; return false; ';
-          }
-        } else {
-          out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
-        }
-        out += ' } else { ';
-      } else {
-        out += ' if ( ';
-        var arr2 = $required;
-        if (arr2) {
-          var _$property, $i = -1,
-            l2 = arr2.length - 1;
-          while ($i < l2) {
-            _$property = arr2[$i += 1];
-            if ($i) {
-              out += ' || ';
-            }
-            var $prop = it.util.getProperty(_$property);
-            out += ' ( ' + ($data) + ($prop) + ' === undefined && (missing' + ($lvl) + ' = ' + (it.util.toQuotedString(it.opts.jsonPointers ? _$property : $prop)) + ') ) ';
-          }
-        }
-        out += ') {  ';
-        var $propertyPath = 'missing' + $lvl,
-          $missingProperty = '\' + ' + $propertyPath + ' + \'';
-        if (it.opts._errorDataPathProperty) {
-          it.errorPath = it.opts.jsonPointers ? it.util.getPathExpr($currentErrorPath, $propertyPath, true) : $currentErrorPath + ' + ' + $propertyPath;
-        }
-        var $$outStack = $$outStack || [];
-        $$outStack.push(out);
-        out = ''; /* istanbul ignore else */
-        if (it.createErrors !== false) {
-          out += ' { keyword: \'' + ('required') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { missingProperty: \'' + ($missingProperty) + '\' } ';
-          if (it.opts.messages !== false) {
-            out += ' , message: \'';
-            if (it.opts._errorDataPathProperty) {
-              out += 'is a required property';
-            } else {
-              out += 'should have required property \\\'' + ($missingProperty) + '\\\'';
-            }
-            out += '\' ';
-          }
-          if (it.opts.verbose) {
-            out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
-          }
-          out += ' } ';
-        } else {
-          out += ' {} ';
-        }
-        var __err = out;
-        out = $$outStack.pop();
-        if (!it.compositeRule && $breakOnError) { /* istanbul ignore if */
-          if (it.async) {
-            out += ' throw new ValidationError([' + (__err) + ']); ';
-          } else {
-            out += ' validate.errors = [' + (__err) + ']; return false; ';
-          }
-        } else {
-          out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
-        }
-        out += ' } else { ';
-      }
-    } else {
-      if ($loopRequired) {
-        if (!$isData) {
-          out += ' var ' + ($vSchema) + ' = validate.schema' + ($schemaPath) + '; ';
-        }
-        var $i = 'i' + $lvl,
-          $propertyPath = 'schema' + $lvl + '[' + $i + ']',
-          $missingProperty = '\' + ' + $propertyPath + ' + \'';
-        if (it.opts._errorDataPathProperty) {
-          it.errorPath = it.util.getPathExpr($currentErrorPath, $propertyPath, it.opts.jsonPointers);
-        }
-        if ($isData) {
-          out += ' if (' + ($vSchema) + ' && !Array.isArray(' + ($vSchema) + ')) {  var err =   '; /* istanbul ignore else */
-          if (it.createErrors !== false) {
-            out += ' { keyword: \'' + ('required') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { missingProperty: \'' + ($missingProperty) + '\' } ';
-            if (it.opts.messages !== false) {
-              out += ' , message: \'';
-              if (it.opts._errorDataPathProperty) {
-                out += 'is a required property';
-              } else {
-                out += 'should have required property \\\'' + ($missingProperty) + '\\\'';
-              }
-              out += '\' ';
-            }
-            if (it.opts.verbose) {
-              out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
-            }
-            out += ' } ';
-          } else {
-            out += ' {} ';
-          }
-          out += ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; } else if (' + ($vSchema) + ' !== undefined) { ';
-        }
-        out += ' for (var ' + ($i) + ' = 0; ' + ($i) + ' < ' + ($vSchema) + '.length; ' + ($i) + '++) { if (' + ($data) + '[' + ($vSchema) + '[' + ($i) + ']] === undefined) {  var err =   '; /* istanbul ignore else */
-        if (it.createErrors !== false) {
-          out += ' { keyword: \'' + ('required') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { missingProperty: \'' + ($missingProperty) + '\' } ';
-          if (it.opts.messages !== false) {
-            out += ' , message: \'';
-            if (it.opts._errorDataPathProperty) {
-              out += 'is a required property';
-            } else {
-              out += 'should have required property \\\'' + ($missingProperty) + '\\\'';
-            }
-            out += '\' ';
-          }
-          if (it.opts.verbose) {
-            out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
-          }
-          out += ' } ';
-        } else {
-          out += ' {} ';
-        }
-        out += ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; } } ';
-        if ($isData) {
-          out += '  }  ';
-        }
-      } else {
-        var arr3 = $required;
-        if (arr3) {
-          var $reqProperty, i3 = -1,
-            l3 = arr3.length - 1;
-          while (i3 < l3) {
-            $reqProperty = arr3[i3 += 1];
-            var $prop = it.util.getProperty($reqProperty),
-              $missingProperty = it.util.escapeQuotes($reqProperty);
-            if (it.opts._errorDataPathProperty) {
-              it.errorPath = it.util.getPath($currentErrorPath, $reqProperty, it.opts.jsonPointers);
-            }
-            out += ' if (' + ($data) + ($prop) + ' === undefined) {  var err =   '; /* istanbul ignore else */
-            if (it.createErrors !== false) {
-              out += ' { keyword: \'' + ('required') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { missingProperty: \'' + ($missingProperty) + '\' } ';
-              if (it.opts.messages !== false) {
-                out += ' , message: \'';
-                if (it.opts._errorDataPathProperty) {
-                  out += 'is a required property';
-                } else {
-                  out += 'should have required property \\\'' + ($missingProperty) + '\\\'';
-                }
-                out += '\' ';
-              }
-              if (it.opts.verbose) {
-                out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
-              }
-              out += ' } ';
-            } else {
-              out += ' {} ';
-            }
-            out += ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; } ';
-          }
-        }
-      }
-    }
-    it.errorPath = $currentErrorPath;
-  } else if ($breakOnError) {
-    out += ' if (true) {';
-  }
-  return out;
-}
-
-},{}],70:[function(require,module,exports){
-'use strict';
-module.exports = function generate_switch(it, $keyword) {
-  var out = ' ';
-  var $lvl = it.level;
-  var $dataLvl = it.dataLevel;
-  var $schema = it.schema[$keyword];
-  var $schemaPath = it.schemaPath + it.util.getProperty($keyword);
-  var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
-  var $breakOnError = !it.opts.allErrors;
-  var $data = 'data' + ($dataLvl || '');
-  var $valid = 'valid' + $lvl;
-  var $errs = 'errs__' + $lvl;
-  var $it = it.util.copy(it);
-  var $closingBraces = '';
-  $it.level++;
-  var $nextValid = 'valid' + $it.level;
-  var $ifPassed = 'ifPassed' + it.level,
-    $currentBaseId = $it.baseId,
-    $shouldContinue;
-  out += 'var ' + ($ifPassed) + ';';
-  var arr1 = $schema;
-  if (arr1) {
-    var $sch, $caseIndex = -1,
-      l1 = arr1.length - 1;
-    while ($caseIndex < l1) {
-      $sch = arr1[$caseIndex += 1];
-      if ($caseIndex && !$shouldContinue) {
-        out += ' if (!' + ($ifPassed) + ') { ';
-        $closingBraces += '}';
-      }
-      if ($sch.if && it.util.schemaHasRules($sch.if, it.RULES.all)) {
-        out += ' var ' + ($errs) + ' = errors;   ';
-        var $wasComposite = it.compositeRule;
-        it.compositeRule = $it.compositeRule = true;
-        $it.createErrors = false;
-        $it.schema = $sch.if;
-        $it.schemaPath = $schemaPath + '[' + $caseIndex + '].if';
-        $it.errSchemaPath = $errSchemaPath + '/' + $caseIndex + '/if';
-        out += '  ' + (it.validate($it)) + ' ';
-        $it.baseId = $currentBaseId;
-        $it.createErrors = true;
-        it.compositeRule = $it.compositeRule = $wasComposite;
-        out += ' ' + ($ifPassed) + ' = ' + ($nextValid) + '; if (' + ($ifPassed) + ') {  ';
-        if (typeof $sch.then == 'boolean') {
-          if ($sch.then === false) {
-            var $$outStack = $$outStack || [];
-            $$outStack.push(out);
-            out = ''; /* istanbul ignore else */
-            if (it.createErrors !== false) {
-              out += ' { keyword: \'' + ('switch') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { caseIndex: ' + ($caseIndex) + ' } ';
-              if (it.opts.messages !== false) {
-                out += ' , message: \'should pass "switch" keyword validation\' ';
-              }
-              if (it.opts.verbose) {
-                out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
-              }
-              out += ' } ';
-            } else {
-              out += ' {} ';
-            }
-            var __err = out;
-            out = $$outStack.pop();
-            if (!it.compositeRule && $breakOnError) { /* istanbul ignore if */
-              if (it.async) {
-                out += ' throw new ValidationError([' + (__err) + ']); ';
-              } else {
-                out += ' validate.errors = [' + (__err) + ']; return false; ';
-              }
-            } else {
-              out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
-            }
-          }
-          out += ' var ' + ($nextValid) + ' = ' + ($sch.then) + '; ';
-        } else {
-          $it.schema = $sch.then;
-          $it.schemaPath = $schemaPath + '[' + $caseIndex + '].then';
-          $it.errSchemaPath = $errSchemaPath + '/' + $caseIndex + '/then';
-          out += '  ' + (it.validate($it)) + ' ';
-          $it.baseId = $currentBaseId;
-        }
-        out += '  } else {  errors = ' + ($errs) + '; if (vErrors !== null) { if (' + ($errs) + ') vErrors.length = ' + ($errs) + '; else vErrors = null; } } ';
-      } else {
-        out += ' ' + ($ifPassed) + ' = true;  ';
-        if (typeof $sch.then == 'boolean') {
-          if ($sch.then === false) {
-            var $$outStack = $$outStack || [];
-            $$outStack.push(out);
-            out = ''; /* istanbul ignore else */
-            if (it.createErrors !== false) {
-              out += ' { keyword: \'' + ('switch') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { caseIndex: ' + ($caseIndex) + ' } ';
-              if (it.opts.messages !== false) {
-                out += ' , message: \'should pass "switch" keyword validation\' ';
-              }
-              if (it.opts.verbose) {
-                out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
-              }
-              out += ' } ';
-            } else {
-              out += ' {} ';
-            }
-            var __err = out;
-            out = $$outStack.pop();
-            if (!it.compositeRule && $breakOnError) { /* istanbul ignore if */
-              if (it.async) {
-                out += ' throw new ValidationError([' + (__err) + ']); ';
-              } else {
-                out += ' validate.errors = [' + (__err) + ']; return false; ';
-              }
-            } else {
-              out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
-            }
-          }
-          out += ' var ' + ($nextValid) + ' = ' + ($sch.then) + '; ';
-        } else {
-          $it.schema = $sch.then;
-          $it.schemaPath = $schemaPath + '[' + $caseIndex + '].then';
-          $it.errSchemaPath = $errSchemaPath + '/' + $caseIndex + '/then';
-          out += '  ' + (it.validate($it)) + ' ';
-          $it.baseId = $currentBaseId;
-        }
-      }
-      $shouldContinue = $sch.continue
-    }
-  }
-  out += '' + ($closingBraces) + 'var ' + ($valid) + ' = ' + ($nextValid) + '; ';
-  out = it.util.cleanUpCode(out);
-  return out;
-}
-
-},{}],71:[function(require,module,exports){
-'use strict';
-module.exports = function generate_uniqueItems(it, $keyword) {
-  var out = ' ';
-  var $lvl = it.level;
-  var $dataLvl = it.dataLevel;
-  var $schema = it.schema[$keyword];
-  var $schemaPath = it.schemaPath + it.util.getProperty($keyword);
-  var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
-  var $breakOnError = !it.opts.allErrors;
-  var $data = 'data' + ($dataLvl || '');
-  var $valid = 'valid' + $lvl;
-  var $isData = it.opts.v5 && $schema && $schema.$data,
-    $schemaValue;
-  if ($isData) {
-    out += ' var schema' + ($lvl) + ' = ' + (it.util.getData($schema.$data, $dataLvl, it.dataPathArr)) + '; ';
-    $schemaValue = 'schema' + $lvl;
-  } else {
-    $schemaValue = $schema;
-  }
-  if (($schema || $isData) && it.opts.uniqueItems !== false) {
-    if ($isData) {
-      out += ' var ' + ($valid) + '; if (' + ($schemaValue) + ' === false || ' + ($schemaValue) + ' === undefined) ' + ($valid) + ' = true; else if (typeof ' + ($schemaValue) + ' != \'boolean\') ' + ($valid) + ' = false; else { ';
-    }
-    out += ' var ' + ($valid) + ' = true; if (' + ($data) + '.length > 1) { var i = ' + ($data) + '.length, j; outer: for (;i--;) { for (j = i; j--;) { if (equal(' + ($data) + '[i], ' + ($data) + '[j])) { ' + ($valid) + ' = false; break outer; } } } } ';
-    if ($isData) {
-      out += '  }  ';
-    }
-    out += ' if (!' + ($valid) + ') {   ';
-    var $$outStack = $$outStack || [];
-    $$outStack.push(out);
-    out = ''; /* istanbul ignore else */
-    if (it.createErrors !== false) {
-      out += ' { keyword: \'' + ('uniqueItems') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { i: i, j: j } ';
-      if (it.opts.messages !== false) {
-        out += ' , message: \'should NOT have duplicate items (items ## \' + j + \' and \' + i + \' are identical)\' ';
-      }
-      if (it.opts.verbose) {
-        out += ' , schema:  ';
-        if ($isData) {
-          out += 'validate.schema' + ($schemaPath);
-        } else {
-          out += '' + ($schema);
-        }
-        out += '         , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
-      }
-      out += ' } ';
-    } else {
-      out += ' {} ';
-    }
-    var __err = out;
-    out = $$outStack.pop();
-    if (!it.compositeRule && $breakOnError) { /* istanbul ignore if */
-      if (it.async) {
-        out += ' throw new ValidationError([' + (__err) + ']); ';
-      } else {
-        out += ' validate.errors = [' + (__err) + ']; return false; ';
-      }
-    } else {
-      out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
-    }
-    out += ' } ';
-    if ($breakOnError) {
-      out += ' else { ';
-    }
-  } else {
-    if ($breakOnError) {
-      out += ' if (true) { ';
-    }
-  }
-  return out;
-}
-
-},{}],72:[function(require,module,exports){
-'use strict';
-module.exports = function generate_validate(it, $keyword) {
-  var out = '';
-  var $async = it.schema.$async === true;
-  if (it.isTop) {
-    var $top = it.isTop,
-      $lvl = it.level = 0,
-      $dataLvl = it.dataLevel = 0,
-      $data = 'data';
-    it.rootId = it.resolve.fullPath(it.root.schema.id);
-    it.baseId = it.baseId || it.rootId;
-    if ($async) {
-      it.async = true;
-      var $es7 = it.opts.async == 'es7';
-      it.yieldAwait = $es7 ? 'await' : 'yield';
-    }
-    delete it.isTop;
-    it.dataPathArr = [undefined];
-    out += ' var validate = ';
-    if ($async) {
-      if ($es7) {
-        out += ' (async function ';
-      } else {
-        if (it.opts.async == 'co*') {
-          out += 'co.wrap';
-        }
-        out += '(function* ';
-      }
-    } else {
-      out += ' (function ';
-    }
-    out += ' (data, dataPath, parentData, parentDataProperty, rootData) { \'use strict\'; var vErrors = null; ';
-    out += ' var errors = 0;     ';
-    out += ' if (rootData === undefined) rootData = data;';
-  } else {
-    var $lvl = it.level,
-      $dataLvl = it.dataLevel,
-      $data = 'data' + ($dataLvl || '');
-    if (it.schema.id) it.baseId = it.resolve.url(it.baseId, it.schema.id);
-    if ($async && !it.async) throw new Error('async schema in sync schema');
-    out += ' var errs_' + ($lvl) + ' = errors;';
-  }
-  var $valid = 'valid' + $lvl,
-    $breakOnError = !it.opts.allErrors,
-    $closingBraces1 = '',
-    $closingBraces2 = '';
-  var $typeSchema = it.schema.type,
-    $typeIsArray = Array.isArray($typeSchema);
-  if ($typeSchema && it.opts.coerceTypes) {
-    var $coerceToTypes = it.util.coerceToTypes(it.opts.coerceTypes, $typeSchema);
-    if ($coerceToTypes) {
-      var $schemaPath = it.schemaPath + '.type',
-        $errSchemaPath = it.errSchemaPath + '/type',
-        $method = $typeIsArray ? 'checkDataTypes' : 'checkDataType';
-      out += ' if (' + (it.util[$method]($typeSchema, $data, true)) + ') {  ';
-      var $dataType = 'dataType' + $lvl,
-        $coerced = 'coerced' + $lvl;
-      out += ' var ' + ($dataType) + ' = typeof ' + ($data) + '; ';
-      if (it.opts.coerceTypes == 'array') {
-        out += ' if (' + ($dataType) + ' == \'object\' && Array.isArray(' + ($data) + ')) ' + ($dataType) + ' = \'array\'; ';
-      }
-      out += ' var ' + ($coerced) + ' = undefined; ';
-      var $bracesCoercion = '';
-      var arr1 = $coerceToTypes;
-      if (arr1) {
-        var $type, $i = -1,
-          l1 = arr1.length - 1;
-        while ($i < l1) {
-          $type = arr1[$i += 1];
-          if ($i) {
-            out += ' if (' + ($coerced) + ' === undefined) { ';
-            $bracesCoercion += '}';
-          }
-          if (it.opts.coerceTypes == 'array' && $type != 'array') {
-            out += ' if (' + ($dataType) + ' == \'array\' && ' + ($data) + '.length == 1) { ' + ($coerced) + ' = ' + ($data) + ' = ' + ($data) + '[0]; ' + ($dataType) + ' = typeof ' + ($data) + ';  } ';
-          }
-          if ($type == 'string') {
-            out += ' if (' + ($dataType) + ' == \'number\' || ' + ($dataType) + ' == \'boolean\') ' + ($coerced) + ' = \'\' + ' + ($data) + '; else if (' + ($data) + ' === null) ' + ($coerced) + ' = \'\'; ';
-          } else if ($type == 'number' || $type == 'integer') {
-            out += ' if (' + ($dataType) + ' == \'boolean\' || ' + ($data) + ' === null || (' + ($dataType) + ' == \'string\' && ' + ($data) + ' && ' + ($data) + ' == +' + ($data) + ' ';
-            if ($type == 'integer') {
-              out += ' && !(' + ($data) + ' % 1)';
-            }
-            out += ')) ' + ($coerced) + ' = +' + ($data) + '; ';
-          } else if ($type == 'boolean') {
-            out += ' if (' + ($data) + ' === \'false\' || ' + ($data) + ' === 0 || ' + ($data) + ' === null) ' + ($coerced) + ' = false; else if (' + ($data) + ' === \'true\' || ' + ($data) + ' === 1) ' + ($coerced) + ' = true; ';
-          } else if ($type == 'null') {
-            out += ' if (' + ($data) + ' === \'\' || ' + ($data) + ' === 0 || ' + ($data) + ' === false) ' + ($coerced) + ' = null; ';
-          } else if (it.opts.coerceTypes == 'array' && $type == 'array') {
-            out += ' if (' + ($dataType) + ' == \'string\' || ' + ($dataType) + ' == \'number\' || ' + ($dataType) + ' == \'boolean\' || ' + ($data) + ' == null) ' + ($coerced) + ' = [' + ($data) + ']; ';
-          }
-        }
-      }
-      out += ' ' + ($bracesCoercion) + ' if (' + ($coerced) + ' === undefined) {   ';
-      var $$outStack = $$outStack || [];
-      $$outStack.push(out);
-      out = ''; /* istanbul ignore else */
-      if (it.createErrors !== false) {
-        out += ' { keyword: \'' + ('type') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { type: \'';
-        if ($typeIsArray) {
-          out += '' + ($typeSchema.join(","));
-        } else {
-          out += '' + ($typeSchema);
-        }
-        out += '\' } ';
-        if (it.opts.messages !== false) {
-          out += ' , message: \'should be ';
-          if ($typeIsArray) {
-            out += '' + ($typeSchema.join(","));
-          } else {
-            out += '' + ($typeSchema);
-          }
-          out += '\' ';
-        }
-        if (it.opts.verbose) {
-          out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
-        }
-        out += ' } ';
-      } else {
-        out += ' {} ';
-      }
-      var __err = out;
-      out = $$outStack.pop();
-      if (!it.compositeRule && $breakOnError) { /* istanbul ignore if */
-        if (it.async) {
-          out += ' throw new ValidationError([' + (__err) + ']); ';
-        } else {
-          out += ' validate.errors = [' + (__err) + ']; return false; ';
-        }
-      } else {
-        out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
-      }
-      out += ' } else {  ';
-      var $parentData = $dataLvl ? 'data' + (($dataLvl - 1) || '') : 'parentData',
-        $parentDataProperty = $dataLvl ? it.dataPathArr[$dataLvl] : 'parentDataProperty';
-      out += ' ' + ($data) + ' = ' + ($coerced) + '; ';
-      if (!$dataLvl) {
-        out += 'if (' + ($parentData) + ' !== undefined)';
-      }
-      out += ' ' + ($parentData) + '[' + ($parentDataProperty) + '] = ' + ($coerced) + '; } } ';
-    }
-  }
-  var $refKeywords;
-  if (it.schema.$ref && ($refKeywords = it.util.schemaHasRulesExcept(it.schema, it.RULES.all, '$ref'))) {
-    if (it.opts.extendRefs == 'fail') {
-      throw new Error('$ref: validation keywords used in schema at path "' + it.errSchemaPath + '"');
-    } else if (it.opts.extendRefs == 'ignore') {
-      $refKeywords = false;
-      console.log('$ref: keywords ignored in schema at path "' + it.errSchemaPath + '"');
-    } else if (it.opts.extendRefs !== true) {
-      console.log('$ref: all keywords used in schema at path "' + it.errSchemaPath + '". It will change in the next major version, see issue #260. Use option { extendRefs: true } to keep current behaviour');
-    }
-  }
-  if (it.schema.$ref && !$refKeywords) {
-    out += ' ' + (it.RULES.all.$ref.code(it, '$ref')) + ' ';
-    if ($breakOnError) {
-      out += ' } if (errors === ';
-      if ($top) {
-        out += '0';
-      } else {
-        out += 'errs_' + ($lvl);
-      }
-      out += ') { ';
-      $closingBraces2 += '}';
-    }
-  } else {
-    var arr2 = it.RULES;
-    if (arr2) {
-      var $rulesGroup, i2 = -1,
-        l2 = arr2.length - 1;
-      while (i2 < l2) {
-        $rulesGroup = arr2[i2 += 1];
-        if ($shouldUseGroup($rulesGroup)) {
-          if ($rulesGroup.type) {
-            out += ' if (' + (it.util.checkDataType($rulesGroup.type, $data)) + ') { ';
-          }
-          if (it.opts.useDefaults && !it.compositeRule) {
-            if ($rulesGroup.type == 'object' && it.schema.properties) {
-              var $schema = it.schema.properties,
-                $schemaKeys = Object.keys($schema);
-              var arr3 = $schemaKeys;
-              if (arr3) {
-                var $propertyKey, i3 = -1,
-                  l3 = arr3.length - 1;
-                while (i3 < l3) {
-                  $propertyKey = arr3[i3 += 1];
-                  var $sch = $schema[$propertyKey];
-                  if ($sch.default !== undefined) {
-                    var $passData = $data + it.util.getProperty($propertyKey);
-                    out += '  if (' + ($passData) + ' === undefined) ' + ($passData) + ' = ';
-                    if (it.opts.useDefaults == 'shared') {
-                      out += ' ' + (it.useDefault($sch.default)) + ' ';
-                    } else {
-                      out += ' ' + (JSON.stringify($sch.default)) + ' ';
-                    }
-                    out += '; ';
-                  }
-                }
-              }
-            } else if ($rulesGroup.type == 'array' && Array.isArray(it.schema.items)) {
-              var arr4 = it.schema.items;
-              if (arr4) {
-                var $sch, $i = -1,
-                  l4 = arr4.length - 1;
-                while ($i < l4) {
-                  $sch = arr4[$i += 1];
-                  if ($sch.default !== undefined) {
-                    var $passData = $data + '[' + $i + ']';
-                    out += '  if (' + ($passData) + ' === undefined) ' + ($passData) + ' = ';
-                    if (it.opts.useDefaults == 'shared') {
-                      out += ' ' + (it.useDefault($sch.default)) + ' ';
-                    } else {
-                      out += ' ' + (JSON.stringify($sch.default)) + ' ';
-                    }
-                    out += '; ';
-                  }
-                }
-              }
-            }
-          }
-          var arr5 = $rulesGroup.rules;
-          if (arr5) {
-            var $rule, i5 = -1,
-              l5 = arr5.length - 1;
-            while (i5 < l5) {
-              $rule = arr5[i5 += 1];
-              if ($shouldUseRule($rule)) {
-                out += ' ' + ($rule.code(it, $rule.keyword)) + ' ';
-                if ($breakOnError) {
-                  $closingBraces1 += '}';
-                }
-              }
-            }
-          }
-          if ($breakOnError) {
-            out += ' ' + ($closingBraces1) + ' ';
-            $closingBraces1 = '';
-          }
-          if ($rulesGroup.type) {
-            out += ' } ';
-            if ($typeSchema && $typeSchema === $rulesGroup.type && !$coerceToTypes) {
-              var $typeChecked = true;
-              out += ' else { ';
-              var $schemaPath = it.schemaPath + '.type',
-                $errSchemaPath = it.errSchemaPath + '/type';
-              var $$outStack = $$outStack || [];
-              $$outStack.push(out);
-              out = ''; /* istanbul ignore else */
-              if (it.createErrors !== false) {
-                out += ' { keyword: \'' + ('type') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { type: \'';
-                if ($typeIsArray) {
-                  out += '' + ($typeSchema.join(","));
-                } else {
-                  out += '' + ($typeSchema);
-                }
-                out += '\' } ';
-                if (it.opts.messages !== false) {
-                  out += ' , message: \'should be ';
-                  if ($typeIsArray) {
-                    out += '' + ($typeSchema.join(","));
-                  } else {
-                    out += '' + ($typeSchema);
-                  }
-                  out += '\' ';
-                }
-                if (it.opts.verbose) {
-                  out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
-                }
-                out += ' } ';
-              } else {
-                out += ' {} ';
-              }
-              var __err = out;
-              out = $$outStack.pop();
-              if (!it.compositeRule && $breakOnError) { /* istanbul ignore if */
-                if (it.async) {
-                  out += ' throw new ValidationError([' + (__err) + ']); ';
-                } else {
-                  out += ' validate.errors = [' + (__err) + ']; return false; ';
-                }
-              } else {
-                out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
-              }
-              out += ' } ';
-            }
-          }
-          if ($breakOnError) {
-            out += ' if (errors === ';
-            if ($top) {
-              out += '0';
-            } else {
-              out += 'errs_' + ($lvl);
-            }
-            out += ') { ';
-            $closingBraces2 += '}';
-          }
-        }
-      }
-    }
-  }
-  if ($typeSchema && !$typeChecked && !$coerceToTypes) {
-    var $schemaPath = it.schemaPath + '.type',
-      $errSchemaPath = it.errSchemaPath + '/type',
-      $method = $typeIsArray ? 'checkDataTypes' : 'checkDataType';
-    out += ' if (' + (it.util[$method]($typeSchema, $data, true)) + ') {   ';
-    var $$outStack = $$outStack || [];
-    $$outStack.push(out);
-    out = ''; /* istanbul ignore else */
-    if (it.createErrors !== false) {
-      out += ' { keyword: \'' + ('type') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { type: \'';
-      if ($typeIsArray) {
-        out += '' + ($typeSchema.join(","));
-      } else {
-        out += '' + ($typeSchema);
-      }
-      out += '\' } ';
-      if (it.opts.messages !== false) {
-        out += ' , message: \'should be ';
-        if ($typeIsArray) {
-          out += '' + ($typeSchema.join(","));
-        } else {
-          out += '' + ($typeSchema);
-        }
-        out += '\' ';
-      }
-      if (it.opts.verbose) {
-        out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
-      }
-      out += ' } ';
-    } else {
-      out += ' {} ';
-    }
-    var __err = out;
-    out = $$outStack.pop();
-    if (!it.compositeRule && $breakOnError) { /* istanbul ignore if */
-      if (it.async) {
-        out += ' throw new ValidationError([' + (__err) + ']); ';
-      } else {
-        out += ' validate.errors = [' + (__err) + ']; return false; ';
-      }
-    } else {
-      out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
-    }
-    out += ' }';
-  }
-  if ($breakOnError) {
-    out += ' ' + ($closingBraces2) + ' ';
-  }
-  if ($top) {
-    if ($async) {
-      out += ' if (errors === 0) return true;           ';
-      out += ' else throw new ValidationError(vErrors); ';
-    } else {
-      out += ' validate.errors = vErrors; ';
-      out += ' return errors === 0;       ';
-    }
-    out += ' }); return validate;';
-  } else {
-    out += ' var ' + ($valid) + ' = errors === errs_' + ($lvl) + ';';
-  }
-  out = it.util.cleanUpCode(out);
-  if ($top && $breakOnError) {
-    out = it.util.cleanUpVarErrors(out, $async);
-  }
-
-  function $shouldUseGroup($rulesGroup) {
-    for (var i = 0; i < $rulesGroup.rules.length; i++)
-      if ($shouldUseRule($rulesGroup.rules[i])) return true;
-  }
-
-  function $shouldUseRule($rule) {
-    return it.schema[$rule.keyword] !== undefined || ($rule.keyword == 'properties' && (it.schema.additionalProperties === false || typeof it.schema.additionalProperties == 'object' || (it.schema.patternProperties && Object.keys(it.schema.patternProperties).length) || (it.opts.v5 && it.schema.patternGroups && Object.keys(it.schema.patternGroups).length)));
-  }
-  return out;
-}
-
-},{}],73:[function(require,module,exports){
-'use strict';
-
-var IDENTIFIER = /^[a-z_$][a-z0-9_$\-]*$/i;
-var customRuleCode = require('./dotjs/custom');
-
-module.exports = {
-  add: addKeyword,
-  get: getKeyword,
-  remove: removeKeyword
-};
-
-/**
- * Define custom keyword
- * @this  Ajv
- * @param {String} keyword custom keyword, should be unique (including different from all standard, custom and macro keywords).
- * @param {Object} definition keyword definition object with properties `type` (type(s) which the keyword applies to), `validate` or `compile`.
- */
-function addKeyword(keyword, definition) {
-  /* jshint validthis: true */
-  /* eslint no-shadow: 0 */
-  var RULES = this.RULES;
-
-  if (RULES.keywords[keyword])
-    throw new Error('Keyword ' + keyword + ' is already defined');
-
-  if (!IDENTIFIER.test(keyword))
-    throw new Error('Keyword ' + keyword + ' is not a valid identifier');
-
-  if (definition) {
-    if (definition.macro && definition.valid !== undefined)
-      throw new Error('"valid" option cannot be used with macro keywords');
-
-    var dataType = definition.type;
-    if (Array.isArray(dataType)) {
-      var i, len = dataType.length;
-      for (i=0; i<len; i++) checkDataType(dataType[i]);
-      for (i=0; i<len; i++) _addRule(keyword, dataType[i], definition);
-    } else {
-      if (dataType) checkDataType(dataType);
-      _addRule(keyword, dataType, definition);
-    }
-
-    var $data = definition.$data === true && this._opts.v5;
-    if ($data && !definition.validate)
-      throw new Error('$data support: "validate" function is not defined');
-
-    var metaSchema = definition.metaSchema;
-    if (metaSchema) {
-      if ($data) {
-        metaSchema = {
-          anyOf: [
-            metaSchema,
-            { '$ref': 'https://raw.githubusercontent.com/epoberezkin/ajv/master/lib/refs/json-schema-v5.json#/definitions/$data' }
-          ]
-        };
-      }
-      definition.validateSchema = this.compile(metaSchema, true);
-    }
-  }
-
-  RULES.keywords[keyword] = RULES.all[keyword] = true;
-
-
-  function _addRule(keyword, dataType, definition) {
-    var ruleGroup;
-    for (var i=0; i<RULES.length; i++) {
-      var rg = RULES[i];
-      if (rg.type == dataType) {
-        ruleGroup = rg;
-        break;
-      }
-    }
-
-    if (!ruleGroup) {
-      ruleGroup = { type: dataType, rules: [] };
-      RULES.push(ruleGroup);
-    }
-
-    var rule = {
-      keyword: keyword,
-      definition: definition,
-      custom: true,
-      code: customRuleCode
-    };
-    ruleGroup.rules.push(rule);
-    RULES.custom[keyword] = rule;
-  }
-
-
-  function checkDataType(dataType) {
-    if (!RULES.types[dataType]) throw new Error('Unknown type ' + dataType);
-  }
-}
-
-
-/**
- * Get keyword
- * @this  Ajv
- * @param {String} keyword pre-defined or custom keyword.
- * @return {Object|Boolean} custom keyword definition, `true` if it is a predefined keyword, `false` otherwise.
- */
-function getKeyword(keyword) {
-  /* jshint validthis: true */
-  var rule = this.RULES.custom[keyword];
-  return rule ? rule.definition : this.RULES.keywords[keyword] || false;
-}
-
-
-/**
- * Remove keyword
- * @this  Ajv
- * @param {String} keyword pre-defined or custom keyword.
- */
-function removeKeyword(keyword) {
-  /* jshint validthis: true */
-  var RULES = this.RULES;
-  delete RULES.keywords[keyword];
-  delete RULES.all[keyword];
-  delete RULES.custom[keyword];
-  for (var i=0; i<RULES.length; i++) {
-    var rules = RULES[i].rules;
-    for (var j=0; j<rules.length; j++) {
-      if (rules[j].keyword == keyword) {
-        rules.splice(j, 1);
-        break;
-      }
-    }
-  }
-}
-
-},{"./dotjs/custom":57}],74:[function(require,module,exports){
-module.exports={
-    "id": "http://json-schema.org/draft-04/schema#",
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "description": "Core schema meta-schema",
-    "definitions": {
-        "schemaArray": {
-            "type": "array",
-            "minItems": 1,
-            "items": { "$ref": "#" }
-        },
-        "positiveInteger": {
-            "type": "integer",
-            "minimum": 0
-        },
-        "positiveIntegerDefault0": {
-            "allOf": [ { "$ref": "#/definitions/positiveInteger" }, { "default": 0 } ]
-        },
-        "simpleTypes": {
-            "enum": [ "array", "boolean", "integer", "null", "number", "object", "string" ]
-        },
-        "stringArray": {
-            "type": "array",
-            "items": { "type": "string" },
-            "minItems": 1,
-            "uniqueItems": true
-        }
-    },
-    "type": "object",
-    "properties": {
-        "id": {
-            "type": "string",
-            "format": "uri"
-        },
-        "$schema": {
-            "type": "string",
-            "format": "uri"
-        },
-        "title": {
-            "type": "string"
-        },
-        "description": {
-            "type": "string"
-        },
-        "default": {},
-        "multipleOf": {
-            "type": "number",
-            "minimum": 0,
-            "exclusiveMinimum": true
-        },
-        "maximum": {
-            "type": "number"
-        },
-        "exclusiveMaximum": {
-            "type": "boolean",
-            "default": false
-        },
-        "minimum": {
-            "type": "number"
-        },
-        "exclusiveMinimum": {
-            "type": "boolean",
-            "default": false
-        },
-        "maxLength": { "$ref": "#/definitions/positiveInteger" },
-        "minLength": { "$ref": "#/definitions/positiveIntegerDefault0" },
-        "pattern": {
-            "type": "string",
-            "format": "regex"
-        },
-        "additionalItems": {
-            "anyOf": [
-                { "type": "boolean" },
-                { "$ref": "#" }
-            ],
-            "default": {}
-        },
-        "items": {
-            "anyOf": [
-                { "$ref": "#" },
-                { "$ref": "#/definitions/schemaArray" }
-            ],
-            "default": {}
-        },
-        "maxItems": { "$ref": "#/definitions/positiveInteger" },
-        "minItems": { "$ref": "#/definitions/positiveIntegerDefault0" },
-        "uniqueItems": {
-            "type": "boolean",
-            "default": false
-        },
-        "maxProperties": { "$ref": "#/definitions/positiveInteger" },
-        "minProperties": { "$ref": "#/definitions/positiveIntegerDefault0" },
-        "required": { "$ref": "#/definitions/stringArray" },
-        "additionalProperties": {
-            "anyOf": [
-                { "type": "boolean" },
-                { "$ref": "#" }
-            ],
-            "default": {}
-        },
-        "definitions": {
-            "type": "object",
-            "additionalProperties": { "$ref": "#" },
-            "default": {}
-        },
-        "properties": {
-            "type": "object",
-            "additionalProperties": { "$ref": "#" },
-            "default": {}
-        },
-        "patternProperties": {
-            "type": "object",
-            "additionalProperties": { "$ref": "#" },
-            "default": {}
-        },
-        "dependencies": {
-            "type": "object",
-            "additionalProperties": {
-                "anyOf": [
-                    { "$ref": "#" },
-                    { "$ref": "#/definitions/stringArray" }
-                ]
-            }
-        },
-        "enum": {
-            "type": "array",
-            "minItems": 1,
-            "uniqueItems": true
-        },
-        "type": {
-            "anyOf": [
-                { "$ref": "#/definitions/simpleTypes" },
-                {
-                    "type": "array",
-                    "items": { "$ref": "#/definitions/simpleTypes" },
-                    "minItems": 1,
-                    "uniqueItems": true
-                }
-            ]
-        },
-        "allOf": { "$ref": "#/definitions/schemaArray" },
-        "anyOf": { "$ref": "#/definitions/schemaArray" },
-        "oneOf": { "$ref": "#/definitions/schemaArray" },
-        "not": { "$ref": "#" }
-    },
-    "dependencies": {
-        "exclusiveMaximum": [ "maximum" ],
-        "exclusiveMinimum": [ "minimum" ]
-    },
-    "default": {}
-}
-
-},{}],75:[function(require,module,exports){
-module.exports={
-    "id": "https://raw.githubusercontent.com/epoberezkin/ajv/master/lib/refs/json-schema-v5.json#",
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "description": "Core schema meta-schema (v5 proposals)",
-    "definitions": {
-        "schemaArray": {
-            "type": "array",
-            "minItems": 1,
-            "items": { "$ref": "#" }
-        },
-        "positiveInteger": {
-            "type": "integer",
-            "minimum": 0
-        },
-        "positiveIntegerDefault0": {
-            "allOf": [ { "$ref": "#/definitions/positiveInteger" }, { "default": 0 } ]
-        },
-        "simpleTypes": {
-            "enum": [ "array", "boolean", "integer", "null", "number", "object", "string" ]
-        },
-        "stringArray": {
-            "type": "array",
-            "items": { "type": "string" },
-            "minItems": 1,
-            "uniqueItems": true
-        },
-        "$data": {
-            "type": "object",
-            "required": [ "$data" ],
-            "properties": {
-                "$data": {
-                    "type": "string",
-                    "anyOf": [
-                        { "format": "relative-json-pointer" }, 
-                        { "format": "json-pointer" }
-                    ]
-                }
-            },
-            "additionalProperties": false
-        }
-    },
-    "type": "object",
-    "properties": {
-        "id": {
-            "type": "string",
-            "format": "uri"
-        },
-        "$schema": {
-            "type": "string",
-            "format": "uri"
-        },
-        "title": {
-            "type": "string"
-        },
-        "description": {
-            "type": "string"
-        },
-        "default": {},
-        "multipleOf": {
-            "anyOf": [
-                {
-                    "type": "number",
-                    "minimum": 0,
-                    "exclusiveMinimum": true
-                },
-                { "$ref": "#/definitions/$data" }
-            ]
-        },
-        "maximum": {
-            "anyOf": [
-                { "type": "number" },
-                { "$ref": "#/definitions/$data" }
-            ]
-        },
-        "exclusiveMaximum": {
-            "anyOf": [
-                {
-                    "type": "boolean",
-                    "default": false
-                },
-                { "$ref": "#/definitions/$data" }
-            ]
-        },
-        "minimum": {
-            "anyOf": [
-                { "type": "number" },
-                { "$ref": "#/definitions/$data" }
-            ]
-        },
-        "exclusiveMinimum": {
-            "anyOf": [
-                {
-                    "type": "boolean",
-                    "default": false
-                },
-                { "$ref": "#/definitions/$data" }
-            ]
-        },
-        "maxLength": {
-            "anyOf": [
-                { "$ref": "#/definitions/positiveInteger" },
-                { "$ref": "#/definitions/$data" }
-            ]
-        },
-        "minLength": {
-            "anyOf": [
-                { "$ref": "#/definitions/positiveIntegerDefault0" },
-                { "$ref": "#/definitions/$data" }
-            ]
-        },
-        "pattern": {
-            "anyOf": [
-                {
-                    "type": "string",
-                    "format": "regex"
-                },
-                { "$ref": "#/definitions/$data" }
-            ]
-        },
-        "additionalItems": {
-            "anyOf": [
-                { "type": "boolean" },
-                { "$ref": "#" },
-                { "$ref": "#/definitions/$data" }
-            ],
-            "default": {}
-        },
-        "items": {
-            "anyOf": [
-                { "$ref": "#" },
-                { "$ref": "#/definitions/schemaArray" }
-            ],
-            "default": {}
-        },
-        "maxItems": {
-            "anyOf": [
-                { "$ref": "#/definitions/positiveInteger" },
-                { "$ref": "#/definitions/$data" }
-            ]
-        },
-        "minItems": {
-            "anyOf": [
-                { "$ref": "#/definitions/positiveIntegerDefault0" },
-                { "$ref": "#/definitions/$data" }
-            ]
-        },
-        "uniqueItems": {
-            "anyOf": [
-                {
-                    "type": "boolean",
-                    "default": false
-                },
-                { "$ref": "#/definitions/$data" }
-            ]
-        },
-        "maxProperties": {
-            "anyOf": [
-                { "$ref": "#/definitions/positiveInteger" },
-                { "$ref": "#/definitions/$data" }
-            ]
-        },
-        "minProperties": {
-            "anyOf": [
-                { "$ref": "#/definitions/positiveIntegerDefault0" },
-                { "$ref": "#/definitions/$data" }
-            ]
-        },
-        "required": {
-            "anyOf": [
-                { "$ref": "#/definitions/stringArray" },
-                { "$ref": "#/definitions/$data" }
-            ]
-        },
-        "additionalProperties": {
-            "anyOf": [
-                { "type": "boolean" },
-                { "$ref": "#" },
-                { "$ref": "#/definitions/$data" }
-            ],
-            "default": {}
-        },
-        "definitions": {
-            "type": "object",
-            "additionalProperties": { "$ref": "#" },
-            "default": {}
-        },
-        "properties": {
-            "type": "object",
-            "additionalProperties": { "$ref": "#" },
-            "default": {}
-        },
-        "patternProperties": {
-            "type": "object",
-            "additionalProperties": { "$ref": "#" },
-            "default": {}
-        },
-        "dependencies": {
-            "type": "object",
-            "additionalProperties": {
-                "anyOf": [
-                    { "$ref": "#" },
-                    { "$ref": "#/definitions/stringArray" }
-                ]
-            }
-        },
-        "enum": {
-            "anyOf": [
-                {
-                    "type": "array",
-                    "minItems": 1,
-                    "uniqueItems": true
-                },
-                { "$ref": "#/definitions/$data" }
-            ]
-        },
-        "type": {
-            "anyOf": [
-                { "$ref": "#/definitions/simpleTypes" },
-                {
-                    "type": "array",
-                    "items": { "$ref": "#/definitions/simpleTypes" },
-                    "minItems": 1,
-                    "uniqueItems": true
-                }
-            ]
-        },
-        "allOf": { "$ref": "#/definitions/schemaArray" },
-        "anyOf": { "$ref": "#/definitions/schemaArray" },
-        "oneOf": { "$ref": "#/definitions/schemaArray" },
-        "not": { "$ref": "#" },
-        "format": {
-            "anyOf": [
-                { "type": "string" },
-                { "$ref": "#/definitions/$data" }
-            ]
-        },
-        "formatMaximum": {
-            "anyOf": [
-                { "type": "string" },
-                { "$ref": "#/definitions/$data" }
-            ]
-        },
-        "formatMinimum": {
-            "anyOf": [
-                { "type": "string" },
-                { "$ref": "#/definitions/$data" }
-            ]
-        },
-        "formatExclusiveMaximum": {
-            "anyOf": [
-                {
-                    "type": "boolean",
-                    "default": false
-                },
-                { "$ref": "#/definitions/$data" }
-            ]
-        },
-        "formatExclusiveMinimum": {
-            "anyOf": [
-                {
-                    "type": "boolean",
-                    "default": false
-                },
-                { "$ref": "#/definitions/$data" }
-            ]
-        },
-        "constant": {
-            "anyOf": [
-                {},
-                { "$ref": "#/definitions/$data" }
-            ]
-        },
-        "contains": { "$ref": "#" },
-        "patternGroups": {
-            "type": "object",
-            "additionalProperties": {
-                "type": "object",
-                "required": [ "schema" ],
-                "properties": {
-                    "maximum": {
-                        "anyOf": [
-                            { "$ref": "#/definitions/positiveInteger" },
-                            { "$ref": "#/definitions/$data" }
-                        ]
-                    },
-                    "minimum": {
-                        "anyOf": [
-                            { "$ref": "#/definitions/positiveIntegerDefault0" },
-                            { "$ref": "#/definitions/$data" }
-                        ]
-                    },
-                    "schema": { "$ref": "#" }
-                },
-                "additionalProperties": false
-            },
-            "default": {}
-        },
-        "switch": {
-            "type": "array",
-            "items": {
-                "required": [ "then" ],
-                "properties": {
-                    "if": { "$ref": "#" },
-                    "then": {
-                        "anyOf": [
-                            { "type": "boolean" },
-                            { "$ref": "#" }
-                        ]
-                    },
-                    "continue": { "type": "boolean" }
-                },
-                "additionalProperties": false,
-                "dependencies": {
-                    "continue": [ "if" ]
-                }
-            }
-        }
-    },
-    "dependencies": {
-        "exclusiveMaximum": [ "maximum" ],
-        "exclusiveMinimum": [ "minimum" ],
-        "formatMaximum": [ "format" ],
-        "formatMinimum": [ "format" ],
-        "formatExclusiveMaximum": [ "formatMaximum" ],
-        "formatExclusiveMinimum": [ "formatMinimum" ]
-    },
-    "default": {}
-}
-
-},{}],76:[function(require,module,exports){
-'use strict';
-
-var META_SCHEMA_ID = 'https://raw.githubusercontent.com/epoberezkin/ajv/master/lib/refs/json-schema-v5.json';
-
-module.exports = {
-  enable: enableV5,
-  META_SCHEMA_ID: META_SCHEMA_ID
-};
-
-
-function enableV5(ajv) {
-  var inlineFunctions = {
-    'switch': require('./dotjs/switch'),
-    'constant': require('./dotjs/constant'),
-    '_formatLimit': require('./dotjs/_formatLimit'),
-    'patternRequired': require('./dotjs/patternRequired')
-  };
-
-  if (ajv._opts.meta !== false) {
-    var metaSchema = require('./refs/json-schema-v5.json');
-    ajv.addMetaSchema(metaSchema, META_SCHEMA_ID);
-  }
-  _addKeyword('constant');
-  ajv.addKeyword('contains', { type: 'array', macro: containsMacro });
-
-  _addKeyword('formatMaximum', 'string', inlineFunctions._formatLimit);
-  _addKeyword('formatMinimum', 'string', inlineFunctions._formatLimit);
-  ajv.addKeyword('formatExclusiveMaximum');
-  ajv.addKeyword('formatExclusiveMinimum');
-
-  ajv.addKeyword('patternGroups'); // implemented in properties.jst
-  _addKeyword('patternRequired', 'object');
-  _addKeyword('switch');
-
-
-  function _addKeyword(keyword, types, inlineFunc) {
-    var definition = {
-      inline: inlineFunc || inlineFunctions[keyword],
-      statements: true,
-      errors: 'full'
-    };
-    if (types) definition.type = types;
-    ajv.addKeyword(keyword, definition);
-  }
-}
-
-
-function containsMacro(schema) {
-  return {
-    not: { items: { not: schema } }
-  };
-}
-
-},{"./dotjs/_formatLimit":49,"./dotjs/constant":56,"./dotjs/patternRequired":66,"./dotjs/switch":70,"./refs/json-schema-v5.json":75}],77:[function(require,module,exports){
-
-/**
- * slice() reference.
- */
-
-var slice = Array.prototype.slice;
-
-/**
- * Expose `co`.
- */
-
-module.exports = co['default'] = co.co = co;
-
-/**
- * Wrap the given generator `fn` into a
- * function that returns a promise.
- * This is a separate function so that
- * every `co()` call doesn't create a new,
- * unnecessary closure.
- *
- * @param {GeneratorFunction} fn
- * @return {Function}
- * @api public
- */
-
-co.wrap = function (fn) {
-  createPromise.__generatorFunction__ = fn;
-  return createPromise;
-  function createPromise() {
-    return co.call(this, fn.apply(this, arguments));
-  }
-};
-
-/**
- * Execute the generator function or a generator
- * and return a promise.
- *
- * @param {Function} fn
- * @return {Promise}
- * @api public
- */
-
-function co(gen) {
-  var ctx = this;
-  var args = slice.call(arguments, 1)
-
-  // we wrap everything in a promise to avoid promise chaining,
-  // which leads to memory leak errors.
-  // see https://github.com/tj/co/issues/180
-  return new Promise(function(resolve, reject) {
-    if (typeof gen === 'function') gen = gen.apply(ctx, args);
-    if (!gen || typeof gen.next !== 'function') return resolve(gen);
-
-    onFulfilled();
-
-    /**
-     * @param {Mixed} res
-     * @return {Promise}
-     * @api private
-     */
-
-    function onFulfilled(res) {
-      var ret;
-      try {
-        ret = gen.next(res);
-      } catch (e) {
-        return reject(e);
-      }
-      next(ret);
-    }
-
-    /**
-     * @param {Error} err
-     * @return {Promise}
-     * @api private
-     */
-
-    function onRejected(err) {
-      var ret;
-      try {
-        ret = gen.throw(err);
-      } catch (e) {
-        return reject(e);
-      }
-      next(ret);
-    }
-
-    /**
-     * Get the next value in the generator,
-     * return a promise.
-     *
-     * @param {Object} ret
-     * @return {Promise}
-     * @api private
-     */
-
-    function next(ret) {
-      if (ret.done) return resolve(ret.value);
-      var value = toPromise.call(ctx, ret.value);
-      if (value && isPromise(value)) return value.then(onFulfilled, onRejected);
-      return onRejected(new TypeError('You may only yield a function, promise, generator, array, or object, '
-        + 'but the following object was passed: "' + String(ret.value) + '"'));
-    }
-  });
-}
-
-/**
- * Convert a `yield`ed value into a promise.
- *
- * @param {Mixed} obj
- * @return {Promise}
- * @api private
- */
-
-function toPromise(obj) {
-  if (!obj) return obj;
-  if (isPromise(obj)) return obj;
-  if (isGeneratorFunction(obj) || isGenerator(obj)) return co.call(this, obj);
-  if ('function' == typeof obj) return thunkToPromise.call(this, obj);
-  if (Array.isArray(obj)) return arrayToPromise.call(this, obj);
-  if (isObject(obj)) return objectToPromise.call(this, obj);
-  return obj;
-}
-
-/**
- * Convert a thunk to a promise.
- *
- * @param {Function}
- * @return {Promise}
- * @api private
- */
-
-function thunkToPromise(fn) {
-  var ctx = this;
-  return new Promise(function (resolve, reject) {
-    fn.call(ctx, function (err, res) {
-      if (err) return reject(err);
-      if (arguments.length > 2) res = slice.call(arguments, 1);
-      resolve(res);
-    });
-  });
-}
-
-/**
- * Convert an array of "yieldables" to a promise.
- * Uses `Promise.all()` internally.
- *
- * @param {Array} obj
- * @return {Promise}
- * @api private
- */
-
-function arrayToPromise(obj) {
-  return Promise.all(obj.map(toPromise, this));
-}
-
-/**
- * Convert an object of "yieldables" to a promise.
- * Uses `Promise.all()` internally.
- *
- * @param {Object} obj
- * @return {Promise}
- * @api private
- */
-
-function objectToPromise(obj){
-  var results = new obj.constructor();
-  var keys = Object.keys(obj);
-  var promises = [];
-  for (var i = 0; i < keys.length; i++) {
-    var key = keys[i];
-    var promise = toPromise.call(this, obj[key]);
-    if (promise && isPromise(promise)) defer(promise, key);
-    else results[key] = obj[key];
-  }
-  return Promise.all(promises).then(function () {
-    return results;
-  });
-
-  function defer(promise, key) {
-    // predefine the key in the result
-    results[key] = undefined;
-    promises.push(promise.then(function (res) {
-      results[key] = res;
-    }));
-  }
-}
-
-/**
- * Check if `obj` is a promise.
- *
- * @param {Object} obj
- * @return {Boolean}
- * @api private
- */
-
-function isPromise(obj) {
-  return 'function' == typeof obj.then;
-}
-
-/**
- * Check if `obj` is a generator.
- *
- * @param {Mixed} obj
- * @return {Boolean}
- * @api private
- */
-
-function isGenerator(obj) {
-  return 'function' == typeof obj.next && 'function' == typeof obj.throw;
-}
-
-/**
- * Check if `obj` is a generator function.
- *
- * @param {Mixed} obj
- * @return {Boolean}
- * @api private
- */
-function isGeneratorFunction(obj) {
-  var constructor = obj.constructor;
-  if (!constructor) return false;
-  if ('GeneratorFunction' === constructor.name || 'GeneratorFunction' === constructor.displayName) return true;
-  return isGenerator(constructor.prototype);
-}
-
-/**
- * Check for plain object.
- *
- * @param {Mixed} val
- * @return {Boolean}
- * @api private
- */
-
-function isObject(val) {
-  return Object == val.constructor;
-}
-
-},{}],78:[function(require,module,exports){
-var json = typeof JSON !== 'undefined' ? JSON : require('jsonify');
-
-module.exports = function (obj, opts) {
-    if (!opts) opts = {};
-    if (typeof opts === 'function') opts = { cmp: opts };
-    var space = opts.space || '';
-    if (typeof space === 'number') space = Array(space+1).join(' ');
-    var cycles = (typeof opts.cycles === 'boolean') ? opts.cycles : false;
-    var replacer = opts.replacer || function(key, value) { return value; };
-
-    var cmp = opts.cmp && (function (f) {
-        return function (node) {
-            return function (a, b) {
-                var aobj = { key: a, value: node[a] };
-                var bobj = { key: b, value: node[b] };
-                return f(aobj, bobj);
-            };
-        };
-    })(opts.cmp);
-
-    var seen = [];
-    return (function stringify (parent, key, node, level) {
-        var indent = space ? ('\n' + new Array(level + 1).join(space)) : '';
-        var colonSeparator = space ? ': ' : ':';
-
-        if (node && node.toJSON && typeof node.toJSON === 'function') {
-            node = node.toJSON();
-        }
-
-        node = replacer.call(parent, key, node);
-
-        if (node === undefined) {
-            return;
-        }
-        if (typeof node !== 'object' || node === null) {
-            return json.stringify(node);
-        }
-        if (isArray(node)) {
-            var out = [];
-            for (var i = 0; i < node.length; i++) {
-                var item = stringify(node, i, node[i], level+1) || json.stringify(null);
-                out.push(indent + space + item);
-            }
-            return '[' + out.join(',') + indent + ']';
-        }
-        else {
-            if (seen.indexOf(node) !== -1) {
-                if (cycles) return json.stringify('__cycle__');
-                throw new TypeError('Converting circular structure to JSON');
-            }
-            else seen.push(node);
-
-            var keys = objectKeys(node).sort(cmp && cmp(node));
-            var out = [];
-            for (var i = 0; i < keys.length; i++) {
-                var key = keys[i];
-                var value = stringify(node, key, node[key], level+1);
-
-                if(!value) continue;
-
-                var keyValue = json.stringify(key)
-                    + colonSeparator
-                    + value;
-                ;
-                out.push(indent + space + keyValue);
-            }
-            seen.splice(seen.indexOf(node), 1);
-            return '{' + out.join(',') + indent + '}';
-        }
-    })({ '': obj }, '', obj, 0);
-};
-
-var isArray = Array.isArray || function (x) {
-    return {}.toString.call(x) === '[object Array]';
-};
-
-var objectKeys = Object.keys || function (obj) {
-    var has = Object.prototype.hasOwnProperty || function () { return true };
-    var keys = [];
-    for (var key in obj) {
-        if (has.call(obj, key)) keys.push(key);
-    }
-    return keys;
-};
-
-},{"jsonify":79}],79:[function(require,module,exports){
-exports.parse = require('./lib/parse');
-exports.stringify = require('./lib/stringify');
-
-},{"./lib/parse":80,"./lib/stringify":81}],80:[function(require,module,exports){
-var at, // The index of the current character
-    ch, // The current character
-    escapee = {
-        '"':  '"',
-        '\\': '\\',
-        '/':  '/',
-        b:    '\b',
-        f:    '\f',
-        n:    '\n',
-        r:    '\r',
-        t:    '\t'
-    },
-    text,
-
-    error = function (m) {
-        // Call error when something is wrong.
-        throw {
-            name:    'SyntaxError',
-            message: m,
-            at:      at,
-            text:    text
-        };
-    },
-    
-    next = function (c) {
-        // If a c parameter is provided, verify that it matches the current character.
-        if (c && c !== ch) {
-            error("Expected '" + c + "' instead of '" + ch + "'");
-        }
-        
-        // Get the next character. When there are no more characters,
-        // return the empty string.
-        
-        ch = text.charAt(at);
-        at += 1;
-        return ch;
-    },
-    
-    number = function () {
-        // Parse a number value.
-        var number,
-            string = '';
-        
-        if (ch === '-') {
-            string = '-';
-            next('-');
-        }
-        while (ch >= '0' && ch <= '9') {
-            string += ch;
-            next();
-        }
-        if (ch === '.') {
-            string += '.';
-            while (next() && ch >= '0' && ch <= '9') {
-                string += ch;
-            }
-        }
-        if (ch === 'e' || ch === 'E') {
-            string += ch;
-            next();
-            if (ch === '-' || ch === '+') {
-                string += ch;
-                next();
-            }
-            while (ch >= '0' && ch <= '9') {
-                string += ch;
-                next();
-            }
-        }
-        number = +string;
-        if (!isFinite(number)) {
-            error("Bad number");
-        } else {
-            return number;
-        }
-    },
-    
-    string = function () {
-        // Parse a string value.
-        var hex,
-            i,
-            string = '',
-            uffff;
-        
-        // When parsing for string values, we must look for " and \ characters.
-        if (ch === '"') {
-            while (next()) {
-                if (ch === '"') {
-                    next();
-                    return string;
-                } else if (ch === '\\') {
-                    next();
-                    if (ch === 'u') {
-                        uffff = 0;
-                        for (i = 0; i < 4; i += 1) {
-                            hex = parseInt(next(), 16);
-                            if (!isFinite(hex)) {
-                                break;
-                            }
-                            uffff = uffff * 16 + hex;
-                        }
-                        string += String.fromCharCode(uffff);
-                    } else if (typeof escapee[ch] === 'string') {
-                        string += escapee[ch];
-                    } else {
-                        break;
-                    }
-                } else {
-                    string += ch;
-                }
-            }
-        }
-        error("Bad string");
-    },
-
-    white = function () {
-
-// Skip whitespace.
-
-        while (ch && ch <= ' ') {
-            next();
-        }
-    },
-
-    word = function () {
-
-// true, false, or null.
-
-        switch (ch) {
-        case 't':
-            next('t');
-            next('r');
-            next('u');
-            next('e');
-            return true;
-        case 'f':
-            next('f');
-            next('a');
-            next('l');
-            next('s');
-            next('e');
-            return false;
-        case 'n':
-            next('n');
-            next('u');
-            next('l');
-            next('l');
-            return null;
-        }
-        error("Unexpected '" + ch + "'");
-    },
-
-    value,  // Place holder for the value function.
-
-    array = function () {
-
-// Parse an array value.
-
-        var array = [];
-
-        if (ch === '[') {
-            next('[');
-            white();
-            if (ch === ']') {
-                next(']');
-                return array;   // empty array
-            }
-            while (ch) {
-                array.push(value());
-                white();
-                if (ch === ']') {
-                    next(']');
-                    return array;
-                }
-                next(',');
-                white();
-            }
-        }
-        error("Bad array");
-    },
-
-    object = function () {
-
-// Parse an object value.
-
-        var key,
-            object = {};
-
-        if (ch === '{') {
-            next('{');
-            white();
-            if (ch === '}') {
-                next('}');
-                return object;   // empty object
-            }
-            while (ch) {
-                key = string();
-                white();
-                next(':');
-                if (Object.hasOwnProperty.call(object, key)) {
-                    error('Duplicate key "' + key + '"');
-                }
-                object[key] = value();
-                white();
-                if (ch === '}') {
-                    next('}');
-                    return object;
-                }
-                next(',');
-                white();
-            }
-        }
-        error("Bad object");
-    };
-
-value = function () {
-
-// Parse a JSON value. It could be an object, an array, a string, a number,
-// or a word.
-
-    white();
-    switch (ch) {
-    case '{':
-        return object();
-    case '[':
-        return array();
-    case '"':
-        return string();
-    case '-':
-        return number();
-    default:
-        return ch >= '0' && ch <= '9' ? number() : word();
-    }
-};
-
-// Return the json_parse function. It will have access to all of the above
-// functions and variables.
-
-module.exports = function (source, reviver) {
-    var result;
-    
-    text = source;
-    at = 0;
-    ch = ' ';
-    result = value();
-    white();
-    if (ch) {
-        error("Syntax error");
-    }
-
-    // If there is a reviver function, we recursively walk the new structure,
-    // passing each name/value pair to the reviver function for possible
-    // transformation, starting with a temporary root object that holds the result
-    // in an empty key. If there is not a reviver function, we simply return the
-    // result.
-
-    return typeof reviver === 'function' ? (function walk(holder, key) {
-        var k, v, value = holder[key];
-        if (value && typeof value === 'object') {
-            for (k in value) {
-                if (Object.prototype.hasOwnProperty.call(value, k)) {
-                    v = walk(value, k);
-                    if (v !== undefined) {
-                        value[k] = v;
-                    } else {
-                        delete value[k];
-                    }
-                }
-            }
-        }
-        return reviver.call(holder, key, value);
-    }({'': result}, '')) : result;
-};
-
-},{}],81:[function(require,module,exports){
-var cx = /[\u0000\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/g,
-    escapable = /[\\\"\x00-\x1f\x7f-\x9f\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/g,
-    gap,
-    indent,
-    meta = {    // table of character substitutions
-        '\b': '\\b',
-        '\t': '\\t',
-        '\n': '\\n',
-        '\f': '\\f',
-        '\r': '\\r',
-        '"' : '\\"',
-        '\\': '\\\\'
-    },
-    rep;
-
-function quote(string) {
-    // If the string contains no control characters, no quote characters, and no
-    // backslash characters, then we can safely slap some quotes around it.
-    // Otherwise we must also replace the offending characters with safe escape
-    // sequences.
-    
-    escapable.lastIndex = 0;
-    return escapable.test(string) ? '"' + string.replace(escapable, function (a) {
-        var c = meta[a];
-        return typeof c === 'string' ? c :
-            '\\u' + ('0000' + a.charCodeAt(0).toString(16)).slice(-4);
-    }) + '"' : '"' + string + '"';
-}
-
-function str(key, holder) {
-    // Produce a string from holder[key].
-    var i,          // The loop counter.
-        k,          // The member key.
-        v,          // The member value.
-        length,
-        mind = gap,
-        partial,
-        value = holder[key];
-    
-    // If the value has a toJSON method, call it to obtain a replacement value.
-    if (value && typeof value === 'object' &&
-            typeof value.toJSON === 'function') {
-        value = value.toJSON(key);
-    }
-    
-    // If we were called with a replacer function, then call the replacer to
-    // obtain a replacement value.
-    if (typeof rep === 'function') {
-        value = rep.call(holder, key, value);
-    }
-    
-    // What happens next depends on the value's type.
-    switch (typeof value) {
-        case 'string':
-            return quote(value);
-        
-        case 'number':
-            // JSON numbers must be finite. Encode non-finite numbers as null.
-            return isFinite(value) ? String(value) : 'null';
-        
-        case 'boolean':
-        case 'null':
-            // If the value is a boolean or null, convert it to a string. Note:
-            // typeof null does not produce 'null'. The case is included here in
-            // the remote chance that this gets fixed someday.
-            return String(value);
-            
-        case 'object':
-            if (!value) return 'null';
-            gap += indent;
-            partial = [];
-            
-            // Array.isArray
-            if (Object.prototype.toString.apply(value) === '[object Array]') {
-                length = value.length;
-                for (i = 0; i < length; i += 1) {
-                    partial[i] = str(i, value) || 'null';
-                }
-                
-                // Join all of the elements together, separated with commas, and
-                // wrap them in brackets.
-                v = partial.length === 0 ? '[]' : gap ?
-                    '[\n' + gap + partial.join(',\n' + gap) + '\n' + mind + ']' :
-                    '[' + partial.join(',') + ']';
-                gap = mind;
-                return v;
-            }
-            
-            // If the replacer is an array, use it to select the members to be
-            // stringified.
-            if (rep && typeof rep === 'object') {
-                length = rep.length;
-                for (i = 0; i < length; i += 1) {
-                    k = rep[i];
-                    if (typeof k === 'string') {
-                        v = str(k, value);
-                        if (v) {
-                            partial.push(quote(k) + (gap ? ': ' : ':') + v);
-                        }
-                    }
-                }
-            }
-            else {
-                // Otherwise, iterate through all of the keys in the object.
-                for (k in value) {
-                    if (Object.prototype.hasOwnProperty.call(value, k)) {
-                        v = str(k, value);
-                        if (v) {
-                            partial.push(quote(k) + (gap ? ': ' : ':') + v);
-                        }
-                    }
-                }
-            }
-            
-        // Join all of the member texts together, separated with commas,
-        // and wrap them in braces.
-
-        v = partial.length === 0 ? '{}' : gap ?
-            '{\n' + gap + partial.join(',\n' + gap) + '\n' + mind + '}' :
-            '{' + partial.join(',') + '}';
-        gap = mind;
-        return v;
-    }
-}
-
-module.exports = function (value, replacer, space) {
-    var i;
-    gap = '';
-    indent = '';
-    
-    // If the space parameter is a number, make an indent string containing that
-    // many spaces.
-    if (typeof space === 'number') {
-        for (i = 0; i < space; i += 1) {
-            indent += ' ';
-        }
-    }
-    // If the space parameter is a string, it will be used as the indent string.
-    else if (typeof space === 'string') {
-        indent = space;
-    }
-
-    // If there is a replacer, it must be a function or an array.
-    // Otherwise, throw an error.
-    rep = replacer;
-    if (replacer && typeof replacer !== 'function'
-    && (typeof replacer !== 'object' || typeof replacer.length !== 'number')) {
-        throw new Error('JSON.stringify');
-    }
-    
-    // Make a fake root object containing our value under the key of ''.
-    // Return the result of stringifying the value.
-    return str('', {'': value});
-};
-
-},{}],82:[function(require,module,exports){
-"use strict";
-
-// rawAsap provides everything we need except exception management.
-var rawAsap = require("./raw");
-// RawTasks are recycled to reduce GC churn.
-var freeTasks = [];
-// We queue errors to ensure they are thrown in right order (FIFO).
-// Array-as-queue is good enough here, since we are just dealing with exceptions.
-var pendingErrors = [];
-var requestErrorThrow = rawAsap.makeRequestCallFromTimer(throwFirstError);
-
-function throwFirstError() {
-    if (pendingErrors.length) {
-        throw pendingErrors.shift();
-    }
-}
-
-/**
- * Calls a task as soon as possible after returning, in its own event, with priority
- * over other events like animation, reflow, and repaint. An error thrown from an
- * event will not interrupt, nor even substantially slow down the processing of
- * other events, but will be rather postponed to a lower priority event.
- * @param {{call}} task A callable object, typically a function that takes no
- * arguments.
- */
-module.exports = asap;
-function asap(task) {
-    var rawTask;
-    if (freeTasks.length) {
-        rawTask = freeTasks.pop();
-    } else {
-        rawTask = new RawTask();
-    }
-    rawTask.task = task;
-    rawAsap(rawTask);
-}
-
-// We wrap tasks with recyclable task objects.  A task object implements
-// `call`, just like a function.
-function RawTask() {
-    this.task = null;
-}
-
-// The sole purpose of wrapping the task is to catch the exception and recycle
-// the task object after its single use.
-RawTask.prototype.call = function () {
-    try {
-        this.task.call();
-    } catch (error) {
-        if (asap.onerror) {
-            // This hook exists purely for testing purposes.
-            // Its name will be periodically randomized to break any code that
-            // depends on its existence.
-            asap.onerror(error);
-        } else {
-            // In a web browser, exceptions are not fatal. However, to avoid
-            // slowing down the queue of pending tasks, we rethrow the error in a
-            // lower priority turn.
-            pendingErrors.push(error);
-            requestErrorThrow();
-        }
-    } finally {
-        this.task = null;
-        freeTasks[freeTasks.length] = this;
-    }
-};
-
-},{"./raw":83}],83:[function(require,module,exports){
-(function (global){
-"use strict";
-
-// Use the fastest means possible to execute a task in its own turn, with
-// priority over other events including IO, animation, reflow, and redraw
-// events in browsers.
-//
-// An exception thrown by a task will permanently interrupt the processing of
-// subsequent tasks. The higher level `asap` function ensures that if an
-// exception is thrown by a task, that the task queue will continue flushing as
-// soon as possible, but if you use `rawAsap` directly, you are responsible to
-// either ensure that no exceptions are thrown from your task, or to manually
-// call `rawAsap.requestFlush` if an exception is thrown.
-module.exports = rawAsap;
-function rawAsap(task) {
-    if (!queue.length) {
-        requestFlush();
-        flushing = true;
-    }
-    // Equivalent to push, but avoids a function call.
-    queue[queue.length] = task;
-}
-
-var queue = [];
-// Once a flush has been requested, no further calls to `requestFlush` are
-// necessary until the next `flush` completes.
-var flushing = false;
-// `requestFlush` is an implementation-specific method that attempts to kick
-// off a `flush` event as quickly as possible. `flush` will attempt to exhaust
-// the event queue before yielding to the browser's own event loop.
-var requestFlush;
-// The position of the next task to execute in the task queue. This is
-// preserved between calls to `flush` so that it can be resumed if
-// a task throws an exception.
-var index = 0;
-// If a task schedules additional tasks recursively, the task queue can grow
-// unbounded. To prevent memory exhaustion, the task queue will periodically
-// truncate already-completed tasks.
-var capacity = 1024;
-
-// The flush function processes all tasks that have been scheduled with
-// `rawAsap` unless and until one of those tasks throws an exception.
-// If a task throws an exception, `flush` ensures that its state will remain
-// consistent and will resume where it left off when called again.
-// However, `flush` does not make any arrangements to be called again if an
-// exception is thrown.
-function flush() {
-    while (index < queue.length) {
-        var currentIndex = index;
-        // Advance the index before calling the task. This ensures that we will
-        // begin flushing on the next task the task throws an error.
-        index = index + 1;
-        queue[currentIndex].call();
-        // Prevent leaking memory for long chains of recursive calls to `asap`.
-        // If we call `asap` within tasks scheduled by `asap`, the queue will
-        // grow, but to avoid an O(n) walk for every task we execute, we don't
-        // shift tasks off the queue after they have been executed.
-        // Instead, we periodically shift 1024 tasks off the queue.
-        if (index > capacity) {
-            // Manually shift all values starting at the index back to the
-            // beginning of the queue.
-            for (var scan = 0, newLength = queue.length - index; scan < newLength; scan++) {
-                queue[scan] = queue[scan + index];
-            }
-            queue.length -= index;
-            index = 0;
-        }
-    }
-    queue.length = 0;
-    index = 0;
-    flushing = false;
-}
-
-// `requestFlush` is implemented using a strategy based on data collected from
-// every available SauceLabs Selenium web driver worker at time of writing.
-// https://docs.google.com/spreadsheets/d/1mG-5UYGup5qxGdEMWkhP6BWCz053NUb2E1QoUTU16uA/edit#gid=783724593
-
-// Safari 6 and 6.1 for desktop, iPad, and iPhone are the only browsers that
-// have WebKitMutationObserver but not un-prefixed MutationObserver.
-// Must use `global` or `self` instead of `window` to work in both frames and web
-// workers. `global` is a provision of Browserify, Mr, Mrs, or Mop.
-
-/* globals self */
-var scope = typeof global !== "undefined" ? global : self;
-var BrowserMutationObserver = scope.MutationObserver || scope.WebKitMutationObserver;
-
-// MutationObservers are desirable because they have high priority and work
-// reliably everywhere they are implemented.
-// They are implemented in all modern browsers.
-//
-// - Android 4-4.3
-// - Chrome 26-34
-// - Firefox 14-29
-// - Internet Explorer 11
-// - iPad Safari 6-7.1
-// - iPhone Safari 7-7.1
-// - Safari 6-7
-if (typeof BrowserMutationObserver === "function") {
-    requestFlush = makeRequestCallFromMutationObserver(flush);
-
-// MessageChannels are desirable because they give direct access to the HTML
-// task queue, are implemented in Internet Explorer 10, Safari 5.0-1, and Opera
-// 11-12, and in web workers in many engines.
-// Although message channels yield to any queued rendering and IO tasks, they
-// would be better than imposing the 4ms delay of timers.
-// However, they do not work reliably in Internet Explorer or Safari.
-
-// Internet Explorer 10 is the only browser that has setImmediate but does
-// not have MutationObservers.
-// Although setImmediate yields to the browser's renderer, it would be
-// preferrable to falling back to setTimeout since it does not have
-// the minimum 4ms penalty.
-// Unfortunately there appears to be a bug in Internet Explorer 10 Mobile (and
-// Desktop to a lesser extent) that renders both setImmediate and
-// MessageChannel useless for the purposes of ASAP.
-// https://github.com/kriskowal/q/issues/396
-
-// Timers are implemented universally.
-// We fall back to timers in workers in most engines, and in foreground
-// contexts in the following browsers.
-// However, note that even this simple case requires nuances to operate in a
-// broad spectrum of browsers.
-//
-// - Firefox 3-13
-// - Internet Explorer 6-9
-// - iPad Safari 4.3
-// - Lynx 2.8.7
-} else {
-    requestFlush = makeRequestCallFromTimer(flush);
-}
-
-// `requestFlush` requests that the high priority event queue be flushed as
-// soon as possible.
-// This is useful to prevent an error thrown in a task from stalling the event
-// queue if the exception handled by Node.js’s
-// `process.on("uncaughtException")` or by a domain.
-rawAsap.requestFlush = requestFlush;
-
-// To request a high priority event, we induce a mutation observer by toggling
-// the text of a text node between "1" and "-1".
-function makeRequestCallFromMutationObserver(callback) {
-    var toggle = 1;
-    var observer = new BrowserMutationObserver(callback);
-    var node = document.createTextNode("");
-    observer.observe(node, {characterData: true});
-    return function requestCall() {
-        toggle = -toggle;
-        node.data = toggle;
-    };
-}
-
-// The message channel technique was discovered by Malte Ubl and was the
-// original foundation for this library.
-// http://www.nonblocking.io/2011/06/windownexttick.html
-
-// Safari 6.0.5 (at least) intermittently fails to create message ports on a
-// page's first load. Thankfully, this version of Safari supports
-// MutationObservers, so we don't need to fall back in that case.
-
-// function makeRequestCallFromMessageChannel(callback) {
-//     var channel = new MessageChannel();
-//     channel.port1.onmessage = callback;
-//     return function requestCall() {
-//         channel.port2.postMessage(0);
-//     };
-// }
-
-// For reasons explained above, we are also unable to use `setImmediate`
-// under any circumstances.
-// Even if we were, there is another bug in Internet Explorer 10.
-// It is not sufficient to assign `setImmediate` to `requestFlush` because
-// `setImmediate` must be called *by name* and therefore must be wrapped in a
-// closure.
-// Never forget.
-
-// function makeRequestCallFromSetImmediate(callback) {
-//     return function requestCall() {
-//         setImmediate(callback);
-//     };
-// }
-
-// Safari 6.0 has a problem where timers will get lost while the user is
-// scrolling. This problem does not impact ASAP because Safari 6.0 supports
-// mutation observers, so that implementation is used instead.
-// However, if we ever elect to use timers in Safari, the prevalent work-around
-// is to add a scroll event listener that calls for a flush.
-
-// `setTimeout` does not call the passed callback if the delay is less than
-// approximately 7 in web workers in Firefox 8 through 18, and sometimes not
-// even then.
-
-function makeRequestCallFromTimer(callback) {
-    return function requestCall() {
-        // We dispatch a timeout with a specified delay of 0 for engines that
-        // can reliably accommodate that request. This will usually be snapped
-        // to a 4 milisecond delay, but once we're flushing, there's no delay
-        // between events.
-        var timeoutHandle = setTimeout(handleTimer, 0);
-        // However, since this timer gets frequently dropped in Firefox
-        // workers, we enlist an interval handle that will try to fire
-        // an event 20 times per second until it succeeds.
-        var intervalHandle = setInterval(handleTimer, 50);
-
-        function handleTimer() {
-            // Whichever timer succeeds will cancel both timers and
-            // execute the callback.
-            clearTimeout(timeoutHandle);
-            clearInterval(intervalHandle);
-            callback();
-        }
-    };
-}
-
-// This is for `asap.js` only.
-// Its name will be periodically randomized to break any code that depends on
-// its existence.
-rawAsap.makeRequestCallFromTimer = makeRequestCallFromTimer;
-
-// ASAP was originally a nextTick shim included in Q. This was factored out
-// into this ASAP package. It was later adapted to RSVP which made further
-// amendments. These decisions, particularly to marginalize MessageChannel and
-// to capture the MutationObserver implementation in a closure, were integrated
-// back into ASAP proper.
-// https://github.com/tildeio/rsvp.js/blob/cddf7232546a9cf858524b75cde6f9edf72620a7/lib/rsvp/asap.js
-
-}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],84:[function(require,module,exports){
+},{}],37:[function(require,module,exports){
 // (public) Constructor
 function BigInteger(a, b, c) {
   if (!(this instanceof BigInteger))
@@ -11891,7 +5181,7 @@ BigInteger.valueOf = nbv
 
 module.exports = BigInteger
 
-},{"../package.json":87}],85:[function(require,module,exports){
+},{"../package.json":40}],38:[function(require,module,exports){
 (function (Buffer){
 // FIXME: Kind of a weird way to throw exceptions, consider removing
 var assert = require('assert')
@@ -11986,19 +5276,19 @@ BigInteger.prototype.toHex = function(size) {
 }
 
 }).call(this,require("buffer").Buffer)
-},{"./bigi":84,"assert":156,"buffer":188}],86:[function(require,module,exports){
+},{"./bigi":37,"assert":102,"buffer":134}],39:[function(require,module,exports){
 var BigInteger = require('./bigi')
 
 //addons
 require('./convert')
 
 module.exports = BigInteger
-},{"./bigi":84,"./convert":85}],87:[function(require,module,exports){
+},{"./bigi":37,"./convert":38}],40:[function(require,module,exports){
 module.exports={
   "_args": [
     [
       "bigi@1.4.2",
-      "/Users/larry/git/blockstack.js"
+      "/home/aaron/devel/blockstack.js"
     ]
   ],
   "_from": "bigi@1.4.2",
@@ -12024,7 +5314,7 @@ module.exports={
   ],
   "_resolved": "https://registry.npmjs.org/bigi/-/bigi-1.4.2.tgz",
   "_spec": "1.4.2",
-  "_where": "/Users/larry/git/blockstack.js",
+  "_where": "/home/aaron/devel/blockstack.js",
   "bugs": {
     "url": "https://github.com/cryptocoinjs/bigi/issues"
   },
@@ -12084,7 +5374,7 @@ module.exports={
   "version": "1.4.2"
 }
 
-},{}],88:[function(require,module,exports){
+},{}],41:[function(require,module,exports){
 // base-x encoding
 // Forked from https://github.com/cryptocoinjs/bs58
 // Originally written by Mike Hearn for BitcoinJ
@@ -12172,7 +5462,7 @@ module.exports = function base (ALPHABET) {
   }
 }
 
-},{}],89:[function(require,module,exports){
+},{}],42:[function(require,module,exports){
 // Reference https://github.com/bitcoin/bips/blob/master/bip-0066.mediawiki
 // Format: 0x30 [total-length] 0x02 [R-length] [R] 0x02 [S-length] [S]
 // NOTE: SIGHASH byte ignored AND restricted, truncate before use
@@ -12287,13 +5577,13 @@ module.exports = {
   encode: encode
 }
 
-},{"safe-buffer":481}],90:[function(require,module,exports){
+},{"safe-buffer":403}],43:[function(require,module,exports){
 var basex = require('base-x')
 var ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
 
 module.exports = basex(ALPHABET)
 
-},{"base-x":88}],91:[function(require,module,exports){
+},{"base-x":41}],44:[function(require,module,exports){
 (function (Buffer){
 'use strict'
 
@@ -12356,7 +5646,7 @@ module.exports = {
 }
 
 }).call(this,require("buffer").Buffer)
-},{"bs58":90,"buffer":188,"create-hash":96}],92:[function(require,module,exports){
+},{"bs58":43,"buffer":134,"create-hash":49}],45:[function(require,module,exports){
 module.exports = function(a, b) {
   if (typeof a.compare === 'function') return a.compare(b)
   if (a === b) return 0
@@ -12383,7 +5673,7 @@ module.exports = function(a, b) {
 }
 
 
-},{}],93:[function(require,module,exports){
+},{}],46:[function(require,module,exports){
 (function (Buffer){
 'use strict';
 module.exports = function (a, b) {
@@ -12413,7 +5703,7 @@ module.exports = function (a, b) {
 };
 
 }).call(this,{"isBuffer":require("../../../browserify/node_modules/is-buffer/index.js")})
-},{"../../../browserify/node_modules/is-buffer/index.js":214}],94:[function(require,module,exports){
+},{"../../../browserify/node_modules/is-buffer/index.js":159}],47:[function(require,module,exports){
 (function (Buffer){
 module.exports = function reverse (src) {
   var buffer = new Buffer(src.length)
@@ -12427,7 +5717,7 @@ module.exports = function reverse (src) {
 }
 
 }).call(this,require("buffer").Buffer)
-},{"buffer":188}],95:[function(require,module,exports){
+},{"buffer":134}],48:[function(require,module,exports){
 var Buffer = require('safe-buffer').Buffer
 var Transform = require('stream').Transform
 var StringDecoder = require('string_decoder').StringDecoder
@@ -12528,7 +5818,7 @@ CipherBase.prototype._toString = function (value, enc, fin) {
 
 module.exports = CipherBase
 
-},{"inherits":101,"safe-buffer":481,"stream":264,"string_decoder":269}],96:[function(require,module,exports){
+},{"inherits":54,"safe-buffer":403,"stream":205,"string_decoder":206}],49:[function(require,module,exports){
 (function (Buffer){
 'use strict'
 var inherits = require('inherits')
@@ -12584,7 +5874,7 @@ module.exports = function createHash (alg) {
 }
 
 }).call(this,require("buffer").Buffer)
-},{"./md5":98,"buffer":188,"cipher-base":95,"inherits":101,"ripemd160":103,"sha.js":105}],97:[function(require,module,exports){
+},{"./md5":51,"buffer":134,"cipher-base":48,"inherits":54,"ripemd160":56,"sha.js":58}],50:[function(require,module,exports){
 (function (Buffer){
 'use strict'
 var intSize = 4
@@ -12618,7 +5908,7 @@ module.exports = function hash (buf, fn) {
 }
 
 }).call(this,require("buffer").Buffer)
-},{"buffer":188}],98:[function(require,module,exports){
+},{"buffer":134}],51:[function(require,module,exports){
 'use strict'
 /*
  * A JavaScript implementation of the RSA Data Security, Inc. MD5 Message
@@ -12771,7 +6061,7 @@ module.exports = function md5 (buf) {
   return makeHash(buf, core_md5)
 }
 
-},{"./make-hash":97}],99:[function(require,module,exports){
+},{"./make-hash":50}],52:[function(require,module,exports){
 'use strict'
 var inherits = require('inherits')
 var Legacy = require('./legacy')
@@ -12835,7 +6125,7 @@ module.exports = function createHmac (alg, key) {
   return new Hmac(alg, key)
 }
 
-},{"./legacy":100,"cipher-base":95,"create-hash/md5":98,"inherits":101,"ripemd160":103,"safe-buffer":481,"sha.js":105}],100:[function(require,module,exports){
+},{"./legacy":53,"cipher-base":48,"create-hash/md5":51,"inherits":54,"ripemd160":56,"safe-buffer":403,"sha.js":58}],53:[function(require,module,exports){
 'use strict'
 var inherits = require('inherits')
 var Buffer = require('safe-buffer').Buffer
@@ -12883,7 +6173,7 @@ Hmac.prototype._final = function () {
 }
 module.exports = Hmac
 
-},{"cipher-base":95,"inherits":101,"safe-buffer":481}],101:[function(require,module,exports){
+},{"cipher-base":48,"inherits":54,"safe-buffer":403}],54:[function(require,module,exports){
 if (typeof Object.create === 'function') {
   // implementation from standard node.js 'util' module
   module.exports = function inherits(ctor, superCtor) {
@@ -12908,7 +6198,7 @@ if (typeof Object.create === 'function') {
   }
 }
 
-},{}],102:[function(require,module,exports){
+},{}],55:[function(require,module,exports){
 (function (process,global){
 'use strict'
 
@@ -12950,7 +6240,7 @@ function randomBytes (size, cb) {
 }
 
 }).call(this,require('_process'),typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"_process":229,"safe-buffer":481}],103:[function(require,module,exports){
+},{"_process":174,"safe-buffer":403}],56:[function(require,module,exports){
 (function (Buffer){
 'use strict'
 var inherits = require('inherits')
@@ -13245,7 +6535,7 @@ function fn5 (a, b, c, d, e, m, k, s) {
 module.exports = RIPEMD160
 
 }).call(this,require("buffer").Buffer)
-},{"buffer":188,"hash-base":359,"inherits":101}],104:[function(require,module,exports){
+},{"buffer":134,"hash-base":292,"inherits":54}],57:[function(require,module,exports){
 var Buffer = require('safe-buffer').Buffer
 
 // prototype class for hash functions
@@ -13328,7 +6618,7 @@ Hash.prototype._update = function () {
 
 module.exports = Hash
 
-},{"safe-buffer":481}],105:[function(require,module,exports){
+},{"safe-buffer":403}],58:[function(require,module,exports){
 var exports = module.exports = function SHA (algorithm) {
   algorithm = algorithm.toLowerCase()
 
@@ -13345,7 +6635,7 @@ exports.sha256 = require('./sha256')
 exports.sha384 = require('./sha384')
 exports.sha512 = require('./sha512')
 
-},{"./sha":106,"./sha1":107,"./sha224":108,"./sha256":109,"./sha384":110,"./sha512":111}],106:[function(require,module,exports){
+},{"./sha":59,"./sha1":60,"./sha224":61,"./sha256":62,"./sha384":63,"./sha512":64}],59:[function(require,module,exports){
 /*
  * A JavaScript implementation of the Secure Hash Algorithm, SHA-0, as defined
  * in FIPS PUB 180-1
@@ -13441,7 +6731,7 @@ Sha.prototype._hash = function () {
 
 module.exports = Sha
 
-},{"./hash":104,"inherits":101,"safe-buffer":481}],107:[function(require,module,exports){
+},{"./hash":57,"inherits":54,"safe-buffer":403}],60:[function(require,module,exports){
 /*
  * A JavaScript implementation of the Secure Hash Algorithm, SHA-1, as defined
  * in FIPS PUB 180-1
@@ -13542,7 +6832,7 @@ Sha1.prototype._hash = function () {
 
 module.exports = Sha1
 
-},{"./hash":104,"inherits":101,"safe-buffer":481}],108:[function(require,module,exports){
+},{"./hash":57,"inherits":54,"safe-buffer":403}],61:[function(require,module,exports){
 /**
  * A JavaScript implementation of the Secure Hash Algorithm, SHA-256, as defined
  * in FIPS 180-2
@@ -13597,7 +6887,7 @@ Sha224.prototype._hash = function () {
 
 module.exports = Sha224
 
-},{"./hash":104,"./sha256":109,"inherits":101,"safe-buffer":481}],109:[function(require,module,exports){
+},{"./hash":57,"./sha256":62,"inherits":54,"safe-buffer":403}],62:[function(require,module,exports){
 /**
  * A JavaScript implementation of the Secure Hash Algorithm, SHA-256, as defined
  * in FIPS 180-2
@@ -13734,7 +7024,7 @@ Sha256.prototype._hash = function () {
 
 module.exports = Sha256
 
-},{"./hash":104,"inherits":101,"safe-buffer":481}],110:[function(require,module,exports){
+},{"./hash":57,"inherits":54,"safe-buffer":403}],63:[function(require,module,exports){
 var inherits = require('inherits')
 var SHA512 = require('./sha512')
 var Hash = require('./hash')
@@ -13793,7 +7083,7 @@ Sha384.prototype._hash = function () {
 
 module.exports = Sha384
 
-},{"./hash":104,"./sha512":111,"inherits":101,"safe-buffer":481}],111:[function(require,module,exports){
+},{"./hash":57,"./sha512":64,"inherits":54,"safe-buffer":403}],64:[function(require,module,exports){
 var inherits = require('inherits')
 var Hash = require('./hash')
 var Buffer = require('safe-buffer').Buffer
@@ -14055,7 +7345,7 @@ Sha512.prototype._hash = function () {
 
 module.exports = Sha512
 
-},{"./hash":104,"inherits":101,"safe-buffer":481}],112:[function(require,module,exports){
+},{"./hash":57,"inherits":54,"safe-buffer":403}],65:[function(require,module,exports){
 var native = require('./native')
 
 function getTypeName (fn) {
@@ -14161,7 +7451,7 @@ module.exports = {
   getValueTypeName: getValueTypeName
 }
 
-},{"./native":115}],113:[function(require,module,exports){
+},{"./native":68}],66:[function(require,module,exports){
 (function (Buffer){
 var NATIVE = require('./native')
 var ERRORS = require('./errors')
@@ -14235,7 +7525,7 @@ for (var typeName in types) {
 module.exports = types
 
 }).call(this,{"isBuffer":require("../../../browserify/node_modules/is-buffer/index.js")})
-},{"../../../browserify/node_modules/is-buffer/index.js":214,"./errors":112,"./native":115}],114:[function(require,module,exports){
+},{"../../../browserify/node_modules/is-buffer/index.js":159,"./errors":65,"./native":68}],67:[function(require,module,exports){
 var ERRORS = require('./errors')
 var NATIVE = require('./native')
 
@@ -14470,7 +7760,7 @@ typeforce.TfPropertyTypeError = TfPropertyTypeError
 
 module.exports = typeforce
 
-},{"./errors":112,"./extra":113,"./native":115}],115:[function(require,module,exports){
+},{"./errors":65,"./extra":66,"./native":68}],68:[function(require,module,exports){
 var types = {
   Array: function (value) { return value !== null && value !== undefined && value.constructor === Array },
   Boolean: function (value) { return typeof value === 'boolean' },
@@ -14493,7 +7783,7 @@ for (var typeName in types) {
 
 module.exports = types
 
-},{}],116:[function(require,module,exports){
+},{}],69:[function(require,module,exports){
 (function (Buffer){
 var bs58check = require('bs58check')
 
@@ -14560,7 +7850,7 @@ module.exports = {
 }
 
 }).call(this,require("buffer").Buffer)
-},{"bs58check":91,"buffer":188}],117:[function(require,module,exports){
+},{"bs58check":44,"buffer":134}],70:[function(require,module,exports){
 (function (Buffer){
 var bs58check = require('bs58check')
 var bscript = require('./script')
@@ -14616,7 +7906,7 @@ module.exports = {
 }
 
 }).call(this,require("buffer").Buffer)
-},{"./networks":127,"./script":129,"./types":133,"bs58check":91,"buffer":188,"typeforce":114}],118:[function(require,module,exports){
+},{"./networks":80,"./script":82,"./types":86,"bs58check":44,"buffer":134,"typeforce":67}],71:[function(require,module,exports){
 (function (Buffer){
 var createHash = require('create-hash')
 var bufferutils = require('./bufferutils')
@@ -14793,7 +8083,7 @@ Block.prototype.checkProofOfWork = function () {
 module.exports = Block
 
 }).call(this,require("buffer").Buffer)
-},{"./bufferutils":119,"./crypto":120,"./transaction":131,"buffer":188,"buffer-compare":92,"buffer-reverse":94,"create-hash":96}],119:[function(require,module,exports){
+},{"./bufferutils":72,"./crypto":73,"./transaction":84,"buffer":134,"buffer-compare":45,"buffer-reverse":47,"create-hash":49}],72:[function(require,module,exports){
 (function (Buffer){
 var opcodes = require('./opcodes.json')
 
@@ -14979,7 +8269,7 @@ module.exports = {
 }
 
 }).call(this,require("buffer").Buffer)
-},{"./opcodes.json":128,"buffer":188,"buffer-equals":93,"buffer-reverse":94}],120:[function(require,module,exports){
+},{"./opcodes.json":81,"buffer":134,"buffer-equals":46,"buffer-reverse":47}],73:[function(require,module,exports){
 var createHash = require('create-hash')
 
 function hash160 (buffer) {
@@ -15010,7 +8300,7 @@ module.exports = {
   sha256: sha256
 }
 
-},{"create-hash":96}],121:[function(require,module,exports){
+},{"create-hash":49}],74:[function(require,module,exports){
 (function (Buffer){
 var createHmac = require('create-hmac')
 var typeforce = require('typeforce')
@@ -15263,7 +8553,7 @@ module.exports = {
 }
 
 }).call(this,require("buffer").Buffer)
-},{"./ecsignature":123,"./types":133,"bigi":86,"buffer":188,"create-hmac":99,"ecurve":314,"typeforce":114}],122:[function(require,module,exports){
+},{"./ecsignature":76,"./types":86,"bigi":39,"buffer":134,"create-hmac":52,"ecurve":247,"typeforce":67}],75:[function(require,module,exports){
 var baddress = require('./address')
 var bcrypto = require('./crypto')
 var ecdsa = require('./ecdsa')
@@ -15396,7 +8686,7 @@ ECPair.prototype.verify = function (hash, signature) {
 
 module.exports = ECPair
 
-},{"./address":117,"./crypto":120,"./ecdsa":121,"./networks":127,"./types":133,"bigi":86,"ecurve":314,"randombytes":102,"typeforce":114,"wif":116}],123:[function(require,module,exports){
+},{"./address":70,"./crypto":73,"./ecdsa":74,"./networks":80,"./types":86,"bigi":39,"ecurve":247,"randombytes":55,"typeforce":67,"wif":69}],76:[function(require,module,exports){
 (function (Buffer){
 var bip66 = require('bip66')
 var typeforce = require('typeforce')
@@ -15487,7 +8777,7 @@ ECSignature.prototype.toScriptSignature = function (hashType) {
 module.exports = ECSignature
 
 }).call(this,require("buffer").Buffer)
-},{"./types":133,"bigi":86,"bip66":89,"buffer":188,"typeforce":114}],124:[function(require,module,exports){
+},{"./types":86,"bigi":39,"bip66":42,"buffer":134,"typeforce":67}],77:[function(require,module,exports){
 (function (Buffer){
 var base58check = require('bs58check')
 var bcrypto = require('./crypto')
@@ -15813,7 +9103,7 @@ HDNode.prototype.toString = HDNode.prototype.toBase58
 module.exports = HDNode
 
 }).call(this,require("buffer").Buffer)
-},{"./crypto":120,"./ecpair":122,"./networks":127,"./types":133,"bigi":86,"bs58check":91,"buffer":188,"create-hmac":99,"ecurve":314,"typeforce":114}],125:[function(require,module,exports){
+},{"./crypto":73,"./ecpair":75,"./networks":80,"./types":86,"bigi":39,"bs58check":44,"buffer":134,"create-hmac":52,"ecurve":247,"typeforce":67}],78:[function(require,module,exports){
 module.exports = {
   Block: require('./block'),
   ECPair: require('./ecpair'),
@@ -15831,7 +9121,7 @@ module.exports = {
   script: require('./script')
 }
 
-},{"./address":117,"./block":118,"./bufferutils":119,"./crypto":120,"./ecpair":122,"./ecsignature":123,"./hdnode":124,"./message":126,"./networks":127,"./opcodes.json":128,"./script":129,"./transaction":131,"./transaction_builder":132}],126:[function(require,module,exports){
+},{"./address":70,"./block":71,"./bufferutils":72,"./crypto":73,"./ecpair":75,"./ecsignature":76,"./hdnode":77,"./message":79,"./networks":80,"./opcodes.json":81,"./script":82,"./transaction":84,"./transaction_builder":85}],79:[function(require,module,exports){
 (function (Buffer){
 var bufferutils = require('./bufferutils')
 var bcrypto = require('./crypto')
@@ -15889,7 +9179,7 @@ module.exports = {
 }
 
 }).call(this,require("buffer").Buffer)
-},{"./bufferutils":119,"./crypto":120,"./ecdsa":121,"./ecpair":122,"./ecsignature":123,"./networks":127,"bigi":86,"buffer":188}],127:[function(require,module,exports){
+},{"./bufferutils":72,"./crypto":73,"./ecdsa":74,"./ecpair":75,"./ecsignature":76,"./networks":80,"bigi":39,"buffer":134}],80:[function(require,module,exports){
 // https://en.bitcoin.it/wiki/List_of_address_prefixes
 // Dogecoin BIP32 is a proposed standard: https://bitcointalk.org/index.php?topic=409731
 
@@ -15940,7 +9230,7 @@ module.exports = {
   }
 }
 
-},{}],128:[function(require,module,exports){
+},{}],81:[function(require,module,exports){
 module.exports={
   "OP_FALSE": 0,
   "OP_0": 0,
@@ -16072,7 +9362,7 @@ module.exports={
   "OP_INVALIDOPCODE": 255
 }
 
-},{}],129:[function(require,module,exports){
+},{}],82:[function(require,module,exports){
 (function (Buffer){
 var bip66 = require('bip66')
 var bufferutils = require('./bufferutils')
@@ -16522,7 +9812,7 @@ module.exports = {
 }
 
 }).call(this,require("buffer").Buffer)
-},{"./bufferutils":119,"./opcodes.json":128,"./script_number":130,"./types":133,"bip66":89,"buffer":188,"typeforce":114}],130:[function(require,module,exports){
+},{"./bufferutils":72,"./opcodes.json":81,"./script_number":83,"./types":86,"bip66":42,"buffer":134,"typeforce":67}],83:[function(require,module,exports){
 (function (Buffer){
 function decode (buffer, maxLength, minimal) {
   maxLength = maxLength || 4
@@ -16592,7 +9882,7 @@ module.exports = {
 }
 
 }).call(this,require("buffer").Buffer)
-},{"buffer":188}],131:[function(require,module,exports){
+},{"buffer":134}],84:[function(require,module,exports){
 (function (Buffer){
 var bcrypto = require('./crypto')
 var bscript = require('./script')
@@ -16919,7 +10209,7 @@ Transaction.prototype.setInputScript = function (index, scriptSig) {
 module.exports = Transaction
 
 }).call(this,require("buffer").Buffer)
-},{"./bufferutils":119,"./crypto":120,"./opcodes.json":128,"./script":129,"./types":133,"buffer":188,"buffer-reverse":94,"typeforce":114}],132:[function(require,module,exports){
+},{"./bufferutils":72,"./crypto":73,"./opcodes.json":81,"./script":82,"./types":86,"buffer":134,"buffer-reverse":47,"typeforce":67}],85:[function(require,module,exports){
 (function (Buffer){
 var baddress = require('./address')
 var bcrypto = require('./crypto')
@@ -17424,7 +10714,7 @@ TransactionBuilder.prototype.sign = function (index, keyPair, redeemScript, hash
 module.exports = TransactionBuilder
 
 }).call(this,require("buffer").Buffer)
-},{"./address":117,"./crypto":120,"./ecpair":122,"./ecsignature":123,"./networks":127,"./opcodes.json":128,"./script":129,"./transaction":131,"./types":133,"buffer":188,"buffer-equals":93,"buffer-reverse":94,"typeforce":114}],133:[function(require,module,exports){
+},{"./address":70,"./crypto":73,"./ecpair":75,"./ecsignature":76,"./networks":80,"./opcodes.json":81,"./script":82,"./transaction":84,"./types":86,"buffer":134,"buffer-equals":46,"buffer-reverse":47,"typeforce":67}],86:[function(require,module,exports){
 var typeforce = require('typeforce')
 
 function nBuffer (value, n) {
@@ -17499,2900 +10789,7 @@ for (var typeName in typeforce) {
 
 module.exports = types
 
-},{"typeforce":114}],134:[function(require,module,exports){
-(function (Buffer){
-'use strict';
-
-Object.defineProperty(exports, "__esModule", {
-   value: true
-});
-exports.datastoreGetId = datastoreGetId;
-exports.sanitizePath = sanitizePath;
-exports.dirname = dirname;
-exports.basename = basename;
-exports.datastoreCreateRequest = datastoreCreateRequest;
-exports.datastoreCreate = datastoreCreate;
-exports.datastoreDeleteRequest = datastoreDeleteRequest;
-exports.datastoreDelete = datastoreDelete;
-exports.datastoreMount = datastoreMount;
-exports.datastoreMountOrCreate = datastoreMountOrCreate;
-exports.lookup = lookup;
-exports.listdir = listdir;
-exports.stat = stat;
-exports.getFile = getFile;
-exports.putFile = putFile;
-exports.mkdir = mkdir;
-exports.deleteFile = deleteFile;
-exports.rmdir = rmdir;
-
-var _schemas = require('./schemas');
-
-var _inode = require('./inode');
-
-var _util = require('./util');
-
-var http = require('http');
-var uuid4 = require('uuid/v4');
-var bitcoinjs = require('bitcoinjs-lib');
-var BigInteger = require('bigi');
-var Promise = require('promise');
-var assert = require('assert');
-var Ajv = require('ajv');
-var jsontokens = require('jsontokens');
-
-var EPERM = 1;
-var ENOENT = 2;
-var EACCES = 13;
-var EEXIST = 17;
-var ENOTDIR = 20;
-var EINVAL = 22;
-var EREMOTEIO = 121;
-
-var LOCAL_STORAGE_ID = "blockstack";
-var SUPPORTED_STORAGE_CLASSES = ["read_public", "write_public", "read_private", "write_private", "read_local", "write_local"];
-var REPLICATION_STRATEGY_CLASSES = {
-   'local': new Set(['read_local', 'write_local']),
-   'publish': new Set(['read_public', 'write_private']),
-   'public': new Set(['read_public', 'write_public']),
-   'private': new Set(['read_private', 'write_private'])
-};
-
-/*
- * Helper method to validate a JSON response
- * against a schema.  Returns the validated object
- * on success, and throw an exception on error.
- */
-function validateJSONResponse(resp, result_schema) {
-
-   var ajv = new Ajv();
-   if (result_schema) {
-      try {
-         var valid = ajv.validate(result_schema, resp);
-         assert(valid);
-         return resp;
-      } catch (e) {
-         try {
-            // error message
-            var _valid = ajv.validate(_schemas.CORE_ERROR_SCHEMA, resp);
-            assert(_valid);
-            return resp;
-         } catch (e2) {
-            console.log("Failed to validate with desired schema");
-            console.log(e.stack);
-            console.log("Failed to validate with error schema");
-            console.log(e2.stack);
-            console.log("Desired schema:");
-            console.log(result_schema);
-            console.log("Parsed message:");
-            console.log(resp);
-            throw new Error("Invalid core message");
-         }
-      }
-   } else {
-      return resp;
-   }
-}
-
-/*
- * Helper method to issue an HTTP request.
- * @param options (Object) set of HTTP request options
- * @param result_schema (Object) JSON schema of the expected result
- *
- * Returns a structured JSON response on success, conformant to the result_schema.
- * Returns plaintext on success if the content-type is application/octet-stream
- * Returns a structured {'error': ...} object on client-side error
- * Throws on server-side error
- */
-function httpRequest(options, result_schema, body) {
-
-   if (body) {
-      options['body'] = body;
-   }
-
-   var url = 'http://' + options.host + ':' + options.port + options.path;
-   return fetch(url, options).then(function (response) {
-
-      if (response.status >= 500) {
-         throw new Error(response.statusText);
-      }
-
-      if (response.status === 404) {
-         return { 'error': 'No such file or directory', 'errno': ENOENT };
-      }
-
-      if (response.status === 403) {
-         return { 'error': 'Access denied', 'errno': EACCES };
-      }
-
-      if (response.status === 401) {
-         return { 'error': 'Invalid request', 'errno': EINVAL };
-      }
-
-      if (response.status === 400) {
-         return { 'error': 'Operation not permitted', 'errno': EPERM };
-      }
-
-      var resp = null;
-      if (response.headers.get('content-type') === 'application/json') {
-         return response.json().then(function (resp) {
-            return validateJSONResponse(resp, result_schema);
-         });
-      } else {
-         return response.text();
-      }
-   });
-}
-
-/*
- * Convert a datastore public key to its ID.
- * @param ds_public_key (String) hex-encoded ECDSA public key
- */
-function datastoreGetId(ds_public_key_hex) {
-   var ec = bitcoinjs.ECPair.fromPublicKeyBuffer(Buffer.from(ds_public_key_hex, 'hex'));
-   return ec.getAddress();
-}
-
-/*
- * Get a *uncompressed* public key (hex) from private key
- */
-function getPubkeyHex(privkey_hex) {
-   var privkey = BigInteger.fromBuffer((0, _inode.decodePrivateKey)(privkey_hex));
-   var public_key = new bitcoinjs.ECPair(privkey);
-
-   public_key.compressed = false;
-   var public_key_str = public_key.getPublicKeyBuffer().toString('hex');
-   return public_key_str;
-}
-
-/*
- * Get query string device list from datastore context
- */
-function getDeviceList(datastore_ctx) {
-   var escaped_device_ids = [];
-   var _iteratorNormalCompletion = true;
-   var _didIteratorError = false;
-   var _iteratorError = undefined;
-
-   try {
-      for (var _iterator = datastore_ctx.app_public_keys[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
-         var dk = _step.value;
-
-         escaped_device_ids.push(escape(dk.device_id));
-      }
-   } catch (err) {
-      _didIteratorError = true;
-      _iteratorError = err;
-   } finally {
-      try {
-         if (!_iteratorNormalCompletion && _iterator.return) {
-            _iterator.return();
-         }
-      } finally {
-         if (_didIteratorError) {
-            throw _iteratorError;
-         }
-      }
-   }
-
-   var res = escaped_device_ids.join(',');
-   return res;
-}
-
-/*
- * Get query string public key list from datastore context
- */
-function getPublicKeyList(datastore_ctx) {
-   var escaped_public_keys = [];
-   var _iteratorNormalCompletion2 = true;
-   var _didIteratorError2 = false;
-   var _iteratorError2 = undefined;
-
-   try {
-      for (var _iterator2 = datastore_ctx.app_public_keys[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
-         var dk = _step2.value;
-
-         escaped_public_keys.push(escape(dk.public_key));
-      }
-   } catch (err) {
-      _didIteratorError2 = true;
-      _iteratorError2 = err;
-   } finally {
-      try {
-         if (!_iteratorNormalCompletion2 && _iterator2.return) {
-            _iterator2.return();
-         }
-      } finally {
-         if (_didIteratorError2) {
-            throw _iteratorError2;
-         }
-      }
-   }
-
-   var res = escaped_public_keys.join(',');
-   return res;
-}
-
-/*
- * Sanitize a path.  Consolidate // to /, and resolve foo/../bar to bar
- * @param path (String) the path
- *
- * Returns the sanitized path.
- */
-function sanitizePath(path) {
-
-   var parts = path.split('/').filter(function (x) {
-      return x.length > 0;
-   });
-   var retparts = [];
-
-   for (var i = 0; i < parts.length; i++) {
-      if (parts[i] === '..') {
-         retparts.pop();
-      } else {
-         retparts.push(parts[i]);
-      }
-   }
-
-   return '/' + retparts.join('/');
-}
-
-/*
- * Given a path, get the parent directory.
- *
- * @param path (String) the path.  Must be sanitized
- */
-function dirname(path) {
-   return '/' + path.split('/').slice(0, -1).join('/');
-}
-
-/*
- * Given a path, get the base name
- *
- * @param path (String) the path. Must be sanitized
- */
-function basename(path) {
-   return path.split('/').slice(-1)[0];
-}
-
-/*
- * Given a host:port string, split it into
- * a host and port
- *
- * @param hostport (String) the host:port
- *
- * Returns an object with:
- *      .host
- *      .port
- */
-function splitHostPort(hostport) {
-
-   var host = hostport;
-   var port = 80;
-   var parts = hostport.split(':');
-   if (parts.length > 1) {
-      host = parts[0];
-      port = parts[1];
-   }
-
-   return { 'host': host, 'port': port };
-}
-
-/*
- * Create the signed request to create a datastore.
- * This information can be fed into datastoreCreate()
- * Returns an object with:
- *      .datastore_info: datastore information
- *      .datastore_sigs: signatures over the above.
- */
-function datastoreCreateRequest(ds_type, ds_private_key_hex, drivers, device_id, all_device_ids) {
-
-   assert(ds_type === 'datastore' || ds_type === 'collection');
-   var root_uuid = uuid4();
-
-   var ds_public_key = getPubkeyHex(ds_private_key_hex);
-   var datastore_id = datastoreGetId(ds_public_key);
-   var root_blob_info = (0, _inode.makeDirInodeBlob)(datastore_id, datastore_id, root_uuid, {}, device_id, 1);
-
-   // actual datastore payload
-   var datastore_info = {
-      'type': ds_type,
-      'pubkey': ds_public_key,
-      'drivers': drivers,
-      'device_ids': all_device_ids,
-      'root_uuid': root_uuid
-   };
-
-   var data_id = datastore_id + '.datastore';
-   var datastore_blob = (0, _inode.makeMutableDataInfo)(data_id, (0, _util.jsonStableSerialize)(datastore_info), device_id, 1);
-
-   var datastore_str = (0, _util.jsonStableSerialize)(datastore_blob);
-
-   // sign them all
-   var root_sig = (0, _inode.signDataPayload)(root_blob_info.header, ds_private_key_hex);
-   var datastore_sig = (0, _inode.signDataPayload)(datastore_str, ds_private_key_hex);
-
-   // make and sign tombstones for the root
-   var root_tombstones = (0, _inode.makeInodeTombstones)(datastore_id, root_uuid, all_device_ids);
-   var signed_tombstones = (0, _inode.signMutableDataTombstones)(root_tombstones, ds_private_key_hex);
-
-   var info = {
-      'datastore_info': {
-         'datastore_id': datastore_id,
-         'datastore_blob': datastore_str,
-         'root_blob_header': root_blob_info.header,
-         'root_blob_idata': root_blob_info.idata
-      },
-      'datastore_sigs': {
-         'datastore_sig': datastore_sig,
-         'root_sig': root_sig
-      },
-      'root_tombstones': signed_tombstones
-   };
-
-   return info;
-}
-
-/*
- * Create a datastore
- * Asynchronous; returns a Promise that resolves to either {'status': true} (on success)
- * or {'error': ...} (on error)
- */
-function datastoreCreate(blockstack_hostport, blockstack_session_token, datastore_request) {
-
-   var payload = {
-      'datastore_info': {
-         'datastore_blob': datastore_request.datastore_info.datastore_blob,
-         'root_blob_header': datastore_request.datastore_info.root_blob_header,
-         'root_blob_idata': datastore_request.datastore_info.root_blob_idata
-      },
-      'datastore_sigs': {
-         'datastore_sig': datastore_request.datastore_sigs.datastore_sig,
-         'root_sig': datastore_request.datastore_sigs.root_sig
-      },
-      'root_tombstones': datastore_request.root_tombstones
-   };
-
-   var hostinfo = splitHostPort(blockstack_hostport);
-
-   var options = {
-      'method': 'POST',
-      'host': hostinfo.host,
-      'port': hostinfo.port,
-      'path': '/v1/stores'
-   };
-
-   if (blockstack_session_token) {
-      options['headers'] = { 'Authorization': 'bearer ' + blockstack_session_token };
-   }
-
-   var body = JSON.stringify(payload);
-   options['headers']['Content-Type'] = 'application/json';
-   options['headers']['Content-Length'] = body.length;
-
-   return httpRequest(options, _schemas.SUCCESS_FAIL_SCHEMA, body);
-}
-
-/*
- * Generate the data needed to delete a datastore.
- *
- * @param ds (Object) a datastore context (will be loaded from localstorage if not given)
- *
- * Returns an object to be given to datastoreDelete()
- */
-function datastoreDeleteRequest() {
-   var ds = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : null;
-
-
-   if (!ds) {
-      var blockchain_id = getSessionBlockchainID();
-      assert(blockchain_id);
-
-      ds = getCachedMountContext(blockchain_id);
-      assert(ds);
-   }
-
-   var datastore_id = ds.datastore_id;
-   var device_ids = ds.datastore.device_ids;
-   var root_uuid = ds.datastore.root_uuid;
-   var data_id = datastore_id + '.datastore';
-
-   var tombstones = (0, _inode.makeMutableDataTombstones)(device_ids, data_id);
-   var signed_tombstones = (0, _inode.signMutableDataTombstones)(tombstones, ds.privkey_hex);
-
-   var root_tombstones = (0, _inode.makeInodeTombstones)(datastore_id, root_uuid, device_ids);
-   var signed_root_tombstones = (0, _inode.signMutableDataTombstones)(root_tombstones, ds.privkey_hex);
-
-   var ret = {
-      'datastore_tombstones': signed_tombstones,
-      'root_tombstones': signed_root_tombstones
-   };
-
-   return ret;
-}
-
-/*
- * Delete a datastore
- *
- * @param ds (Object) OPTINOAL: the datastore context (will be loaded from localStorage if not given)
- * @param ds_tombstones (Object) OPTINOAL: signed information from datastoreDeleteRequest()
- * @param root_tombstones (Object) OPTINAL: signed information from datastoreDeleteRequest()
- *
- * Asynchronous; returns a Promise that resolves to either {'status': true} on success
- * or {'error': ...} on error
- */
-function datastoreDelete() {
-   var ds = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : null;
-   var ds_tombstones = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : null;
-   var root_tombstones = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : null;
-
-
-   if (!ds) {
-      var blockchain_id = getSessionBlockchainID();
-      assert(blockchain_id);
-
-      ds = getCachedMountContext(blockchain_id);
-      assert(ds);
-   }
-
-   if (!ds_tombstones || !root_tombstones) {
-      var delete_info = datastoreDeleteRequest(ds);
-      ds_tombstones = delete_info['datastore_tombstones'];
-      root_tombstones = delete_info['root_tombstones'];
-   }
-
-   var device_list = getDeviceList(ds);
-   var payload = {
-      'datastore_tombstones': ds_tombstones,
-      'root_tombstones': root_tombstones
-   };
-
-   var options = {
-      'method': 'DELETE',
-      'host': ds.host,
-      'port': ds.port,
-      'path': '/v1/stores?device_ids=' + device_list
-   };
-
-   if (ds.session_token) {
-      options['headers'] = { 'Authorization': 'bearer ' + ds.session_token };
-   }
-
-   var body = JSON.stringify(payload);
-   options['headers']['Content-Type'] = 'application/json';
-   options['headers']['Content-Length'] = body.length;
-
-   return httpRequest(options, _schemas.SUCCESS_FAIL_SCHEMA, body);
-}
-
-/*
- * Look up a datastore and establish enough contextual information to do subsequent storage operations.
- * Asynchronous; returns a Promise
- *
- * opts is an object that must contain either:
- * * appPrivateKey (string) the application private key
- * * (optional) sessionToken (string) the Core session token, OR
- * * (optional) device_id (string) the device ID
- *
- * OR:
- *
- * * blockchainID (string) the blockchain ID of the user whose datastore we're going to access
- * * appName (string) the name of the application
- *
- * TODO: support accessing datastores from other users
- *
- * Returns a Promise that resolves to a datastore connection,
- * with the following properties:
- *      .host: blockstack host
- *      .datastore: datastore object
- *
- * Returns a Promise that resolves to null, if the datastore does not exist.
- *
- * Throws an error on all other errors
- */
-function datastoreMount(opts) {
-
-   var data_privkey_hex = opts.appPrivateKey;
-   var sessionToken = opts.sessionToken;
-
-   // TODO: only support single-user datastore access
-   assert(data_privkey_hex);
-
-   var datastore_id = null;
-   var device_id = null;
-   var blockchain_id = null;
-   var api_endpoint = null;
-   var app_public_keys = null;
-
-   if (!sessionToken) {
-      // load from user data
-      var userData = getUserData();
-
-      sessionToken = userData.coreSessionToken;
-      assert(sessionToken);
-   }
-
-   var session = jsontokens.decodeToken(sessionToken).payload;
-
-   if (data_privkey_hex) {
-      datastore_id = datastoreGetId(getPubkeyHex(data_privkey_hex));
-   } else {
-      blockchain_id = opts.blockchainID;
-      var app_name = opts.appName;
-
-      if (!blockchain_id) {
-         blockchain_id = getSessionBlockchainID();
-      }
-
-      assert(blockchain_id);
-      assert(app_name);
-
-      // TODO: look up the datastore information via Core
-      // TODO: blocked by Core's lack of support for token files
-      // TODO: set device_id, blockchain_id, app_public_keys
-   }
-
-   if (!device_id) {
-      device_id = session.device_id;
-      assert(device_id);
-   }
-
-   if (!api_endpoint) {
-      api_endpoint = session.api_endpoint;
-      assert(api_endpoint);
-   }
-
-   if (!blockchain_id) {
-      blockchain_id = getBlockchainIDFromSessionOrDefault(session);
-   }
-
-   if (!app_public_keys) {
-      app_public_keys = session.app_public_keys;
-      assert(app_public_keys);
-   }
-
-   var blockstack_hostport = api_endpoint.split('://').reverse()[0];
-   var hostinfo = splitHostPort(blockstack_hostport);
-
-   var ctx = {
-      'host': hostinfo.host,
-      'port': hostinfo.port,
-      'blockchain_id': blockchain_id,
-      'device_id': device_id,
-      'datastore_id': datastore_id,
-      'session_token': sessionToken,
-      'app_public_keys': app_public_keys,
-      'session': session,
-      'datastore': null
-   };
-
-   if (data_privkey_hex) {
-      ctx.privkey_hex = data_privkey_hex;
-   }
-
-   var options = {
-      'method': 'GET',
-      'host': hostinfo.host,
-      'port': hostinfo.port,
-      'path': '/v1/stores/' + datastore_id + '?device_ids=' + device_id + '&blockchain_id=' + blockchain_id
-   };
-
-   options['headers'] = { 'Authorization': 'bearer ' + sessionToken };
-
-   return httpRequest(options, _schemas.DATASTORE_RESPONSE_SCHEMA).then(function (ds) {
-      if (!ds || ds.error) {
-         // ENOENT?
-         if (!ds || ds.errno === ENOENT) {
-            return null;
-         } else {
-            var errorMsg = ds.error || 'No response given';
-            throw new Error('Failed to get datastore: ' + errorMsg);
-         }
-      } else {
-         ctx['datastore'] = ds.datastore;
-
-         // save
-         setCachedMountContext(blockchain_id, ctx);
-
-         // this is required for testing purposes, since the core session token will not have been set
-         var _userData = getUserData();
-         if (!_userData.coreSessionToken) {
-            console.log("In test framework; saving session token");
-            _userData.coreSessionToken = sessionToken;
-            setUserData(_userData);
-         }
-
-         return ctx;
-      }
-   });
-}
-
-/*
- * Get local storage object for Blockstack
- * Throws on error
- */
-function getUserData() {
-   var userData = localStorage.getItem(LOCAL_STORAGE_ID);
-   if (userData === null) {
-      userData = '{}';
-   }
-
-   userData = JSON.parse(userData);
-   return userData;
-}
-
-/*
- * Save local storage
- */
-function setUserData(userData) {
-
-   var u = getUserData();
-   if (u.coreSessionToken && userData.coreSessionToken) {
-      // only store the newer one 
-      var coreSessionToken = null;
-      if (u.coreSessionToken.timestamp < userData.coreSessionToken.timestamp) {
-         coreSessionToken = userData.coreSessionToken;
-      } else {
-         coreSessionToken = u.coreSessionToken;
-      }
-      userData.coreSessionToken = coreSessionToken;
-   }
-
-   localStorage.setItem(LOCAL_STORAGE_ID, JSON.stringify(userData));
-}
-
-/*
- * Get a cached app-specific datastore mount context for a given blockchain ID and application
- * Return null if not found
- * Throws on error
- */
-function getCachedMountContext(blockchain_id) {
-
-   var userData = getUserData();
-   if (!userData.datastore_contexts) {
-      console.log("No datastore contexts defined");
-      return null;
-   }
-
-   if (!userData.datastore_contexts[blockchain_id]) {
-      console.log('No datastore contexts for ' + blockchain_id);
-      return null;
-   }
-
-   var ctx = userData.datastore_contexts[blockchain_id];
-   if (!ctx) {
-      console.log('Null datastore context for ' + blockchain_id);
-      return null;
-   }
-
-   return ctx;
-}
-
-/*
- * Cache a mount context for a blockchain ID
- */
-function setCachedMountContext(blockchain_id, datastore_context) {
-
-   var userData = getUserData();
-   if (!userData.datastore_contexts) {
-      userData.datastore_contexts = {};
-   }
-
-   userData.datastore_contexts[blockchain_id] = datastore_context;
-   setUserData(userData);
-}
-
-function getBlockchainIDFromSessionOrDefault(session) {
-   if (!session.blockchain_id) {
-      return (0, _inode.hashRawData)(Buffer.from(session.app_user_id).toString('base64'));
-   } else {
-      return session.blockchain_id;
-   }
-}
-
-/*
- * Get the current session's blockchain ID
- * Throw if not defined or not present.
- */
-function getSessionBlockchainID() {
-
-   var userData = getUserData();
-   assert(userData);
-   assert(userData.coreSessionToken);
-
-   var session = jsontokens.decodeToken(userData.coreSessionToken).payload;
-
-   return getBlockchainIDFromSessionOrDefault(session);
-}
-
-/*
- * Fulfill a replication strategy using the drivers available to us.
- *
- * replication_strategy (object): a dict that maps strategies (i.e. 'local', 'public', 'private') to integer counts
- * classes (object): this is session.storage.classes (i.e. the driver classification; maps a driver name to its list of classes)
- *
- * Returns the list of drivers to use.
- * Throws on error.
- */
-function selectDrivers(replication_strategy, classes) {
-
-   // select defaults from classification and replication strategy
-   var driver_sets = []; // driver_sets[i] is the set of drivers that support SUPPORTED_STORAGE_CLASSES[i]
-   var driver_classes = {}; // map driver name to set of classes
-   var all_drivers = new Set([]); // set of all drivers available to us
-   var available_drivers = []; // drivers available to us
-   var selected_drivers = []; // drivers compatible with our replication strategy (return value)
-   var have_drivers = false; // whether or not we selected drivers that fulfill our replication strategy
-
-   for (var i = 0; i < SUPPORTED_STORAGE_CLASSES.length; i++) {
-      var driver_set = new Set(classes[SUPPORTED_STORAGE_CLASSES[i]]);
-      driver_sets.push(driver_set);
-
-      var _iteratorNormalCompletion3 = true;
-      var _didIteratorError3 = false;
-      var _iteratorError3 = undefined;
-
-      try {
-         for (var _iterator3 = driver_set[Symbol.iterator](), _step3; !(_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done); _iteratorNormalCompletion3 = true) {
-            var d = _step3.value;
-
-            all_drivers.add(d);
-         }
-      } catch (err) {
-         _didIteratorError3 = true;
-         _iteratorError3 = err;
-      } finally {
-         try {
-            if (!_iteratorNormalCompletion3 && _iterator3.return) {
-               _iterator3.return();
-            }
-         } finally {
-            if (_didIteratorError3) {
-               throw _iteratorError3;
-            }
-         }
-      }
-
-      var _iteratorNormalCompletion4 = true;
-      var _didIteratorError4 = false;
-      var _iteratorError4 = undefined;
-
-      try {
-         for (var _iterator4 = driver_set[Symbol.iterator](), _step4; !(_iteratorNormalCompletion4 = (_step4 = _iterator4.next()).done); _iteratorNormalCompletion4 = true) {
-            var _d = _step4.value;
-
-            console.log('Driver ' + _d + ' implementes ' + SUPPORTED_STORAGE_CLASSES[i]);
-            if (driver_classes[_d]) {
-               driver_classes[_d].push(SUPPORTED_STORAGE_CLASSES[i]);
-            } else {
-               driver_classes[_d] = [SUPPORTED_STORAGE_CLASSES[i]];
-            }
-         }
-      } catch (err) {
-         _didIteratorError4 = true;
-         _iteratorError4 = err;
-      } finally {
-         try {
-            if (!_iteratorNormalCompletion4 && _iterator4.return) {
-               _iterator4.return();
-            }
-         } finally {
-            if (_didIteratorError4) {
-               throw _iteratorError4;
-            }
-         }
-      }
-   }
-
-   var concern_fulfillment = {};
-
-   var _iteratorNormalCompletion5 = true;
-   var _didIteratorError5 = false;
-   var _iteratorError5 = undefined;
-
-   try {
-      for (var _iterator5 = all_drivers[Symbol.iterator](), _step5; !(_iteratorNormalCompletion5 = (_step5 = _iterator5.next()).done); _iteratorNormalCompletion5 = true) {
-         var _d2 = _step5.value;
-
-         var _classes = driver_classes[_d2];
-
-         // a driver fits the replication strategy if all of its
-         // classes matches at least one concern (i.e. 'local', 'public')
-         var _iteratorNormalCompletion6 = true;
-         var _didIteratorError6 = false;
-         var _iteratorError6 = undefined;
-
-         try {
-            for (var _iterator6 = Object.keys(replication_strategy)[Symbol.iterator](), _step6; !(_iteratorNormalCompletion6 = (_step6 = _iterator6.next()).done); _iteratorNormalCompletion6 = true) {
-               var concern = _step6.value;
-
-
-               var matches = false;
-               var _iteratorNormalCompletion7 = true;
-               var _didIteratorError7 = false;
-               var _iteratorError7 = undefined;
-
-               try {
-                  for (var _iterator7 = _classes[Symbol.iterator](), _step7; !(_iteratorNormalCompletion7 = (_step7 = _iterator7.next()).done); _iteratorNormalCompletion7 = true) {
-                     var dclass = _step7.value;
-
-                     if (REPLICATION_STRATEGY_CLASSES[concern].has(dclass)) {
-                        matches = true;
-                        break;
-                     }
-                  }
-               } catch (err) {
-                  _didIteratorError7 = true;
-                  _iteratorError7 = err;
-               } finally {
-                  try {
-                     if (!_iteratorNormalCompletion7 && _iterator7.return) {
-                        _iterator7.return();
-                     }
-                  } finally {
-                     if (_didIteratorError7) {
-                        throw _iteratorError7;
-                     }
-                  }
-               }
-
-               if (matches) {
-                  console.log('Driver ' + _d2 + ' fulfills replication concern ' + concern);
-
-                  if (concern_fulfillment[concern]) {
-                     concern_fulfillment[concern] += 1;
-                  } else {
-                     concern_fulfillment[concern] = 1;
-                  }
-
-                  if (concern_fulfillment[concern] <= replication_strategy[concern]) {
-                     console.log('Select driver ' + _d2);
-                     selected_drivers.push(_d2);
-                  }
-               }
-
-               // strategy fulfilled?
-               var fulfilled = true;
-               var _iteratorNormalCompletion8 = true;
-               var _didIteratorError8 = false;
-               var _iteratorError8 = undefined;
-
-               try {
-                  for (var _iterator8 = Object.keys(replication_strategy)[Symbol.iterator](), _step8; !(_iteratorNormalCompletion8 = (_step8 = _iterator8.next()).done); _iteratorNormalCompletion8 = true) {
-                     var _concern = _step8.value;
-
-                     var count = 0;
-                     if (concern_fulfillment[_concern]) {
-                        count = concern_fulfillment[_concern];
-                     }
-
-                     if (count < replication_strategy[_concern]) {
-                        fulfilled = false;
-                        break;
-                     }
-                  }
-               } catch (err) {
-                  _didIteratorError8 = true;
-                  _iteratorError8 = err;
-               } finally {
-                  try {
-                     if (!_iteratorNormalCompletion8 && _iterator8.return) {
-                        _iterator8.return();
-                     }
-                  } finally {
-                     if (_didIteratorError8) {
-                        throw _iteratorError8;
-                     }
-                  }
-               }
-
-               if (fulfilled) {
-                  have_drivers = true;
-                  break;
-               }
-            }
-         } catch (err) {
-            _didIteratorError6 = true;
-            _iteratorError6 = err;
-         } finally {
-            try {
-               if (!_iteratorNormalCompletion6 && _iterator6.return) {
-                  _iterator6.return();
-               }
-            } finally {
-               if (_didIteratorError6) {
-                  throw _iteratorError6;
-               }
-            }
-         }
-
-         if (have_drivers) {
-            break;
-         }
-      }
-   } catch (err) {
-      _didIteratorError5 = true;
-      _iteratorError5 = err;
-   } finally {
-      try {
-         if (!_iteratorNormalCompletion5 && _iterator5.return) {
-            _iterator5.return();
-         }
-      } finally {
-         if (_didIteratorError5) {
-            throw _iteratorError5;
-         }
-      }
-   }
-
-   if (!have_drivers) {
-      throw new Error("Unsatisfiable replication strategy");
-   }
-
-   return selected_drivers;
-}
-
-/*
- * Connect to or create a datastore.
- * Asynchronous, returns a Promise
- *
- * Returns a Promise that yields a datastore connection.
- * Throws on error.
- *
- */
-function datastoreMountOrCreate() {
-   var replication_strategy = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : { 'public': 1, 'local': 1 };
-   var sessionToken = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : null;
-   var appPrivateKey = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : null;
-
-
-   if (!sessionToken) {
-      var userData = getUserData();
-
-      sessionToken = userData.coreSessionToken;
-      assert(sessionToken);
-   }
-
-   // decode
-   var session = jsontokens.decodeToken(sessionToken).payload;
-   var blockchain_id = getBlockchainIDFromSessionOrDefault(session);
-
-   var ds = getCachedMountContext(blockchain_id);
-   if (ds) {
-      return new Promise(function (resolve, reject) {
-         resolve(ds);
-      });
-   }
-
-   // no cached datastore context.
-   // go ahead and create one (need appPrivateKey)
-   if (!appPrivateKey) {
-      var _userData2 = getUserData();
-
-      appPrivateKey = _userData2.appPrivateKey;
-      assert(appPrivateKey);
-   }
-
-   // sanity check
-   var _iteratorNormalCompletion9 = true;
-   var _didIteratorError9 = false;
-   var _iteratorError9 = undefined;
-
-   try {
-      for (var _iterator9 = Object.keys(replication_strategy)[Symbol.iterator](), _step9; !(_iteratorNormalCompletion9 = (_step9 = _iterator9.next()).done); _iteratorNormalCompletion9 = true) {
-         var strategy = _step9.value;
-
-         var supported = false;
-         var _iteratorNormalCompletion10 = true;
-         var _didIteratorError10 = false;
-         var _iteratorError10 = undefined;
-
-         try {
-            for (var _iterator10 = Object.keys(REPLICATION_STRATEGY_CLASSES)[Symbol.iterator](), _step10; !(_iteratorNormalCompletion10 = (_step10 = _iterator10.next()).done); _iteratorNormalCompletion10 = true) {
-               var supported_strategy = _step10.value;
-
-               if (supported_strategy === strategy) {
-                  supported = true;
-                  break;
-               }
-            }
-         } catch (err) {
-            _didIteratorError10 = true;
-            _iteratorError10 = err;
-         } finally {
-            try {
-               if (!_iteratorNormalCompletion10 && _iterator10.return) {
-                  _iterator10.return();
-               }
-            } finally {
-               if (_didIteratorError10) {
-                  throw _iteratorError10;
-               }
-            }
-         }
-
-         if (!supported) {
-            throw new Error('Unsupported replication strategy ' + strategy);
-         }
-      }
-   } catch (err) {
-      _didIteratorError9 = true;
-      _iteratorError9 = err;
-   } finally {
-      try {
-         if (!_iteratorNormalCompletion9 && _iterator9.return) {
-            _iterator9.return();
-         }
-      } finally {
-         if (_didIteratorError9) {
-            throw _iteratorError9;
-         }
-      }
-   }
-
-   var drivers = null;
-
-   // find satisfactory storage drivers
-   if (Object.keys(session.storage.preferences).includes(session.app_domain)) {
-
-      // app-specific preference
-      drivers = session.storage.preferences[app_domain];
-   } else {
-
-      // select defaults given the replication strategy
-      drivers = selectDrivers(replication_strategy, session.storage.classes);
-   }
-
-   var hostport = session.api_endpoint.split('://').reverse()[0];
-   var appPublicKeys = session.app_public_keys;
-   var deviceID = session.device_id;
-   var allDeviceIDs = [];
-
-   for (var i = 0; i < appPublicKeys.length; i++) {
-      allDeviceIDs.push(appPublicKeys[i].device_id);
-   }
-
-   console.log('Will use drivers ' + drivers.join(','));
-   console.log('Datastore will span devices ' + allDeviceIDs.join(','));
-
-   var datastoreOpts = {
-      'appPrivateKey': appPrivateKey,
-      'sessionToken': sessionToken
-   };
-
-   return datastoreMount(datastoreOpts).then(function (datastore_ctx) {
-      if (!datastore_ctx) {
-         // does not exist
-         console.log("Datastore does not exist; creating...");
-
-         var info = datastoreCreateRequest('datastore', appPrivateKey, drivers, deviceID, allDeviceIDs);
-
-         // go create it
-         return datastoreCreate(hostport, sessionToken, info).then(function (res) {
-            if (res.error) {
-               console.log(error);
-               var errorNo = res.errno || 'UNKNOWN';
-               var errorMsg = res.error || 'UNKNOWN';
-               throw new Error('Failed to create datastore (errno ' + errorNo + '): ' + errorMsg);
-            }
-
-            // connect to it now
-            return datastoreMount(datastoreOpts);
-         });
-      } else if (datastore_ctx.error) {
-         // some other error
-         var errorMsg = datastore_ctx.error || 'UNKNOWN';
-         var errorNo = datastore_ctx.errno || 'UNKNOWN';
-         throw new Error('Failed to access datastore (errno ' + errorNo + '): ' + errorMsg);
-      } else {
-         // exists
-         return datastore_ctx;
-      }
-   });
-}
-
-/*
- * Path lookup
- *
- * @param ds (Object) a datastore context
- * @param path (String) the path to the inode
- * @param opts (Object) optional arguments:
- *      .extended (Bool) whether or not to include the entire path's inode information
- *      .force (Bool) if True, then ignore stale inode errors.
- *      .idata (Bool) if True, then get the inode payload as well
- *      .blockchain_id (String) this is the blockchain ID of the datastore owner, if different from the session token
- *      .ds (datastore context) if given, then use this datastore mount context instead of one from localstorage
- *
- * Returns a promise that resolves to a lookup response schema (or an extended lookup response schema, if opts.extended is set)
- */
-function lookup(path) {
-   var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-
-
-   var blockchain_id = opts.blockchain_id;
-
-   if (!opts.blockchain_id) {
-      blockchain_id = getSessionBlockchainID();
-   }
-
-   return datastoreMountOrCreate().then(function (ds) {
-      assert(ds);
-
-      var datastore_id = ds.datastore_id;
-      var device_list = getDeviceList(ds);
-      var device_pubkeys = getPublicKeyList(ds);
-      var options = {
-         'method': 'GET',
-         'host': ds.host,
-         'port': ds.port,
-         'path': '/v1/stores/' + datastore_id + '/inodes?path=' + escape(sanitizePath(path)) + '&device_ids=' + device_list + '&device_pubkeys=' + device_pubkeys + '&blockchain_id=' + ds.blockchain_id
-      };
-
-      if (!opts) {
-         opts = {};
-      }
-
-      var schema = _schemas.DATASTORE_LOOKUP_RESPONSE_SCHEMA;
-
-      if (opts.extended) {
-         options['path'] += '&extended=1';
-         schema = _schemas.DATASTORE_LOOKUP_EXTENDED_RESPONSE_SCHEMA;
-      }
-
-      if (opts.force) {
-         options['path'] += '&force=1';
-      }
-
-      if (opts.idata) {
-         options['idata'] += '&idata=1';
-      }
-
-      return httpRequest(options, schema).then(function (lookup_response) {
-         if (lookup_response.error || lookup_response.errno) {
-            var errorMsg = lookup_response.error || 'UNKNOWN';
-            var errorNo = lookup_response.errno || 'UNKNOWN';
-            throw new Error('Failed to look up ' + path + ' (errno: ' + errorNo + '): ' + errorMsg);
-         } else {
-            return lookup_response;
-         }
-      });
-   });
-}
-
-/*
- * List a directory.
- *
- * @param ds (Object) a datastore context
- * @param path (String) the path to the directory to list
- * @param opts (Object) optional arguments:
- *      .extended (Bool) whether or not to include the entire path's inode inforamtion
- *      .force (Bool) if True, then ignore stale inode errors.
- *      .blockchain_id (string) this is the blockchain ID of the datastore owner (if different from the session)
- *      .ds (datastore context) this is the mount context for the datastore, if different from one that we have cached
- *
- * Asynchronous; returns a Promise that resolves to either directory idata, or an extended mutable datum response (if opts.extended is set)
- */
-function listdir(path) {
-   var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-
-
-   var blockchain_id = opts.blockchain_id;
-
-   if (!opts.blockchain_id) {
-      blockchain_id = getSessionBlockchainID();
-   }
-
-   return datastoreMountOrCreate().then(function (ds) {
-
-      assert(ds);
-
-      var datastore_id = ds.datastore_id;
-      var device_list = getDeviceList(ds);
-      var device_pubkeys = getPublicKeyList(ds);
-      var options = {
-         'method': 'GET',
-         'host': ds.host,
-         'port': ds.port,
-         'path': '/v1/stores/' + datastore_id + '/directories?path=' + escape(sanitizePath(path)) + '&idata=1&device_ids=' + device_list + '&device_pubkeys=' + device_pubkeys + '&blockchain_id=' + ds.blockchain_id
-      };
-
-      var schema = _schemas.MUTABLE_DATUM_DIR_IDATA_SCHEMA;
-
-      if (!opts) {
-         opts = {};
-      }
-
-      if (opts.extended) {
-         options['path'] += '&extended=1';
-         schema = MUTABLE_DATUM_EXTENDED_RESPONSE_SCHEMA;
-      }
-
-      if (opts.force) {
-         optsion['path'] += '&force=1';
-      }
-
-      if (ds.session_token) {
-         options['headers'] = { 'Authorization': 'bearer ' + ds.session_token };
-      }
-
-      return httpRequest(options, schema).then(function (response) {
-         if (response.error || response.errno) {
-            var errorMsg = response.error || 'UNKNOWN';
-            var errorNo = response.errno || 'UNKNOWN';
-            throw new Error('Failed to listdir ' + path + ' (errno: ' + errorNo + '): ' + errorMsg);
-         } else {
-            return response;
-         }
-      });
-   });
-}
-
-/*
- * Stat a file or directory (i.e. get the inode header)
- *
- * @param ds (Object) a datastore context
- * @param path (String) the path to the directory to list
- * @param opts (Object) optional arguments:
- *      .extended (Bool) whether or not to include the entire path's inode inforamtion
- *      .force (Bool) if True, then ignore stale inode errors.
- *      .blockchain_id (string) this is the blockchain ID of the datastore owner (if different from the session)
- *      .ds (datastore context) this is the mount context for the datastore, if different from one that we have cached
- *
- * Asynchronous; returns a Promise that resolves to either an inode schema, or a mutable datum extended response schema (if opts.extended is set)
- */
-function stat(path) {
-   var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-
-
-   var ds = opts.ds;
-   var blockchain_id = opts.blockchain_id;
-
-   if (!opts.blockchain_id) {
-      blockchain_id = getSessionBlockchainID();
-   }
-
-   return datastoreMountOrCreate().then(function (ds) {
-
-      assert(ds);
-
-      var datastore_id = ds.datastore_id;
-      var device_list = getDeviceList(ds);
-      var device_pubkeys = getPublicKeyList(ds);
-      var options = {
-         'method': 'GET',
-         'host': ds.host,
-         'port': ds.port,
-         'path': '/v1/stores/' + datastore_id + '/inodes?path=' + escape(sanitizePath(path)) + '&device_ids=' + device_list + '&device_pubkeys=' + device_pubkeys + '&blockchain_id=' + ds.blockchain_id
-      };
-
-      var schema = _schemas.MUTABLE_DATUM_INODE_SCHEMA;
-
-      if (!opts) {
-         opts = {};
-      }
-
-      if (opts.extended) {
-         options['path'] += '&extended=1';
-         schema = MUTABLE_DATUM_EXTENDED_RESPONSE_SCHEMA;
-      }
-
-      if (opts.force) {
-         optsion['path'] += '&force=1';
-      }
-
-      if (ds.session_token) {
-         options['headers'] = { 'Authorization': 'bearer ' + ds.session_token };
-      }
-
-      return httpRequest(options, schema).then(function (response) {
-         if (response.error || response.errno) {
-            var errorMsg = response.error || 'UNKNOWN';
-            var errorNo = response.errno || 'UNKNOWN';
-            throw new Error('Failed to stat ' + path + ' (errno: ' + errorNo + '): ' + errorMsg);
-         } else {
-            return response;
-         }
-      });
-   });
-}
-
-/*
- * Get an undifferentiated file or directory and its data.
- * Low-level method, not meant for external consumption.
- *
- * @param ds (Object) a datastore context
- * @param path (String) the path to the directory to list
- * @param opts (Object) optional arguments:
- *      .extended (Bool) whether or not to include the entire path's inode inforamtion
- *      .force (Bool) if True, then ignore stale inode errors.
- *      .blockchain_id (string) this is the blockchain ID of the datastore owner (if different from the session)
- *      .ds (datastore context) this is the mount context for the datastore, if different from one that we have cached
- *
- * Asynchronous; returns a Promise that resolves to an inode and its data, or an extended mutable datum response (if opts.extended is set)
- */
-function getInode(path) {
-   var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : null;
-
-
-   var blockchain_id = opts.blockchain_id;
-
-   if (!opts.blockchain_id) {
-      blockchain_id = getSessionBlockchainID();
-   }
-
-   return datastoreMountOrCreate().then(function (ds) {
-
-      assert(ds);
-
-      var datastore_id = ds.datastore_id;
-      var device_list = getDeviceList(ds);
-      var device_pubkeys = getPublicKeyList(ds);
-      var options = {
-         'method': 'GET',
-         'host': ds.host,
-         'port': ds.port,
-         'path': '/v1/stores/' + datastore_id + '/inodes?path=' + escape(sanitizePath(path)) + '&idata=1&device_ids=' + device_list + '&device_pubkeys=' + device_pubkeys + '&blockchain_id=' + ds.blockchain_id
-      };
-
-      var schema = _schemas.MUTABLE_DATUM_INODE_SCHEMA;
-
-      if (!opts) {
-         opts = {};
-      }
-
-      if (opts.extended) {
-         options['path'] += '&extended=1';
-         schema = MUTABLE_DATUM_EXTENDED_RESPONSE_SCHEMA;
-      }
-
-      if (opts.force) {
-         options['path'] += '&force=1';
-      }
-
-      if (ds.session_token) {
-         options['headers'] = { 'Authorization': 'bearer ' + ds.session_token };
-      }
-
-      return httpRequest(options, schema).then(function (response) {
-         if (response.error || response.errno) {
-            var errorMsg = response.error || 'UNKNOWN';
-            var errorNo = response.errno || 'UNKNOWN';
-            throw new Error('Failed to getInode ' + path + ' (errno: ' + errorNo + '): ' + errorMsg);
-         } else {
-            return response;
-         }
-      });
-   });
-}
-
-/*
- * Get a file.
- *
- * @param ds (Object) a datastore context
- * @param path (String) the path to the file to read
- * @param opts (Object) optional arguments:
- *      .extended (Bool) whether or not to include the entire path's inode inforamtion
- *      .force (Bool) if True, then ignore stale inode errors.
- *      .blockchain_id (string) this is the blockchain ID of the datastore owner (if different from the session)
- *      .ds (datastore context) this is the mount context for the datastore, if different from one that we have cached
- *
- * Asynchronous; returns a Promise that resolves to either raw data, or an extended mutable data response schema (if opts.extended is set).
- * If the file does not exist, then the Promise resolves to null.  Any other errors result in an Error being thrown.
- */
-function getFile(path) {
-   var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-
-
-   var blockchain_id = opts.blockchain_id;
-
-   if (!opts.blockchain_id) {
-      blockchain_id = getSessionBlockchainID();
-   }
-
-   return datastoreMountOrCreate().then(function (ds) {
-      assert(ds);
-
-      var datastore_id = ds.datastore_id;
-      var device_list = getDeviceList(ds);
-      var device_pubkeys = getPublicKeyList(ds);
-      var options = {
-         'method': 'GET',
-         'host': ds.host,
-         'port': ds.port,
-         'path': '/v1/stores/' + datastore_id + '/files?path=' + escape(sanitizePath(path)) + '&idata=1&device_ids=' + device_list + '&device_pubkeys=' + device_pubkeys + '&blockchain_id=' + ds.blockchain_id
-      };
-
-      var schema = 'bytes';
-
-      if (!opts) {
-         opts = {};
-      }
-
-      if (opts.extended) {
-         options['path'] += '&extended=1';
-         schema = MUTABLE_DATUM_EXTENDED_RESPONSE_SCHEMA;
-      }
-
-      if (opts.force) {
-         options['path'] += '&force=1';
-      }
-
-      if (ds.session_token) {
-         options['headers'] = { 'Authorization': 'bearer ' + ds.session_token };
-      }
-
-      return httpRequest(options, schema).then(function (response) {
-         if (response.error || response.errno) {
-            // ENOENT?
-            if (response.errno === ENOENT) {
-               return null;
-            }
-
-            // some other error
-            var errorMsg = response.error || 'UNKNOWN';
-            var errorNo = response.errno || 'UNKNOWN';
-            throw new Error('Failed to getFile ' + path + ' (errno: ' + errorNo + '): ' + errorMsg);
-         } else {
-            return response;
-         }
-      });
-   });
-}
-
-/*
- * Execute a datastore operation
- *
- * @param ds (Object) a datastore context
- * @param operation (String) the specific operation being carried out.
- * @param path (String) the path of the operation
- * @param inodes (Array) the list of inode headers to replicate
- * @param payloads (Array) the list of inode payloads in 1-to-1 correspondence to the headers
- * @param signatures (Array) the list of signatures over each inode header (also 1-to-1 correspondence)
- * @param tombstones (Array) the list of signed inode tombstones
- *
- * Asynchronous; returns a Promise that resolves to True if the operation succeeded
- */
-function datastoreOperation(ds, operation, path, inodes, payloads, signatures, tombstones) {
-
-   var request_path = null;
-   var http_operation = null;
-   var datastore_id = ds.datastore_id;
-   var datastore_privkey = ds.privkey_hex;
-   var device_list = getDeviceList(ds);
-   var device_pubkeys = getPublicKeyList(ds);
-
-   assert(inodes.length === payloads.length);
-   assert(payloads.length === signatures.length);
-
-   if (operation === 'mkdir') {
-      request_path = '/v1/stores/' + datastore_id + '/directories?path=' + escape(sanitizePath(path)) + '&device_ids=' + device_list + '&device_pubkeys=' + device_pubkeys + '&blockchain_id=' + ds.blockchain_id;
-      http_operation = 'POST';
-
-      assert(inodes.length === 2);
-   } else if (operation === 'putFile') {
-      request_path = '/v1/stores/' + datastore_id + '/files?path=' + escape(sanitizePath(path)) + '&device_ids=' + device_list + '&device_pubkeys=' + device_pubkeys + '&blockchain_id=' + ds.blockchain_id;
-      http_operation = 'PUT';
-
-      assert(inodes.length === 1 || inodes.length === 2);
-   } else if (operation === 'rmdir') {
-      request_path = '/v1/stores/' + datastore_id + '/directories?path=' + escape(sanitizePath(path)) + '&device_pubkeys=' + device_pubkeys + '&device_ids=' + device_list + '&blockchain_id=' + ds.blockchain_id;
-      http_operation = 'DELETE';
-
-      assert(inodes.length === 1);
-      assert(tombstones.length >= 1);
-   } else if (operation === 'deleteFile') {
-      request_path = '/v1/stores/' + datastore_id + '/files?path=' + escape(sanitizePath(path)) + '&device_pubkeys=' + device_pubkeys + '&device_ids=' + device_list + '&blockchain_id=' + ds.blockchain_id;
-      http_operation = 'DELETE';
-
-      assert(inodes.length === 1);
-      assert(tombstones.length >= 1);
-   } else {
-      console.log('invalid operation ' + operation);
-      throw new Error('Invalid operation ' + operation);
-   }
-
-   var options = {
-      'method': http_operation,
-      'host': ds.host,
-      'port': ds.port,
-      'path': request_path
-   };
-
-   if (ds.session_token) {
-      options['headers'] = { 'Authorization': 'bearer ' + ds.session_token };
-   }
-
-   var datastore_str = JSON.stringify(ds.datastore);
-   var datastore_sig = (0, _inode.signRawData)(datastore_str, datastore_privkey);
-
-   var body_struct = {
-      'inodes': inodes,
-      'payloads': payloads,
-      'signatures': signatures,
-      'tombstones': tombstones,
-      'datastore_str': datastore_str,
-      'datastore_sig': datastore_sig
-   };
-
-   var body = JSON.stringify(body_struct);
-   options['headers']['Content-Type'] = 'application/json';
-   options['headers']['Content-Length'] = body.length;
-
-   return httpRequest(options, _schemas.SUCCESS_FAIL_SCHEMA, body).then(function (response) {
-      if (response.error || response.errno) {
-         var errorMsg = response.error || 'UNKNOWN';
-         var errorNo = response.errno || 'UNKNOWN';
-         throw new Error('Failed to ' + operation + ' ' + path + ' (errno: ' + errorNo + '): ' + errorMsg);
-      } else {
-         return true;
-      }
-   });
-}
-
-/*
- * Given a path, get its parent directory
- * Make sure it's a directory.
- *
- * @param ds (Object) a datastore context
- * @param path (String) the path to the inode in question
- * @param opts (Object) lookup options
- *      .extended (Bool) whether or not to include the entire path's inode inforamtion
- *      .force (Bool) if True, then ignore stale inode errors.
- *      .blockchain_id (string) this is the blockchain ID of the datastore owner (if different from the session)
- *      .ds (datastore context) this is the mount context for the datastore, if different from one that we have cached
- *
- * Asynchronous; returns a Promise
- */
-function getParent(path) {
-   var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-
-   var dirpath = dirname(path);
-   return getInode(dirpath, opts).then(function (inode) {
-      if (!inode) {
-         return { 'error': 'Failed to get parent', 'errno': EREMOTEIO };
-      }
-      if (inode.type !== _schemas.MUTABLE_DATUM_DIR_TYPE) {
-         return { 'error': 'Not a directory', 'errno': ENOTDIR };
-      } else {
-         return inode;
-      }
-   }, function (error_resp) {
-      return { 'error': 'Failed to get inode', 'errno': EREMOTEIO };
-   });
-}
-
-/*
- * Create or update a file
- *
- * @param ds (Object) a datastore context
- * @param path (String) the path to the file to create (must not exist)
- * @param file_buffer (Buffer or String) the file contents
- * @param opts (Object) lookup options
- *      .extended (Bool) whether or not to include the entire path's inode inforamtion
- *      .force (Bool) if True, then ignore stale inode errors.
- *      .blockchain_id (string) this is the blockchain ID of the datastore owner (if different from the session)
- *      .ds (datastore context) this is the mount context for the datastore, if different from one that we have cached
- *
- * Asynchronous; returns a Promise
- */
-function putFile(path, file_buffer) {
-   var opts = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
-
-
-   var blockchain_id = opts.blockchain_id;
-
-   if (!opts.blockchain_id) {
-      blockchain_id = getSessionBlockchainID();
-   }
-
-   return datastoreMountOrCreate().then(function (ds) {
-
-      assert(ds);
-
-      var datastore_id = ds.datastore_id;
-      var device_id = ds.device_id;
-      var privkey_hex = ds.privkey_hex;
-
-      path = sanitizePath(path);
-      var child_name = basename(path);
-
-      assert(typeof file_buffer === 'string' || file_buffer instanceof Buffer);
-
-      // get parent dir
-      return getParent(path, opts).then(function (parent_dir) {
-         if (parent_dir.error) {
-            return parent_dir;
-         }
-
-         // make the file inode information
-         var file_payload = file_buffer;
-         var file_hash = null;
-         if (typeof file_payload !== 'string') {
-            // buffer
-            file_payload = file_buffer.toString('base64');
-            file_hash = (0, _inode.hashDataPayload)(file_buffer.toString());
-         } else {
-            // string
-            file_payload = Buffer.from(file_buffer).toString('base64');
-            file_hash = (0, _inode.hashDataPayload)(file_buffer);
-         }
-
-         assert(file_hash);
-
-         var inode_uuid = null;
-         var new_parent_dir_inode = null;
-         var child_version = null;
-
-         // new or existing?
-         if (Object.keys(parent_dir['idata']['children']).includes(child_name)) {
-
-            // existing; no directory change
-            inode_uuid = parent_dir['idata']['children'][child_name]['uuid'];
-            new_parent_dir_inode = (0, _inode.inodeDirLink)(parent_dir, _schemas.MUTABLE_DATUM_FILE_TYPE, child_name, inode_uuid, true);
-         } else {
-
-            // new
-            inode_uuid = uuid4();
-            new_parent_dir_inode = (0, _inode.inodeDirLink)(parent_dir, _schemas.MUTABLE_DATUM_FILE_TYPE, child_name, inode_uuid, false);
-         }
-
-         var version = (0, _inode.getChildVersion)(parent_dir, child_name);
-         var inode_info = (0, _inode.makeFileInodeBlob)(datastore_id, datastore_id, inode_uuid, file_hash, device_id, version);
-         var inode_sig = (0, _inode.signDataPayload)(inode_info['header'], privkey_hex);
-
-         // make the directory inode information
-         var new_parent_info = (0, _inode.makeDirInodeBlob)(datastore_id, new_parent_dir_inode['owner'], new_parent_dir_inode['uuid'], new_parent_dir_inode['idata']['children'], device_id, new_parent_dir_inode['version'] + 1);
-         var new_parent_sig = (0, _inode.signDataPayload)(new_parent_info['header'], privkey_hex);
-
-         // post them
-         var new_parent_info_b64 = new Buffer(new_parent_info['idata']).toString('base64');
-         return datastoreOperation(ds, 'putFile', path, [inode_info['header'], new_parent_info['header']], [file_payload, new_parent_info_b64], [inode_sig, new_parent_sig], []);
-      });
-   });
-}
-
-/*
- * Create a directory.
- *
- * @param ds (Object) datastore context
- * @param path (String) path to the directory
- * @param opts (object) optional arguments
- *      .blockchain_id (string) this is the blockchain ID of the datastore owner (if different from the session)
- *      .ds (datastore context) this is the mount context for the datastore, if different from one that we have cached
- *
- * Asynchronous; returns a Promise
- */
-function mkdir(path) {
-   var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-
-
-   var blockchain_id = opts.blockchain_id;
-
-   if (!opts.blockchain_id) {
-      blockchain_id = getSessionBlockchainID();
-   }
-
-   return datastoreMountOrCreate().then(function (ds) {
-
-      assert(ds);
-
-      var datastore_id = ds.datastore_id;
-      var device_id = ds.device_id;
-      var privkey_hex = ds.privkey_hex;
-
-      path = sanitizePath(path);
-      var child_name = basename(path);
-
-      return getParent(path, opts).then(function (parent_dir) {
-         if (parent_dir.error) {
-            return parent_dir;
-         }
-
-         // must not exist
-         if (Object.keys(parent_dir['idata']['children']).includes(child_name)) {
-            return { 'error': 'File or directory exists', 'errno': EEXIST };
-         }
-
-         // make the directory inode information
-         var inode_uuid = uuid4();
-         var inode_info = (0, _inode.makeDirInodeBlob)(datastore_id, datastore_id, inode_uuid, {}, device_id);
-         var inode_sig = (0, _inode.signDataPayload)(inode_info['header'], privkey_hex);
-
-         // make the new parent directory information
-         var new_parent_dir_inode = (0, _inode.inodeDirLink)(parent_dir, _schemas.MUTABLE_DATUM_DIR_TYPE, child_name, inode_uuid);
-         var new_parent_info = (0, _inode.makeDirInodeBlob)(datastore_id, new_parent_dir_inode['owner'], new_parent_dir_inode['uuid'], new_parent_dir_inode['idata']['children'], device_id, new_parent_dir_inode['version'] + 1);
-         var new_parent_sig = (0, _inode.signDataPayload)(new_parent_info['header'], privkey_hex);
-
-         // post them
-         return datastoreOperation(ds, 'mkdir', path, [inode_info['header'], new_parent_info['header']], [inode_info['idata'], new_parent_info['idata']], [inode_sig, new_parent_sig], []);
-      });
-   });
-}
-
-/*
- * Delete a file
- *
- * @param ds (Object) datastore context
- * @param path (String) path to the directory
- * @param opts (Object) options for this call
- *      .blockchain_id (string) this is the blockchain ID of the datastore owner (if different from the session)
- *      .ds (datastore context) this is the mount context for the datastore, if different from one that we have cached
- *
- * Asynchronous; returns a Promise
- */
-function deleteFile(path) {
-   var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-
-
-   var blockchain_id = opts.blockchain_id;
-
-   if (!opts.blockchain_id) {
-      blockchain_id = getSessionBlockchainID();
-   }
-
-   return datastoreMountOrCreate().then(function (ds) {
-
-      assert(ds);
-
-      var datastore_id = ds.datastore_id;
-      var device_id = ds.device_id;
-      var privkey_hex = ds.privkey_hex;
-      var all_device_ids = ds.datastore.device_ids;
-
-      path = sanitizePath(path);
-      var child_name = basename(path);
-
-      return getParent(path, opts).then(function (parent_dir) {
-         if (parent_dir.error) {
-            return parent_dir;
-         }
-
-         // no longer exists?
-         if (!Object.keys(parent_dir['idata']['children']).includes(child_name)) {
-            return { 'error': 'No such file or directory', 'errno': ENOENT };
-         }
-
-         var inode_uuid = parent_dir['idata']['children'][child_name]['uuid'];
-
-         // unlink
-         var new_parent_dir_inode = (0, _inode.inodeDirUnlink)(parent_dir, child_name);
-         var new_parent_info = (0, _inode.makeDirInodeBlob)(datastore_id, new_parent_dir_inode['owner'], new_parent_dir_inode['uuid'], new_parent_dir_inode['idata']['children'], device_id, new_parent_dir_inode['version'] + 1);
-         var new_parent_sig = (0, _inode.signDataPayload)(new_parent_info['header'], privkey_hex);
-
-         // make tombstones
-         var tombstones = (0, _inode.makeInodeTombstones)(datastore_id, inode_uuid, all_device_ids);
-         var signed_tombstones = (0, _inode.signMutableDataTombstones)(tombstones, privkey_hex);
-
-         // post them
-         return datastoreOperation(ds, 'deleteFile', path, [new_parent_info['header']], [new_parent_info['idata']], [new_parent_sig], signed_tombstones);
-      });
-   });
-}
-
-/*
- * Remove a directory
- *
- * @param ds (Object) datastore context
- * @param path (String) path to the directory
- * @param opts (Object) options for this call
- *      .blockchain_id (string) this is the blockchain ID of the datastore owner (if different from the session)
- *      .ds (datastore context) this is the mount context for the datastore, if different from one that we have cached
- *
- * Asynchronous; returns a Promise
- */
-function rmdir(path) {
-   var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-
-
-   var blockchain_id = opts.blockchain_id;
-
-   if (!opts.blockchain_id) {
-      blockchain_id = getSessionBlockchainID();
-   }
-
-   return datastoreMountOrCreate().then(function (ds) {
-
-      assert(ds);
-
-      var datastore_id = ds.datastore_id;
-      var device_id = ds.device_id;
-      var privkey_hex = ds.privkey_hex;
-      var all_device_ids = ds.datastore.device_ids;
-
-      path = sanitizePath(path);
-      var child_name = basename(path);
-
-      return getParent(path, opts).then(function (parent_dir) {
-         if (parent_dir.error) {
-            return parent_dir;
-         }
-
-         // no longer exists?
-         if (!Object.keys(parent_dir['idata']['children']).includes(child_name)) {
-            return { 'error': 'No such file or directory', 'errno': ENOENT };
-         }
-
-         var inode_uuid = parent_dir['idata']['children'][child_name]['uuid'];
-
-         // unlink
-         var new_parent_dir_inode = (0, _inode.inodeDirUnlink)(parent_dir, child_name);
-         var new_parent_info = (0, _inode.makeDirInodeBlob)(datastore_id, new_parent_dir_inode['owner'], new_parent_dir_inode['uuid'], new_parent_dir_inode['idata']['children'], device_id, new_parent_dir_inode['version'] + 1);
-         var new_parent_sig = (0, _inode.signDataPayload)(new_parent_info['header'], privkey_hex);
-
-         // make tombstones
-         var tombstones = (0, _inode.makeInodeTombstones)(datastore_id, inode_uuid, all_device_ids);
-         var signed_tombstones = (0, _inode.signMutableDataTombstones)(tombstones, privkey_hex);
-
-         // post them
-         return datastoreOperation(ds, 'rmdir', path, [new_parent_info['header']], [new_parent_info['idata']], [new_parent_sig], signed_tombstones);
-      });
-   });
-}
-}).call(this,require("buffer").Buffer)
-},{"./inode":137,"./schemas":138,"./util":139,"ajv":36,"assert":156,"bigi":86,"bitcoinjs-lib":125,"buffer":188,"http":265,"jsontokens":381,"promise":470,"uuid/v4":487}],135:[function(require,module,exports){
-'use strict';
-
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
-
-var UnsupportedNetstringTypeError = exports.UnsupportedNetstringTypeError = function (_Error) {
-  _inherits(UnsupportedNetstringTypeError, _Error);
-
-  function UnsupportedNetstringTypeError(message) {
-    _classCallCheck(this, UnsupportedNetstringTypeError);
-
-    var _this = _possibleConstructorReturn(this, (UnsupportedNetstringTypeError.__proto__ || Object.getPrototypeOf(UnsupportedNetstringTypeError)).call(this));
-
-    _this.name = 'UnsupportedNetstringTypeError';
-    _this.message = message || '';
-    return _this;
-  }
-
-  return UnsupportedNetstringTypeError;
-}(Error);
-
-var InvalidNetstringError = exports.InvalidNetstringError = function (_Error2) {
-  _inherits(InvalidNetstringError, _Error2);
-
-  function InvalidNetstringError(message) {
-    _classCallCheck(this, InvalidNetstringError);
-
-    var _this2 = _possibleConstructorReturn(this, (InvalidNetstringError.__proto__ || Object.getPrototypeOf(InvalidNetstringError)).call(this));
-
-    _this2.name = 'InvalidNetstringError';
-    _this2.message = message || '';
-    return _this2;
-  }
-
-  return InvalidNetstringError;
-}(Error);
-},{}],136:[function(require,module,exports){
-'use strict';
-
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-
-var _errors = require('./errors');
-
-Object.keys(_errors).forEach(function (key) {
-  if (key === "default" || key === "__esModule") return;
-  Object.defineProperty(exports, key, {
-    enumerable: true,
-    get: function get() {
-      return _errors[key];
-    }
-  });
-});
-
-var _util = require('./util');
-
-Object.keys(_util).forEach(function (key) {
-  if (key === "default" || key === "__esModule") return;
-  Object.defineProperty(exports, key, {
-    enumerable: true,
-    get: function get() {
-      return _util[key];
-    }
-  });
-});
-
-var _datastore = require('./datastore');
-
-Object.keys(_datastore).forEach(function (key) {
-  if (key === "default" || key === "__esModule") return;
-  Object.defineProperty(exports, key, {
-    enumerable: true,
-    get: function get() {
-      return _datastore[key];
-    }
-  });
-});
-
-var _inode = require('./inode');
-
-Object.keys(_inode).forEach(function (key) {
-  if (key === "default" || key === "__esModule") return;
-  Object.defineProperty(exports, key, {
-    enumerable: true,
-    get: function get() {
-      return _inode[key];
-    }
-  });
-});
-
-var _schemas = require('./schemas');
-
-Object.keys(_schemas).forEach(function (key) {
-  if (key === "default" || key === "__esModule") return;
-  Object.defineProperty(exports, key, {
-    enumerable: true,
-    get: function get() {
-      return _schemas[key];
-    }
-  });
-});
-},{"./datastore":134,"./errors":135,"./inode":137,"./schemas":138,"./util":139}],137:[function(require,module,exports){
-(function (Buffer){
-'use strict';
-
-Object.defineProperty(exports, "__esModule", {
-   value: true
-});
-exports.hashDataPayload = hashDataPayload;
-exports.hashRawData = hashRawData;
-exports.decodePrivateKey = decodePrivateKey;
-exports.signRawData = signRawData;
-exports.signDataPayload = signDataPayload;
-exports.makeFullyQualifiedDataId = makeFullyQualifiedDataId;
-exports.makeMutableDataInfo = makeMutableDataInfo;
-exports.makeDataTombstone = makeDataTombstone;
-exports.makeMutableDataTombstones = makeMutableDataTombstones;
-exports.makeInodeTombstones = makeInodeTombstones;
-exports.signDataTombstone = signDataTombstone;
-exports.signMutableDataTombstones = signMutableDataTombstones;
-exports.makeInodeHeaderBlob = makeInodeHeaderBlob;
-exports.makeDirInodeBlob = makeDirInodeBlob;
-exports.makeFileInodeBlob = makeFileInodeBlob;
-exports.getChildVersion = getChildVersion;
-exports.inodeDirLink = inodeDirLink;
-exports.inodeDirUnlink = inodeDirUnlink;
-
-var _util = require('./util');
-
-var _schemas = require('./schemas');
-
-var assert = require('assert');
-var crypto = require('crypto');
-var EC = require('elliptic').ec;
-var ec = EC('secp256k1');
-var Ajv = require('ajv');
-
-var BLOCKSTACK_STORAGE_PROTO_VERSION = 1;
-
-/*
- * Hash an inode payload and its length.
- * Specifically hash `${payload.length}:${payload},`
- *
- * @param payload_buffer (String) the payload to hash
- *
- * Return the sha256
- */
-function hashDataPayload(payload_buffer) {
-   var hash = crypto.createHash('sha256');
-
-   // this forces the hash to be computed over the bytestring
-   // (important when computing length!) which will make it
-   // match with the Python hash verifier
-   var payload_str = Buffer.from(payload_buffer);
-
-   hash.update(payload_str.length + ':');
-   hash.update(payload_str);
-   hash.update(',');
-
-   return hash.digest('hex');
-}
-
-/*
- * Hash raw data
- * @param payload_buffer (Buffer) the buffer to hash
- *
- * Return the sha256
- */
-function hashRawData(payload_buffer) {
-   var hash = crypto.createHash('sha256');
-
-   hash.update(payload_buffer);
-
-   return hash.digest('hex');
-}
-
-/*
- * Decode a hex string into a byte buffer.
- *
- * @param hex (String) a string of hex digits.
- *
- * Returns a buffer with the raw bytes
- */
-function decodeHexString(hex) {
-   var bytes = [];
-   for (var i = 0; i < hex.length - 1; i += 2) {
-      bytes.push(parseInt(hex.substr(i, 2), 16));
-   }
-   return Buffer.from(bytes);
-}
-
-/*
- * Decode an ECDSA private key into a byte buffer
- * (compatible with Bitcoin's 'compressed' flag quirk)
- *
- * @param privkey_hex (String) a hex-encoded ECDSA private key on secp256k1; optionally ending in '01'
- *
- * Returns a Buffer with the private key data
- */
-function decodePrivateKey(privatekey_hex) {
-   if (privatekey_hex.length === 66 && privatekey_hex.slice(64, 66) === '01') {
-      // truncate the '01', which is a hint to Bitcoin to expect a compressed public key
-      privatekey_hex = privatekey_hex.slice(0, 64);
-   }
-   return decodeHexString(privatekey_hex);
-}
-
-/*
- * Sign a string of data.
- *
- * @param payload_buffer (Buffer) the buffer to sign
- * @param privkey_hex (String) the hex-encoded ECDSA private key
- * @param hash (String) optional; the hash of the payload.  payload_buffer can be null if hash is given.
- *
- * Return the base64-encoded signature
- */
-function signRawData(payload_buffer, privkey_hex, hash) {
-
-   var privkey = decodePrivateKey(privkey_hex);
-
-   if (!hash) {
-      hash = hashRawData(payload_buffer);
-   }
-
-   var sig = ec.sign(hash, privkey, { canonical: true });
-
-   // use signature encoding compatible with Blockstack
-   var r_array = sig.r.toArray();
-   var s_array = sig.s.toArray();
-   var r_buf = Buffer.from(r_array).toString('hex');
-   var s_buf = Buffer.from(s_array).toString('hex');
-
-   if (r_buf.length < 64) {
-      while (r_buf.length < 64) {
-         r_buf = "0" + r_buf;
-      }
-   }
-
-   if (s_buf.length < 64) {
-      while (s_buf.length < 64) {
-         s_buf = "0" + s_buf;
-      }
-   }
-
-   var sig_buf_hex = r_buf + s_buf;
-
-   assert(sig_buf_hex.length == 128);
-
-   var sigb64 = Buffer.from(sig_buf_hex, 'hex').toString('base64');
-   return sigb64;
-}
-
-/*
- * Sign a data payload and its length.
- * Specifically sign `${payload.length}:${payload},`
- *
- * @payload_string (String) the string to sign
- * @privkey_hex (String) the hex-encoded private key
- *
- * Return the base64-encoded signature
- */
-function signDataPayload(payload_string, privkey_hex) {
-   return signRawData(Buffer.concat([Buffer.from(payload_string.length + ':'), Buffer.from(payload_string), Buffer.from(',')]), privkey_hex);
-}
-
-/*
- * Make a fully-qualified data ID (i.e. includes the device ID)
- * equivalent to this in Python: urllib.quote(str('{}:{}'.format(device_id, data_id).replace('/', '\\x2f')))
- * 
- * @param device_id (String) the device ID 
- * @param data_id (String) the device-agnostic part of the data ID
- *
- * Returns the fully-qualified data ID
- */
-function makeFullyQualifiedDataId(device_id, data_id) {
-   return escape((device_id + ':' + data_id).replace('/', '\\x2f'));
-}
-
-/*
- * Make a mutable data payload
- * 
- * @param data_id (String) the data identifier (not fully qualified)
- * @param data_payload (String) the data payload to store
- * @param version (Int) the version number
- * @param device_id (String) the ID of the device creating this data
- *
- * Returns an mutable data payload object.
- */
-function makeMutableDataInfo(data_id, data_payload, device_id, version) {
-   var fq_data_id = makeFullyQualifiedDataId(device_id, data_id);
-   var timestamp = new Date().getTime();
-
-   var ret = {
-      'fq_data_id': fq_data_id,
-      'data': data_payload,
-      'version': version,
-      'timestamp': timestamp
-   };
-
-   return ret;
-}
-
-/*
- * Make a single datum tombstone.
- *
- * @param tombstone_payload (String) the string that encodes the tombstone
- *
- * Returns the tombstone (to be fed into the storage driver)
- */
-function makeDataTombstone(tombstone_payload) {
-   var now = parseInt(new Date().getTime() / 1000);
-   return 'delete-' + now + ':' + tombstone_payload;
-}
-
-/*
- * Make a list of mutable data tombstones.
- *
- * @param device_ids (Array) the list of device IDs
- * @param data_id (String) the datum ID
- * 
- * Returns a list of tombstones.
- */
-function makeMutableDataTombstones(device_ids, data_id) {
-   var ts = [];
-   var _iteratorNormalCompletion = true;
-   var _didIteratorError = false;
-   var _iteratorError = undefined;
-
-   try {
-      for (var _iterator = device_ids[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
-         var device_id = _step.value;
-
-         ts.push(makeDataTombstone(makeFullyQualifiedDataId(device_id, data_id)));
-      }
-   } catch (err) {
-      _didIteratorError = true;
-      _iteratorError = err;
-   } finally {
-      try {
-         if (!_iteratorNormalCompletion && _iterator.return) {
-            _iterator.return();
-         }
-      } finally {
-         if (_didIteratorError) {
-            throw _iteratorError;
-         }
-      }
-   }
-
-   return ts;
-}
-
-/*
- * Make a list of inode tombstones.
- *
- * @param datastore_id (String) the datastore ID
- * @param inode_uuid (String) the inode ID
- * @param device_ids (Array) the list of device IDs
- *
- * Returns a list of tombstones.
- */
-function makeInodeTombstones(datastore_id, inode_uuid, device_ids) {
-   assert(device_ids.length > 0);
-
-   var header_id = datastore_id + '.' + inode_uuid + '.hdr';
-   var header_tombstones = makeMutableDataTombstones(device_ids, header_id);
-
-   var idata_id = datastore_id + '.' + inode_uuid;
-   var idata_tombstones = makeMutableDataTombstones(device_ids, idata_id);
-
-   return header_tombstones.concat(idata_tombstones);
-}
-
-/*
- * Sign a datum tombstone
- *
- * @param tombstone (String) the tombstone string
- * @param privkey (String) the hex-encoded private key
- * 
- * Returns the signed tombstone as a String
- */
-function signDataTombstone(tombstone, privkey) {
-   var sigb64 = signRawData(tombstone, privkey);
-   return tombstone + ':' + sigb64;
-}
-
-/* 
- * Sign a list of mutable data tombstones
- *
- * @param tobmstones (Array) the list of per-device tombstones
- * @param privkey (String) the hex-encoded private key
- *
- * Returns the list of signed tombstones as an Array.
- */
-function signMutableDataTombstones(tombstones, privkey) {
-   var sts = [];
-   var _iteratorNormalCompletion2 = true;
-   var _didIteratorError2 = false;
-   var _iteratorError2 = undefined;
-
-   try {
-      for (var _iterator2 = tombstones[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
-         var ts = _step2.value;
-
-         sts.push(signDataTombstone(ts, privkey));
-      }
-   } catch (err) {
-      _didIteratorError2 = true;
-      _iteratorError2 = err;
-   } finally {
-      try {
-         if (!_iteratorNormalCompletion2 && _iterator2.return) {
-            _iterator2.return();
-         }
-      } finally {
-         if (_didIteratorError2) {
-            throw _iteratorError2;
-         }
-      }
-   }
-
-   ;
-   return sts;
-}
-
-/*
- * Make an inode header blob.
- *
- * @param datastore_id (String) the ID of the datastore for this inode
- * @param inode_type (Int) 1 for file, 2 for directory
- * @param owner_id (String) a string that encodes the owner of this inode (i.e. pass datastore_id for now)
- * @param inode_uuid (String) the inode ID
- * @param data_hash (String) the hex-encoded sha256 of the data
- * @param version (Int) the version of this inode.
- * @param device_id (String) the ID of this device
- *
- * Returns an object encoding an inode header.
- */
-function makeInodeHeaderBlob(datastore_id, inode_type, owner_id, inode_uuid, data_hash, device_id, version) {
-
-   var header = {
-      'type': inode_type,
-      'owner': owner_id,
-      'uuid': inode_uuid,
-      'readers': [], // unused for now
-      'data_hash': data_hash,
-      'version': version,
-      'proto_version': BLOCKSTACK_STORAGE_PROTO_VERSION
-   };
-
-   var valid = null;
-   var ajv = new Ajv();
-   try {
-      valid = ajv.validate(_schemas.MUTABLE_DATUM_INODE_HEADER_SCHEMA, header);
-      assert(valid);
-   } catch (e) {
-      console.log('header: ' + JSON.stringify(header));
-      console.log('schema: ' + JSON.stringify(_schemas.MUTABLE_DATUM_INODE_HEADER_SCHEMA));
-      console.log(e.stack);
-      throw e;
-   }
-
-   var inode_data_id = datastore_id + '.' + inode_uuid + '.hdr';
-   var inode_data_payload = (0, _util.jsonStableSerialize)(header);
-   var inode_header_blob = makeMutableDataInfo(inode_data_id, inode_data_payload, device_id, version);
-   return (0, _util.jsonStableSerialize)(inode_header_blob);
-}
-
-/*
- * Make a directory inode header for a particular datastore and owner.
- *
- * @param datastore_id (String) the ID of the datastore for this inode
- * @param owner_id (String) a string that encodes the owner of this directory (i.e. pass datastore_id for now)
- * @param inode_uuid (String) the ID of the inode
- * @param dir_listing (Object) a MUTABLE_DATUM_DIR_IDATA_SCHEMA-conformant object that describes the directory listing.
- * @param device_id (String) this device ID
- *
- * Returns an object encoding a directory's header and idata
- */
-function makeDirInodeBlob(datastore_id, owner_id, inode_uuid, dir_listing, device_id, version) {
-
-   var ajv = new Ajv();
-   var valid = null;
-   try {
-      valid = ajv.validate(_schemas.MUTABLE_DATUM_DIR_IDATA_SCHEMA.properties.children, dir_listing);
-      assert(valid);
-   } catch (e) {
-      console.log('dir listing: ' + JSON.stringify(dir_listing));
-      console.log('schema:      ' + JSON.stringify(_schemas.MUTABLE_DATUM_DIR_IDATA_SCHEMA));
-      throw e;
-   }
-
-   if (!version) {
-      version = 1;
-   }
-
-   var empty_hash = '0000000000000000000000000000000000000000000000000000000000000000';
-   var internal_header_blob = makeInodeHeaderBlob(datastore_id, _schemas.MUTABLE_DATUM_DIR_TYPE, owner_id, inode_uuid, empty_hash, device_id, version);
-
-   // recover header 
-   var internal_header = JSON.parse(JSON.parse(internal_header_blob).data);
-   var idata_payload = {
-      children: dir_listing,
-      header: internal_header
-   };
-
-   var idata_payload_str = (0, _util.jsonStableSerialize)(idata_payload);
-   var idata_hash = hashDataPayload(idata_payload_str);
-
-   var header_blob = makeInodeHeaderBlob(datastore_id, _schemas.MUTABLE_DATUM_DIR_TYPE, owner_id, inode_uuid, idata_hash, device_id, version);
-   return { 'header': header_blob, 'idata': idata_payload_str };
-}
-
-/*
- * Make a file inode header for a particular datastore and owner.
- *
- * @param datastore_id (String) the ID of the datastore for this niode
- * @param owner_id (String) a string that encodes the owner of this file (i.e. pass datastore_id for now)
- * @param inode_uuid (String) the ID of the inode
- * @param data_hash (String) the hash of the file data
- * @param device_id (String) this device ID
- *
- * Returns an object encoding a file's header
- */
-function makeFileInodeBlob(datastore_id, owner_id, inode_uuid, data_hash, device_id, version) {
-
-   var header_blob = makeInodeHeaderBlob(datastore_id, _schemas.MUTABLE_DATUM_FILE_TYPE, owner_id, inode_uuid, data_hash, device_id, version);
-   return { 'header': header_blob };
-}
-
-/*
- * Get the child inode version from a directory
- * @param parent_dir (Object) directory inode
- * @param child_name (String) name of the directory
- *
- * Raises if there is no child
- */
-function getChildVersion(parent_dir, child_name) {
-   assert(parent_dir['idata']['children'][child_name]);
-   return parent_dir['idata']['children'][child_name].version;
-}
-
-/*
- * Insert an entry into a directory's listing.
- *
- * @param parent_dir (Object) a directory inode structure
- * @param child_type (Int) 1 for file, 2 for directory
- * @param child_name (String) the name of the child inode (must be unique in this directory)
- * @param child_uuid (String) the ID of the child inode.
- * @param exists (Bool) if given, and if True, then expect the child to exist.
- *
- * Returns the new parent directory inode object.
- */
-function inodeDirLink(parent_dir, child_type, child_name, child_uuid, exists) {
-
-   assert(parent_dir['type'] === _schemas.MUTABLE_DATUM_DIR_TYPE);
-   assert(parent_dir['idata']);
-   assert(parent_dir['idata']['children']);
-
-   if (!exists) {
-      assert(!Object.keys(parent_dir['idata']['children']).includes(child_name));
-   }
-
-   var new_dirent = {
-      uuid: child_uuid,
-      type: child_type,
-      version: 1
-   };
-
-   if (parent_dir['idata']['children']['version']) {
-      new_dirent.version = parent_dir['idata']['children']['version'] + 1;
-   }
-
-   parent_dir['idata']['children'][child_name] = new_dirent;
-   parent_dir['version'] += 1;
-   return parent_dir;
-}
-
-/*
- * Detach an inode from a directory.
- *
- * @param parent_dir (Object) a directory inode structure
- * @param child_name (String) the name of the child to detach
- *
- * Returns the new parent directory inode object.
- */
-function inodeDirUnlink(parent_dir, child_name) {
-
-   assert(parent_dir['type'] === _schemas.MUTABLE_DATUM_DIR_TYPE);
-   assert(parent_dir['idata']);
-   assert(parent_dir['idata']['children']);
-
-   assert(Object.keys(parent_dir['idata']['children']).includes(child_name));
-
-   delete parent_dir['idata']['children'][child_name];
-   parent_dir['version'] += 1;
-   return parent_dir;
-}
-}).call(this,require("buffer").Buffer)
-},{"./schemas":138,"./util":139,"ajv":36,"assert":156,"buffer":188,"crypto":198,"elliptic":317}],138:[function(require,module,exports){
-'use strict';
-
-Object.defineProperty(exports, "__esModule", {
-    value: true
-});
-var MUTABLE_DATUM_FILE_TYPE = exports.MUTABLE_DATUM_FILE_TYPE = 1;
-var MUTABLE_DATUM_DIR_TYPE = exports.MUTABLE_DATUM_DIR_TYPE = 2;
-
-var OP_BASE58CHECK_PATTERN = exports.OP_BASE58CHECK_PATTERN = "^([123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]+)$";
-var OP_ADDRESS_PATTERN = exports.OP_ADDRESS_PATTERN = OP_BASE58CHECK_PATTERN;
-var OP_UUID_PATTERN = exports.OP_UUID_PATTERN = "^([0-9a-fA-F\-]+)$";
-var OP_HEX_PATTERN = exports.OP_HEX_PATTERN = "^([0-9a-fA-F]+)$";
-var OP_URLENCODED_NOSLASH_PATTERN = exports.OP_URLENCODED_NOSLASH_PATTERN = "^([a-zA-Z0-9\-_.~%]+)$";
-var OP_URLENCODED_PATTERN = exports.OP_URLENCODED_PATTERN = "^([a-zA-Z0-9\-_.~%/]+)$";
-var OP_URLENCODED_NOSLASH_OR_EMPTY_PATTERN = exports.OP_URLENCODED_NOSLASH_OR_EMPTY_PATTERN = "^([a-zA-Z0-9\-_.~%]*)$";
-var OP_URLENCODED_OR_EMPTY_PATTERN = exports.OP_URLENCODED_OR_EMPTY_PATTERN = "^([a-zA-Z0-9\-_.~%/]*)$";
-var OP_PUBKEY_PATTERN = exports.OP_PUBKEY_PATTERN = OP_HEX_PATTERN;
-var OP_BASE64_PATTERN = exports.OP_BASE64_PATTERN = "(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})";
-
-var SUCCESS_FAIL_SCHEMA = exports.SUCCESS_FAIL_SCHEMA = {
-    anyOf: [{
-        type: 'object',
-        properties: {
-            status: {
-                type: 'boolean'
-            }
-        }
-    }, {
-        type: 'object',
-        properties: {
-            error: {
-                type: 'string'
-            }
-        }
-    }]
-};
-
-var MUTABLE_DATUM_SCHEMA_BASE_PROPERTIES = exports.MUTABLE_DATUM_SCHEMA_BASE_PROPERTIES = {
-    type: {
-        type: 'integer',
-        minimum: MUTABLE_DATUM_FILE_TYPE,
-        maximum: MUTABLE_DATUM_DIR_TYPE
-    },
-    owner: {
-        type: 'string',
-        pattern: OP_ADDRESS_PATTERN
-    },
-    uuid: {
-        type: 'string',
-        pattern: OP_UUID_PATTERN
-    },
-    readers: {
-        type: 'array',
-        items: {
-            type: 'string',
-            pattern: OP_ADDRESS_PATTERN
-        }
-    },
-    reader_pubkeys: {
-        type: 'array',
-        items: {
-            type: 'string',
-            pattern: OP_HEX_PATTERN
-        }
-    },
-    version: {
-        type: 'integer'
-    },
-    proto_version: {
-        type: 'integer'
-    }
-};
-
-var MUTABLE_DATUM_SCHEMA_HEADER_PROPERTIES = exports.MUTABLE_DATUM_SCHEMA_HEADER_PROPERTIES = Object.assign({}, MUTABLE_DATUM_SCHEMA_BASE_PROPERTIES);
-MUTABLE_DATUM_SCHEMA_HEADER_PROPERTIES['data_hash'] = {
-    type: 'string',
-    pattern: OP_HEX_PATTERN
-};
-
-var MUTABLE_DATUM_INODE_HEADER_SCHEMA = exports.MUTABLE_DATUM_INODE_HEADER_SCHEMA = {
-    type: 'object',
-    properties: MUTABLE_DATUM_SCHEMA_HEADER_PROPERTIES,
-    additionalProperties: false,
-    required: Object.keys(MUTABLE_DATUM_SCHEMA_HEADER_PROPERTIES).filter(function (x) {
-        return x != 'reader_pubkeys';
-    }) // reader_pubkeys is optional
-};
-
-var MUTABLE_DATUM_DIRENT_SCHEMA = exports.MUTABLE_DATUM_DIRENT_SCHEMA = {
-    type: 'object',
-    properties: {
-        type: {
-            type: 'integer',
-            minimum: MUTABLE_DATUM_FILE_TYPE,
-            maximum: MUTABLE_DATUM_DIR_TYPE
-        },
-        uuid: {
-            type: 'string',
-            pattern: OP_UUID_PATTERN
-        },
-        version: {
-            type: 'integer'
-        }
-    },
-    additionalProperties: false,
-    required: ['type', 'uuid', 'version']
-};
-
-var MUTABLE_DATUM_DIR_IDATA_SCHEMA = exports.MUTABLE_DATUM_DIR_IDATA_SCHEMA = {
-    type: 'object',
-    properties: {
-        children: {
-            type: 'object',
-            patternProperties: {
-                OP_URLENCODED_NOSLASH_PATTERN: MUTABLE_DATUM_DIRENT_SCHEMA
-            }
-        },
-        header: MUTABLE_DATUM_INODE_HEADER_SCHEMA
-    },
-    strict: true,
-    required: ['children', 'header']
-};
-
-var MUTABLE_DATUM_FILE_SCHEMA_PROPERTIES = exports.MUTABLE_DATUM_FILE_SCHEMA_PROPERTIES = Object.assign({}, MUTABLE_DATUM_SCHEMA_BASE_PROPERTIES);
-MUTABLE_DATUM_FILE_SCHEMA_PROPERTIES['idata'] = {
-    type: 'string',
-    pattern: OP_BASE64_PATTERN
-};
-
-var MUTABLE_DATUM_DIR_SCHEMA_PROPERTIES = exports.MUTABLE_DATUM_DIR_SCHEMA_PROPERTIES = Object.assign({}, MUTABLE_DATUM_SCHEMA_BASE_PROPERTIES);
-MUTABLE_DATUM_DIR_SCHEMA_PROPERTIES['idata'] = Object.assign({}, MUTABLE_DATUM_DIR_IDATA_SCHEMA);
-
-var MUTABLE_DATUM_FILE_SCHEMA = exports.MUTABLE_DATUM_FILE_SCHEMA = {
-    type: 'object',
-    properties: MUTABLE_DATUM_FILE_SCHEMA_PROPERTIES,
-    additionalProperties: false,
-    required: Object.keys(MUTABLE_DATUM_FILE_SCHEMA_PROPERTIES).filter(function (x) {
-        return x != 'reader_pubkeys';
-    }) // reader_pubkeys is optional
-};
-
-var MUTABLE_DATUM_DIR_SCHEMA = exports.MUTABLE_DATUM_DIR_SCHEMA = {
-    type: 'object',
-    properties: MUTABLE_DATUM_DIR_SCHEMA_PROPERTIES,
-    additionalProperties: false,
-    required: Object.keys(MUTABLE_DATUM_DIR_SCHEMA_PROPERTIES)
-};
-
-var MUTABLE_DATUM_INODE_SCHEMA = exports.MUTABLE_DATUM_INODE_SCHEMA = {
-    anyOf: [Object.assign({}, MUTABLE_DATUM_FILE_SCHEMA), Object.assign({}, MUTABLE_DATUM_DIR_SCHEMA), Object.assign({}, MUTABLE_DATUM_INODE_HEADER_SCHEMA)]
-};
-
-var MUTABLE_DATUM_PATH_INFO_SCHEMA = exports.MUTABLE_DATUM_PATH_INFO_SCHEMA = {
-    type: 'object',
-    patternProperties: {
-        OP_URLENCODED_PATTERN: {
-            uuid: {
-                type: 'string',
-                pattern: OP_UUID_PATTERN
-            },
-            name: {
-                type: 'string',
-                pattern: OP_URLENCODED_NOSLASH_PATTERN
-            },
-            parent: {
-                type: 'string',
-                pattern: OP_URLENCODED_PATTERN
-            },
-            inode: {
-                anyOf: [MUTABLE_DATUM_DIR_SCHEMA, MUTABLE_DATUM_FILE_SCHEMA, MUTABLE_DATUM_INODE_HEADER_SCHEMA]
-            }
-        }
-    },
-    additionalProperties: false
-};
-
-var MUTABLE_DATUM_RESPONSE_SCHEMA = exports.MUTABLE_DATUM_RESPONSE_SCHEMA = {
-    type: 'object',
-    properties: {
-        status: {
-            type: 'boolean'
-        },
-        file: MUTABLE_DATUM_FILE_SCHEMA,
-        dir: MUTABLE_DATUM_DIR_SCHEMA,
-        inode: MUTABLE_DATUM_INODE_SCHEMA
-    },
-    additionalProperties: false,
-    required: ['status']
-};
-
-var MUTABLE_DATUM_EXTENDED_RESPONSE_SCHEMA = exports.MUTABLE_DATUM_EXTENDED_RESPONSE_SCHEMA = Object.assign({}, MUTABLE_DATUM_RESPONSE_SCHEMA);
-MUTABLE_DATUM_EXTENDED_RESPONSE_SCHEMA['path_info'] = MUTABLE_DATUM_PATH_INFO_SCHEMA;
-
-var DATASTORE_SCHEMA = exports.DATASTORE_SCHEMA = {
-    type: 'object',
-    properties: {
-        type: {
-            type: 'string',
-            pattern: "([a-zA-Z0-9_]+)$"
-        },
-        pubkey: {
-            type: 'string',
-            pattern: OP_PUBKEY_PATTERN
-        },
-        drivers: {
-            type: 'array',
-            items: {
-                type: 'string'
-            }
-        },
-        device_ids: {
-            type: 'array',
-            items: {
-                'type': 'string'
-            }
-        },
-        root_uuid: {
-            type: 'string',
-            pattern: OP_UUID_PATTERN
-        }
-    },
-    additionalProperties: false,
-    required: ['type', 'pubkey', 'drivers', 'device_ids', 'root_uuid']
-};
-
-var DATASTORE_RESPONSE_SCHEMA = exports.DATASTORE_RESPONSE_SCHEMA = {
-    type: 'object',
-    properties: {
-        datastore: DATASTORE_SCHEMA
-    },
-    additionalProperties: false,
-    required: ['datastore']
-};
-
-var DATASTORE_LOOKUP_PATH_ENTRY_SCHEMA = exports.DATASTORE_LOOKUP_PATH_ENTRY_SCHEMA = {
-    type: 'object',
-    properties: {
-        name: {
-            type: 'string',
-            pattern: OP_URLENCODED_NOSLASH_OR_EMPTY_PATTERN
-        },
-        uuid: {
-            type: 'string',
-            pattern: OP_UUID_PATTERN
-        },
-        parent: {
-            type: 'string',
-            pattern: OP_URLENCODED_OR_EMPTY_PATTERN
-        },
-        inode: MUTABLE_DATUM_DIR_SCHEMA
-    },
-    additionalProperties: false,
-    required: ['name', 'uuid', 'parent', 'inode']
-};
-
-var DATASTORE_LOOKUP_INODE_SCHEMA = exports.DATASTORE_LOOKUP_INODE_SCHEMA = {
-    type: 'object',
-    properties: {
-        name: {
-            type: 'string',
-            pattern: OP_URLENCODED_NOSLASH_OR_EMPTY_PATTERN
-        },
-        uuid: {
-            type: 'string',
-            pattern: OP_UUID_PATTERN
-        },
-        parent: {
-            type: 'string',
-            pattern: OP_URLENCODED_OR_EMPTY_PATTERN
-        },
-        inode: {
-            anyOf: [MUTABLE_DATUM_DIR_SCHEMA, MUTABLE_DATUM_FILE_SCHEMA, MUTABLE_DATUM_INODE_HEADER_SCHEMA]
-        }
-    },
-    additionalProperties: false,
-    required: ['name', 'uuid', 'parent', 'inode']
-};
-
-var DATASTORE_LOOKUP_RESPONSE_SCHEMA = exports.DATASTORE_LOOKUP_RESPONSE_SCHEMA = {
-    type: 'object',
-    properties: {
-        inode: {
-            anyOf: [MUTABLE_DATUM_DIR_SCHEMA, MUTABLE_DATUM_FILE_SCHEMA, MUTABLE_DATUM_INODE_HEADER_SCHEMA]
-        },
-        status: {
-            type: 'boolean'
-        }
-    },
-    additionalProperties: false,
-    required: ['inode', 'status']
-};
-
-var DATASTORE_LOOKUP_EXTENDED_RESPONSE_SCHEMA = exports.DATASTORE_LOOKUP_EXTENDED_RESPONSE_SCHEMA = {
-    type: 'object',
-    properties: {
-        path_info: {
-            type: 'object',
-            patternProperties: {
-                OP_URLENCODED_OR_EMPTY_PATTERN: DATASTORE_LOOKUP_INODE_SCHEMA
-            },
-            additionalProperties: false
-        },
-        inode_info: DATASTORE_LOOKUP_INODE_SCHEMA,
-        status: {
-            type: 'boolean'
-        }
-    },
-    additionalProperties: false,
-    required: ['path_info', 'inode_info', 'status']
-};
-
-var CORE_ERROR_SCHEMA = exports.CORE_ERROR_SCHEMA = {
-    type: 'object',
-    properties: {
-        error: {
-            type: 'string'
-        },
-        errno: {
-            type: 'integer'
-        }
-    },
-    additionalProperties: false,
-    required: ['errno', 'error']
-};
-},{}],139:[function(require,module,exports){
-'use strict';
-
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-
-var _json_stable_serialize = require('./json_stable_serialize');
-
-Object.defineProperty(exports, 'jsonStableSerialize', {
-  enumerable: true,
-  get: function get() {
-    return _json_stable_serialize.jsonStableSerialize;
-  }
-});
-},{"./json_stable_serialize":140}],140:[function(require,module,exports){
-'use strict';
-
-Object.defineProperty(exports, "__esModule", {
-    value: true
-});
-
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
-
-exports.jsonStableSerialize = jsonStableSerialize;
-// Gratefully borrowed with light modification from https://github.com/substack/json-stable-stringify/blob/master/index.js
-
-var json = typeof JSON !== 'undefined' ? JSON : require('jsonify');
-
-function jsonStableSerialize(obj, opts) {
-    if (!opts) opts = {};
-    if (typeof opts === 'function') opts = { cmp: opts };
-    var space = opts.space || '';
-    if (typeof space === 'number') space = Array(space + 1).join(' ');
-    var cycles = typeof opts.cycles === 'boolean' ? opts.cycles : false;
-    var replacer = opts.replacer || function (key, value) {
-        return value;
-    };
-
-    var cmp = opts.cmp && function (f) {
-        return function (node) {
-            return function (a, b) {
-                var aobj = { key: a, value: node[a] };
-                var bobj = { key: b, value: node[b] };
-                return f(aobj, bobj);
-            };
-        };
-    }(opts.cmp);
-
-    var seen = [];
-    return function jsonStableSerialize(parent, key, node, level) {
-        var indent = space ? '\n' + new Array(level + 1).join(space) : '';
-        var colonSeparator = space ? ': ' : ':';
-
-        if (node && node.toJSON && typeof node.toJSON === 'function') {
-            node = node.toJSON();
-        }
-
-        node = replacer.call(parent, key, node);
-
-        if (node === undefined) {
-            return;
-        }
-        if ((typeof node === 'undefined' ? 'undefined' : _typeof(node)) !== 'object' || node === null) {
-            return json.stringify(node);
-        }
-        if (isArray(node)) {
-            var out = [];
-            for (var i = 0; i < node.length; i++) {
-                var item = jsonStableSerialize(node, i, node[i], level + 1) || json.stringify(null);
-                out.push(indent + space + item);
-            }
-            return '[' + out.join(',') + indent + ']';
-        } else {
-            if (seen.indexOf(node) !== -1) {
-                if (cycles) return json.stringify('__cycle__');
-                throw new TypeError('Converting circular structure to JSON');
-            } else seen.push(node);
-
-            var keys = objectKeys(node).sort(cmp && cmp(node));
-            var out = [];
-            for (var i = 0; i < keys.length; i++) {
-                var key = keys[i];
-                var value = jsonStableSerialize(node, key, node[key], level + 1);
-
-                if (!value) continue;
-
-                var keyValue = json.stringify(key) + colonSeparator + value;
-                ;
-                out.push(indent + space + keyValue);
-            }
-            seen.splice(seen.indexOf(node), 1);
-            return '{' + out.join(',') + indent + '}';
-        }
-    }({ '': obj }, '', obj, 0);
-};
-
-var isArray = Array.isArray || function (x) {
-    return {}.toString.call(x) === '[object Array]';
-};
-
-var objectKeys = Object.keys || function (obj) {
-    var has = Object.prototype.hasOwnProperty || function () {
-        return true;
-    };
-    var keys = [];
-    for (var key in obj) {
-        if (has.call(obj, key)) keys.push(key);
-    }
-    return keys;
-};
-},{"jsonify":373}],141:[function(require,module,exports){
+},{"typeforce":67}],87:[function(require,module,exports){
 module.exports = {
 	trueFunc: function trueFunc(){
 		return true;
@@ -20401,7 +10798,7 @@ module.exports = {
 		return false;
 	}
 };
-},{}],142:[function(require,module,exports){
+},{}],88:[function(require,module,exports){
 var asn1 = exports;
 
 asn1.bignum = require('bn.js');
@@ -20412,7 +10809,7 @@ asn1.constants = require('./asn1/constants');
 asn1.decoders = require('./asn1/decoders');
 asn1.encoders = require('./asn1/encoders');
 
-},{"./asn1/api":143,"./asn1/base":145,"./asn1/constants":149,"./asn1/decoders":151,"./asn1/encoders":154,"bn.js":158}],143:[function(require,module,exports){
+},{"./asn1/api":89,"./asn1/base":91,"./asn1/constants":95,"./asn1/decoders":97,"./asn1/encoders":100,"bn.js":104}],89:[function(require,module,exports){
 var asn1 = require('../asn1');
 var inherits = require('inherits');
 
@@ -20475,7 +10872,7 @@ Entity.prototype.encode = function encode(data, enc, /* internal */ reporter) {
   return this._getEncoder(enc).encode(data, reporter);
 };
 
-},{"../asn1":142,"inherits":213,"vm":277}],144:[function(require,module,exports){
+},{"../asn1":88,"inherits":158,"vm":211}],90:[function(require,module,exports){
 var inherits = require('inherits');
 var Reporter = require('../base').Reporter;
 var Buffer = require('buffer').Buffer;
@@ -20593,7 +10990,7 @@ EncoderBuffer.prototype.join = function join(out, offset) {
   return out;
 };
 
-},{"../base":145,"buffer":188,"inherits":213}],145:[function(require,module,exports){
+},{"../base":91,"buffer":134,"inherits":158}],91:[function(require,module,exports){
 var base = exports;
 
 base.Reporter = require('./reporter').Reporter;
@@ -20601,7 +10998,7 @@ base.DecoderBuffer = require('./buffer').DecoderBuffer;
 base.EncoderBuffer = require('./buffer').EncoderBuffer;
 base.Node = require('./node');
 
-},{"./buffer":144,"./node":146,"./reporter":147}],146:[function(require,module,exports){
+},{"./buffer":90,"./node":92,"./reporter":93}],92:[function(require,module,exports){
 var Reporter = require('../base').Reporter;
 var EncoderBuffer = require('../base').EncoderBuffer;
 var DecoderBuffer = require('../base').DecoderBuffer;
@@ -21237,7 +11634,7 @@ Node.prototype._isPrintstr = function isPrintstr(str) {
   return /^[A-Za-z0-9 '\(\)\+,\-\.\/:=\?]*$/.test(str);
 };
 
-},{"../base":145,"minimalistic-assert":217}],147:[function(require,module,exports){
+},{"../base":91,"minimalistic-assert":162}],93:[function(require,module,exports){
 var inherits = require('inherits');
 
 function Reporter(options) {
@@ -21360,7 +11757,7 @@ ReporterError.prototype.rethrow = function rethrow(msg) {
   return this;
 };
 
-},{"inherits":213}],148:[function(require,module,exports){
+},{"inherits":158}],94:[function(require,module,exports){
 var constants = require('../constants');
 
 exports.tagClass = {
@@ -21404,7 +11801,7 @@ exports.tag = {
 };
 exports.tagByName = constants._reverse(exports.tag);
 
-},{"../constants":149}],149:[function(require,module,exports){
+},{"../constants":95}],95:[function(require,module,exports){
 var constants = exports;
 
 // Helper
@@ -21425,7 +11822,7 @@ constants._reverse = function reverse(map) {
 
 constants.der = require('./der');
 
-},{"./der":148}],150:[function(require,module,exports){
+},{"./der":94}],96:[function(require,module,exports){
 var inherits = require('inherits');
 
 var asn1 = require('../../asn1');
@@ -21751,13 +12148,13 @@ function derDecodeLen(buf, primitive, fail) {
   return len;
 }
 
-},{"../../asn1":142,"inherits":213}],151:[function(require,module,exports){
+},{"../../asn1":88,"inherits":158}],97:[function(require,module,exports){
 var decoders = exports;
 
 decoders.der = require('./der');
 decoders.pem = require('./pem');
 
-},{"./der":150,"./pem":152}],152:[function(require,module,exports){
+},{"./der":96,"./pem":98}],98:[function(require,module,exports){
 var inherits = require('inherits');
 var Buffer = require('buffer').Buffer;
 
@@ -21808,7 +12205,7 @@ PEMDecoder.prototype.decode = function decode(data, options) {
   return DERDecoder.prototype.decode.call(this, input, options);
 };
 
-},{"./der":150,"buffer":188,"inherits":213}],153:[function(require,module,exports){
+},{"./der":96,"buffer":134,"inherits":158}],99:[function(require,module,exports){
 var inherits = require('inherits');
 var Buffer = require('buffer').Buffer;
 
@@ -22105,13 +12502,13 @@ function encodeTag(tag, primitive, cls, reporter) {
   return res;
 }
 
-},{"../../asn1":142,"buffer":188,"inherits":213}],154:[function(require,module,exports){
+},{"../../asn1":88,"buffer":134,"inherits":158}],100:[function(require,module,exports){
 var encoders = exports;
 
 encoders.der = require('./der');
 encoders.pem = require('./pem');
 
-},{"./der":153,"./pem":155}],155:[function(require,module,exports){
+},{"./der":99,"./pem":101}],101:[function(require,module,exports){
 var inherits = require('inherits');
 
 var DEREncoder = require('./der');
@@ -22134,7 +12531,7 @@ PEMEncoder.prototype.encode = function encode(data, options) {
   return out.join('\n');
 };
 
-},{"./der":153,"inherits":213}],156:[function(require,module,exports){
+},{"./der":99,"inherits":158}],102:[function(require,module,exports){
 (function (global){
 'use strict';
 
@@ -22628,7 +13025,7 @@ var objectKeys = Object.keys || function (obj) {
 };
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"util/":276}],157:[function(require,module,exports){
+},{"util/":210}],103:[function(require,module,exports){
 'use strict'
 
 exports.byteLength = byteLength
@@ -22744,7 +13141,7 @@ function fromByteArray (uint8) {
   return parts.join('')
 }
 
-},{}],158:[function(require,module,exports){
+},{}],104:[function(require,module,exports){
 (function (module, exports) {
   'use strict';
 
@@ -26173,7 +16570,7 @@ function fromByteArray (uint8) {
   };
 })(typeof module === 'undefined' || module, this);
 
-},{"buffer":160}],159:[function(require,module,exports){
+},{"buffer":106}],105:[function(require,module,exports){
 var r;
 
 module.exports = function rand(len) {
@@ -26240,9 +16637,9 @@ if (typeof self === 'object') {
   }
 }
 
-},{"crypto":160}],160:[function(require,module,exports){
+},{"crypto":106}],106:[function(require,module,exports){
 
-},{}],161:[function(require,module,exports){
+},{}],107:[function(require,module,exports){
 // based on the aes implimentation in triple sec
 // https://github.com/keybase/triplesec
 // which is in turn based on the one from crypto-js
@@ -26472,7 +16869,7 @@ AES.prototype.scrub = function () {
 
 module.exports.AES = AES
 
-},{"safe-buffer":481}],162:[function(require,module,exports){
+},{"safe-buffer":403}],108:[function(require,module,exports){
 var aes = require('./aes')
 var Buffer = require('safe-buffer').Buffer
 var Transform = require('cipher-base')
@@ -26566,7 +16963,7 @@ StreamCipher.prototype.setAAD = function setAAD (buf) {
 
 module.exports = StreamCipher
 
-},{"./aes":161,"./ghash":166,"buffer-xor":187,"cipher-base":190,"inherits":213,"safe-buffer":481}],163:[function(require,module,exports){
+},{"./aes":107,"./ghash":112,"buffer-xor":133,"cipher-base":135,"inherits":158,"safe-buffer":403}],109:[function(require,module,exports){
 var ciphers = require('./encrypter')
 var deciphers = require('./decrypter')
 var modes = require('./modes/list.json')
@@ -26581,7 +16978,7 @@ exports.createDecipher = exports.Decipher = deciphers.createDecipher
 exports.createDecipheriv = exports.Decipheriv = deciphers.createDecipheriv
 exports.listCiphers = exports.getCiphers = getCiphers
 
-},{"./decrypter":164,"./encrypter":165,"./modes/list.json":174}],164:[function(require,module,exports){
+},{"./decrypter":110,"./encrypter":111,"./modes/list.json":120}],110:[function(require,module,exports){
 var AuthCipher = require('./authCipher')
 var Buffer = require('safe-buffer').Buffer
 var MODES = require('./modes')
@@ -26704,7 +17101,7 @@ function createDecipher (suite, password) {
 exports.createDecipher = createDecipher
 exports.createDecipheriv = createDecipheriv
 
-},{"./aes":161,"./authCipher":162,"./modes":173,"./streamCipher":176,"cipher-base":190,"evp_bytestokey":210,"inherits":213,"safe-buffer":481}],165:[function(require,module,exports){
+},{"./aes":107,"./authCipher":108,"./modes":119,"./streamCipher":122,"cipher-base":135,"evp_bytestokey":155,"inherits":158,"safe-buffer":403}],111:[function(require,module,exports){
 var MODES = require('./modes')
 var AuthCipher = require('./authCipher')
 var Buffer = require('safe-buffer').Buffer
@@ -26820,7 +17217,7 @@ function createCipher (suite, password) {
 exports.createCipheriv = createCipheriv
 exports.createCipher = createCipher
 
-},{"./aes":161,"./authCipher":162,"./modes":173,"./streamCipher":176,"cipher-base":190,"evp_bytestokey":210,"inherits":213,"safe-buffer":481}],166:[function(require,module,exports){
+},{"./aes":107,"./authCipher":108,"./modes":119,"./streamCipher":122,"cipher-base":135,"evp_bytestokey":155,"inherits":158,"safe-buffer":403}],112:[function(require,module,exports){
 var Buffer = require('safe-buffer').Buffer
 var ZEROES = Buffer.alloc(16, 0)
 
@@ -26911,7 +17308,7 @@ GHASH.prototype.final = function (abl, bl) {
 
 module.exports = GHASH
 
-},{"safe-buffer":481}],167:[function(require,module,exports){
+},{"safe-buffer":403}],113:[function(require,module,exports){
 var xor = require('buffer-xor')
 
 exports.encrypt = function (self, block) {
@@ -26930,7 +17327,7 @@ exports.decrypt = function (self, block) {
   return xor(out, pad)
 }
 
-},{"buffer-xor":187}],168:[function(require,module,exports){
+},{"buffer-xor":133}],114:[function(require,module,exports){
 var Buffer = require('safe-buffer').Buffer
 var xor = require('buffer-xor')
 
@@ -26965,7 +17362,7 @@ exports.encrypt = function (self, data, decrypt) {
   return out
 }
 
-},{"buffer-xor":187,"safe-buffer":481}],169:[function(require,module,exports){
+},{"buffer-xor":133,"safe-buffer":403}],115:[function(require,module,exports){
 var Buffer = require('safe-buffer').Buffer
 
 function encryptByte (self, byteParam, decrypt) {
@@ -27009,7 +17406,7 @@ exports.encrypt = function (self, chunk, decrypt) {
   return out
 }
 
-},{"safe-buffer":481}],170:[function(require,module,exports){
+},{"safe-buffer":403}],116:[function(require,module,exports){
 (function (Buffer){
 function encryptByte (self, byteParam, decrypt) {
   var pad = self._cipher.encryptBlock(self._prev)
@@ -27036,7 +17433,7 @@ exports.encrypt = function (self, chunk, decrypt) {
 }
 
 }).call(this,require("buffer").Buffer)
-},{"buffer":188}],171:[function(require,module,exports){
+},{"buffer":134}],117:[function(require,module,exports){
 (function (Buffer){
 var xor = require('buffer-xor')
 
@@ -27083,7 +17480,7 @@ exports.encrypt = function (self, chunk) {
 }
 
 }).call(this,require("buffer").Buffer)
-},{"buffer":188,"buffer-xor":187}],172:[function(require,module,exports){
+},{"buffer":134,"buffer-xor":133}],118:[function(require,module,exports){
 exports.encrypt = function (self, block) {
   return self._cipher.encryptBlock(block)
 }
@@ -27092,7 +17489,7 @@ exports.decrypt = function (self, block) {
   return self._cipher.decryptBlock(block)
 }
 
-},{}],173:[function(require,module,exports){
+},{}],119:[function(require,module,exports){
 var modeModules = {
   ECB: require('./ecb'),
   CBC: require('./cbc'),
@@ -27112,7 +17509,7 @@ for (var key in modes) {
 
 module.exports = modes
 
-},{"./cbc":167,"./cfb":168,"./cfb1":169,"./cfb8":170,"./ctr":171,"./ecb":172,"./list.json":174,"./ofb":175}],174:[function(require,module,exports){
+},{"./cbc":113,"./cfb":114,"./cfb1":115,"./cfb8":116,"./ctr":117,"./ecb":118,"./list.json":120,"./ofb":121}],120:[function(require,module,exports){
 module.exports={
   "aes-128-ecb": {
     "cipher": "AES",
@@ -27305,7 +17702,7 @@ module.exports={
   }
 }
 
-},{}],175:[function(require,module,exports){
+},{}],121:[function(require,module,exports){
 (function (Buffer){
 var xor = require('buffer-xor')
 
@@ -27325,7 +17722,7 @@ exports.encrypt = function (self, chunk) {
 }
 
 }).call(this,require("buffer").Buffer)
-},{"buffer":188,"buffer-xor":187}],176:[function(require,module,exports){
+},{"buffer":134,"buffer-xor":133}],122:[function(require,module,exports){
 var aes = require('./aes')
 var Buffer = require('safe-buffer').Buffer
 var Transform = require('cipher-base')
@@ -27354,7 +17751,7 @@ StreamCipher.prototype._final = function () {
 
 module.exports = StreamCipher
 
-},{"./aes":161,"cipher-base":190,"inherits":213,"safe-buffer":481}],177:[function(require,module,exports){
+},{"./aes":107,"cipher-base":135,"inherits":158,"safe-buffer":403}],123:[function(require,module,exports){
 var ebtk = require('evp_bytestokey')
 var aes = require('browserify-aes/browser')
 var DES = require('browserify-des')
@@ -27429,7 +17826,7 @@ function getCiphers () {
 }
 exports.listCiphers = exports.getCiphers = getCiphers
 
-},{"browserify-aes/browser":163,"browserify-aes/modes":173,"browserify-des":178,"browserify-des/modes":179,"evp_bytestokey":210}],178:[function(require,module,exports){
+},{"browserify-aes/browser":109,"browserify-aes/modes":119,"browserify-des":124,"browserify-des/modes":125,"evp_bytestokey":155}],124:[function(require,module,exports){
 (function (Buffer){
 var CipherBase = require('cipher-base')
 var des = require('des.js')
@@ -27476,7 +17873,7 @@ DES.prototype._final = function () {
 }
 
 }).call(this,require("buffer").Buffer)
-},{"buffer":188,"cipher-base":190,"des.js":199,"inherits":213}],179:[function(require,module,exports){
+},{"buffer":134,"cipher-base":135,"des.js":144,"inherits":158}],125:[function(require,module,exports){
 exports['des-ecb'] = {
   key: 8,
   iv: 0
@@ -27502,7 +17899,7 @@ exports['des-ede'] = {
   iv: 0
 }
 
-},{}],180:[function(require,module,exports){
+},{}],126:[function(require,module,exports){
 (function (Buffer){
 var bn = require('bn.js');
 var randomBytes = require('randombytes');
@@ -27546,10 +17943,10 @@ function getr(priv) {
 }
 
 }).call(this,require("buffer").Buffer)
-},{"bn.js":158,"buffer":188,"randombytes":240}],181:[function(require,module,exports){
+},{"bn.js":104,"buffer":134,"randombytes":181}],127:[function(require,module,exports){
 module.exports = require('./browser/algorithms.json')
 
-},{"./browser/algorithms.json":182}],182:[function(require,module,exports){
+},{"./browser/algorithms.json":128}],128:[function(require,module,exports){
 module.exports={
   "sha224WithRSAEncryption": {
     "sign": "rsa",
@@ -27703,7 +18100,7 @@ module.exports={
   }
 }
 
-},{}],183:[function(require,module,exports){
+},{}],129:[function(require,module,exports){
 module.exports={
   "1.3.132.0.10": "secp256k1",
   "1.3.132.0.33": "p224",
@@ -27713,7 +18110,7 @@ module.exports={
   "1.3.132.0.35": "p521"
 }
 
-},{}],184:[function(require,module,exports){
+},{}],130:[function(require,module,exports){
 (function (Buffer){
 var createHash = require('create-hash')
 var stream = require('stream')
@@ -27808,7 +18205,7 @@ module.exports = {
 }
 
 }).call(this,require("buffer").Buffer)
-},{"./algorithms.json":182,"./sign":185,"./verify":186,"buffer":188,"create-hash":193,"inherits":213,"stream":264}],185:[function(require,module,exports){
+},{"./algorithms.json":128,"./sign":131,"./verify":132,"buffer":134,"create-hash":138,"inherits":158,"stream":205}],131:[function(require,module,exports){
 (function (Buffer){
 // much of this based on https://github.com/indutny/self-signed/blob/gh-pages/lib/rsa.js
 var createHmac = require('create-hmac')
@@ -27957,7 +18354,7 @@ module.exports.getKey = getKey
 module.exports.makeKey = makeKey
 
 }).call(this,require("buffer").Buffer)
-},{"./curves.json":183,"bn.js":158,"browserify-rsa":180,"buffer":188,"create-hmac":196,"elliptic":317,"parse-asn1":222}],186:[function(require,module,exports){
+},{"./curves.json":129,"bn.js":104,"browserify-rsa":126,"buffer":134,"create-hmac":141,"elliptic":250,"parse-asn1":167}],132:[function(require,module,exports){
 (function (Buffer){
 // much of this based on https://github.com/indutny/self-signed/blob/gh-pages/lib/rsa.js
 var BN = require('bn.js')
@@ -28044,7 +18441,7 @@ function checkValue (b, q) {
 module.exports = verify
 
 }).call(this,require("buffer").Buffer)
-},{"./curves.json":183,"bn.js":158,"buffer":188,"elliptic":317,"parse-asn1":222}],187:[function(require,module,exports){
+},{"./curves.json":129,"bn.js":104,"buffer":134,"elliptic":250,"parse-asn1":167}],133:[function(require,module,exports){
 (function (Buffer){
 module.exports = function xor (a, b) {
   var length = Math.min(a.length, b.length)
@@ -28058,7 +18455,7 @@ module.exports = function xor (a, b) {
 }
 
 }).call(this,require("buffer").Buffer)
-},{"buffer":188}],188:[function(require,module,exports){
+},{"buffer":134}],134:[function(require,module,exports){
 (function (global){
 /*!
  * The buffer module from node.js, for the browser.
@@ -29851,75 +20248,9 @@ function isnan (val) {
 }
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"base64-js":157,"ieee754":211,"isarray":215}],189:[function(require,module,exports){
-module.exports = {
-  "100": "Continue",
-  "101": "Switching Protocols",
-  "102": "Processing",
-  "200": "OK",
-  "201": "Created",
-  "202": "Accepted",
-  "203": "Non-Authoritative Information",
-  "204": "No Content",
-  "205": "Reset Content",
-  "206": "Partial Content",
-  "207": "Multi-Status",
-  "208": "Already Reported",
-  "226": "IM Used",
-  "300": "Multiple Choices",
-  "301": "Moved Permanently",
-  "302": "Found",
-  "303": "See Other",
-  "304": "Not Modified",
-  "305": "Use Proxy",
-  "307": "Temporary Redirect",
-  "308": "Permanent Redirect",
-  "400": "Bad Request",
-  "401": "Unauthorized",
-  "402": "Payment Required",
-  "403": "Forbidden",
-  "404": "Not Found",
-  "405": "Method Not Allowed",
-  "406": "Not Acceptable",
-  "407": "Proxy Authentication Required",
-  "408": "Request Timeout",
-  "409": "Conflict",
-  "410": "Gone",
-  "411": "Length Required",
-  "412": "Precondition Failed",
-  "413": "Payload Too Large",
-  "414": "URI Too Long",
-  "415": "Unsupported Media Type",
-  "416": "Range Not Satisfiable",
-  "417": "Expectation Failed",
-  "418": "I'm a teapot",
-  "421": "Misdirected Request",
-  "422": "Unprocessable Entity",
-  "423": "Locked",
-  "424": "Failed Dependency",
-  "425": "Unordered Collection",
-  "426": "Upgrade Required",
-  "428": "Precondition Required",
-  "429": "Too Many Requests",
-  "431": "Request Header Fields Too Large",
-  "451": "Unavailable For Legal Reasons",
-  "500": "Internal Server Error",
-  "501": "Not Implemented",
-  "502": "Bad Gateway",
-  "503": "Service Unavailable",
-  "504": "Gateway Timeout",
-  "505": "HTTP Version Not Supported",
-  "506": "Variant Also Negotiates",
-  "507": "Insufficient Storage",
-  "508": "Loop Detected",
-  "509": "Bandwidth Limit Exceeded",
-  "510": "Not Extended",
-  "511": "Network Authentication Required"
-}
-
-},{}],190:[function(require,module,exports){
-arguments[4][95][0].apply(exports,arguments)
-},{"dup":95,"inherits":213,"safe-buffer":481,"stream":264,"string_decoder":269}],191:[function(require,module,exports){
+},{"base64-js":103,"ieee754":156,"isarray":160}],135:[function(require,module,exports){
+arguments[4][48][0].apply(exports,arguments)
+},{"dup":48,"inherits":158,"safe-buffer":403,"stream":205,"string_decoder":206}],136:[function(require,module,exports){
 (function (Buffer){
 // Copyright Joyent, Inc. and other Node contributors.
 //
@@ -30030,7 +20361,7 @@ function objectToString(o) {
 }
 
 }).call(this,{"isBuffer":require("../../is-buffer/index.js")})
-},{"../../is-buffer/index.js":214}],192:[function(require,module,exports){
+},{"../../is-buffer/index.js":159}],137:[function(require,module,exports){
 (function (Buffer){
 var elliptic = require('elliptic');
 var BN = require('bn.js');
@@ -30156,17 +20487,17 @@ function formatReturnValue(bn, enc, len) {
 }
 
 }).call(this,require("buffer").Buffer)
-},{"bn.js":158,"buffer":188,"elliptic":317}],193:[function(require,module,exports){
-arguments[4][96][0].apply(exports,arguments)
-},{"./md5":195,"buffer":188,"cipher-base":190,"dup":96,"inherits":213,"ripemd160":255,"sha.js":257}],194:[function(require,module,exports){
-arguments[4][97][0].apply(exports,arguments)
-},{"buffer":188,"dup":97}],195:[function(require,module,exports){
-arguments[4][98][0].apply(exports,arguments)
-},{"./make-hash":194,"dup":98}],196:[function(require,module,exports){
-arguments[4][99][0].apply(exports,arguments)
-},{"./legacy":197,"cipher-base":190,"create-hash/md5":195,"dup":99,"inherits":213,"ripemd160":255,"safe-buffer":481,"sha.js":257}],197:[function(require,module,exports){
-arguments[4][100][0].apply(exports,arguments)
-},{"cipher-base":190,"dup":100,"inherits":213,"safe-buffer":481}],198:[function(require,module,exports){
+},{"bn.js":104,"buffer":134,"elliptic":250}],138:[function(require,module,exports){
+arguments[4][49][0].apply(exports,arguments)
+},{"./md5":140,"buffer":134,"cipher-base":135,"dup":49,"inherits":158,"ripemd160":196,"sha.js":198}],139:[function(require,module,exports){
+arguments[4][50][0].apply(exports,arguments)
+},{"buffer":134,"dup":50}],140:[function(require,module,exports){
+arguments[4][51][0].apply(exports,arguments)
+},{"./make-hash":139,"dup":51}],141:[function(require,module,exports){
+arguments[4][52][0].apply(exports,arguments)
+},{"./legacy":142,"cipher-base":135,"create-hash/md5":140,"dup":52,"inherits":158,"ripemd160":196,"safe-buffer":403,"sha.js":198}],142:[function(require,module,exports){
+arguments[4][53][0].apply(exports,arguments)
+},{"cipher-base":135,"dup":53,"inherits":158,"safe-buffer":403}],143:[function(require,module,exports){
 'use strict'
 
 exports.randomBytes = exports.rng = exports.pseudoRandomBytes = exports.prng = require('randombytes')
@@ -30260,7 +20591,7 @@ exports.constants = {
   'POINT_CONVERSION_HYBRID': 6
 }
 
-},{"browserify-cipher":177,"browserify-sign":184,"browserify-sign/algos":181,"create-ecdh":192,"create-hash":193,"create-hmac":196,"diffie-hellman":205,"pbkdf2":223,"public-encrypt":230,"randombytes":240}],199:[function(require,module,exports){
+},{"browserify-cipher":123,"browserify-sign":130,"browserify-sign/algos":127,"create-ecdh":137,"create-hash":138,"create-hmac":141,"diffie-hellman":150,"pbkdf2":168,"public-encrypt":175,"randombytes":181}],144:[function(require,module,exports){
 'use strict';
 
 exports.utils = require('./des/utils');
@@ -30269,7 +20600,7 @@ exports.DES = require('./des/des');
 exports.CBC = require('./des/cbc');
 exports.EDE = require('./des/ede');
 
-},{"./des/cbc":200,"./des/cipher":201,"./des/des":202,"./des/ede":203,"./des/utils":204}],200:[function(require,module,exports){
+},{"./des/cbc":145,"./des/cipher":146,"./des/des":147,"./des/ede":148,"./des/utils":149}],145:[function(require,module,exports){
 'use strict';
 
 var assert = require('minimalistic-assert');
@@ -30336,7 +20667,7 @@ proto._update = function _update(inp, inOff, out, outOff) {
   }
 };
 
-},{"inherits":213,"minimalistic-assert":217}],201:[function(require,module,exports){
+},{"inherits":158,"minimalistic-assert":162}],146:[function(require,module,exports){
 'use strict';
 
 var assert = require('minimalistic-assert');
@@ -30479,7 +20810,7 @@ Cipher.prototype._finalDecrypt = function _finalDecrypt() {
   return this._unpad(out);
 };
 
-},{"minimalistic-assert":217}],202:[function(require,module,exports){
+},{"minimalistic-assert":162}],147:[function(require,module,exports){
 'use strict';
 
 var assert = require('minimalistic-assert');
@@ -30624,7 +20955,7 @@ DES.prototype._decrypt = function _decrypt(state, lStart, rStart, out, off) {
   utils.rip(l, r, out, off);
 };
 
-},{"../des":199,"inherits":213,"minimalistic-assert":217}],203:[function(require,module,exports){
+},{"../des":144,"inherits":158,"minimalistic-assert":162}],148:[function(require,module,exports){
 'use strict';
 
 var assert = require('minimalistic-assert');
@@ -30681,7 +21012,7 @@ EDE.prototype._update = function _update(inp, inOff, out, outOff) {
 EDE.prototype._pad = DES.prototype._pad;
 EDE.prototype._unpad = DES.prototype._unpad;
 
-},{"../des":199,"inherits":213,"minimalistic-assert":217}],204:[function(require,module,exports){
+},{"../des":144,"inherits":158,"minimalistic-assert":162}],149:[function(require,module,exports){
 'use strict';
 
 exports.readUInt32BE = function readUInt32BE(bytes, off) {
@@ -30939,7 +21270,7 @@ exports.padSplit = function padSplit(num, size, group) {
   return out.join(' ');
 };
 
-},{}],205:[function(require,module,exports){
+},{}],150:[function(require,module,exports){
 (function (Buffer){
 var generatePrime = require('./lib/generatePrime')
 var primes = require('./lib/primes.json')
@@ -30985,7 +21316,7 @@ exports.DiffieHellmanGroup = exports.createDiffieHellmanGroup = exports.getDiffi
 exports.createDiffieHellman = exports.DiffieHellman = createDiffieHellman
 
 }).call(this,require("buffer").Buffer)
-},{"./lib/dh":206,"./lib/generatePrime":207,"./lib/primes.json":208,"buffer":188}],206:[function(require,module,exports){
+},{"./lib/dh":151,"./lib/generatePrime":152,"./lib/primes.json":153,"buffer":134}],151:[function(require,module,exports){
 (function (Buffer){
 var BN = require('bn.js');
 var MillerRabin = require('miller-rabin');
@@ -31153,7 +21484,7 @@ function formatReturnValue(bn, enc) {
 }
 
 }).call(this,require("buffer").Buffer)
-},{"./generatePrime":207,"bn.js":158,"buffer":188,"miller-rabin":216,"randombytes":240}],207:[function(require,module,exports){
+},{"./generatePrime":152,"bn.js":104,"buffer":134,"miller-rabin":161,"randombytes":181}],152:[function(require,module,exports){
 var randomBytes = require('randombytes');
 module.exports = findPrime;
 findPrime.simpleSieve = simpleSieve;
@@ -31260,7 +21591,7 @@ function findPrime(bits, gen) {
 
 }
 
-},{"bn.js":158,"miller-rabin":216,"randombytes":240}],208:[function(require,module,exports){
+},{"bn.js":104,"miller-rabin":161,"randombytes":181}],153:[function(require,module,exports){
 module.exports={
     "modp1": {
         "gen": "02",
@@ -31295,7 +21626,7 @@ module.exports={
         "prime": "ffffffffffffffffc90fdaa22168c234c4c6628b80dc1cd129024e088a67cc74020bbea63b139b22514a08798e3404ddef9519b3cd3a431b302b0a6df25f14374fe1356d6d51c245e485b576625e7ec6f44c42e9a637ed6b0bff5cb6f406b7edee386bfb5a899fa5ae9f24117c4b1fe649286651ece45b3dc2007cb8a163bf0598da48361c55d39a69163fa8fd24cf5f83655d23dca3ad961c62f356208552bb9ed529077096966d670c354e4abc9804f1746c08ca18217c32905e462e36ce3be39e772c180e86039b2783a2ec07a28fb5c55df06f4c52c9de2bcbf6955817183995497cea956ae515d2261898fa051015728e5a8aaac42dad33170d04507a33a85521abdf1cba64ecfb850458dbef0a8aea71575d060c7db3970f85a6e1e4c7abf5ae8cdb0933d71e8c94e04a25619dcee3d2261ad2ee6bf12ffa06d98a0864d87602733ec86a64521f2b18177b200cbbe117577a615d6c770988c0bad946e208e24fa074e5ab3143db5bfce0fd108e4b82d120a92108011a723c12a787e6d788719a10bdba5b2699c327186af4e23c1a946834b6150bda2583e9ca2ad44ce8dbbbc2db04de8ef92e8efc141fbecaa6287c59474e6bc05d99b2964fa090c3a2233ba186515be7ed1f612970cee2d7afb81bdd762170481cd0069127d5b05aa993b4ea988d8fddc186ffb7dc90a6c08f4df435c93402849236c3fab4d27c7026c1d4dcb2602646dec9751e763dba37bdf8ff9406ad9e530ee5db382f413001aeb06a53ed9027d831179727b0865a8918da3edbebcf9b14ed44ce6cbaced4bb1bdb7f1447e6cc254b332051512bd7af426fb8f401378cd2bf5983ca01c64b92ecf032ea15d1721d03f482d7ce6e74fef6d55e702f46980c82b5a84031900b1c9e59e7c97fbec7e8f323a97a7e36cc88be0f1d45b7ff585ac54bd407b22b4154aacc8f6d7ebf48e1d814cc5ed20f8037e0a79715eef29be32806a1d58bb7c5da76f550aa3d8a1fbff0eb19ccb1a313d55cda56c9ec2ef29632387fe8d76e3c0468043e8f663f4860ee12bf2d5b0b7474d6e694f91e6dbe115974a3926f12fee5e438777cb6a932df8cd8bec4d073b931ba3bc832b68d9dd300741fa7bf8afc47ed2576f6936ba424663aab639c5ae4f5683423b4742bf1c978238f16cbe39d652de3fdb8befc848ad922222e04a4037c0713eb57a81a23f0c73473fc646cea306b4bcbc8862f8385ddfa9d4b7fa2c087e879683303ed5bdd3a062b3cf5b3a278a66d2a13f83f44f82ddf310ee074ab6a364597e899a0255dc164f31cc50846851df9ab48195ded7ea1b1d510bd7ee74d73faf36bc31ecfa268359046f4eb879f924009438b481c6cd7889a002ed5ee382bc9190da6fc026e479558e4475677e9aa9e3050e2765694dfc81f56e880b96e7160c980dd98edd3dfffffffffffffffff"
     }
 }
-},{}],209:[function(require,module,exports){
+},{}],154:[function(require,module,exports){
 // Copyright Joyent, Inc. and other Node contributors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -31599,7 +21930,7 @@ function isUndefined(arg) {
   return arg === void 0;
 }
 
-},{}],210:[function(require,module,exports){
+},{}],155:[function(require,module,exports){
 var Buffer = require('safe-buffer').Buffer
 var MD5 = require('md5.js')
 
@@ -31646,7 +21977,7 @@ function EVP_BytesToKey (password, salt, keyBits, ivLen) {
 
 module.exports = EVP_BytesToKey
 
-},{"md5.js":464,"safe-buffer":481}],211:[function(require,module,exports){
+},{"md5.js":394,"safe-buffer":403}],156:[function(require,module,exports){
 exports.read = function (buffer, offset, isLE, mLen, nBytes) {
   var e, m
   var eLen = nBytes * 8 - mLen - 1
@@ -31732,7 +22063,7 @@ exports.write = function (buffer, value, offset, isLE, mLen, nBytes) {
   buffer[offset + i - d] |= s * 128
 }
 
-},{}],212:[function(require,module,exports){
+},{}],157:[function(require,module,exports){
 
 var indexOf = [].indexOf;
 
@@ -31743,9 +22074,9 @@ module.exports = function(arr, obj){
   }
   return -1;
 };
-},{}],213:[function(require,module,exports){
-arguments[4][101][0].apply(exports,arguments)
-},{"dup":101}],214:[function(require,module,exports){
+},{}],158:[function(require,module,exports){
+arguments[4][54][0].apply(exports,arguments)
+},{"dup":54}],159:[function(require,module,exports){
 /*!
  * Determine if an object is a Buffer
  *
@@ -31768,14 +22099,14 @@ function isSlowBuffer (obj) {
   return typeof obj.readFloatLE === 'function' && typeof obj.slice === 'function' && isBuffer(obj.slice(0, 0))
 }
 
-},{}],215:[function(require,module,exports){
+},{}],160:[function(require,module,exports){
 var toString = {}.toString;
 
 module.exports = Array.isArray || function (arr) {
   return toString.call(arr) == '[object Array]';
 };
 
-},{}],216:[function(require,module,exports){
+},{}],161:[function(require,module,exports){
 var bn = require('bn.js');
 var brorand = require('brorand');
 
@@ -31892,7 +22223,7 @@ MillerRabin.prototype.getDivisor = function getDivisor(n, k) {
   return false;
 };
 
-},{"bn.js":158,"brorand":159}],217:[function(require,module,exports){
+},{"bn.js":104,"brorand":105}],162:[function(require,module,exports){
 module.exports = assert;
 
 function assert(val, msg) {
@@ -31905,7 +22236,7 @@ assert.equal = function assertEqual(l, r, msg) {
     throw new Error(msg || ('Assertion failed: ' + l + ' != ' + r));
 };
 
-},{}],218:[function(require,module,exports){
+},{}],163:[function(require,module,exports){
 module.exports={"2.16.840.1.101.3.4.1.1": "aes-128-ecb",
 "2.16.840.1.101.3.4.1.2": "aes-128-cbc",
 "2.16.840.1.101.3.4.1.3": "aes-128-ofb",
@@ -31919,7 +22250,7 @@ module.exports={"2.16.840.1.101.3.4.1.1": "aes-128-ecb",
 "2.16.840.1.101.3.4.1.43": "aes-256-ofb",
 "2.16.840.1.101.3.4.1.44": "aes-256-cfb"
 }
-},{}],219:[function(require,module,exports){
+},{}],164:[function(require,module,exports){
 // from https://github.com/indutny/self-signed/blob/gh-pages/lib/asn1.js
 // Fedor, you are amazing.
 'use strict'
@@ -32043,7 +22374,7 @@ exports.signature = asn1.define('signature', function () {
   )
 })
 
-},{"./certificate":220,"asn1.js":142}],220:[function(require,module,exports){
+},{"./certificate":165,"asn1.js":88}],165:[function(require,module,exports){
 // from https://github.com/Rantanen/node-dtls/blob/25a7dc861bda38cfeac93a723500eea4f0ac2e86/Certificate.js
 // thanks to @Rantanen
 
@@ -32133,7 +22464,7 @@ var X509Certificate = asn.define('X509Certificate', function () {
 
 module.exports = X509Certificate
 
-},{"asn1.js":142}],221:[function(require,module,exports){
+},{"asn1.js":88}],166:[function(require,module,exports){
 (function (Buffer){
 // adapted from https://github.com/apatil/pemstrip
 var findProc = /Proc-Type: 4,ENCRYPTED\n\r?DEK-Info: AES-((?:128)|(?:192)|(?:256))-CBC,([0-9A-H]+)\n\r?\n\r?([0-9A-z\n\r\+\/\=]+)\n\r?/m
@@ -32167,7 +22498,7 @@ module.exports = function (okey, password) {
 }
 
 }).call(this,require("buffer").Buffer)
-},{"browserify-aes":163,"buffer":188,"evp_bytestokey":210}],222:[function(require,module,exports){
+},{"browserify-aes":109,"buffer":134,"evp_bytestokey":155}],167:[function(require,module,exports){
 (function (Buffer){
 var asn1 = require('./asn1')
 var aesid = require('./aesid.json')
@@ -32277,13 +22608,13 @@ function decrypt (data, password) {
 }
 
 }).call(this,require("buffer").Buffer)
-},{"./aesid.json":218,"./asn1":219,"./fixProc":221,"browserify-aes":163,"buffer":188,"pbkdf2":223}],223:[function(require,module,exports){
+},{"./aesid.json":163,"./asn1":164,"./fixProc":166,"browserify-aes":109,"buffer":134,"pbkdf2":168}],168:[function(require,module,exports){
 
 exports.pbkdf2 = require('./lib/async')
 
 exports.pbkdf2Sync = require('./lib/sync')
 
-},{"./lib/async":224,"./lib/sync":227}],224:[function(require,module,exports){
+},{"./lib/async":169,"./lib/sync":172}],169:[function(require,module,exports){
 (function (process,global){
 var checkParameters = require('./precondition')
 var defaultEncoding = require('./default-encoding')
@@ -32385,7 +22716,7 @@ module.exports = function (password, salt, iterations, keylen, digest, callback)
 }
 
 }).call(this,require('_process'),typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./default-encoding":225,"./precondition":226,"./sync":227,"_process":229,"safe-buffer":481}],225:[function(require,module,exports){
+},{"./default-encoding":170,"./precondition":171,"./sync":172,"_process":174,"safe-buffer":403}],170:[function(require,module,exports){
 (function (process){
 var defaultEncoding
 /* istanbul ignore next */
@@ -32399,7 +22730,7 @@ if (process.browser) {
 module.exports = defaultEncoding
 
 }).call(this,require('_process'))
-},{"_process":229}],226:[function(require,module,exports){
+},{"_process":174}],171:[function(require,module,exports){
 var MAX_ALLOC = Math.pow(2, 30) - 1 // default in iojs
 module.exports = function (iterations, keylen) {
   if (typeof iterations !== 'number') {
@@ -32419,7 +22750,7 @@ module.exports = function (iterations, keylen) {
   }
 }
 
-},{}],227:[function(require,module,exports){
+},{}],172:[function(require,module,exports){
 var md5 = require('create-hash/md5')
 var rmd160 = require('ripemd160')
 var sha = require('sha.js')
@@ -32522,7 +22853,7 @@ function pbkdf2 (password, salt, iterations, keylen, digest) {
 
 module.exports = pbkdf2
 
-},{"./default-encoding":225,"./precondition":226,"create-hash/md5":195,"ripemd160":255,"safe-buffer":481,"sha.js":257}],228:[function(require,module,exports){
+},{"./default-encoding":170,"./precondition":171,"create-hash/md5":140,"ripemd160":196,"safe-buffer":403,"sha.js":198}],173:[function(require,module,exports){
 (function (process){
 'use strict';
 
@@ -32569,7 +22900,7 @@ function nextTick(fn, arg1, arg2, arg3) {
 }
 
 }).call(this,require('_process'))
-},{"_process":229}],229:[function(require,module,exports){
+},{"_process":174}],174:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 
@@ -32755,7 +23086,7 @@ process.chdir = function (dir) {
 };
 process.umask = function() { return 0; };
 
-},{}],230:[function(require,module,exports){
+},{}],175:[function(require,module,exports){
 exports.publicEncrypt = require('./publicEncrypt');
 exports.privateDecrypt = require('./privateDecrypt');
 
@@ -32766,7 +23097,7 @@ exports.privateEncrypt = function privateEncrypt(key, buf) {
 exports.publicDecrypt = function publicDecrypt(key, buf) {
   return exports.privateDecrypt(key, buf, true);
 };
-},{"./privateDecrypt":232,"./publicEncrypt":233}],231:[function(require,module,exports){
+},{"./privateDecrypt":177,"./publicEncrypt":178}],176:[function(require,module,exports){
 (function (Buffer){
 var createHash = require('create-hash');
 module.exports = function (seed, len) {
@@ -32785,7 +23116,7 @@ function i2ops(c) {
   return out;
 }
 }).call(this,require("buffer").Buffer)
-},{"buffer":188,"create-hash":193}],232:[function(require,module,exports){
+},{"buffer":134,"create-hash":138}],177:[function(require,module,exports){
 (function (Buffer){
 var parseKeys = require('parse-asn1');
 var mgf = require('./mgf');
@@ -32896,7 +23227,7 @@ function compare(a, b){
   return dif;
 }
 }).call(this,require("buffer").Buffer)
-},{"./mgf":231,"./withPublic":234,"./xor":235,"bn.js":158,"browserify-rsa":180,"buffer":188,"create-hash":193,"parse-asn1":222}],233:[function(require,module,exports){
+},{"./mgf":176,"./withPublic":179,"./xor":180,"bn.js":104,"browserify-rsa":126,"buffer":134,"create-hash":138,"parse-asn1":167}],178:[function(require,module,exports){
 (function (Buffer){
 var parseKeys = require('parse-asn1');
 var randomBytes = require('randombytes');
@@ -32994,7 +23325,7 @@ function nonZero(len, crypto) {
   return out;
 }
 }).call(this,require("buffer").Buffer)
-},{"./mgf":231,"./withPublic":234,"./xor":235,"bn.js":158,"browserify-rsa":180,"buffer":188,"create-hash":193,"parse-asn1":222,"randombytes":240}],234:[function(require,module,exports){
+},{"./mgf":176,"./withPublic":179,"./xor":180,"bn.js":104,"browserify-rsa":126,"buffer":134,"create-hash":138,"parse-asn1":167,"randombytes":181}],179:[function(require,module,exports){
 (function (Buffer){
 var bn = require('bn.js');
 function withPublic(paddedMsg, key) {
@@ -33007,7 +23338,7 @@ function withPublic(paddedMsg, key) {
 
 module.exports = withPublic;
 }).call(this,require("buffer").Buffer)
-},{"bn.js":158,"buffer":188}],235:[function(require,module,exports){
+},{"bn.js":104,"buffer":134}],180:[function(require,module,exports){
 module.exports = function xor(a, b) {
   var len = a.length;
   var i = -1;
@@ -33016,728 +23347,12 @@ module.exports = function xor(a, b) {
   }
   return a
 };
-},{}],236:[function(require,module,exports){
-(function (global){
-/*! https://mths.be/punycode v1.4.1 by @mathias */
-;(function(root) {
-
-	/** Detect free variables */
-	var freeExports = typeof exports == 'object' && exports &&
-		!exports.nodeType && exports;
-	var freeModule = typeof module == 'object' && module &&
-		!module.nodeType && module;
-	var freeGlobal = typeof global == 'object' && global;
-	if (
-		freeGlobal.global === freeGlobal ||
-		freeGlobal.window === freeGlobal ||
-		freeGlobal.self === freeGlobal
-	) {
-		root = freeGlobal;
-	}
-
-	/**
-	 * The `punycode` object.
-	 * @name punycode
-	 * @type Object
-	 */
-	var punycode,
-
-	/** Highest positive signed 32-bit float value */
-	maxInt = 2147483647, // aka. 0x7FFFFFFF or 2^31-1
-
-	/** Bootstring parameters */
-	base = 36,
-	tMin = 1,
-	tMax = 26,
-	skew = 38,
-	damp = 700,
-	initialBias = 72,
-	initialN = 128, // 0x80
-	delimiter = '-', // '\x2D'
-
-	/** Regular expressions */
-	regexPunycode = /^xn--/,
-	regexNonASCII = /[^\x20-\x7E]/, // unprintable ASCII chars + non-ASCII chars
-	regexSeparators = /[\x2E\u3002\uFF0E\uFF61]/g, // RFC 3490 separators
-
-	/** Error messages */
-	errors = {
-		'overflow': 'Overflow: input needs wider integers to process',
-		'not-basic': 'Illegal input >= 0x80 (not a basic code point)',
-		'invalid-input': 'Invalid input'
-	},
-
-	/** Convenience shortcuts */
-	baseMinusTMin = base - tMin,
-	floor = Math.floor,
-	stringFromCharCode = String.fromCharCode,
-
-	/** Temporary variable */
-	key;
-
-	/*--------------------------------------------------------------------------*/
-
-	/**
-	 * A generic error utility function.
-	 * @private
-	 * @param {String} type The error type.
-	 * @returns {Error} Throws a `RangeError` with the applicable error message.
-	 */
-	function error(type) {
-		throw new RangeError(errors[type]);
-	}
-
-	/**
-	 * A generic `Array#map` utility function.
-	 * @private
-	 * @param {Array} array The array to iterate over.
-	 * @param {Function} callback The function that gets called for every array
-	 * item.
-	 * @returns {Array} A new array of values returned by the callback function.
-	 */
-	function map(array, fn) {
-		var length = array.length;
-		var result = [];
-		while (length--) {
-			result[length] = fn(array[length]);
-		}
-		return result;
-	}
-
-	/**
-	 * A simple `Array#map`-like wrapper to work with domain name strings or email
-	 * addresses.
-	 * @private
-	 * @param {String} domain The domain name or email address.
-	 * @param {Function} callback The function that gets called for every
-	 * character.
-	 * @returns {Array} A new string of characters returned by the callback
-	 * function.
-	 */
-	function mapDomain(string, fn) {
-		var parts = string.split('@');
-		var result = '';
-		if (parts.length > 1) {
-			// In email addresses, only the domain name should be punycoded. Leave
-			// the local part (i.e. everything up to `@`) intact.
-			result = parts[0] + '@';
-			string = parts[1];
-		}
-		// Avoid `split(regex)` for IE8 compatibility. See #17.
-		string = string.replace(regexSeparators, '\x2E');
-		var labels = string.split('.');
-		var encoded = map(labels, fn).join('.');
-		return result + encoded;
-	}
-
-	/**
-	 * Creates an array containing the numeric code points of each Unicode
-	 * character in the string. While JavaScript uses UCS-2 internally,
-	 * this function will convert a pair of surrogate halves (each of which
-	 * UCS-2 exposes as separate characters) into a single code point,
-	 * matching UTF-16.
-	 * @see `punycode.ucs2.encode`
-	 * @see <https://mathiasbynens.be/notes/javascript-encoding>
-	 * @memberOf punycode.ucs2
-	 * @name decode
-	 * @param {String} string The Unicode input string (UCS-2).
-	 * @returns {Array} The new array of code points.
-	 */
-	function ucs2decode(string) {
-		var output = [],
-		    counter = 0,
-		    length = string.length,
-		    value,
-		    extra;
-		while (counter < length) {
-			value = string.charCodeAt(counter++);
-			if (value >= 0xD800 && value <= 0xDBFF && counter < length) {
-				// high surrogate, and there is a next character
-				extra = string.charCodeAt(counter++);
-				if ((extra & 0xFC00) == 0xDC00) { // low surrogate
-					output.push(((value & 0x3FF) << 10) + (extra & 0x3FF) + 0x10000);
-				} else {
-					// unmatched surrogate; only append this code unit, in case the next
-					// code unit is the high surrogate of a surrogate pair
-					output.push(value);
-					counter--;
-				}
-			} else {
-				output.push(value);
-			}
-		}
-		return output;
-	}
-
-	/**
-	 * Creates a string based on an array of numeric code points.
-	 * @see `punycode.ucs2.decode`
-	 * @memberOf punycode.ucs2
-	 * @name encode
-	 * @param {Array} codePoints The array of numeric code points.
-	 * @returns {String} The new Unicode string (UCS-2).
-	 */
-	function ucs2encode(array) {
-		return map(array, function(value) {
-			var output = '';
-			if (value > 0xFFFF) {
-				value -= 0x10000;
-				output += stringFromCharCode(value >>> 10 & 0x3FF | 0xD800);
-				value = 0xDC00 | value & 0x3FF;
-			}
-			output += stringFromCharCode(value);
-			return output;
-		}).join('');
-	}
-
-	/**
-	 * Converts a basic code point into a digit/integer.
-	 * @see `digitToBasic()`
-	 * @private
-	 * @param {Number} codePoint The basic numeric code point value.
-	 * @returns {Number} The numeric value of a basic code point (for use in
-	 * representing integers) in the range `0` to `base - 1`, or `base` if
-	 * the code point does not represent a value.
-	 */
-	function basicToDigit(codePoint) {
-		if (codePoint - 48 < 10) {
-			return codePoint - 22;
-		}
-		if (codePoint - 65 < 26) {
-			return codePoint - 65;
-		}
-		if (codePoint - 97 < 26) {
-			return codePoint - 97;
-		}
-		return base;
-	}
-
-	/**
-	 * Converts a digit/integer into a basic code point.
-	 * @see `basicToDigit()`
-	 * @private
-	 * @param {Number} digit The numeric value of a basic code point.
-	 * @returns {Number} The basic code point whose value (when used for
-	 * representing integers) is `digit`, which needs to be in the range
-	 * `0` to `base - 1`. If `flag` is non-zero, the uppercase form is
-	 * used; else, the lowercase form is used. The behavior is undefined
-	 * if `flag` is non-zero and `digit` has no uppercase form.
-	 */
-	function digitToBasic(digit, flag) {
-		//  0..25 map to ASCII a..z or A..Z
-		// 26..35 map to ASCII 0..9
-		return digit + 22 + 75 * (digit < 26) - ((flag != 0) << 5);
-	}
-
-	/**
-	 * Bias adaptation function as per section 3.4 of RFC 3492.
-	 * https://tools.ietf.org/html/rfc3492#section-3.4
-	 * @private
-	 */
-	function adapt(delta, numPoints, firstTime) {
-		var k = 0;
-		delta = firstTime ? floor(delta / damp) : delta >> 1;
-		delta += floor(delta / numPoints);
-		for (/* no initialization */; delta > baseMinusTMin * tMax >> 1; k += base) {
-			delta = floor(delta / baseMinusTMin);
-		}
-		return floor(k + (baseMinusTMin + 1) * delta / (delta + skew));
-	}
-
-	/**
-	 * Converts a Punycode string of ASCII-only symbols to a string of Unicode
-	 * symbols.
-	 * @memberOf punycode
-	 * @param {String} input The Punycode string of ASCII-only symbols.
-	 * @returns {String} The resulting string of Unicode symbols.
-	 */
-	function decode(input) {
-		// Don't use UCS-2
-		var output = [],
-		    inputLength = input.length,
-		    out,
-		    i = 0,
-		    n = initialN,
-		    bias = initialBias,
-		    basic,
-		    j,
-		    index,
-		    oldi,
-		    w,
-		    k,
-		    digit,
-		    t,
-		    /** Cached calculation results */
-		    baseMinusT;
-
-		// Handle the basic code points: let `basic` be the number of input code
-		// points before the last delimiter, or `0` if there is none, then copy
-		// the first basic code points to the output.
-
-		basic = input.lastIndexOf(delimiter);
-		if (basic < 0) {
-			basic = 0;
-		}
-
-		for (j = 0; j < basic; ++j) {
-			// if it's not a basic code point
-			if (input.charCodeAt(j) >= 0x80) {
-				error('not-basic');
-			}
-			output.push(input.charCodeAt(j));
-		}
-
-		// Main decoding loop: start just after the last delimiter if any basic code
-		// points were copied; start at the beginning otherwise.
-
-		for (index = basic > 0 ? basic + 1 : 0; index < inputLength; /* no final expression */) {
-
-			// `index` is the index of the next character to be consumed.
-			// Decode a generalized variable-length integer into `delta`,
-			// which gets added to `i`. The overflow checking is easier
-			// if we increase `i` as we go, then subtract off its starting
-			// value at the end to obtain `delta`.
-			for (oldi = i, w = 1, k = base; /* no condition */; k += base) {
-
-				if (index >= inputLength) {
-					error('invalid-input');
-				}
-
-				digit = basicToDigit(input.charCodeAt(index++));
-
-				if (digit >= base || digit > floor((maxInt - i) / w)) {
-					error('overflow');
-				}
-
-				i += digit * w;
-				t = k <= bias ? tMin : (k >= bias + tMax ? tMax : k - bias);
-
-				if (digit < t) {
-					break;
-				}
-
-				baseMinusT = base - t;
-				if (w > floor(maxInt / baseMinusT)) {
-					error('overflow');
-				}
-
-				w *= baseMinusT;
-
-			}
-
-			out = output.length + 1;
-			bias = adapt(i - oldi, out, oldi == 0);
-
-			// `i` was supposed to wrap around from `out` to `0`,
-			// incrementing `n` each time, so we'll fix that now:
-			if (floor(i / out) > maxInt - n) {
-				error('overflow');
-			}
-
-			n += floor(i / out);
-			i %= out;
-
-			// Insert `n` at position `i` of the output
-			output.splice(i++, 0, n);
-
-		}
-
-		return ucs2encode(output);
-	}
-
-	/**
-	 * Converts a string of Unicode symbols (e.g. a domain name label) to a
-	 * Punycode string of ASCII-only symbols.
-	 * @memberOf punycode
-	 * @param {String} input The string of Unicode symbols.
-	 * @returns {String} The resulting Punycode string of ASCII-only symbols.
-	 */
-	function encode(input) {
-		var n,
-		    delta,
-		    handledCPCount,
-		    basicLength,
-		    bias,
-		    j,
-		    m,
-		    q,
-		    k,
-		    t,
-		    currentValue,
-		    output = [],
-		    /** `inputLength` will hold the number of code points in `input`. */
-		    inputLength,
-		    /** Cached calculation results */
-		    handledCPCountPlusOne,
-		    baseMinusT,
-		    qMinusT;
-
-		// Convert the input in UCS-2 to Unicode
-		input = ucs2decode(input);
-
-		// Cache the length
-		inputLength = input.length;
-
-		// Initialize the state
-		n = initialN;
-		delta = 0;
-		bias = initialBias;
-
-		// Handle the basic code points
-		for (j = 0; j < inputLength; ++j) {
-			currentValue = input[j];
-			if (currentValue < 0x80) {
-				output.push(stringFromCharCode(currentValue));
-			}
-		}
-
-		handledCPCount = basicLength = output.length;
-
-		// `handledCPCount` is the number of code points that have been handled;
-		// `basicLength` is the number of basic code points.
-
-		// Finish the basic string - if it is not empty - with a delimiter
-		if (basicLength) {
-			output.push(delimiter);
-		}
-
-		// Main encoding loop:
-		while (handledCPCount < inputLength) {
-
-			// All non-basic code points < n have been handled already. Find the next
-			// larger one:
-			for (m = maxInt, j = 0; j < inputLength; ++j) {
-				currentValue = input[j];
-				if (currentValue >= n && currentValue < m) {
-					m = currentValue;
-				}
-			}
-
-			// Increase `delta` enough to advance the decoder's <n,i> state to <m,0>,
-			// but guard against overflow
-			handledCPCountPlusOne = handledCPCount + 1;
-			if (m - n > floor((maxInt - delta) / handledCPCountPlusOne)) {
-				error('overflow');
-			}
-
-			delta += (m - n) * handledCPCountPlusOne;
-			n = m;
-
-			for (j = 0; j < inputLength; ++j) {
-				currentValue = input[j];
-
-				if (currentValue < n && ++delta > maxInt) {
-					error('overflow');
-				}
-
-				if (currentValue == n) {
-					// Represent delta as a generalized variable-length integer
-					for (q = delta, k = base; /* no condition */; k += base) {
-						t = k <= bias ? tMin : (k >= bias + tMax ? tMax : k - bias);
-						if (q < t) {
-							break;
-						}
-						qMinusT = q - t;
-						baseMinusT = base - t;
-						output.push(
-							stringFromCharCode(digitToBasic(t + qMinusT % baseMinusT, 0))
-						);
-						q = floor(qMinusT / baseMinusT);
-					}
-
-					output.push(stringFromCharCode(digitToBasic(q, 0)));
-					bias = adapt(delta, handledCPCountPlusOne, handledCPCount == basicLength);
-					delta = 0;
-					++handledCPCount;
-				}
-			}
-
-			++delta;
-			++n;
-
-		}
-		return output.join('');
-	}
-
-	/**
-	 * Converts a Punycode string representing a domain name or an email address
-	 * to Unicode. Only the Punycoded parts of the input will be converted, i.e.
-	 * it doesn't matter if you call it on a string that has already been
-	 * converted to Unicode.
-	 * @memberOf punycode
-	 * @param {String} input The Punycoded domain name or email address to
-	 * convert to Unicode.
-	 * @returns {String} The Unicode representation of the given Punycode
-	 * string.
-	 */
-	function toUnicode(input) {
-		return mapDomain(input, function(string) {
-			return regexPunycode.test(string)
-				? decode(string.slice(4).toLowerCase())
-				: string;
-		});
-	}
-
-	/**
-	 * Converts a Unicode string representing a domain name or an email address to
-	 * Punycode. Only the non-ASCII parts of the domain name will be converted,
-	 * i.e. it doesn't matter if you call it with a domain that's already in
-	 * ASCII.
-	 * @memberOf punycode
-	 * @param {String} input The domain name or email address to convert, as a
-	 * Unicode string.
-	 * @returns {String} The Punycode representation of the given domain name or
-	 * email address.
-	 */
-	function toASCII(input) {
-		return mapDomain(input, function(string) {
-			return regexNonASCII.test(string)
-				? 'xn--' + encode(string)
-				: string;
-		});
-	}
-
-	/*--------------------------------------------------------------------------*/
-
-	/** Define the public API */
-	punycode = {
-		/**
-		 * A string representing the current Punycode.js version number.
-		 * @memberOf punycode
-		 * @type String
-		 */
-		'version': '1.4.1',
-		/**
-		 * An object of methods to convert from JavaScript's internal character
-		 * representation (UCS-2) to Unicode code points, and back.
-		 * @see <https://mathiasbynens.be/notes/javascript-encoding>
-		 * @memberOf punycode
-		 * @type Object
-		 */
-		'ucs2': {
-			'decode': ucs2decode,
-			'encode': ucs2encode
-		},
-		'decode': decode,
-		'encode': encode,
-		'toASCII': toASCII,
-		'toUnicode': toUnicode
-	};
-
-	/** Expose `punycode` */
-	// Some AMD build optimizers, like r.js, check for specific condition patterns
-	// like the following:
-	if (
-		typeof define == 'function' &&
-		typeof define.amd == 'object' &&
-		define.amd
-	) {
-		define('punycode', function() {
-			return punycode;
-		});
-	} else if (freeExports && freeModule) {
-		if (module.exports == freeExports) {
-			// in Node.js, io.js, or RingoJS v0.8.0+
-			freeModule.exports = punycode;
-		} else {
-			// in Narwhal or RingoJS v0.7.0-
-			for (key in punycode) {
-				punycode.hasOwnProperty(key) && (freeExports[key] = punycode[key]);
-			}
-		}
-	} else {
-		// in Rhino or a web browser
-		root.punycode = punycode;
-	}
-
-}(this));
-
-}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],237:[function(require,module,exports){
-// Copyright Joyent, Inc. and other Node contributors.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a
-// copy of this software and associated documentation files (the
-// "Software"), to deal in the Software without restriction, including
-// without limitation the rights to use, copy, modify, merge, publish,
-// distribute, sublicense, and/or sell copies of the Software, and to permit
-// persons to whom the Software is furnished to do so, subject to the
-// following conditions:
-//
-// The above copyright notice and this permission notice shall be included
-// in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
-// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
-// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
-// USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-'use strict';
-
-// If obj.hasOwnProperty has been overridden, then calling
-// obj.hasOwnProperty(prop) will break.
-// See: https://github.com/joyent/node/issues/1707
-function hasOwnProperty(obj, prop) {
-  return Object.prototype.hasOwnProperty.call(obj, prop);
-}
-
-module.exports = function(qs, sep, eq, options) {
-  sep = sep || '&';
-  eq = eq || '=';
-  var obj = {};
-
-  if (typeof qs !== 'string' || qs.length === 0) {
-    return obj;
-  }
-
-  var regexp = /\+/g;
-  qs = qs.split(sep);
-
-  var maxKeys = 1000;
-  if (options && typeof options.maxKeys === 'number') {
-    maxKeys = options.maxKeys;
-  }
-
-  var len = qs.length;
-  // maxKeys <= 0 means that we should not limit keys count
-  if (maxKeys > 0 && len > maxKeys) {
-    len = maxKeys;
-  }
-
-  for (var i = 0; i < len; ++i) {
-    var x = qs[i].replace(regexp, '%20'),
-        idx = x.indexOf(eq),
-        kstr, vstr, k, v;
-
-    if (idx >= 0) {
-      kstr = x.substr(0, idx);
-      vstr = x.substr(idx + 1);
-    } else {
-      kstr = x;
-      vstr = '';
-    }
-
-    k = decodeURIComponent(kstr);
-    v = decodeURIComponent(vstr);
-
-    if (!hasOwnProperty(obj, k)) {
-      obj[k] = v;
-    } else if (isArray(obj[k])) {
-      obj[k].push(v);
-    } else {
-      obj[k] = [obj[k], v];
-    }
-  }
-
-  return obj;
-};
-
-var isArray = Array.isArray || function (xs) {
-  return Object.prototype.toString.call(xs) === '[object Array]';
-};
-
-},{}],238:[function(require,module,exports){
-// Copyright Joyent, Inc. and other Node contributors.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a
-// copy of this software and associated documentation files (the
-// "Software"), to deal in the Software without restriction, including
-// without limitation the rights to use, copy, modify, merge, publish,
-// distribute, sublicense, and/or sell copies of the Software, and to permit
-// persons to whom the Software is furnished to do so, subject to the
-// following conditions:
-//
-// The above copyright notice and this permission notice shall be included
-// in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
-// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
-// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
-// USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-'use strict';
-
-var stringifyPrimitive = function(v) {
-  switch (typeof v) {
-    case 'string':
-      return v;
-
-    case 'boolean':
-      return v ? 'true' : 'false';
-
-    case 'number':
-      return isFinite(v) ? v : '';
-
-    default:
-      return '';
-  }
-};
-
-module.exports = function(obj, sep, eq, name) {
-  sep = sep || '&';
-  eq = eq || '=';
-  if (obj === null) {
-    obj = undefined;
-  }
-
-  if (typeof obj === 'object') {
-    return map(objectKeys(obj), function(k) {
-      var ks = encodeURIComponent(stringifyPrimitive(k)) + eq;
-      if (isArray(obj[k])) {
-        return map(obj[k], function(v) {
-          return ks + encodeURIComponent(stringifyPrimitive(v));
-        }).join(sep);
-      } else {
-        return ks + encodeURIComponent(stringifyPrimitive(obj[k]));
-      }
-    }).join(sep);
-
-  }
-
-  if (!name) return '';
-  return encodeURIComponent(stringifyPrimitive(name)) + eq +
-         encodeURIComponent(stringifyPrimitive(obj));
-};
-
-var isArray = Array.isArray || function (xs) {
-  return Object.prototype.toString.call(xs) === '[object Array]';
-};
-
-function map (xs, f) {
-  if (xs.map) return xs.map(f);
-  var res = [];
-  for (var i = 0; i < xs.length; i++) {
-    res.push(f(xs[i], i));
-  }
-  return res;
-}
-
-var objectKeys = Object.keys || function (obj) {
-  var res = [];
-  for (var key in obj) {
-    if (Object.prototype.hasOwnProperty.call(obj, key)) res.push(key);
-  }
-  return res;
-};
-
-},{}],239:[function(require,module,exports){
-'use strict';
-
-exports.decode = exports.parse = require('./decode');
-exports.encode = exports.stringify = require('./encode');
-
-},{"./decode":237,"./encode":238}],240:[function(require,module,exports){
-arguments[4][102][0].apply(exports,arguments)
-},{"_process":229,"dup":102,"safe-buffer":481}],241:[function(require,module,exports){
+},{}],181:[function(require,module,exports){
+arguments[4][55][0].apply(exports,arguments)
+},{"_process":174,"dup":55,"safe-buffer":403}],182:[function(require,module,exports){
 module.exports = require('./lib/_stream_duplex.js');
 
-},{"./lib/_stream_duplex.js":242}],242:[function(require,module,exports){
+},{"./lib/_stream_duplex.js":183}],183:[function(require,module,exports){
 // Copyright Joyent, Inc. and other Node contributors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -33862,7 +23477,7 @@ function forEach(xs, f) {
     f(xs[i], i);
   }
 }
-},{"./_stream_readable":244,"./_stream_writable":246,"core-util-is":191,"inherits":213,"process-nextick-args":228}],243:[function(require,module,exports){
+},{"./_stream_readable":185,"./_stream_writable":187,"core-util-is":136,"inherits":158,"process-nextick-args":173}],184:[function(require,module,exports){
 // Copyright Joyent, Inc. and other Node contributors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -33910,7 +23525,7 @@ function PassThrough(options) {
 PassThrough.prototype._transform = function (chunk, encoding, cb) {
   cb(null, chunk);
 };
-},{"./_stream_transform":245,"core-util-is":191,"inherits":213}],244:[function(require,module,exports){
+},{"./_stream_transform":186,"core-util-is":136,"inherits":158}],185:[function(require,module,exports){
 (function (process,global){
 // Copyright Joyent, Inc. and other Node contributors.
 //
@@ -34920,7 +24535,7 @@ function indexOf(xs, x) {
   return -1;
 }
 }).call(this,require('_process'),typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./_stream_duplex":242,"./internal/streams/BufferList":247,"./internal/streams/destroy":248,"./internal/streams/stream":249,"_process":229,"core-util-is":191,"events":209,"inherits":213,"isarray":215,"process-nextick-args":228,"safe-buffer":481,"string_decoder/":250,"util":160}],245:[function(require,module,exports){
+},{"./_stream_duplex":183,"./internal/streams/BufferList":188,"./internal/streams/destroy":189,"./internal/streams/stream":190,"_process":174,"core-util-is":136,"events":154,"inherits":158,"isarray":160,"process-nextick-args":173,"safe-buffer":403,"string_decoder/":191,"util":106}],186:[function(require,module,exports){
 // Copyright Joyent, Inc. and other Node contributors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -35135,7 +24750,7 @@ function done(stream, er, data) {
 
   return stream.push(null);
 }
-},{"./_stream_duplex":242,"core-util-is":191,"inherits":213}],246:[function(require,module,exports){
+},{"./_stream_duplex":183,"core-util-is":136,"inherits":158}],187:[function(require,module,exports){
 (function (process,global){
 // Copyright Joyent, Inc. and other Node contributors.
 //
@@ -35802,7 +25417,7 @@ Writable.prototype._destroy = function (err, cb) {
   cb(err);
 };
 }).call(this,require('_process'),typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./_stream_duplex":242,"./internal/streams/destroy":248,"./internal/streams/stream":249,"_process":229,"core-util-is":191,"inherits":213,"process-nextick-args":228,"safe-buffer":481,"util-deprecate":273}],247:[function(require,module,exports){
+},{"./_stream_duplex":183,"./internal/streams/destroy":189,"./internal/streams/stream":190,"_process":174,"core-util-is":136,"inherits":158,"process-nextick-args":173,"safe-buffer":403,"util-deprecate":207}],188:[function(require,module,exports){
 'use strict';
 
 /*<replacement>*/
@@ -35877,7 +25492,7 @@ module.exports = function () {
 
   return BufferList;
 }();
-},{"safe-buffer":481}],248:[function(require,module,exports){
+},{"safe-buffer":403}],189:[function(require,module,exports){
 'use strict';
 
 /*<replacement>*/
@@ -35950,10 +25565,10 @@ module.exports = {
   destroy: destroy,
   undestroy: undestroy
 };
-},{"process-nextick-args":228}],249:[function(require,module,exports){
+},{"process-nextick-args":173}],190:[function(require,module,exports){
 module.exports = require('events').EventEmitter;
 
-},{"events":209}],250:[function(require,module,exports){
+},{"events":154}],191:[function(require,module,exports){
 'use strict';
 
 var Buffer = require('safe-buffer').Buffer;
@@ -36226,10 +25841,10 @@ function simpleWrite(buf) {
 function simpleEnd(buf) {
   return buf && buf.length ? this.write(buf) : '';
 }
-},{"safe-buffer":481}],251:[function(require,module,exports){
+},{"safe-buffer":403}],192:[function(require,module,exports){
 module.exports = require('./readable').PassThrough
 
-},{"./readable":252}],252:[function(require,module,exports){
+},{"./readable":193}],193:[function(require,module,exports){
 exports = module.exports = require('./lib/_stream_readable.js');
 exports.Stream = exports;
 exports.Readable = exports;
@@ -36238,31 +25853,31 @@ exports.Duplex = require('./lib/_stream_duplex.js');
 exports.Transform = require('./lib/_stream_transform.js');
 exports.PassThrough = require('./lib/_stream_passthrough.js');
 
-},{"./lib/_stream_duplex.js":242,"./lib/_stream_passthrough.js":243,"./lib/_stream_readable.js":244,"./lib/_stream_transform.js":245,"./lib/_stream_writable.js":246}],253:[function(require,module,exports){
+},{"./lib/_stream_duplex.js":183,"./lib/_stream_passthrough.js":184,"./lib/_stream_readable.js":185,"./lib/_stream_transform.js":186,"./lib/_stream_writable.js":187}],194:[function(require,module,exports){
 module.exports = require('./readable').Transform
 
-},{"./readable":252}],254:[function(require,module,exports){
+},{"./readable":193}],195:[function(require,module,exports){
 module.exports = require('./lib/_stream_writable.js');
 
-},{"./lib/_stream_writable.js":246}],255:[function(require,module,exports){
-arguments[4][103][0].apply(exports,arguments)
-},{"buffer":188,"dup":103,"hash-base":359,"inherits":213}],256:[function(require,module,exports){
-arguments[4][104][0].apply(exports,arguments)
-},{"dup":104,"safe-buffer":481}],257:[function(require,module,exports){
-arguments[4][105][0].apply(exports,arguments)
-},{"./sha":258,"./sha1":259,"./sha224":260,"./sha256":261,"./sha384":262,"./sha512":263,"dup":105}],258:[function(require,module,exports){
-arguments[4][106][0].apply(exports,arguments)
-},{"./hash":256,"dup":106,"inherits":213,"safe-buffer":481}],259:[function(require,module,exports){
-arguments[4][107][0].apply(exports,arguments)
-},{"./hash":256,"dup":107,"inherits":213,"safe-buffer":481}],260:[function(require,module,exports){
-arguments[4][108][0].apply(exports,arguments)
-},{"./hash":256,"./sha256":261,"dup":108,"inherits":213,"safe-buffer":481}],261:[function(require,module,exports){
-arguments[4][109][0].apply(exports,arguments)
-},{"./hash":256,"dup":109,"inherits":213,"safe-buffer":481}],262:[function(require,module,exports){
-arguments[4][110][0].apply(exports,arguments)
-},{"./hash":256,"./sha512":263,"dup":110,"inherits":213,"safe-buffer":481}],263:[function(require,module,exports){
-arguments[4][111][0].apply(exports,arguments)
-},{"./hash":256,"dup":111,"inherits":213,"safe-buffer":481}],264:[function(require,module,exports){
+},{"./lib/_stream_writable.js":187}],196:[function(require,module,exports){
+arguments[4][56][0].apply(exports,arguments)
+},{"buffer":134,"dup":56,"hash-base":292,"inherits":158}],197:[function(require,module,exports){
+arguments[4][57][0].apply(exports,arguments)
+},{"dup":57,"safe-buffer":403}],198:[function(require,module,exports){
+arguments[4][58][0].apply(exports,arguments)
+},{"./sha":199,"./sha1":200,"./sha224":201,"./sha256":202,"./sha384":203,"./sha512":204,"dup":58}],199:[function(require,module,exports){
+arguments[4][59][0].apply(exports,arguments)
+},{"./hash":197,"dup":59,"inherits":158,"safe-buffer":403}],200:[function(require,module,exports){
+arguments[4][60][0].apply(exports,arguments)
+},{"./hash":197,"dup":60,"inherits":158,"safe-buffer":403}],201:[function(require,module,exports){
+arguments[4][61][0].apply(exports,arguments)
+},{"./hash":197,"./sha256":202,"dup":61,"inherits":158,"safe-buffer":403}],202:[function(require,module,exports){
+arguments[4][62][0].apply(exports,arguments)
+},{"./hash":197,"dup":62,"inherits":158,"safe-buffer":403}],203:[function(require,module,exports){
+arguments[4][63][0].apply(exports,arguments)
+},{"./hash":197,"./sha512":204,"dup":63,"inherits":158,"safe-buffer":403}],204:[function(require,module,exports){
+arguments[4][64][0].apply(exports,arguments)
+},{"./hash":197,"dup":64,"inherits":158,"safe-buffer":403}],205:[function(require,module,exports){
 // Copyright Joyent, Inc. and other Node contributors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -36391,658 +26006,7 @@ Stream.prototype.pipe = function(dest, options) {
   return dest;
 };
 
-},{"events":209,"inherits":213,"readable-stream/duplex.js":241,"readable-stream/passthrough.js":251,"readable-stream/readable.js":252,"readable-stream/transform.js":253,"readable-stream/writable.js":254}],265:[function(require,module,exports){
-(function (global){
-var ClientRequest = require('./lib/request')
-var extend = require('xtend')
-var statusCodes = require('builtin-status-codes')
-var url = require('url')
-
-var http = exports
-
-http.request = function (opts, cb) {
-	if (typeof opts === 'string')
-		opts = url.parse(opts)
-	else
-		opts = extend(opts)
-
-	// Normally, the page is loaded from http or https, so not specifying a protocol
-	// will result in a (valid) protocol-relative url. However, this won't work if
-	// the protocol is something else, like 'file:'
-	var defaultProtocol = global.location.protocol.search(/^https?:$/) === -1 ? 'http:' : ''
-
-	var protocol = opts.protocol || defaultProtocol
-	var host = opts.hostname || opts.host
-	var port = opts.port
-	var path = opts.path || '/'
-
-	// Necessary for IPv6 addresses
-	if (host && host.indexOf(':') !== -1)
-		host = '[' + host + ']'
-
-	// This may be a relative url. The browser should always be able to interpret it correctly.
-	opts.url = (host ? (protocol + '//' + host) : '') + (port ? ':' + port : '') + path
-	opts.method = (opts.method || 'GET').toUpperCase()
-	opts.headers = opts.headers || {}
-
-	// Also valid opts.auth, opts.mode
-
-	var req = new ClientRequest(opts)
-	if (cb)
-		req.on('response', cb)
-	return req
-}
-
-http.get = function get (opts, cb) {
-	var req = http.request(opts, cb)
-	req.end()
-	return req
-}
-
-http.Agent = function () {}
-http.Agent.defaultMaxSockets = 4
-
-http.STATUS_CODES = statusCodes
-
-http.METHODS = [
-	'CHECKOUT',
-	'CONNECT',
-	'COPY',
-	'DELETE',
-	'GET',
-	'HEAD',
-	'LOCK',
-	'M-SEARCH',
-	'MERGE',
-	'MKACTIVITY',
-	'MKCOL',
-	'MOVE',
-	'NOTIFY',
-	'OPTIONS',
-	'PATCH',
-	'POST',
-	'PROPFIND',
-	'PROPPATCH',
-	'PURGE',
-	'PUT',
-	'REPORT',
-	'SEARCH',
-	'SUBSCRIBE',
-	'TRACE',
-	'UNLOCK',
-	'UNSUBSCRIBE'
-]
-}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./lib/request":267,"builtin-status-codes":189,"url":271,"xtend":278}],266:[function(require,module,exports){
-(function (global){
-exports.fetch = isFunction(global.fetch) && isFunction(global.ReadableStream)
-
-exports.blobConstructor = false
-try {
-	new Blob([new ArrayBuffer(1)])
-	exports.blobConstructor = true
-} catch (e) {}
-
-// The xhr request to example.com may violate some restrictive CSP configurations,
-// so if we're running in a browser that supports `fetch`, avoid calling getXHR()
-// and assume support for certain features below.
-var xhr
-function getXHR () {
-	// Cache the xhr value
-	if (xhr !== undefined) return xhr
-
-	if (global.XMLHttpRequest) {
-		xhr = new global.XMLHttpRequest()
-		// If XDomainRequest is available (ie only, where xhr might not work
-		// cross domain), use the page location. Otherwise use example.com
-		// Note: this doesn't actually make an http request.
-		try {
-			xhr.open('GET', global.XDomainRequest ? '/' : 'https://example.com')
-		} catch(e) {
-			xhr = null
-		}
-	} else {
-		// Service workers don't have XHR
-		xhr = null
-	}
-	return xhr
-}
-
-function checkTypeSupport (type) {
-	var xhr = getXHR()
-	if (!xhr) return false
-	try {
-		xhr.responseType = type
-		return xhr.responseType === type
-	} catch (e) {}
-	return false
-}
-
-// For some strange reason, Safari 7.0 reports typeof global.ArrayBuffer === 'object'.
-// Safari 7.1 appears to have fixed this bug.
-var haveArrayBuffer = typeof global.ArrayBuffer !== 'undefined'
-var haveSlice = haveArrayBuffer && isFunction(global.ArrayBuffer.prototype.slice)
-
-// If fetch is supported, then arraybuffer will be supported too. Skip calling
-// checkTypeSupport(), since that calls getXHR().
-exports.arraybuffer = exports.fetch || (haveArrayBuffer && checkTypeSupport('arraybuffer'))
-
-// These next two tests unavoidably show warnings in Chrome. Since fetch will always
-// be used if it's available, just return false for these to avoid the warnings.
-exports.msstream = !exports.fetch && haveSlice && checkTypeSupport('ms-stream')
-exports.mozchunkedarraybuffer = !exports.fetch && haveArrayBuffer &&
-	checkTypeSupport('moz-chunked-arraybuffer')
-
-// If fetch is supported, then overrideMimeType will be supported too. Skip calling
-// getXHR().
-exports.overrideMimeType = exports.fetch || (getXHR() ? isFunction(getXHR().overrideMimeType) : false)
-
-exports.vbArray = isFunction(global.VBArray)
-
-function isFunction (value) {
-	return typeof value === 'function'
-}
-
-xhr = null // Help gc
-
-}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],267:[function(require,module,exports){
-(function (process,global,Buffer){
-var capability = require('./capability')
-var inherits = require('inherits')
-var response = require('./response')
-var stream = require('readable-stream')
-var toArrayBuffer = require('to-arraybuffer')
-
-var IncomingMessage = response.IncomingMessage
-var rStates = response.readyStates
-
-function decideMode (preferBinary, useFetch) {
-	if (capability.fetch && useFetch) {
-		return 'fetch'
-	} else if (capability.mozchunkedarraybuffer) {
-		return 'moz-chunked-arraybuffer'
-	} else if (capability.msstream) {
-		return 'ms-stream'
-	} else if (capability.arraybuffer && preferBinary) {
-		return 'arraybuffer'
-	} else if (capability.vbArray && preferBinary) {
-		return 'text:vbarray'
-	} else {
-		return 'text'
-	}
-}
-
-var ClientRequest = module.exports = function (opts) {
-	var self = this
-	stream.Writable.call(self)
-
-	self._opts = opts
-	self._body = []
-	self._headers = {}
-	if (opts.auth)
-		self.setHeader('Authorization', 'Basic ' + new Buffer(opts.auth).toString('base64'))
-	Object.keys(opts.headers).forEach(function (name) {
-		self.setHeader(name, opts.headers[name])
-	})
-
-	var preferBinary
-	var useFetch = true
-	if (opts.mode === 'disable-fetch' || 'timeout' in opts) {
-		// If the use of XHR should be preferred and includes preserving the 'content-type' header.
-		// Force XHR to be used since the Fetch API does not yet support timeouts.
-		useFetch = false
-		preferBinary = true
-	} else if (opts.mode === 'prefer-streaming') {
-		// If streaming is a high priority but binary compatibility and
-		// the accuracy of the 'content-type' header aren't
-		preferBinary = false
-	} else if (opts.mode === 'allow-wrong-content-type') {
-		// If streaming is more important than preserving the 'content-type' header
-		preferBinary = !capability.overrideMimeType
-	} else if (!opts.mode || opts.mode === 'default' || opts.mode === 'prefer-fast') {
-		// Use binary if text streaming may corrupt data or the content-type header, or for speed
-		preferBinary = true
-	} else {
-		throw new Error('Invalid value for opts.mode')
-	}
-	self._mode = decideMode(preferBinary, useFetch)
-
-	self.on('finish', function () {
-		self._onFinish()
-	})
-}
-
-inherits(ClientRequest, stream.Writable)
-
-ClientRequest.prototype.setHeader = function (name, value) {
-	var self = this
-	var lowerName = name.toLowerCase()
-	// This check is not necessary, but it prevents warnings from browsers about setting unsafe
-	// headers. To be honest I'm not entirely sure hiding these warnings is a good thing, but
-	// http-browserify did it, so I will too.
-	if (unsafeHeaders.indexOf(lowerName) !== -1)
-		return
-
-	self._headers[lowerName] = {
-		name: name,
-		value: value
-	}
-}
-
-ClientRequest.prototype.getHeader = function (name) {
-	var header = this._headers[name.toLowerCase()]
-	if (header)
-		return header.value
-	return null
-}
-
-ClientRequest.prototype.removeHeader = function (name) {
-	var self = this
-	delete self._headers[name.toLowerCase()]
-}
-
-ClientRequest.prototype._onFinish = function () {
-	var self = this
-
-	if (self._destroyed)
-		return
-	var opts = self._opts
-
-	var headersObj = self._headers
-	var body = null
-	if (opts.method !== 'GET' && opts.method !== 'HEAD') {
-		if (capability.blobConstructor) {
-			body = new global.Blob(self._body.map(function (buffer) {
-				return toArrayBuffer(buffer)
-			}), {
-				type: (headersObj['content-type'] || {}).value || ''
-			})
-		} else {
-			// get utf8 string
-			body = Buffer.concat(self._body).toString()
-		}
-	}
-
-	// create flattened list of headers
-	var headersList = []
-	Object.keys(headersObj).forEach(function (keyName) {
-		var name = headersObj[keyName].name
-		var value = headersObj[keyName].value
-		if (Array.isArray(value)) {
-			value.forEach(function (v) {
-				headersList.push([name, v])
-			})
-		} else {
-			headersList.push([name, value])
-		}
-	})
-
-	if (self._mode === 'fetch') {
-		global.fetch(self._opts.url, {
-			method: self._opts.method,
-			headers: headersList,
-			body: body || undefined,
-			mode: 'cors',
-			credentials: opts.withCredentials ? 'include' : 'same-origin'
-		}).then(function (response) {
-			self._fetchResponse = response
-			self._connect()
-		}, function (reason) {
-			self.emit('error', reason)
-		})
-	} else {
-		var xhr = self._xhr = new global.XMLHttpRequest()
-		try {
-			xhr.open(self._opts.method, self._opts.url, true)
-		} catch (err) {
-			process.nextTick(function () {
-				self.emit('error', err)
-			})
-			return
-		}
-
-		// Can't set responseType on really old browsers
-		if ('responseType' in xhr)
-			xhr.responseType = self._mode.split(':')[0]
-
-		if ('withCredentials' in xhr)
-			xhr.withCredentials = !!opts.withCredentials
-
-		if (self._mode === 'text' && 'overrideMimeType' in xhr)
-			xhr.overrideMimeType('text/plain; charset=x-user-defined')
-
-		if ('timeout' in opts) {
-			xhr.timeout = opts.timeout
-			xhr.ontimeout = function () {
-				self.emit('timeout')
-			}
-		}
-
-		headersList.forEach(function (header) {
-			xhr.setRequestHeader(header[0], header[1])
-		})
-
-		self._response = null
-		xhr.onreadystatechange = function () {
-			switch (xhr.readyState) {
-				case rStates.LOADING:
-				case rStates.DONE:
-					self._onXHRProgress()
-					break
-			}
-		}
-		// Necessary for streaming in Firefox, since xhr.response is ONLY defined
-		// in onprogress, not in onreadystatechange with xhr.readyState = 3
-		if (self._mode === 'moz-chunked-arraybuffer') {
-			xhr.onprogress = function () {
-				self._onXHRProgress()
-			}
-		}
-
-		xhr.onerror = function () {
-			if (self._destroyed)
-				return
-			self.emit('error', new Error('XHR error'))
-		}
-
-		try {
-			xhr.send(body)
-		} catch (err) {
-			process.nextTick(function () {
-				self.emit('error', err)
-			})
-			return
-		}
-	}
-}
-
-/**
- * Checks if xhr.status is readable and non-zero, indicating no error.
- * Even though the spec says it should be available in readyState 3,
- * accessing it throws an exception in IE8
- */
-function statusValid (xhr) {
-	try {
-		var status = xhr.status
-		return (status !== null && status !== 0)
-	} catch (e) {
-		return false
-	}
-}
-
-ClientRequest.prototype._onXHRProgress = function () {
-	var self = this
-
-	if (!statusValid(self._xhr) || self._destroyed)
-		return
-
-	if (!self._response)
-		self._connect()
-
-	self._response._onXHRProgress()
-}
-
-ClientRequest.prototype._connect = function () {
-	var self = this
-
-	if (self._destroyed)
-		return
-
-	self._response = new IncomingMessage(self._xhr, self._fetchResponse, self._mode)
-	self._response.on('error', function(err) {
-		self.emit('error', err)
-	})
-
-	self.emit('response', self._response)
-}
-
-ClientRequest.prototype._write = function (chunk, encoding, cb) {
-	var self = this
-
-	self._body.push(chunk)
-	cb()
-}
-
-ClientRequest.prototype.abort = ClientRequest.prototype.destroy = function () {
-	var self = this
-	self._destroyed = true
-	if (self._response)
-		self._response._destroyed = true
-	if (self._xhr)
-		self._xhr.abort()
-	// Currently, there isn't a way to truly abort a fetch.
-	// If you like bikeshedding, see https://github.com/whatwg/fetch/issues/27
-}
-
-ClientRequest.prototype.end = function (data, encoding, cb) {
-	var self = this
-	if (typeof data === 'function') {
-		cb = data
-		data = undefined
-	}
-
-	stream.Writable.prototype.end.call(self, data, encoding, cb)
-}
-
-ClientRequest.prototype.flushHeaders = function () {}
-ClientRequest.prototype.setTimeout = function () {}
-ClientRequest.prototype.setNoDelay = function () {}
-ClientRequest.prototype.setSocketKeepAlive = function () {}
-
-// Taken from http://www.w3.org/TR/XMLHttpRequest/#the-setrequestheader%28%29-method
-var unsafeHeaders = [
-	'accept-charset',
-	'accept-encoding',
-	'access-control-request-headers',
-	'access-control-request-method',
-	'connection',
-	'content-length',
-	'cookie',
-	'cookie2',
-	'date',
-	'dnt',
-	'expect',
-	'host',
-	'keep-alive',
-	'origin',
-	'referer',
-	'te',
-	'trailer',
-	'transfer-encoding',
-	'upgrade',
-	'user-agent',
-	'via'
-]
-
-}).call(this,require('_process'),typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {},require("buffer").Buffer)
-},{"./capability":266,"./response":268,"_process":229,"buffer":188,"inherits":213,"readable-stream":252,"to-arraybuffer":270}],268:[function(require,module,exports){
-(function (process,global,Buffer){
-var capability = require('./capability')
-var inherits = require('inherits')
-var stream = require('readable-stream')
-
-var rStates = exports.readyStates = {
-	UNSENT: 0,
-	OPENED: 1,
-	HEADERS_RECEIVED: 2,
-	LOADING: 3,
-	DONE: 4
-}
-
-var IncomingMessage = exports.IncomingMessage = function (xhr, response, mode) {
-	var self = this
-	stream.Readable.call(self)
-
-	self._mode = mode
-	self.headers = {}
-	self.rawHeaders = []
-	self.trailers = {}
-	self.rawTrailers = []
-
-	// Fake the 'close' event, but only once 'end' fires
-	self.on('end', function () {
-		// The nextTick is necessary to prevent the 'request' module from causing an infinite loop
-		process.nextTick(function () {
-			self.emit('close')
-		})
-	})
-
-	if (mode === 'fetch') {
-		self._fetchResponse = response
-
-		self.url = response.url
-		self.statusCode = response.status
-		self.statusMessage = response.statusText
-		
-		response.headers.forEach(function(header, key){
-			self.headers[key.toLowerCase()] = header
-			self.rawHeaders.push(key, header)
-		})
-
-
-		// TODO: this doesn't respect backpressure. Once WritableStream is available, this can be fixed
-		var reader = response.body.getReader()
-		function read () {
-			reader.read().then(function (result) {
-				if (self._destroyed)
-					return
-				if (result.done) {
-					self.push(null)
-					return
-				}
-				self.push(new Buffer(result.value))
-				read()
-			}).catch(function(err) {
-				self.emit('error', err)
-			})
-		}
-		read()
-
-	} else {
-		self._xhr = xhr
-		self._pos = 0
-
-		self.url = xhr.responseURL
-		self.statusCode = xhr.status
-		self.statusMessage = xhr.statusText
-		var headers = xhr.getAllResponseHeaders().split(/\r?\n/)
-		headers.forEach(function (header) {
-			var matches = header.match(/^([^:]+):\s*(.*)/)
-			if (matches) {
-				var key = matches[1].toLowerCase()
-				if (key === 'set-cookie') {
-					if (self.headers[key] === undefined) {
-						self.headers[key] = []
-					}
-					self.headers[key].push(matches[2])
-				} else if (self.headers[key] !== undefined) {
-					self.headers[key] += ', ' + matches[2]
-				} else {
-					self.headers[key] = matches[2]
-				}
-				self.rawHeaders.push(matches[1], matches[2])
-			}
-		})
-
-		self._charset = 'x-user-defined'
-		if (!capability.overrideMimeType) {
-			var mimeType = self.rawHeaders['mime-type']
-			if (mimeType) {
-				var charsetMatch = mimeType.match(/;\s*charset=([^;])(;|$)/)
-				if (charsetMatch) {
-					self._charset = charsetMatch[1].toLowerCase()
-				}
-			}
-			if (!self._charset)
-				self._charset = 'utf-8' // best guess
-		}
-	}
-}
-
-inherits(IncomingMessage, stream.Readable)
-
-IncomingMessage.prototype._read = function () {}
-
-IncomingMessage.prototype._onXHRProgress = function () {
-	var self = this
-
-	var xhr = self._xhr
-
-	var response = null
-	switch (self._mode) {
-		case 'text:vbarray': // For IE9
-			if (xhr.readyState !== rStates.DONE)
-				break
-			try {
-				// This fails in IE8
-				response = new global.VBArray(xhr.responseBody).toArray()
-			} catch (e) {}
-			if (response !== null) {
-				self.push(new Buffer(response))
-				break
-			}
-			// Falls through in IE8	
-		case 'text':
-			try { // This will fail when readyState = 3 in IE9. Switch mode and wait for readyState = 4
-				response = xhr.responseText
-			} catch (e) {
-				self._mode = 'text:vbarray'
-				break
-			}
-			if (response.length > self._pos) {
-				var newData = response.substr(self._pos)
-				if (self._charset === 'x-user-defined') {
-					var buffer = new Buffer(newData.length)
-					for (var i = 0; i < newData.length; i++)
-						buffer[i] = newData.charCodeAt(i) & 0xff
-
-					self.push(buffer)
-				} else {
-					self.push(newData, self._charset)
-				}
-				self._pos = response.length
-			}
-			break
-		case 'arraybuffer':
-			if (xhr.readyState !== rStates.DONE || !xhr.response)
-				break
-			response = xhr.response
-			self.push(new Buffer(new Uint8Array(response)))
-			break
-		case 'moz-chunked-arraybuffer': // take whole
-			response = xhr.response
-			if (xhr.readyState !== rStates.LOADING || !response)
-				break
-			self.push(new Buffer(new Uint8Array(response)))
-			break
-		case 'ms-stream':
-			response = xhr.response
-			if (xhr.readyState !== rStates.LOADING)
-				break
-			var reader = new global.MSStreamReader()
-			reader.onprogress = function () {
-				if (reader.result.byteLength > self._pos) {
-					self.push(new Buffer(new Uint8Array(reader.result.slice(self._pos))))
-					self._pos = reader.result.byteLength
-				}
-			}
-			reader.onload = function () {
-				self.push(null)
-			}
-			// reader.onerror = ??? // TODO: this
-			reader.readAsArrayBuffer(response)
-			break
-	}
-
-	// The ms-stream case handles end separately in reader.onload()
-	if (self._xhr.readyState === rStates.DONE && self._mode !== 'ms-stream') {
-		self.push(null)
-	}
-}
-
-}).call(this,require('_process'),typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {},require("buffer").Buffer)
-},{"./capability":266,"_process":229,"buffer":188,"inherits":213,"readable-stream":252}],269:[function(require,module,exports){
+},{"events":154,"inherits":158,"readable-stream/duplex.js":182,"readable-stream/passthrough.js":192,"readable-stream/readable.js":193,"readable-stream/transform.js":194,"readable-stream/writable.js":195}],206:[function(require,module,exports){
 // Copyright Joyent, Inc. and other Node contributors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -37265,788 +26229,7 @@ function base64DetectIncompleteChar(buffer) {
   this.charLength = this.charReceived ? 3 : 0;
 }
 
-},{"buffer":188}],270:[function(require,module,exports){
-var Buffer = require('buffer').Buffer
-
-module.exports = function (buf) {
-	// If the buffer is backed by a Uint8Array, a faster version will work
-	if (buf instanceof Uint8Array) {
-		// If the buffer isn't a subarray, return the underlying ArrayBuffer
-		if (buf.byteOffset === 0 && buf.byteLength === buf.buffer.byteLength) {
-			return buf.buffer
-		} else if (typeof buf.buffer.slice === 'function') {
-			// Otherwise we need to get a proper copy
-			return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength)
-		}
-	}
-
-	if (Buffer.isBuffer(buf)) {
-		// This is the slow version that will work with any Buffer
-		// implementation (even in old browsers)
-		var arrayCopy = new Uint8Array(buf.length)
-		var len = buf.length
-		for (var i = 0; i < len; i++) {
-			arrayCopy[i] = buf[i]
-		}
-		return arrayCopy.buffer
-	} else {
-		throw new Error('Argument must be a Buffer')
-	}
-}
-
-},{"buffer":188}],271:[function(require,module,exports){
-// Copyright Joyent, Inc. and other Node contributors.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a
-// copy of this software and associated documentation files (the
-// "Software"), to deal in the Software without restriction, including
-// without limitation the rights to use, copy, modify, merge, publish,
-// distribute, sublicense, and/or sell copies of the Software, and to permit
-// persons to whom the Software is furnished to do so, subject to the
-// following conditions:
-//
-// The above copyright notice and this permission notice shall be included
-// in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
-// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
-// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
-// USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-'use strict';
-
-var punycode = require('punycode');
-var util = require('./util');
-
-exports.parse = urlParse;
-exports.resolve = urlResolve;
-exports.resolveObject = urlResolveObject;
-exports.format = urlFormat;
-
-exports.Url = Url;
-
-function Url() {
-  this.protocol = null;
-  this.slashes = null;
-  this.auth = null;
-  this.host = null;
-  this.port = null;
-  this.hostname = null;
-  this.hash = null;
-  this.search = null;
-  this.query = null;
-  this.pathname = null;
-  this.path = null;
-  this.href = null;
-}
-
-// Reference: RFC 3986, RFC 1808, RFC 2396
-
-// define these here so at least they only have to be
-// compiled once on the first module load.
-var protocolPattern = /^([a-z0-9.+-]+:)/i,
-    portPattern = /:[0-9]*$/,
-
-    // Special case for a simple path URL
-    simplePathPattern = /^(\/\/?(?!\/)[^\?\s]*)(\?[^\s]*)?$/,
-
-    // RFC 2396: characters reserved for delimiting URLs.
-    // We actually just auto-escape these.
-    delims = ['<', '>', '"', '`', ' ', '\r', '\n', '\t'],
-
-    // RFC 2396: characters not allowed for various reasons.
-    unwise = ['{', '}', '|', '\\', '^', '`'].concat(delims),
-
-    // Allowed by RFCs, but cause of XSS attacks.  Always escape these.
-    autoEscape = ['\''].concat(unwise),
-    // Characters that are never ever allowed in a hostname.
-    // Note that any invalid chars are also handled, but these
-    // are the ones that are *expected* to be seen, so we fast-path
-    // them.
-    nonHostChars = ['%', '/', '?', ';', '#'].concat(autoEscape),
-    hostEndingChars = ['/', '?', '#'],
-    hostnameMaxLen = 255,
-    hostnamePartPattern = /^[+a-z0-9A-Z_-]{0,63}$/,
-    hostnamePartStart = /^([+a-z0-9A-Z_-]{0,63})(.*)$/,
-    // protocols that can allow "unsafe" and "unwise" chars.
-    unsafeProtocol = {
-      'javascript': true,
-      'javascript:': true
-    },
-    // protocols that never have a hostname.
-    hostlessProtocol = {
-      'javascript': true,
-      'javascript:': true
-    },
-    // protocols that always contain a // bit.
-    slashedProtocol = {
-      'http': true,
-      'https': true,
-      'ftp': true,
-      'gopher': true,
-      'file': true,
-      'http:': true,
-      'https:': true,
-      'ftp:': true,
-      'gopher:': true,
-      'file:': true
-    },
-    querystring = require('querystring');
-
-function urlParse(url, parseQueryString, slashesDenoteHost) {
-  if (url && util.isObject(url) && url instanceof Url) return url;
-
-  var u = new Url;
-  u.parse(url, parseQueryString, slashesDenoteHost);
-  return u;
-}
-
-Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
-  if (!util.isString(url)) {
-    throw new TypeError("Parameter 'url' must be a string, not " + typeof url);
-  }
-
-  // Copy chrome, IE, opera backslash-handling behavior.
-  // Back slashes before the query string get converted to forward slashes
-  // See: https://code.google.com/p/chromium/issues/detail?id=25916
-  var queryIndex = url.indexOf('?'),
-      splitter =
-          (queryIndex !== -1 && queryIndex < url.indexOf('#')) ? '?' : '#',
-      uSplit = url.split(splitter),
-      slashRegex = /\\/g;
-  uSplit[0] = uSplit[0].replace(slashRegex, '/');
-  url = uSplit.join(splitter);
-
-  var rest = url;
-
-  // trim before proceeding.
-  // This is to support parse stuff like "  http://foo.com  \n"
-  rest = rest.trim();
-
-  if (!slashesDenoteHost && url.split('#').length === 1) {
-    // Try fast path regexp
-    var simplePath = simplePathPattern.exec(rest);
-    if (simplePath) {
-      this.path = rest;
-      this.href = rest;
-      this.pathname = simplePath[1];
-      if (simplePath[2]) {
-        this.search = simplePath[2];
-        if (parseQueryString) {
-          this.query = querystring.parse(this.search.substr(1));
-        } else {
-          this.query = this.search.substr(1);
-        }
-      } else if (parseQueryString) {
-        this.search = '';
-        this.query = {};
-      }
-      return this;
-    }
-  }
-
-  var proto = protocolPattern.exec(rest);
-  if (proto) {
-    proto = proto[0];
-    var lowerProto = proto.toLowerCase();
-    this.protocol = lowerProto;
-    rest = rest.substr(proto.length);
-  }
-
-  // figure out if it's got a host
-  // user@server is *always* interpreted as a hostname, and url
-  // resolution will treat //foo/bar as host=foo,path=bar because that's
-  // how the browser resolves relative URLs.
-  if (slashesDenoteHost || proto || rest.match(/^\/\/[^@\/]+@[^@\/]+/)) {
-    var slashes = rest.substr(0, 2) === '//';
-    if (slashes && !(proto && hostlessProtocol[proto])) {
-      rest = rest.substr(2);
-      this.slashes = true;
-    }
-  }
-
-  if (!hostlessProtocol[proto] &&
-      (slashes || (proto && !slashedProtocol[proto]))) {
-
-    // there's a hostname.
-    // the first instance of /, ?, ;, or # ends the host.
-    //
-    // If there is an @ in the hostname, then non-host chars *are* allowed
-    // to the left of the last @ sign, unless some host-ending character
-    // comes *before* the @-sign.
-    // URLs are obnoxious.
-    //
-    // ex:
-    // http://a@b@c/ => user:a@b host:c
-    // http://a@b?@c => user:a host:c path:/?@c
-
-    // v0.12 TODO(isaacs): This is not quite how Chrome does things.
-    // Review our test case against browsers more comprehensively.
-
-    // find the first instance of any hostEndingChars
-    var hostEnd = -1;
-    for (var i = 0; i < hostEndingChars.length; i++) {
-      var hec = rest.indexOf(hostEndingChars[i]);
-      if (hec !== -1 && (hostEnd === -1 || hec < hostEnd))
-        hostEnd = hec;
-    }
-
-    // at this point, either we have an explicit point where the
-    // auth portion cannot go past, or the last @ char is the decider.
-    var auth, atSign;
-    if (hostEnd === -1) {
-      // atSign can be anywhere.
-      atSign = rest.lastIndexOf('@');
-    } else {
-      // atSign must be in auth portion.
-      // http://a@b/c@d => host:b auth:a path:/c@d
-      atSign = rest.lastIndexOf('@', hostEnd);
-    }
-
-    // Now we have a portion which is definitely the auth.
-    // Pull that off.
-    if (atSign !== -1) {
-      auth = rest.slice(0, atSign);
-      rest = rest.slice(atSign + 1);
-      this.auth = decodeURIComponent(auth);
-    }
-
-    // the host is the remaining to the left of the first non-host char
-    hostEnd = -1;
-    for (var i = 0; i < nonHostChars.length; i++) {
-      var hec = rest.indexOf(nonHostChars[i]);
-      if (hec !== -1 && (hostEnd === -1 || hec < hostEnd))
-        hostEnd = hec;
-    }
-    // if we still have not hit it, then the entire thing is a host.
-    if (hostEnd === -1)
-      hostEnd = rest.length;
-
-    this.host = rest.slice(0, hostEnd);
-    rest = rest.slice(hostEnd);
-
-    // pull out port.
-    this.parseHost();
-
-    // we've indicated that there is a hostname,
-    // so even if it's empty, it has to be present.
-    this.hostname = this.hostname || '';
-
-    // if hostname begins with [ and ends with ]
-    // assume that it's an IPv6 address.
-    var ipv6Hostname = this.hostname[0] === '[' &&
-        this.hostname[this.hostname.length - 1] === ']';
-
-    // validate a little.
-    if (!ipv6Hostname) {
-      var hostparts = this.hostname.split(/\./);
-      for (var i = 0, l = hostparts.length; i < l; i++) {
-        var part = hostparts[i];
-        if (!part) continue;
-        if (!part.match(hostnamePartPattern)) {
-          var newpart = '';
-          for (var j = 0, k = part.length; j < k; j++) {
-            if (part.charCodeAt(j) > 127) {
-              // we replace non-ASCII char with a temporary placeholder
-              // we need this to make sure size of hostname is not
-              // broken by replacing non-ASCII by nothing
-              newpart += 'x';
-            } else {
-              newpart += part[j];
-            }
-          }
-          // we test again with ASCII char only
-          if (!newpart.match(hostnamePartPattern)) {
-            var validParts = hostparts.slice(0, i);
-            var notHost = hostparts.slice(i + 1);
-            var bit = part.match(hostnamePartStart);
-            if (bit) {
-              validParts.push(bit[1]);
-              notHost.unshift(bit[2]);
-            }
-            if (notHost.length) {
-              rest = '/' + notHost.join('.') + rest;
-            }
-            this.hostname = validParts.join('.');
-            break;
-          }
-        }
-      }
-    }
-
-    if (this.hostname.length > hostnameMaxLen) {
-      this.hostname = '';
-    } else {
-      // hostnames are always lower case.
-      this.hostname = this.hostname.toLowerCase();
-    }
-
-    if (!ipv6Hostname) {
-      // IDNA Support: Returns a punycoded representation of "domain".
-      // It only converts parts of the domain name that
-      // have non-ASCII characters, i.e. it doesn't matter if
-      // you call it with a domain that already is ASCII-only.
-      this.hostname = punycode.toASCII(this.hostname);
-    }
-
-    var p = this.port ? ':' + this.port : '';
-    var h = this.hostname || '';
-    this.host = h + p;
-    this.href += this.host;
-
-    // strip [ and ] from the hostname
-    // the host field still retains them, though
-    if (ipv6Hostname) {
-      this.hostname = this.hostname.substr(1, this.hostname.length - 2);
-      if (rest[0] !== '/') {
-        rest = '/' + rest;
-      }
-    }
-  }
-
-  // now rest is set to the post-host stuff.
-  // chop off any delim chars.
-  if (!unsafeProtocol[lowerProto]) {
-
-    // First, make 100% sure that any "autoEscape" chars get
-    // escaped, even if encodeURIComponent doesn't think they
-    // need to be.
-    for (var i = 0, l = autoEscape.length; i < l; i++) {
-      var ae = autoEscape[i];
-      if (rest.indexOf(ae) === -1)
-        continue;
-      var esc = encodeURIComponent(ae);
-      if (esc === ae) {
-        esc = escape(ae);
-      }
-      rest = rest.split(ae).join(esc);
-    }
-  }
-
-
-  // chop off from the tail first.
-  var hash = rest.indexOf('#');
-  if (hash !== -1) {
-    // got a fragment string.
-    this.hash = rest.substr(hash);
-    rest = rest.slice(0, hash);
-  }
-  var qm = rest.indexOf('?');
-  if (qm !== -1) {
-    this.search = rest.substr(qm);
-    this.query = rest.substr(qm + 1);
-    if (parseQueryString) {
-      this.query = querystring.parse(this.query);
-    }
-    rest = rest.slice(0, qm);
-  } else if (parseQueryString) {
-    // no query string, but parseQueryString still requested
-    this.search = '';
-    this.query = {};
-  }
-  if (rest) this.pathname = rest;
-  if (slashedProtocol[lowerProto] &&
-      this.hostname && !this.pathname) {
-    this.pathname = '/';
-  }
-
-  //to support http.request
-  if (this.pathname || this.search) {
-    var p = this.pathname || '';
-    var s = this.search || '';
-    this.path = p + s;
-  }
-
-  // finally, reconstruct the href based on what has been validated.
-  this.href = this.format();
-  return this;
-};
-
-// format a parsed object into a url string
-function urlFormat(obj) {
-  // ensure it's an object, and not a string url.
-  // If it's an obj, this is a no-op.
-  // this way, you can call url_format() on strings
-  // to clean up potentially wonky urls.
-  if (util.isString(obj)) obj = urlParse(obj);
-  if (!(obj instanceof Url)) return Url.prototype.format.call(obj);
-  return obj.format();
-}
-
-Url.prototype.format = function() {
-  var auth = this.auth || '';
-  if (auth) {
-    auth = encodeURIComponent(auth);
-    auth = auth.replace(/%3A/i, ':');
-    auth += '@';
-  }
-
-  var protocol = this.protocol || '',
-      pathname = this.pathname || '',
-      hash = this.hash || '',
-      host = false,
-      query = '';
-
-  if (this.host) {
-    host = auth + this.host;
-  } else if (this.hostname) {
-    host = auth + (this.hostname.indexOf(':') === -1 ?
-        this.hostname :
-        '[' + this.hostname + ']');
-    if (this.port) {
-      host += ':' + this.port;
-    }
-  }
-
-  if (this.query &&
-      util.isObject(this.query) &&
-      Object.keys(this.query).length) {
-    query = querystring.stringify(this.query);
-  }
-
-  var search = this.search || (query && ('?' + query)) || '';
-
-  if (protocol && protocol.substr(-1) !== ':') protocol += ':';
-
-  // only the slashedProtocols get the //.  Not mailto:, xmpp:, etc.
-  // unless they had them to begin with.
-  if (this.slashes ||
-      (!protocol || slashedProtocol[protocol]) && host !== false) {
-    host = '//' + (host || '');
-    if (pathname && pathname.charAt(0) !== '/') pathname = '/' + pathname;
-  } else if (!host) {
-    host = '';
-  }
-
-  if (hash && hash.charAt(0) !== '#') hash = '#' + hash;
-  if (search && search.charAt(0) !== '?') search = '?' + search;
-
-  pathname = pathname.replace(/[?#]/g, function(match) {
-    return encodeURIComponent(match);
-  });
-  search = search.replace('#', '%23');
-
-  return protocol + host + pathname + search + hash;
-};
-
-function urlResolve(source, relative) {
-  return urlParse(source, false, true).resolve(relative);
-}
-
-Url.prototype.resolve = function(relative) {
-  return this.resolveObject(urlParse(relative, false, true)).format();
-};
-
-function urlResolveObject(source, relative) {
-  if (!source) return relative;
-  return urlParse(source, false, true).resolveObject(relative);
-}
-
-Url.prototype.resolveObject = function(relative) {
-  if (util.isString(relative)) {
-    var rel = new Url();
-    rel.parse(relative, false, true);
-    relative = rel;
-  }
-
-  var result = new Url();
-  var tkeys = Object.keys(this);
-  for (var tk = 0; tk < tkeys.length; tk++) {
-    var tkey = tkeys[tk];
-    result[tkey] = this[tkey];
-  }
-
-  // hash is always overridden, no matter what.
-  // even href="" will remove it.
-  result.hash = relative.hash;
-
-  // if the relative url is empty, then there's nothing left to do here.
-  if (relative.href === '') {
-    result.href = result.format();
-    return result;
-  }
-
-  // hrefs like //foo/bar always cut to the protocol.
-  if (relative.slashes && !relative.protocol) {
-    // take everything except the protocol from relative
-    var rkeys = Object.keys(relative);
-    for (var rk = 0; rk < rkeys.length; rk++) {
-      var rkey = rkeys[rk];
-      if (rkey !== 'protocol')
-        result[rkey] = relative[rkey];
-    }
-
-    //urlParse appends trailing / to urls like http://www.example.com
-    if (slashedProtocol[result.protocol] &&
-        result.hostname && !result.pathname) {
-      result.path = result.pathname = '/';
-    }
-
-    result.href = result.format();
-    return result;
-  }
-
-  if (relative.protocol && relative.protocol !== result.protocol) {
-    // if it's a known url protocol, then changing
-    // the protocol does weird things
-    // first, if it's not file:, then we MUST have a host,
-    // and if there was a path
-    // to begin with, then we MUST have a path.
-    // if it is file:, then the host is dropped,
-    // because that's known to be hostless.
-    // anything else is assumed to be absolute.
-    if (!slashedProtocol[relative.protocol]) {
-      var keys = Object.keys(relative);
-      for (var v = 0; v < keys.length; v++) {
-        var k = keys[v];
-        result[k] = relative[k];
-      }
-      result.href = result.format();
-      return result;
-    }
-
-    result.protocol = relative.protocol;
-    if (!relative.host && !hostlessProtocol[relative.protocol]) {
-      var relPath = (relative.pathname || '').split('/');
-      while (relPath.length && !(relative.host = relPath.shift()));
-      if (!relative.host) relative.host = '';
-      if (!relative.hostname) relative.hostname = '';
-      if (relPath[0] !== '') relPath.unshift('');
-      if (relPath.length < 2) relPath.unshift('');
-      result.pathname = relPath.join('/');
-    } else {
-      result.pathname = relative.pathname;
-    }
-    result.search = relative.search;
-    result.query = relative.query;
-    result.host = relative.host || '';
-    result.auth = relative.auth;
-    result.hostname = relative.hostname || relative.host;
-    result.port = relative.port;
-    // to support http.request
-    if (result.pathname || result.search) {
-      var p = result.pathname || '';
-      var s = result.search || '';
-      result.path = p + s;
-    }
-    result.slashes = result.slashes || relative.slashes;
-    result.href = result.format();
-    return result;
-  }
-
-  var isSourceAbs = (result.pathname && result.pathname.charAt(0) === '/'),
-      isRelAbs = (
-          relative.host ||
-          relative.pathname && relative.pathname.charAt(0) === '/'
-      ),
-      mustEndAbs = (isRelAbs || isSourceAbs ||
-                    (result.host && relative.pathname)),
-      removeAllDots = mustEndAbs,
-      srcPath = result.pathname && result.pathname.split('/') || [],
-      relPath = relative.pathname && relative.pathname.split('/') || [],
-      psychotic = result.protocol && !slashedProtocol[result.protocol];
-
-  // if the url is a non-slashed url, then relative
-  // links like ../.. should be able
-  // to crawl up to the hostname, as well.  This is strange.
-  // result.protocol has already been set by now.
-  // Later on, put the first path part into the host field.
-  if (psychotic) {
-    result.hostname = '';
-    result.port = null;
-    if (result.host) {
-      if (srcPath[0] === '') srcPath[0] = result.host;
-      else srcPath.unshift(result.host);
-    }
-    result.host = '';
-    if (relative.protocol) {
-      relative.hostname = null;
-      relative.port = null;
-      if (relative.host) {
-        if (relPath[0] === '') relPath[0] = relative.host;
-        else relPath.unshift(relative.host);
-      }
-      relative.host = null;
-    }
-    mustEndAbs = mustEndAbs && (relPath[0] === '' || srcPath[0] === '');
-  }
-
-  if (isRelAbs) {
-    // it's absolute.
-    result.host = (relative.host || relative.host === '') ?
-                  relative.host : result.host;
-    result.hostname = (relative.hostname || relative.hostname === '') ?
-                      relative.hostname : result.hostname;
-    result.search = relative.search;
-    result.query = relative.query;
-    srcPath = relPath;
-    // fall through to the dot-handling below.
-  } else if (relPath.length) {
-    // it's relative
-    // throw away the existing file, and take the new path instead.
-    if (!srcPath) srcPath = [];
-    srcPath.pop();
-    srcPath = srcPath.concat(relPath);
-    result.search = relative.search;
-    result.query = relative.query;
-  } else if (!util.isNullOrUndefined(relative.search)) {
-    // just pull out the search.
-    // like href='?foo'.
-    // Put this after the other two cases because it simplifies the booleans
-    if (psychotic) {
-      result.hostname = result.host = srcPath.shift();
-      //occationaly the auth can get stuck only in host
-      //this especially happens in cases like
-      //url.resolveObject('mailto:local1@domain1', 'local2@domain2')
-      var authInHost = result.host && result.host.indexOf('@') > 0 ?
-                       result.host.split('@') : false;
-      if (authInHost) {
-        result.auth = authInHost.shift();
-        result.host = result.hostname = authInHost.shift();
-      }
-    }
-    result.search = relative.search;
-    result.query = relative.query;
-    //to support http.request
-    if (!util.isNull(result.pathname) || !util.isNull(result.search)) {
-      result.path = (result.pathname ? result.pathname : '') +
-                    (result.search ? result.search : '');
-    }
-    result.href = result.format();
-    return result;
-  }
-
-  if (!srcPath.length) {
-    // no path at all.  easy.
-    // we've already handled the other stuff above.
-    result.pathname = null;
-    //to support http.request
-    if (result.search) {
-      result.path = '/' + result.search;
-    } else {
-      result.path = null;
-    }
-    result.href = result.format();
-    return result;
-  }
-
-  // if a url ENDs in . or .., then it must get a trailing slash.
-  // however, if it ends in anything else non-slashy,
-  // then it must NOT get a trailing slash.
-  var last = srcPath.slice(-1)[0];
-  var hasTrailingSlash = (
-      (result.host || relative.host || srcPath.length > 1) &&
-      (last === '.' || last === '..') || last === '');
-
-  // strip single dots, resolve double dots to parent dir
-  // if the path tries to go above the root, `up` ends up > 0
-  var up = 0;
-  for (var i = srcPath.length; i >= 0; i--) {
-    last = srcPath[i];
-    if (last === '.') {
-      srcPath.splice(i, 1);
-    } else if (last === '..') {
-      srcPath.splice(i, 1);
-      up++;
-    } else if (up) {
-      srcPath.splice(i, 1);
-      up--;
-    }
-  }
-
-  // if the path is allowed to go above the root, restore leading ..s
-  if (!mustEndAbs && !removeAllDots) {
-    for (; up--; up) {
-      srcPath.unshift('..');
-    }
-  }
-
-  if (mustEndAbs && srcPath[0] !== '' &&
-      (!srcPath[0] || srcPath[0].charAt(0) !== '/')) {
-    srcPath.unshift('');
-  }
-
-  if (hasTrailingSlash && (srcPath.join('/').substr(-1) !== '/')) {
-    srcPath.push('');
-  }
-
-  var isAbsolute = srcPath[0] === '' ||
-      (srcPath[0] && srcPath[0].charAt(0) === '/');
-
-  // put the host back
-  if (psychotic) {
-    result.hostname = result.host = isAbsolute ? '' :
-                                    srcPath.length ? srcPath.shift() : '';
-    //occationaly the auth can get stuck only in host
-    //this especially happens in cases like
-    //url.resolveObject('mailto:local1@domain1', 'local2@domain2')
-    var authInHost = result.host && result.host.indexOf('@') > 0 ?
-                     result.host.split('@') : false;
-    if (authInHost) {
-      result.auth = authInHost.shift();
-      result.host = result.hostname = authInHost.shift();
-    }
-  }
-
-  mustEndAbs = mustEndAbs || (result.host && srcPath.length);
-
-  if (mustEndAbs && !isAbsolute) {
-    srcPath.unshift('');
-  }
-
-  if (!srcPath.length) {
-    result.pathname = null;
-    result.path = null;
-  } else {
-    result.pathname = srcPath.join('/');
-  }
-
-  //to support request.http
-  if (!util.isNull(result.pathname) || !util.isNull(result.search)) {
-    result.path = (result.pathname ? result.pathname : '') +
-                  (result.search ? result.search : '');
-  }
-  result.auth = relative.auth || result.auth;
-  result.slashes = result.slashes || relative.slashes;
-  result.href = result.format();
-  return result;
-};
-
-Url.prototype.parseHost = function() {
-  var host = this.host;
-  var port = portPattern.exec(host);
-  if (port) {
-    port = port[0];
-    if (port !== ':') {
-      this.port = port.substr(1);
-    }
-    host = host.substr(0, host.length - port.length);
-  }
-  if (host) this.hostname = host;
-};
-
-},{"./util":272,"punycode":236,"querystring":239}],272:[function(require,module,exports){
-'use strict';
-
-module.exports = {
-  isString: function(arg) {
-    return typeof(arg) === 'string';
-  },
-  isObject: function(arg) {
-    return typeof(arg) === 'object' && arg !== null;
-  },
-  isNull: function(arg) {
-    return arg === null;
-  },
-  isNullOrUndefined: function(arg) {
-    return arg == null;
-  }
-};
-
-},{}],273:[function(require,module,exports){
+},{"buffer":134}],207:[function(require,module,exports){
 (function (global){
 
 /**
@@ -38117,16 +26300,16 @@ function config (name) {
 }
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],274:[function(require,module,exports){
-arguments[4][101][0].apply(exports,arguments)
-},{"dup":101}],275:[function(require,module,exports){
+},{}],208:[function(require,module,exports){
+arguments[4][54][0].apply(exports,arguments)
+},{"dup":54}],209:[function(require,module,exports){
 module.exports = function isBuffer(arg) {
   return arg && typeof arg === 'object'
     && typeof arg.copy === 'function'
     && typeof arg.fill === 'function'
     && typeof arg.readUInt8 === 'function';
 }
-},{}],276:[function(require,module,exports){
+},{}],210:[function(require,module,exports){
 (function (process,global){
 // Copyright Joyent, Inc. and other Node contributors.
 //
@@ -38716,7 +26899,7 @@ function hasOwnProperty(obj, prop) {
 }
 
 }).call(this,require('_process'),typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./support/isBuffer":275,"_process":229,"inherits":274}],277:[function(require,module,exports){
+},{"./support/isBuffer":209,"_process":174,"inherits":208}],211:[function(require,module,exports){
 var indexOf = require('indexof');
 
 var Object_keys = function (obj) {
@@ -38856,28 +27039,7 @@ exports.createContext = Script.createContext = function (context) {
     return copy;
 };
 
-},{"indexof":212}],278:[function(require,module,exports){
-module.exports = extend
-
-var hasOwnProperty = Object.prototype.hasOwnProperty;
-
-function extend() {
-    var target = {}
-
-    for (var i = 0; i < arguments.length; i++) {
-        var source = arguments[i]
-
-        for (var key in source) {
-            if (hasOwnProperty.call(source, key)) {
-                target[key] = source[key]
-            }
-        }
-    }
-
-    return target
-}
-
-},{}],279:[function(require,module,exports){
+},{"indexof":157}],212:[function(require,module,exports){
 /**
  * Export cheerio (with )
  */
@@ -38890,7 +27052,7 @@ exports = module.exports = require('./lib/cheerio');
 
 exports.version = require('./package.json').version;
 
-},{"./lib/cheerio":285,"./package.json":289}],280:[function(require,module,exports){
+},{"./lib/cheerio":218,"./package.json":222}],213:[function(require,module,exports){
 var $ = require('../static'),
     utils = require('../utils'),
     isTag = utils.isTag,
@@ -39387,7 +27549,7 @@ exports.is = function (selector) {
 };
 
 
-},{"../static":287,"../utils":288,"lodash.assignin":452,"lodash.foreach":457,"lodash.some":463}],281:[function(require,module,exports){
+},{"../static":220,"../utils":221,"lodash.assignin":382,"lodash.foreach":387,"lodash.some":393}],214:[function(require,module,exports){
 var domEach = require('../utils').domEach,
     _ = {
       pick: require('lodash.pick'),
@@ -39510,7 +27672,7 @@ function parse(styles) {
     }, {});
 }
 
-},{"../utils":288,"lodash.pick":460}],282:[function(require,module,exports){
+},{"../utils":221,"lodash.pick":390}],215:[function(require,module,exports){
 // https://github.com/jquery/jquery/blob/2.1.3/src/manipulation/var/rcheckableType.js
 // https://github.com/jquery/jquery/blob/2.1.3/src/serialize.js
 var submittableSelector = 'input,select,textarea,keygen',
@@ -39577,7 +27739,7 @@ exports.serializeArray = function() {
     }).get();
 };
 
-},{"lodash.map":458}],283:[function(require,module,exports){
+},{"lodash.map":388}],216:[function(require,module,exports){
 var parse = require('../parse'),
     $ = require('../static'),
     updateDOM = parse.update,
@@ -40004,7 +28166,7 @@ exports.clone = function() {
   return this._make(cloneDom(this.get(), this.options));
 };
 
-},{"../parse":286,"../static":287,"../utils":288,"lodash.bind":453,"lodash.flatten":456,"lodash.foreach":457}],284:[function(require,module,exports){
+},{"../parse":219,"../static":220,"../utils":221,"lodash.bind":383,"lodash.flatten":386,"lodash.foreach":387}],217:[function(require,module,exports){
 var select = require('css-select'),
     utils = require('../utils'),
     domEach = utils.domEach,
@@ -40435,7 +28597,7 @@ exports.addBack = function(selector) {
   );
 };
 
-},{"../utils":288,"css-select":290,"htmlparser2":369,"lodash.bind":453,"lodash.filter":455,"lodash.foreach":457,"lodash.reduce":461,"lodash.reject":462}],285:[function(require,module,exports){
+},{"../utils":221,"css-select":223,"htmlparser2":302,"lodash.bind":383,"lodash.filter":385,"lodash.foreach":387,"lodash.reduce":391,"lodash.reject":392}],218:[function(require,module,exports){
 /*
   Module dependencies
 */
@@ -40585,7 +28747,7 @@ var isNode = function(obj) {
   return obj.name || obj.type === 'text' || obj.type === 'comment';
 };
 
-},{"./api/attributes":280,"./api/css":281,"./api/forms":282,"./api/manipulation":283,"./api/traversing":284,"./parse":286,"./static":287,"./utils":288,"lodash.assignin":452,"lodash.bind":453,"lodash.defaults":454,"lodash.foreach":457}],286:[function(require,module,exports){
+},{"./api/attributes":213,"./api/css":214,"./api/forms":215,"./api/manipulation":216,"./api/traversing":217,"./parse":219,"./static":220,"./utils":221,"lodash.assignin":382,"lodash.bind":383,"lodash.defaults":384,"lodash.foreach":387}],219:[function(require,module,exports){
 (function (Buffer){
 /*
   Module Dependencies
@@ -40675,7 +28837,7 @@ exports.update = function(arr, parent) {
 // module.exports = $.extend(exports);
 
 }).call(this,{"isBuffer":require("../../browserify/node_modules/is-buffer/index.js")})
-},{"../../browserify/node_modules/is-buffer/index.js":214,"htmlparser2":369}],287:[function(require,module,exports){
+},{"../../browserify/node_modules/is-buffer/index.js":159,"htmlparser2":302}],220:[function(require,module,exports){
 /**
  * Module dependencies
  */
@@ -40864,7 +29026,7 @@ exports.contains = function(container, contained) {
   return false;
 };
 
-},{"./cheerio":285,"./parse":286,"css-select":290,"dom-serializer":299,"lodash.defaults":454,"lodash.merge":459}],288:[function(require,module,exports){
+},{"./cheerio":218,"./parse":219,"css-select":223,"dom-serializer":232,"lodash.defaults":384,"lodash.merge":389}],221:[function(require,module,exports){
 var parse = require('./parse'),
     render = require('dom-serializer');
 
@@ -40949,31 +29111,36 @@ exports.isHtml = function(str) {
   return !!(match && match[1]);
 };
 
-},{"./parse":286,"dom-serializer":299}],289:[function(require,module,exports){
+},{"./parse":219,"dom-serializer":232}],222:[function(require,module,exports){
 module.exports={
-  "_from": "cheerio@^0.22.0",
+  "_args": [
+    [
+      "cheerio@0.22.0",
+      "/home/aaron/devel/blockstack.js"
+    ]
+  ],
+  "_from": "cheerio@0.22.0",
   "_id": "cheerio@0.22.0",
   "_inBundle": false,
   "_integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
   "_location": "/cheerio",
   "_phantomChildren": {},
   "_requested": {
-    "type": "range",
+    "type": "version",
     "registry": true,
-    "raw": "cheerio@^0.22.0",
+    "raw": "cheerio@0.22.0",
     "name": "cheerio",
     "escapedName": "cheerio",
-    "rawSpec": "^0.22.0",
+    "rawSpec": "0.22.0",
     "saveSpec": null,
-    "fetchSpec": "^0.22.0"
+    "fetchSpec": "0.22.0"
   },
   "_requiredBy": [
     "/"
   ],
   "_resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
-  "_shasum": "a9baa860a3f9b595a6b81b1a86873121ed3a269e",
-  "_spec": "cheerio@^0.22.0",
-  "_where": "/Users/larry/git/blockstack.js",
+  "_spec": "0.22.0",
+  "_where": "/home/aaron/devel/blockstack.js",
   "author": {
     "name": "Matt Mueller",
     "email": "mattmuelle@gmail.com",
@@ -40982,7 +29149,6 @@ module.exports={
   "bugs": {
     "url": "https://github.com/cheeriojs/cheerio/issues"
   },
-  "bundleDependencies": false,
   "dependencies": {
     "css-select": "~1.2.0",
     "dom-serializer": "~0.1.0",
@@ -41001,7 +29167,6 @@ module.exports={
     "lodash.reject": "^4.4.0",
     "lodash.some": "^4.4.0"
   },
-  "deprecated": false,
   "description": "Tiny, fast, and elegant implementation of core jQuery designed specifically for the server",
   "devDependencies": {
     "benchmark": "^2.1.0",
@@ -41043,7 +29208,7 @@ module.exports={
   "version": "0.22.0"
 }
 
-},{}],290:[function(require,module,exports){
+},{}],223:[function(require,module,exports){
 "use strict";
 
 module.exports = CSSselect;
@@ -41104,7 +29269,7 @@ CSSselect.iterate = selectAll;
 CSSselect._compileUnsafe = compileUnsafe;
 CSSselect._compileToken = compileToken;
 
-},{"./lib/compile.js":292,"./lib/pseudos.js":295,"boolbase":141,"domutils":305}],291:[function(require,module,exports){
+},{"./lib/compile.js":225,"./lib/pseudos.js":228,"boolbase":87,"domutils":238}],224:[function(require,module,exports){
 var DomUtils  = require("domutils"),
     hasAttrib = DomUtils.hasAttrib,
     getAttributeValue = DomUtils.getAttributeValue,
@@ -41287,7 +29452,7 @@ module.exports = {
 	rules: attributeRules
 };
 
-},{"boolbase":141,"domutils":305}],292:[function(require,module,exports){
+},{"boolbase":87,"domutils":238}],225:[function(require,module,exports){
 /*
 	compiles a selector to an executable function
 */
@@ -41481,7 +29646,7 @@ filters.matches = function(next, token, options, context){
 	return compileToken(token, opts, context);
 };
 
-},{"./general.js":293,"./procedure.json":294,"./pseudos.js":295,"./sort.js":296,"boolbase":141,"css-what":297,"domutils":305}],293:[function(require,module,exports){
+},{"./general.js":226,"./procedure.json":227,"./pseudos.js":228,"./sort.js":229,"boolbase":87,"css-what":230,"domutils":238}],226:[function(require,module,exports){
 var DomUtils    = require("domutils"),
     isTag       = DomUtils.isTag,
     getParent   = DomUtils.getParent,
@@ -41571,7 +29736,7 @@ module.exports = {
 		return next;
 	}
 };
-},{"./attributes.js":291,"./pseudos.js":295,"domutils":305}],294:[function(require,module,exports){
+},{"./attributes.js":224,"./pseudos.js":228,"domutils":238}],227:[function(require,module,exports){
 module.exports={
   "universal": 50,
   "tag": 30,
@@ -41584,7 +29749,7 @@ module.exports={
   "adjacent": -1
 }
 
-},{}],295:[function(require,module,exports){
+},{}],228:[function(require,module,exports){
 /*
 	pseudo selectors
 
@@ -41979,7 +30144,7 @@ module.exports = {
 	pseudos: pseudos
 };
 
-},{"./attributes.js":291,"boolbase":141,"domutils":305,"nth-check":468}],296:[function(require,module,exports){
+},{"./attributes.js":224,"boolbase":87,"domutils":238,"nth-check":398}],229:[function(require,module,exports){
 module.exports = sortByProcedure;
 
 /*
@@ -42061,7 +30226,7 @@ function getProcedure(token){
 	return proc;
 }
 
-},{"./procedure.json":294}],297:[function(require,module,exports){
+},{"./procedure.json":227}],230:[function(require,module,exports){
 "use strict";
 
 module.exports = parse;
@@ -42330,7 +30495,7 @@ function addToken(subselects, tokens){
 	subselects.push(tokens);
 }
 
-},{}],298:[function(require,module,exports){
+},{}],231:[function(require,module,exports){
 function _registerEvent(target, eventType, cb) {
     if (target.addEventListener) {
         target.addEventListener(eventType, cb);
@@ -42552,7 +30717,7 @@ module.exports = function(uri, failCb, successCb, unsupportedCb) {
     }
 }
 
-},{}],299:[function(require,module,exports){
+},{}],232:[function(require,module,exports){
 /*
   Module dependencies
 */
@@ -42732,7 +30897,7 @@ function renderComment(elem) {
   return '<!--' + elem.data + '-->';
 }
 
-},{"domelementtype":300,"entities":351}],300:[function(require,module,exports){
+},{"domelementtype":233,"entities":284}],233:[function(require,module,exports){
 //Types of elements found in the DOM
 module.exports = {
 	Text: "text", //Text
@@ -42747,7 +30912,7 @@ module.exports = {
 		return elem.type === "tag" || elem.type === "script" || elem.type === "style";
 	}
 };
-},{}],301:[function(require,module,exports){
+},{}],234:[function(require,module,exports){
 //Types of elements found in the DOM
 module.exports = {
 	Text: "text", //Text
@@ -42764,7 +30929,7 @@ module.exports = {
 	}
 };
 
-},{}],302:[function(require,module,exports){
+},{}],235:[function(require,module,exports){
 var ElementType = require("domelementtype");
 
 var re_whitespace = /\s+/g;
@@ -42983,7 +31148,7 @@ DomHandler.prototype.onprocessinginstruction = function(name, data){
 
 module.exports = DomHandler;
 
-},{"./lib/element":303,"./lib/node":304,"domelementtype":301}],303:[function(require,module,exports){
+},{"./lib/element":236,"./lib/node":237,"domelementtype":234}],236:[function(require,module,exports){
 // DOM-Level-1-compliant structure
 var NodePrototype = require('./node');
 var ElementPrototype = module.exports = Object.create(NodePrototype);
@@ -43005,7 +31170,7 @@ Object.keys(domLvl1).forEach(function(key) {
 	});
 });
 
-},{"./node":304}],304:[function(require,module,exports){
+},{"./node":237}],237:[function(require,module,exports){
 // This object will be used as the prototype for Nodes when creating a
 // DOM-Level-1-compliant structure.
 var NodePrototype = module.exports = {
@@ -43051,7 +31216,7 @@ Object.keys(domLvl1).forEach(function(key) {
 	});
 });
 
-},{}],305:[function(require,module,exports){
+},{}],238:[function(require,module,exports){
 var DomUtils = module.exports;
 
 [
@@ -43067,7 +31232,7 @@ var DomUtils = module.exports;
 	});
 });
 
-},{"./lib/helpers":306,"./lib/legacy":307,"./lib/manipulation":308,"./lib/querying":309,"./lib/stringify":310,"./lib/traversal":311}],306:[function(require,module,exports){
+},{"./lib/helpers":239,"./lib/legacy":240,"./lib/manipulation":241,"./lib/querying":242,"./lib/stringify":243,"./lib/traversal":244}],239:[function(require,module,exports){
 // removeSubsets
 // Given an array of nodes, remove any member that is contained by another.
 exports.removeSubsets = function(nodes) {
@@ -43210,7 +31375,7 @@ exports.uniqueSort = function(nodes) {
 	return nodes;
 };
 
-},{}],307:[function(require,module,exports){
+},{}],240:[function(require,module,exports){
 var ElementType = require("domelementtype");
 var isTag = exports.isTag = ElementType.isTag;
 
@@ -43299,7 +31464,7 @@ exports.getElementsByTagType = function(type, element, recurse, limit){
 	return this.filter(Checks.tag_type(type), element, recurse, limit);
 };
 
-},{"domelementtype":301}],308:[function(require,module,exports){
+},{"domelementtype":234}],241:[function(require,module,exports){
 exports.removeElement = function(elem){
 	if(elem.prev) elem.prev.next = elem.next;
 	if(elem.next) elem.next.prev = elem.prev;
@@ -43378,7 +31543,7 @@ exports.prepend = function(elem, prev){
 
 
 
-},{}],309:[function(require,module,exports){
+},{}],242:[function(require,module,exports){
 var isTag = require("domelementtype").isTag;
 
 module.exports = {
@@ -43474,7 +31639,7 @@ function findAll(test, elems){
 	return result;
 }
 
-},{"domelementtype":301}],310:[function(require,module,exports){
+},{"domelementtype":234}],243:[function(require,module,exports){
 var ElementType = require("domelementtype"),
     getOuterHTML = require("dom-serializer"),
     isTag = ElementType.isTag;
@@ -43498,7 +31663,7 @@ function getText(elem){
 	return "";
 }
 
-},{"dom-serializer":299,"domelementtype":301}],311:[function(require,module,exports){
+},{"dom-serializer":232,"domelementtype":234}],244:[function(require,module,exports){
 var getChildren = exports.getChildren = function(elem){
 	return elem.children;
 };
@@ -43524,7 +31689,7 @@ exports.getName = function(elem){
 	return elem.name;
 };
 
-},{}],312:[function(require,module,exports){
+},{}],245:[function(require,module,exports){
 var assert = require('assert')
 var BigInteger = require('bigi')
 
@@ -43603,7 +31768,7 @@ Curve.prototype.validate = function (Q) {
 
 module.exports = Curve
 
-},{"./point":316,"assert":156,"bigi":86}],313:[function(require,module,exports){
+},{"./point":249,"assert":102,"bigi":39}],246:[function(require,module,exports){
 module.exports={
   "secp128r1": {
     "p": "fffffffdffffffffffffffffffffffff",
@@ -43670,7 +31835,7 @@ module.exports={
   }
 }
 
-},{}],314:[function(require,module,exports){
+},{}],247:[function(require,module,exports){
 var Point = require('./point')
 var Curve = require('./curve')
 
@@ -43682,7 +31847,7 @@ module.exports = {
   getCurveByName: getCurveByName
 }
 
-},{"./curve":312,"./names":315,"./point":316}],315:[function(require,module,exports){
+},{"./curve":245,"./names":248,"./point":249}],248:[function(require,module,exports){
 var BigInteger = require('bigi')
 
 var curves = require('./curves.json')
@@ -43705,7 +31870,7 @@ function getCurveByName (name) {
 
 module.exports = getCurveByName
 
-},{"./curve":312,"./curves.json":313,"bigi":86}],316:[function(require,module,exports){
+},{"./curve":245,"./curves.json":246,"bigi":39}],249:[function(require,module,exports){
 (function (Buffer){
 var assert = require('assert')
 var BigInteger = require('bigi')
@@ -43952,7 +32117,7 @@ Point.prototype.toString = function () {
 module.exports = Point
 
 }).call(this,require("buffer").Buffer)
-},{"assert":156,"bigi":86,"buffer":188}],317:[function(require,module,exports){
+},{"assert":102,"bigi":39,"buffer":134}],250:[function(require,module,exports){
 'use strict';
 
 var elliptic = exports;
@@ -43967,7 +32132,7 @@ elliptic.curves = require('./elliptic/curves');
 elliptic.ec = require('./elliptic/ec');
 elliptic.eddsa = require('./elliptic/eddsa');
 
-},{"../package.json":350,"./elliptic/curve":320,"./elliptic/curves":323,"./elliptic/ec":324,"./elliptic/eddsa":327,"./elliptic/utils":331,"brorand":333}],318:[function(require,module,exports){
+},{"../package.json":283,"./elliptic/curve":253,"./elliptic/curves":256,"./elliptic/ec":257,"./elliptic/eddsa":260,"./elliptic/utils":264,"brorand":266}],251:[function(require,module,exports){
 'use strict';
 
 var BN = require('bn.js');
@@ -44344,7 +32509,7 @@ BasePoint.prototype.dblp = function dblp(k) {
   return r;
 };
 
-},{"../../elliptic":317,"bn.js":332}],319:[function(require,module,exports){
+},{"../../elliptic":250,"bn.js":265}],252:[function(require,module,exports){
 'use strict';
 
 var curve = require('../curve');
@@ -44779,7 +32944,7 @@ Point.prototype.eqXToP = function eqXToP(x) {
 Point.prototype.toP = Point.prototype.normalize;
 Point.prototype.mixedAdd = Point.prototype.add;
 
-},{"../../elliptic":317,"../curve":320,"bn.js":332,"inherits":347}],320:[function(require,module,exports){
+},{"../../elliptic":250,"../curve":253,"bn.js":265,"inherits":280}],253:[function(require,module,exports){
 'use strict';
 
 var curve = exports;
@@ -44789,7 +32954,7 @@ curve.short = require('./short');
 curve.mont = require('./mont');
 curve.edwards = require('./edwards');
 
-},{"./base":318,"./edwards":319,"./mont":321,"./short":322}],321:[function(require,module,exports){
+},{"./base":251,"./edwards":252,"./mont":254,"./short":255}],254:[function(require,module,exports){
 'use strict';
 
 var curve = require('../curve');
@@ -44971,7 +33136,7 @@ Point.prototype.getX = function getX() {
   return this.x.fromRed();
 };
 
-},{"../../elliptic":317,"../curve":320,"bn.js":332,"inherits":347}],322:[function(require,module,exports){
+},{"../../elliptic":250,"../curve":253,"bn.js":265,"inherits":280}],255:[function(require,module,exports){
 'use strict';
 
 var curve = require('../curve');
@@ -45911,7 +34076,7 @@ JPoint.prototype.isInfinity = function isInfinity() {
   return this.z.cmpn(0) === 0;
 };
 
-},{"../../elliptic":317,"../curve":320,"bn.js":332,"inherits":347}],323:[function(require,module,exports){
+},{"../../elliptic":250,"../curve":253,"bn.js":265,"inherits":280}],256:[function(require,module,exports){
 'use strict';
 
 var curves = exports;
@@ -46118,7 +34283,7 @@ defineCurve('secp256k1', {
   ]
 });
 
-},{"../elliptic":317,"./precomputed/secp256k1":330,"hash.js":334}],324:[function(require,module,exports){
+},{"../elliptic":250,"./precomputed/secp256k1":263,"hash.js":267}],257:[function(require,module,exports){
 'use strict';
 
 var BN = require('bn.js');
@@ -46360,7 +34525,7 @@ EC.prototype.getKeyRecoveryParam = function(e, signature, Q, enc) {
   throw new Error('Unable to find valid recovery factor');
 };
 
-},{"../../elliptic":317,"./key":325,"./signature":326,"bn.js":332,"hmac-drbg":346}],325:[function(require,module,exports){
+},{"../../elliptic":250,"./key":258,"./signature":259,"bn.js":265,"hmac-drbg":279}],258:[function(require,module,exports){
 'use strict';
 
 var BN = require('bn.js');
@@ -46481,7 +34646,7 @@ KeyPair.prototype.inspect = function inspect() {
          ' pub: ' + (this.pub && this.pub.inspect()) + ' >';
 };
 
-},{"../../elliptic":317,"bn.js":332}],326:[function(require,module,exports){
+},{"../../elliptic":250,"bn.js":265}],259:[function(require,module,exports){
 'use strict';
 
 var BN = require('bn.js');
@@ -46618,7 +34783,7 @@ Signature.prototype.toDER = function toDER(enc) {
   return utils.encode(res, enc);
 };
 
-},{"../../elliptic":317,"bn.js":332}],327:[function(require,module,exports){
+},{"../../elliptic":250,"bn.js":265}],260:[function(require,module,exports){
 'use strict';
 
 var hash = require('hash.js');
@@ -46738,7 +34903,7 @@ EDDSA.prototype.isPoint = function isPoint(val) {
   return val instanceof this.pointClass;
 };
 
-},{"../../elliptic":317,"./key":328,"./signature":329,"hash.js":334}],328:[function(require,module,exports){
+},{"../../elliptic":250,"./key":261,"./signature":262,"hash.js":267}],261:[function(require,module,exports){
 'use strict';
 
 var elliptic = require('../../elliptic');
@@ -46836,7 +35001,7 @@ KeyPair.prototype.getPublic = function getPublic(enc) {
 
 module.exports = KeyPair;
 
-},{"../../elliptic":317}],329:[function(require,module,exports){
+},{"../../elliptic":250}],262:[function(require,module,exports){
 'use strict';
 
 var BN = require('bn.js');
@@ -46904,7 +35069,7 @@ Signature.prototype.toHex = function toHex() {
 
 module.exports = Signature;
 
-},{"../../elliptic":317,"bn.js":332}],330:[function(require,module,exports){
+},{"../../elliptic":250,"bn.js":265}],263:[function(require,module,exports){
 module.exports = {
   doubles: {
     step: 4,
@@ -47686,7 +35851,7 @@ module.exports = {
   }
 };
 
-},{}],331:[function(require,module,exports){
+},{}],264:[function(require,module,exports){
 'use strict';
 
 var utils = exports;
@@ -47808,11 +35973,11 @@ function intFromLE(bytes) {
 utils.intFromLE = intFromLE;
 
 
-},{"bn.js":332,"minimalistic-assert":348,"minimalistic-crypto-utils":349}],332:[function(require,module,exports){
-arguments[4][158][0].apply(exports,arguments)
-},{"buffer":160,"dup":158}],333:[function(require,module,exports){
-arguments[4][159][0].apply(exports,arguments)
-},{"crypto":160,"dup":159}],334:[function(require,module,exports){
+},{"bn.js":265,"minimalistic-assert":281,"minimalistic-crypto-utils":282}],265:[function(require,module,exports){
+arguments[4][104][0].apply(exports,arguments)
+},{"buffer":106,"dup":104}],266:[function(require,module,exports){
+arguments[4][105][0].apply(exports,arguments)
+},{"crypto":106,"dup":105}],267:[function(require,module,exports){
 var hash = exports;
 
 hash.utils = require('./hash/utils');
@@ -47829,7 +35994,7 @@ hash.sha384 = hash.sha.sha384;
 hash.sha512 = hash.sha.sha512;
 hash.ripemd160 = hash.ripemd.ripemd160;
 
-},{"./hash/common":335,"./hash/hmac":336,"./hash/ripemd":337,"./hash/sha":338,"./hash/utils":345}],335:[function(require,module,exports){
+},{"./hash/common":268,"./hash/hmac":269,"./hash/ripemd":270,"./hash/sha":271,"./hash/utils":278}],268:[function(require,module,exports){
 'use strict';
 
 var utils = require('./utils');
@@ -47923,7 +36088,7 @@ BlockHash.prototype._pad = function pad() {
   return res;
 };
 
-},{"./utils":345,"minimalistic-assert":348}],336:[function(require,module,exports){
+},{"./utils":278,"minimalistic-assert":281}],269:[function(require,module,exports){
 'use strict';
 
 var utils = require('./utils');
@@ -47972,7 +36137,7 @@ Hmac.prototype.digest = function digest(enc) {
   return this.outer.digest(enc);
 };
 
-},{"./utils":345,"minimalistic-assert":348}],337:[function(require,module,exports){
+},{"./utils":278,"minimalistic-assert":281}],270:[function(require,module,exports){
 'use strict';
 
 var utils = require('./utils');
@@ -48120,7 +36285,7 @@ var sh = [
   8, 5, 12, 9, 12, 5, 14, 6, 8, 13, 6, 5, 15, 13, 11, 11
 ];
 
-},{"./common":335,"./utils":345}],338:[function(require,module,exports){
+},{"./common":268,"./utils":278}],271:[function(require,module,exports){
 'use strict';
 
 exports.sha1 = require('./sha/1');
@@ -48129,7 +36294,7 @@ exports.sha256 = require('./sha/256');
 exports.sha384 = require('./sha/384');
 exports.sha512 = require('./sha/512');
 
-},{"./sha/1":339,"./sha/224":340,"./sha/256":341,"./sha/384":342,"./sha/512":343}],339:[function(require,module,exports){
+},{"./sha/1":272,"./sha/224":273,"./sha/256":274,"./sha/384":275,"./sha/512":276}],272:[function(require,module,exports){
 'use strict';
 
 var utils = require('../utils');
@@ -48205,7 +36370,7 @@ SHA1.prototype._digest = function digest(enc) {
     return utils.split32(this.h, 'big');
 };
 
-},{"../common":335,"../utils":345,"./common":344}],340:[function(require,module,exports){
+},{"../common":268,"../utils":278,"./common":277}],273:[function(require,module,exports){
 'use strict';
 
 var utils = require('../utils');
@@ -48237,7 +36402,7 @@ SHA224.prototype._digest = function digest(enc) {
 };
 
 
-},{"../utils":345,"./256":341}],341:[function(require,module,exports){
+},{"../utils":278,"./256":274}],274:[function(require,module,exports){
 'use strict';
 
 var utils = require('../utils');
@@ -48344,7 +36509,7 @@ SHA256.prototype._digest = function digest(enc) {
     return utils.split32(this.h, 'big');
 };
 
-},{"../common":335,"../utils":345,"./common":344,"minimalistic-assert":348}],342:[function(require,module,exports){
+},{"../common":268,"../utils":278,"./common":277,"minimalistic-assert":281}],275:[function(require,module,exports){
 'use strict';
 
 var utils = require('../utils');
@@ -48381,7 +36546,7 @@ SHA384.prototype._digest = function digest(enc) {
     return utils.split32(this.h.slice(0, 12), 'big');
 };
 
-},{"../utils":345,"./512":343}],343:[function(require,module,exports){
+},{"../utils":278,"./512":276}],276:[function(require,module,exports){
 'use strict';
 
 var utils = require('../utils');
@@ -48713,7 +36878,7 @@ function g1_512_lo(xh, xl) {
   return r;
 }
 
-},{"../common":335,"../utils":345,"minimalistic-assert":348}],344:[function(require,module,exports){
+},{"../common":268,"../utils":278,"minimalistic-assert":281}],277:[function(require,module,exports){
 'use strict';
 
 var utils = require('../utils');
@@ -48764,7 +36929,7 @@ function g1_256(x) {
 }
 exports.g1_256 = g1_256;
 
-},{"../utils":345}],345:[function(require,module,exports){
+},{"../utils":278}],278:[function(require,module,exports){
 'use strict';
 
 var assert = require('minimalistic-assert');
@@ -49019,7 +37184,7 @@ function shr64_lo(ah, al, num) {
 }
 exports.shr64_lo = shr64_lo;
 
-},{"inherits":347,"minimalistic-assert":348}],346:[function(require,module,exports){
+},{"inherits":280,"minimalistic-assert":281}],279:[function(require,module,exports){
 'use strict';
 
 var hash = require('hash.js');
@@ -49134,11 +37299,11 @@ HmacDRBG.prototype.generate = function generate(len, enc, add, addEnc) {
   return utils.encode(res, enc);
 };
 
-},{"hash.js":334,"minimalistic-assert":348,"minimalistic-crypto-utils":349}],347:[function(require,module,exports){
-arguments[4][101][0].apply(exports,arguments)
-},{"dup":101}],348:[function(require,module,exports){
-arguments[4][217][0].apply(exports,arguments)
-},{"dup":217}],349:[function(require,module,exports){
+},{"hash.js":267,"minimalistic-assert":281,"minimalistic-crypto-utils":282}],280:[function(require,module,exports){
+arguments[4][54][0].apply(exports,arguments)
+},{"dup":54}],281:[function(require,module,exports){
+arguments[4][162][0].apply(exports,arguments)
+},{"dup":162}],282:[function(require,module,exports){
 'use strict';
 
 var utils = exports;
@@ -49198,23 +37363,29 @@ utils.encode = function encode(arr, enc) {
     return arr;
 };
 
-},{}],350:[function(require,module,exports){
+},{}],283:[function(require,module,exports){
 module.exports={
-  "_from": "elliptic@^6.4.0",
+  "_args": [
+    [
+      "elliptic@6.4.0",
+      "/home/aaron/devel/blockstack.js"
+    ]
+  ],
+  "_from": "elliptic@6.4.0",
   "_id": "elliptic@6.4.0",
   "_inBundle": false,
   "_integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
   "_location": "/elliptic",
   "_phantomChildren": {},
   "_requested": {
-    "type": "range",
+    "type": "version",
     "registry": true,
-    "raw": "elliptic@^6.4.0",
+    "raw": "elliptic@6.4.0",
     "name": "elliptic",
     "escapedName": "elliptic",
-    "rawSpec": "^6.4.0",
+    "rawSpec": "6.4.0",
     "saveSpec": null,
-    "fetchSpec": "^6.4.0"
+    "fetchSpec": "6.4.0"
   },
   "_requiredBy": [
     "/",
@@ -49224,9 +37395,8 @@ module.exports={
     "/jsontokens"
   ],
   "_resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
-  "_shasum": "cac9af8762c85836187003c8dfe193e5e2eae5df",
-  "_spec": "elliptic@^6.4.0",
-  "_where": "/Users/larry/git/blockstack.js",
+  "_spec": "6.4.0",
+  "_where": "/home/aaron/devel/blockstack.js",
   "author": {
     "name": "Fedor Indutny",
     "email": "fedor@indutny.com"
@@ -49234,7 +37404,6 @@ module.exports={
   "bugs": {
     "url": "https://github.com/indutny/elliptic/issues"
   },
-  "bundleDependencies": false,
   "dependencies": {
     "bn.js": "^4.4.0",
     "brorand": "^1.0.1",
@@ -49244,7 +37413,6 @@ module.exports={
     "minimalistic-assert": "^1.0.0",
     "minimalistic-crypto-utils": "^1.0.0"
   },
-  "deprecated": false,
   "description": "EC cryptography",
   "devDependencies": {
     "brfs": "^1.4.3",
@@ -49290,7 +37458,7 @@ module.exports={
   "version": "6.4.0"
 }
 
-},{}],351:[function(require,module,exports){
+},{}],284:[function(require,module,exports){
 var encode = require("./lib/encode.js"),
     decode = require("./lib/decode.js");
 
@@ -49325,7 +37493,7 @@ exports.decodeHTMLStrict = decode.HTMLStrict;
 
 exports.escape = encode.escape;
 
-},{"./lib/decode.js":352,"./lib/encode.js":354}],352:[function(require,module,exports){
+},{"./lib/decode.js":285,"./lib/encode.js":287}],285:[function(require,module,exports){
 var entityMap = require("../maps/entities.json"),
     legacyMap = require("../maps/legacy.json"),
     xmlMap    = require("../maps/xml.json"),
@@ -49398,7 +37566,7 @@ module.exports = {
 	HTML: decodeHTML,
 	HTMLStrict: decodeHTMLStrict
 };
-},{"../maps/entities.json":356,"../maps/legacy.json":357,"../maps/xml.json":358,"./decode_codepoint.js":353}],353:[function(require,module,exports){
+},{"../maps/entities.json":289,"../maps/legacy.json":290,"../maps/xml.json":291,"./decode_codepoint.js":286}],286:[function(require,module,exports){
 var decodeMap = require("../maps/decode.json");
 
 module.exports = decodeCodePoint;
@@ -49426,7 +37594,7 @@ function decodeCodePoint(codePoint){
 	return output;
 }
 
-},{"../maps/decode.json":355}],354:[function(require,module,exports){
+},{"../maps/decode.json":288}],287:[function(require,module,exports){
 var inverseXML = getInverseObj(require("../maps/xml.json")),
     xmlReplacer = getInverseReplacer(inverseXML);
 
@@ -49501,16 +37669,16 @@ function escapeXML(data){
 
 exports.escape = escapeXML;
 
-},{"../maps/entities.json":356,"../maps/xml.json":358}],355:[function(require,module,exports){
+},{"../maps/entities.json":289,"../maps/xml.json":291}],288:[function(require,module,exports){
 module.exports={"0":65533,"128":8364,"130":8218,"131":402,"132":8222,"133":8230,"134":8224,"135":8225,"136":710,"137":8240,"138":352,"139":8249,"140":338,"142":381,"145":8216,"146":8217,"147":8220,"148":8221,"149":8226,"150":8211,"151":8212,"152":732,"153":8482,"154":353,"155":8250,"156":339,"158":382,"159":376}
-},{}],356:[function(require,module,exports){
+},{}],289:[function(require,module,exports){
 module.exports={"Aacute":"\u00C1","aacute":"\u00E1","Abreve":"\u0102","abreve":"\u0103","ac":"\u223E","acd":"\u223F","acE":"\u223E\u0333","Acirc":"\u00C2","acirc":"\u00E2","acute":"\u00B4","Acy":"\u0410","acy":"\u0430","AElig":"\u00C6","aelig":"\u00E6","af":"\u2061","Afr":"\uD835\uDD04","afr":"\uD835\uDD1E","Agrave":"\u00C0","agrave":"\u00E0","alefsym":"\u2135","aleph":"\u2135","Alpha":"\u0391","alpha":"\u03B1","Amacr":"\u0100","amacr":"\u0101","amalg":"\u2A3F","amp":"&","AMP":"&","andand":"\u2A55","And":"\u2A53","and":"\u2227","andd":"\u2A5C","andslope":"\u2A58","andv":"\u2A5A","ang":"\u2220","ange":"\u29A4","angle":"\u2220","angmsdaa":"\u29A8","angmsdab":"\u29A9","angmsdac":"\u29AA","angmsdad":"\u29AB","angmsdae":"\u29AC","angmsdaf":"\u29AD","angmsdag":"\u29AE","angmsdah":"\u29AF","angmsd":"\u2221","angrt":"\u221F","angrtvb":"\u22BE","angrtvbd":"\u299D","angsph":"\u2222","angst":"\u00C5","angzarr":"\u237C","Aogon":"\u0104","aogon":"\u0105","Aopf":"\uD835\uDD38","aopf":"\uD835\uDD52","apacir":"\u2A6F","ap":"\u2248","apE":"\u2A70","ape":"\u224A","apid":"\u224B","apos":"'","ApplyFunction":"\u2061","approx":"\u2248","approxeq":"\u224A","Aring":"\u00C5","aring":"\u00E5","Ascr":"\uD835\uDC9C","ascr":"\uD835\uDCB6","Assign":"\u2254","ast":"*","asymp":"\u2248","asympeq":"\u224D","Atilde":"\u00C3","atilde":"\u00E3","Auml":"\u00C4","auml":"\u00E4","awconint":"\u2233","awint":"\u2A11","backcong":"\u224C","backepsilon":"\u03F6","backprime":"\u2035","backsim":"\u223D","backsimeq":"\u22CD","Backslash":"\u2216","Barv":"\u2AE7","barvee":"\u22BD","barwed":"\u2305","Barwed":"\u2306","barwedge":"\u2305","bbrk":"\u23B5","bbrktbrk":"\u23B6","bcong":"\u224C","Bcy":"\u0411","bcy":"\u0431","bdquo":"\u201E","becaus":"\u2235","because":"\u2235","Because":"\u2235","bemptyv":"\u29B0","bepsi":"\u03F6","bernou":"\u212C","Bernoullis":"\u212C","Beta":"\u0392","beta":"\u03B2","beth":"\u2136","between":"\u226C","Bfr":"\uD835\uDD05","bfr":"\uD835\uDD1F","bigcap":"\u22C2","bigcirc":"\u25EF","bigcup":"\u22C3","bigodot":"\u2A00","bigoplus":"\u2A01","bigotimes":"\u2A02","bigsqcup":"\u2A06","bigstar":"\u2605","bigtriangledown":"\u25BD","bigtriangleup":"\u25B3","biguplus":"\u2A04","bigvee":"\u22C1","bigwedge":"\u22C0","bkarow":"\u290D","blacklozenge":"\u29EB","blacksquare":"\u25AA","blacktriangle":"\u25B4","blacktriangledown":"\u25BE","blacktriangleleft":"\u25C2","blacktriangleright":"\u25B8","blank":"\u2423","blk12":"\u2592","blk14":"\u2591","blk34":"\u2593","block":"\u2588","bne":"=\u20E5","bnequiv":"\u2261\u20E5","bNot":"\u2AED","bnot":"\u2310","Bopf":"\uD835\uDD39","bopf":"\uD835\uDD53","bot":"\u22A5","bottom":"\u22A5","bowtie":"\u22C8","boxbox":"\u29C9","boxdl":"\u2510","boxdL":"\u2555","boxDl":"\u2556","boxDL":"\u2557","boxdr":"\u250C","boxdR":"\u2552","boxDr":"\u2553","boxDR":"\u2554","boxh":"\u2500","boxH":"\u2550","boxhd":"\u252C","boxHd":"\u2564","boxhD":"\u2565","boxHD":"\u2566","boxhu":"\u2534","boxHu":"\u2567","boxhU":"\u2568","boxHU":"\u2569","boxminus":"\u229F","boxplus":"\u229E","boxtimes":"\u22A0","boxul":"\u2518","boxuL":"\u255B","boxUl":"\u255C","boxUL":"\u255D","boxur":"\u2514","boxuR":"\u2558","boxUr":"\u2559","boxUR":"\u255A","boxv":"\u2502","boxV":"\u2551","boxvh":"\u253C","boxvH":"\u256A","boxVh":"\u256B","boxVH":"\u256C","boxvl":"\u2524","boxvL":"\u2561","boxVl":"\u2562","boxVL":"\u2563","boxvr":"\u251C","boxvR":"\u255E","boxVr":"\u255F","boxVR":"\u2560","bprime":"\u2035","breve":"\u02D8","Breve":"\u02D8","brvbar":"\u00A6","bscr":"\uD835\uDCB7","Bscr":"\u212C","bsemi":"\u204F","bsim":"\u223D","bsime":"\u22CD","bsolb":"\u29C5","bsol":"\\","bsolhsub":"\u27C8","bull":"\u2022","bullet":"\u2022","bump":"\u224E","bumpE":"\u2AAE","bumpe":"\u224F","Bumpeq":"\u224E","bumpeq":"\u224F","Cacute":"\u0106","cacute":"\u0107","capand":"\u2A44","capbrcup":"\u2A49","capcap":"\u2A4B","cap":"\u2229","Cap":"\u22D2","capcup":"\u2A47","capdot":"\u2A40","CapitalDifferentialD":"\u2145","caps":"\u2229\uFE00","caret":"\u2041","caron":"\u02C7","Cayleys":"\u212D","ccaps":"\u2A4D","Ccaron":"\u010C","ccaron":"\u010D","Ccedil":"\u00C7","ccedil":"\u00E7","Ccirc":"\u0108","ccirc":"\u0109","Cconint":"\u2230","ccups":"\u2A4C","ccupssm":"\u2A50","Cdot":"\u010A","cdot":"\u010B","cedil":"\u00B8","Cedilla":"\u00B8","cemptyv":"\u29B2","cent":"\u00A2","centerdot":"\u00B7","CenterDot":"\u00B7","cfr":"\uD835\uDD20","Cfr":"\u212D","CHcy":"\u0427","chcy":"\u0447","check":"\u2713","checkmark":"\u2713","Chi":"\u03A7","chi":"\u03C7","circ":"\u02C6","circeq":"\u2257","circlearrowleft":"\u21BA","circlearrowright":"\u21BB","circledast":"\u229B","circledcirc":"\u229A","circleddash":"\u229D","CircleDot":"\u2299","circledR":"\u00AE","circledS":"\u24C8","CircleMinus":"\u2296","CirclePlus":"\u2295","CircleTimes":"\u2297","cir":"\u25CB","cirE":"\u29C3","cire":"\u2257","cirfnint":"\u2A10","cirmid":"\u2AEF","cirscir":"\u29C2","ClockwiseContourIntegral":"\u2232","CloseCurlyDoubleQuote":"\u201D","CloseCurlyQuote":"\u2019","clubs":"\u2663","clubsuit":"\u2663","colon":":","Colon":"\u2237","Colone":"\u2A74","colone":"\u2254","coloneq":"\u2254","comma":",","commat":"@","comp":"\u2201","compfn":"\u2218","complement":"\u2201","complexes":"\u2102","cong":"\u2245","congdot":"\u2A6D","Congruent":"\u2261","conint":"\u222E","Conint":"\u222F","ContourIntegral":"\u222E","copf":"\uD835\uDD54","Copf":"\u2102","coprod":"\u2210","Coproduct":"\u2210","copy":"\u00A9","COPY":"\u00A9","copysr":"\u2117","CounterClockwiseContourIntegral":"\u2233","crarr":"\u21B5","cross":"\u2717","Cross":"\u2A2F","Cscr":"\uD835\uDC9E","cscr":"\uD835\uDCB8","csub":"\u2ACF","csube":"\u2AD1","csup":"\u2AD0","csupe":"\u2AD2","ctdot":"\u22EF","cudarrl":"\u2938","cudarrr":"\u2935","cuepr":"\u22DE","cuesc":"\u22DF","cularr":"\u21B6","cularrp":"\u293D","cupbrcap":"\u2A48","cupcap":"\u2A46","CupCap":"\u224D","cup":"\u222A","Cup":"\u22D3","cupcup":"\u2A4A","cupdot":"\u228D","cupor":"\u2A45","cups":"\u222A\uFE00","curarr":"\u21B7","curarrm":"\u293C","curlyeqprec":"\u22DE","curlyeqsucc":"\u22DF","curlyvee":"\u22CE","curlywedge":"\u22CF","curren":"\u00A4","curvearrowleft":"\u21B6","curvearrowright":"\u21B7","cuvee":"\u22CE","cuwed":"\u22CF","cwconint":"\u2232","cwint":"\u2231","cylcty":"\u232D","dagger":"\u2020","Dagger":"\u2021","daleth":"\u2138","darr":"\u2193","Darr":"\u21A1","dArr":"\u21D3","dash":"\u2010","Dashv":"\u2AE4","dashv":"\u22A3","dbkarow":"\u290F","dblac":"\u02DD","Dcaron":"\u010E","dcaron":"\u010F","Dcy":"\u0414","dcy":"\u0434","ddagger":"\u2021","ddarr":"\u21CA","DD":"\u2145","dd":"\u2146","DDotrahd":"\u2911","ddotseq":"\u2A77","deg":"\u00B0","Del":"\u2207","Delta":"\u0394","delta":"\u03B4","demptyv":"\u29B1","dfisht":"\u297F","Dfr":"\uD835\uDD07","dfr":"\uD835\uDD21","dHar":"\u2965","dharl":"\u21C3","dharr":"\u21C2","DiacriticalAcute":"\u00B4","DiacriticalDot":"\u02D9","DiacriticalDoubleAcute":"\u02DD","DiacriticalGrave":"`","DiacriticalTilde":"\u02DC","diam":"\u22C4","diamond":"\u22C4","Diamond":"\u22C4","diamondsuit":"\u2666","diams":"\u2666","die":"\u00A8","DifferentialD":"\u2146","digamma":"\u03DD","disin":"\u22F2","div":"\u00F7","divide":"\u00F7","divideontimes":"\u22C7","divonx":"\u22C7","DJcy":"\u0402","djcy":"\u0452","dlcorn":"\u231E","dlcrop":"\u230D","dollar":"$","Dopf":"\uD835\uDD3B","dopf":"\uD835\uDD55","Dot":"\u00A8","dot":"\u02D9","DotDot":"\u20DC","doteq":"\u2250","doteqdot":"\u2251","DotEqual":"\u2250","dotminus":"\u2238","dotplus":"\u2214","dotsquare":"\u22A1","doublebarwedge":"\u2306","DoubleContourIntegral":"\u222F","DoubleDot":"\u00A8","DoubleDownArrow":"\u21D3","DoubleLeftArrow":"\u21D0","DoubleLeftRightArrow":"\u21D4","DoubleLeftTee":"\u2AE4","DoubleLongLeftArrow":"\u27F8","DoubleLongLeftRightArrow":"\u27FA","DoubleLongRightArrow":"\u27F9","DoubleRightArrow":"\u21D2","DoubleRightTee":"\u22A8","DoubleUpArrow":"\u21D1","DoubleUpDownArrow":"\u21D5","DoubleVerticalBar":"\u2225","DownArrowBar":"\u2913","downarrow":"\u2193","DownArrow":"\u2193","Downarrow":"\u21D3","DownArrowUpArrow":"\u21F5","DownBreve":"\u0311","downdownarrows":"\u21CA","downharpoonleft":"\u21C3","downharpoonright":"\u21C2","DownLeftRightVector":"\u2950","DownLeftTeeVector":"\u295E","DownLeftVectorBar":"\u2956","DownLeftVector":"\u21BD","DownRightTeeVector":"\u295F","DownRightVectorBar":"\u2957","DownRightVector":"\u21C1","DownTeeArrow":"\u21A7","DownTee":"\u22A4","drbkarow":"\u2910","drcorn":"\u231F","drcrop":"\u230C","Dscr":"\uD835\uDC9F","dscr":"\uD835\uDCB9","DScy":"\u0405","dscy":"\u0455","dsol":"\u29F6","Dstrok":"\u0110","dstrok":"\u0111","dtdot":"\u22F1","dtri":"\u25BF","dtrif":"\u25BE","duarr":"\u21F5","duhar":"\u296F","dwangle":"\u29A6","DZcy":"\u040F","dzcy":"\u045F","dzigrarr":"\u27FF","Eacute":"\u00C9","eacute":"\u00E9","easter":"\u2A6E","Ecaron":"\u011A","ecaron":"\u011B","Ecirc":"\u00CA","ecirc":"\u00EA","ecir":"\u2256","ecolon":"\u2255","Ecy":"\u042D","ecy":"\u044D","eDDot":"\u2A77","Edot":"\u0116","edot":"\u0117","eDot":"\u2251","ee":"\u2147","efDot":"\u2252","Efr":"\uD835\uDD08","efr":"\uD835\uDD22","eg":"\u2A9A","Egrave":"\u00C8","egrave":"\u00E8","egs":"\u2A96","egsdot":"\u2A98","el":"\u2A99","Element":"\u2208","elinters":"\u23E7","ell":"\u2113","els":"\u2A95","elsdot":"\u2A97","Emacr":"\u0112","emacr":"\u0113","empty":"\u2205","emptyset":"\u2205","EmptySmallSquare":"\u25FB","emptyv":"\u2205","EmptyVerySmallSquare":"\u25AB","emsp13":"\u2004","emsp14":"\u2005","emsp":"\u2003","ENG":"\u014A","eng":"\u014B","ensp":"\u2002","Eogon":"\u0118","eogon":"\u0119","Eopf":"\uD835\uDD3C","eopf":"\uD835\uDD56","epar":"\u22D5","eparsl":"\u29E3","eplus":"\u2A71","epsi":"\u03B5","Epsilon":"\u0395","epsilon":"\u03B5","epsiv":"\u03F5","eqcirc":"\u2256","eqcolon":"\u2255","eqsim":"\u2242","eqslantgtr":"\u2A96","eqslantless":"\u2A95","Equal":"\u2A75","equals":"=","EqualTilde":"\u2242","equest":"\u225F","Equilibrium":"\u21CC","equiv":"\u2261","equivDD":"\u2A78","eqvparsl":"\u29E5","erarr":"\u2971","erDot":"\u2253","escr":"\u212F","Escr":"\u2130","esdot":"\u2250","Esim":"\u2A73","esim":"\u2242","Eta":"\u0397","eta":"\u03B7","ETH":"\u00D0","eth":"\u00F0","Euml":"\u00CB","euml":"\u00EB","euro":"\u20AC","excl":"!","exist":"\u2203","Exists":"\u2203","expectation":"\u2130","exponentiale":"\u2147","ExponentialE":"\u2147","fallingdotseq":"\u2252","Fcy":"\u0424","fcy":"\u0444","female":"\u2640","ffilig":"\uFB03","fflig":"\uFB00","ffllig":"\uFB04","Ffr":"\uD835\uDD09","ffr":"\uD835\uDD23","filig":"\uFB01","FilledSmallSquare":"\u25FC","FilledVerySmallSquare":"\u25AA","fjlig":"fj","flat":"\u266D","fllig":"\uFB02","fltns":"\u25B1","fnof":"\u0192","Fopf":"\uD835\uDD3D","fopf":"\uD835\uDD57","forall":"\u2200","ForAll":"\u2200","fork":"\u22D4","forkv":"\u2AD9","Fouriertrf":"\u2131","fpartint":"\u2A0D","frac12":"\u00BD","frac13":"\u2153","frac14":"\u00BC","frac15":"\u2155","frac16":"\u2159","frac18":"\u215B","frac23":"\u2154","frac25":"\u2156","frac34":"\u00BE","frac35":"\u2157","frac38":"\u215C","frac45":"\u2158","frac56":"\u215A","frac58":"\u215D","frac78":"\u215E","frasl":"\u2044","frown":"\u2322","fscr":"\uD835\uDCBB","Fscr":"\u2131","gacute":"\u01F5","Gamma":"\u0393","gamma":"\u03B3","Gammad":"\u03DC","gammad":"\u03DD","gap":"\u2A86","Gbreve":"\u011E","gbreve":"\u011F","Gcedil":"\u0122","Gcirc":"\u011C","gcirc":"\u011D","Gcy":"\u0413","gcy":"\u0433","Gdot":"\u0120","gdot":"\u0121","ge":"\u2265","gE":"\u2267","gEl":"\u2A8C","gel":"\u22DB","geq":"\u2265","geqq":"\u2267","geqslant":"\u2A7E","gescc":"\u2AA9","ges":"\u2A7E","gesdot":"\u2A80","gesdoto":"\u2A82","gesdotol":"\u2A84","gesl":"\u22DB\uFE00","gesles":"\u2A94","Gfr":"\uD835\uDD0A","gfr":"\uD835\uDD24","gg":"\u226B","Gg":"\u22D9","ggg":"\u22D9","gimel":"\u2137","GJcy":"\u0403","gjcy":"\u0453","gla":"\u2AA5","gl":"\u2277","glE":"\u2A92","glj":"\u2AA4","gnap":"\u2A8A","gnapprox":"\u2A8A","gne":"\u2A88","gnE":"\u2269","gneq":"\u2A88","gneqq":"\u2269","gnsim":"\u22E7","Gopf":"\uD835\uDD3E","gopf":"\uD835\uDD58","grave":"`","GreaterEqual":"\u2265","GreaterEqualLess":"\u22DB","GreaterFullEqual":"\u2267","GreaterGreater":"\u2AA2","GreaterLess":"\u2277","GreaterSlantEqual":"\u2A7E","GreaterTilde":"\u2273","Gscr":"\uD835\uDCA2","gscr":"\u210A","gsim":"\u2273","gsime":"\u2A8E","gsiml":"\u2A90","gtcc":"\u2AA7","gtcir":"\u2A7A","gt":">","GT":">","Gt":"\u226B","gtdot":"\u22D7","gtlPar":"\u2995","gtquest":"\u2A7C","gtrapprox":"\u2A86","gtrarr":"\u2978","gtrdot":"\u22D7","gtreqless":"\u22DB","gtreqqless":"\u2A8C","gtrless":"\u2277","gtrsim":"\u2273","gvertneqq":"\u2269\uFE00","gvnE":"\u2269\uFE00","Hacek":"\u02C7","hairsp":"\u200A","half":"\u00BD","hamilt":"\u210B","HARDcy":"\u042A","hardcy":"\u044A","harrcir":"\u2948","harr":"\u2194","hArr":"\u21D4","harrw":"\u21AD","Hat":"^","hbar":"\u210F","Hcirc":"\u0124","hcirc":"\u0125","hearts":"\u2665","heartsuit":"\u2665","hellip":"\u2026","hercon":"\u22B9","hfr":"\uD835\uDD25","Hfr":"\u210C","HilbertSpace":"\u210B","hksearow":"\u2925","hkswarow":"\u2926","hoarr":"\u21FF","homtht":"\u223B","hookleftarrow":"\u21A9","hookrightarrow":"\u21AA","hopf":"\uD835\uDD59","Hopf":"\u210D","horbar":"\u2015","HorizontalLine":"\u2500","hscr":"\uD835\uDCBD","Hscr":"\u210B","hslash":"\u210F","Hstrok":"\u0126","hstrok":"\u0127","HumpDownHump":"\u224E","HumpEqual":"\u224F","hybull":"\u2043","hyphen":"\u2010","Iacute":"\u00CD","iacute":"\u00ED","ic":"\u2063","Icirc":"\u00CE","icirc":"\u00EE","Icy":"\u0418","icy":"\u0438","Idot":"\u0130","IEcy":"\u0415","iecy":"\u0435","iexcl":"\u00A1","iff":"\u21D4","ifr":"\uD835\uDD26","Ifr":"\u2111","Igrave":"\u00CC","igrave":"\u00EC","ii":"\u2148","iiiint":"\u2A0C","iiint":"\u222D","iinfin":"\u29DC","iiota":"\u2129","IJlig":"\u0132","ijlig":"\u0133","Imacr":"\u012A","imacr":"\u012B","image":"\u2111","ImaginaryI":"\u2148","imagline":"\u2110","imagpart":"\u2111","imath":"\u0131","Im":"\u2111","imof":"\u22B7","imped":"\u01B5","Implies":"\u21D2","incare":"\u2105","in":"\u2208","infin":"\u221E","infintie":"\u29DD","inodot":"\u0131","intcal":"\u22BA","int":"\u222B","Int":"\u222C","integers":"\u2124","Integral":"\u222B","intercal":"\u22BA","Intersection":"\u22C2","intlarhk":"\u2A17","intprod":"\u2A3C","InvisibleComma":"\u2063","InvisibleTimes":"\u2062","IOcy":"\u0401","iocy":"\u0451","Iogon":"\u012E","iogon":"\u012F","Iopf":"\uD835\uDD40","iopf":"\uD835\uDD5A","Iota":"\u0399","iota":"\u03B9","iprod":"\u2A3C","iquest":"\u00BF","iscr":"\uD835\uDCBE","Iscr":"\u2110","isin":"\u2208","isindot":"\u22F5","isinE":"\u22F9","isins":"\u22F4","isinsv":"\u22F3","isinv":"\u2208","it":"\u2062","Itilde":"\u0128","itilde":"\u0129","Iukcy":"\u0406","iukcy":"\u0456","Iuml":"\u00CF","iuml":"\u00EF","Jcirc":"\u0134","jcirc":"\u0135","Jcy":"\u0419","jcy":"\u0439","Jfr":"\uD835\uDD0D","jfr":"\uD835\uDD27","jmath":"\u0237","Jopf":"\uD835\uDD41","jopf":"\uD835\uDD5B","Jscr":"\uD835\uDCA5","jscr":"\uD835\uDCBF","Jsercy":"\u0408","jsercy":"\u0458","Jukcy":"\u0404","jukcy":"\u0454","Kappa":"\u039A","kappa":"\u03BA","kappav":"\u03F0","Kcedil":"\u0136","kcedil":"\u0137","Kcy":"\u041A","kcy":"\u043A","Kfr":"\uD835\uDD0E","kfr":"\uD835\uDD28","kgreen":"\u0138","KHcy":"\u0425","khcy":"\u0445","KJcy":"\u040C","kjcy":"\u045C","Kopf":"\uD835\uDD42","kopf":"\uD835\uDD5C","Kscr":"\uD835\uDCA6","kscr":"\uD835\uDCC0","lAarr":"\u21DA","Lacute":"\u0139","lacute":"\u013A","laemptyv":"\u29B4","lagran":"\u2112","Lambda":"\u039B","lambda":"\u03BB","lang":"\u27E8","Lang":"\u27EA","langd":"\u2991","langle":"\u27E8","lap":"\u2A85","Laplacetrf":"\u2112","laquo":"\u00AB","larrb":"\u21E4","larrbfs":"\u291F","larr":"\u2190","Larr":"\u219E","lArr":"\u21D0","larrfs":"\u291D","larrhk":"\u21A9","larrlp":"\u21AB","larrpl":"\u2939","larrsim":"\u2973","larrtl":"\u21A2","latail":"\u2919","lAtail":"\u291B","lat":"\u2AAB","late":"\u2AAD","lates":"\u2AAD\uFE00","lbarr":"\u290C","lBarr":"\u290E","lbbrk":"\u2772","lbrace":"{","lbrack":"[","lbrke":"\u298B","lbrksld":"\u298F","lbrkslu":"\u298D","Lcaron":"\u013D","lcaron":"\u013E","Lcedil":"\u013B","lcedil":"\u013C","lceil":"\u2308","lcub":"{","Lcy":"\u041B","lcy":"\u043B","ldca":"\u2936","ldquo":"\u201C","ldquor":"\u201E","ldrdhar":"\u2967","ldrushar":"\u294B","ldsh":"\u21B2","le":"\u2264","lE":"\u2266","LeftAngleBracket":"\u27E8","LeftArrowBar":"\u21E4","leftarrow":"\u2190","LeftArrow":"\u2190","Leftarrow":"\u21D0","LeftArrowRightArrow":"\u21C6","leftarrowtail":"\u21A2","LeftCeiling":"\u2308","LeftDoubleBracket":"\u27E6","LeftDownTeeVector":"\u2961","LeftDownVectorBar":"\u2959","LeftDownVector":"\u21C3","LeftFloor":"\u230A","leftharpoondown":"\u21BD","leftharpoonup":"\u21BC","leftleftarrows":"\u21C7","leftrightarrow":"\u2194","LeftRightArrow":"\u2194","Leftrightarrow":"\u21D4","leftrightarrows":"\u21C6","leftrightharpoons":"\u21CB","leftrightsquigarrow":"\u21AD","LeftRightVector":"\u294E","LeftTeeArrow":"\u21A4","LeftTee":"\u22A3","LeftTeeVector":"\u295A","leftthreetimes":"\u22CB","LeftTriangleBar":"\u29CF","LeftTriangle":"\u22B2","LeftTriangleEqual":"\u22B4","LeftUpDownVector":"\u2951","LeftUpTeeVector":"\u2960","LeftUpVectorBar":"\u2958","LeftUpVector":"\u21BF","LeftVectorBar":"\u2952","LeftVector":"\u21BC","lEg":"\u2A8B","leg":"\u22DA","leq":"\u2264","leqq":"\u2266","leqslant":"\u2A7D","lescc":"\u2AA8","les":"\u2A7D","lesdot":"\u2A7F","lesdoto":"\u2A81","lesdotor":"\u2A83","lesg":"\u22DA\uFE00","lesges":"\u2A93","lessapprox":"\u2A85","lessdot":"\u22D6","lesseqgtr":"\u22DA","lesseqqgtr":"\u2A8B","LessEqualGreater":"\u22DA","LessFullEqual":"\u2266","LessGreater":"\u2276","lessgtr":"\u2276","LessLess":"\u2AA1","lesssim":"\u2272","LessSlantEqual":"\u2A7D","LessTilde":"\u2272","lfisht":"\u297C","lfloor":"\u230A","Lfr":"\uD835\uDD0F","lfr":"\uD835\uDD29","lg":"\u2276","lgE":"\u2A91","lHar":"\u2962","lhard":"\u21BD","lharu":"\u21BC","lharul":"\u296A","lhblk":"\u2584","LJcy":"\u0409","ljcy":"\u0459","llarr":"\u21C7","ll":"\u226A","Ll":"\u22D8","llcorner":"\u231E","Lleftarrow":"\u21DA","llhard":"\u296B","lltri":"\u25FA","Lmidot":"\u013F","lmidot":"\u0140","lmoustache":"\u23B0","lmoust":"\u23B0","lnap":"\u2A89","lnapprox":"\u2A89","lne":"\u2A87","lnE":"\u2268","lneq":"\u2A87","lneqq":"\u2268","lnsim":"\u22E6","loang":"\u27EC","loarr":"\u21FD","lobrk":"\u27E6","longleftarrow":"\u27F5","LongLeftArrow":"\u27F5","Longleftarrow":"\u27F8","longleftrightarrow":"\u27F7","LongLeftRightArrow":"\u27F7","Longleftrightarrow":"\u27FA","longmapsto":"\u27FC","longrightarrow":"\u27F6","LongRightArrow":"\u27F6","Longrightarrow":"\u27F9","looparrowleft":"\u21AB","looparrowright":"\u21AC","lopar":"\u2985","Lopf":"\uD835\uDD43","lopf":"\uD835\uDD5D","loplus":"\u2A2D","lotimes":"\u2A34","lowast":"\u2217","lowbar":"_","LowerLeftArrow":"\u2199","LowerRightArrow":"\u2198","loz":"\u25CA","lozenge":"\u25CA","lozf":"\u29EB","lpar":"(","lparlt":"\u2993","lrarr":"\u21C6","lrcorner":"\u231F","lrhar":"\u21CB","lrhard":"\u296D","lrm":"\u200E","lrtri":"\u22BF","lsaquo":"\u2039","lscr":"\uD835\uDCC1","Lscr":"\u2112","lsh":"\u21B0","Lsh":"\u21B0","lsim":"\u2272","lsime":"\u2A8D","lsimg":"\u2A8F","lsqb":"[","lsquo":"\u2018","lsquor":"\u201A","Lstrok":"\u0141","lstrok":"\u0142","ltcc":"\u2AA6","ltcir":"\u2A79","lt":"<","LT":"<","Lt":"\u226A","ltdot":"\u22D6","lthree":"\u22CB","ltimes":"\u22C9","ltlarr":"\u2976","ltquest":"\u2A7B","ltri":"\u25C3","ltrie":"\u22B4","ltrif":"\u25C2","ltrPar":"\u2996","lurdshar":"\u294A","luruhar":"\u2966","lvertneqq":"\u2268\uFE00","lvnE":"\u2268\uFE00","macr":"\u00AF","male":"\u2642","malt":"\u2720","maltese":"\u2720","Map":"\u2905","map":"\u21A6","mapsto":"\u21A6","mapstodown":"\u21A7","mapstoleft":"\u21A4","mapstoup":"\u21A5","marker":"\u25AE","mcomma":"\u2A29","Mcy":"\u041C","mcy":"\u043C","mdash":"\u2014","mDDot":"\u223A","measuredangle":"\u2221","MediumSpace":"\u205F","Mellintrf":"\u2133","Mfr":"\uD835\uDD10","mfr":"\uD835\uDD2A","mho":"\u2127","micro":"\u00B5","midast":"*","midcir":"\u2AF0","mid":"\u2223","middot":"\u00B7","minusb":"\u229F","minus":"\u2212","minusd":"\u2238","minusdu":"\u2A2A","MinusPlus":"\u2213","mlcp":"\u2ADB","mldr":"\u2026","mnplus":"\u2213","models":"\u22A7","Mopf":"\uD835\uDD44","mopf":"\uD835\uDD5E","mp":"\u2213","mscr":"\uD835\uDCC2","Mscr":"\u2133","mstpos":"\u223E","Mu":"\u039C","mu":"\u03BC","multimap":"\u22B8","mumap":"\u22B8","nabla":"\u2207","Nacute":"\u0143","nacute":"\u0144","nang":"\u2220\u20D2","nap":"\u2249","napE":"\u2A70\u0338","napid":"\u224B\u0338","napos":"\u0149","napprox":"\u2249","natural":"\u266E","naturals":"\u2115","natur":"\u266E","nbsp":"\u00A0","nbump":"\u224E\u0338","nbumpe":"\u224F\u0338","ncap":"\u2A43","Ncaron":"\u0147","ncaron":"\u0148","Ncedil":"\u0145","ncedil":"\u0146","ncong":"\u2247","ncongdot":"\u2A6D\u0338","ncup":"\u2A42","Ncy":"\u041D","ncy":"\u043D","ndash":"\u2013","nearhk":"\u2924","nearr":"\u2197","neArr":"\u21D7","nearrow":"\u2197","ne":"\u2260","nedot":"\u2250\u0338","NegativeMediumSpace":"\u200B","NegativeThickSpace":"\u200B","NegativeThinSpace":"\u200B","NegativeVeryThinSpace":"\u200B","nequiv":"\u2262","nesear":"\u2928","nesim":"\u2242\u0338","NestedGreaterGreater":"\u226B","NestedLessLess":"\u226A","NewLine":"\n","nexist":"\u2204","nexists":"\u2204","Nfr":"\uD835\uDD11","nfr":"\uD835\uDD2B","ngE":"\u2267\u0338","nge":"\u2271","ngeq":"\u2271","ngeqq":"\u2267\u0338","ngeqslant":"\u2A7E\u0338","nges":"\u2A7E\u0338","nGg":"\u22D9\u0338","ngsim":"\u2275","nGt":"\u226B\u20D2","ngt":"\u226F","ngtr":"\u226F","nGtv":"\u226B\u0338","nharr":"\u21AE","nhArr":"\u21CE","nhpar":"\u2AF2","ni":"\u220B","nis":"\u22FC","nisd":"\u22FA","niv":"\u220B","NJcy":"\u040A","njcy":"\u045A","nlarr":"\u219A","nlArr":"\u21CD","nldr":"\u2025","nlE":"\u2266\u0338","nle":"\u2270","nleftarrow":"\u219A","nLeftarrow":"\u21CD","nleftrightarrow":"\u21AE","nLeftrightarrow":"\u21CE","nleq":"\u2270","nleqq":"\u2266\u0338","nleqslant":"\u2A7D\u0338","nles":"\u2A7D\u0338","nless":"\u226E","nLl":"\u22D8\u0338","nlsim":"\u2274","nLt":"\u226A\u20D2","nlt":"\u226E","nltri":"\u22EA","nltrie":"\u22EC","nLtv":"\u226A\u0338","nmid":"\u2224","NoBreak":"\u2060","NonBreakingSpace":"\u00A0","nopf":"\uD835\uDD5F","Nopf":"\u2115","Not":"\u2AEC","not":"\u00AC","NotCongruent":"\u2262","NotCupCap":"\u226D","NotDoubleVerticalBar":"\u2226","NotElement":"\u2209","NotEqual":"\u2260","NotEqualTilde":"\u2242\u0338","NotExists":"\u2204","NotGreater":"\u226F","NotGreaterEqual":"\u2271","NotGreaterFullEqual":"\u2267\u0338","NotGreaterGreater":"\u226B\u0338","NotGreaterLess":"\u2279","NotGreaterSlantEqual":"\u2A7E\u0338","NotGreaterTilde":"\u2275","NotHumpDownHump":"\u224E\u0338","NotHumpEqual":"\u224F\u0338","notin":"\u2209","notindot":"\u22F5\u0338","notinE":"\u22F9\u0338","notinva":"\u2209","notinvb":"\u22F7","notinvc":"\u22F6","NotLeftTriangleBar":"\u29CF\u0338","NotLeftTriangle":"\u22EA","NotLeftTriangleEqual":"\u22EC","NotLess":"\u226E","NotLessEqual":"\u2270","NotLessGreater":"\u2278","NotLessLess":"\u226A\u0338","NotLessSlantEqual":"\u2A7D\u0338","NotLessTilde":"\u2274","NotNestedGreaterGreater":"\u2AA2\u0338","NotNestedLessLess":"\u2AA1\u0338","notni":"\u220C","notniva":"\u220C","notnivb":"\u22FE","notnivc":"\u22FD","NotPrecedes":"\u2280","NotPrecedesEqual":"\u2AAF\u0338","NotPrecedesSlantEqual":"\u22E0","NotReverseElement":"\u220C","NotRightTriangleBar":"\u29D0\u0338","NotRightTriangle":"\u22EB","NotRightTriangleEqual":"\u22ED","NotSquareSubset":"\u228F\u0338","NotSquareSubsetEqual":"\u22E2","NotSquareSuperset":"\u2290\u0338","NotSquareSupersetEqual":"\u22E3","NotSubset":"\u2282\u20D2","NotSubsetEqual":"\u2288","NotSucceeds":"\u2281","NotSucceedsEqual":"\u2AB0\u0338","NotSucceedsSlantEqual":"\u22E1","NotSucceedsTilde":"\u227F\u0338","NotSuperset":"\u2283\u20D2","NotSupersetEqual":"\u2289","NotTilde":"\u2241","NotTildeEqual":"\u2244","NotTildeFullEqual":"\u2247","NotTildeTilde":"\u2249","NotVerticalBar":"\u2224","nparallel":"\u2226","npar":"\u2226","nparsl":"\u2AFD\u20E5","npart":"\u2202\u0338","npolint":"\u2A14","npr":"\u2280","nprcue":"\u22E0","nprec":"\u2280","npreceq":"\u2AAF\u0338","npre":"\u2AAF\u0338","nrarrc":"\u2933\u0338","nrarr":"\u219B","nrArr":"\u21CF","nrarrw":"\u219D\u0338","nrightarrow":"\u219B","nRightarrow":"\u21CF","nrtri":"\u22EB","nrtrie":"\u22ED","nsc":"\u2281","nsccue":"\u22E1","nsce":"\u2AB0\u0338","Nscr":"\uD835\uDCA9","nscr":"\uD835\uDCC3","nshortmid":"\u2224","nshortparallel":"\u2226","nsim":"\u2241","nsime":"\u2244","nsimeq":"\u2244","nsmid":"\u2224","nspar":"\u2226","nsqsube":"\u22E2","nsqsupe":"\u22E3","nsub":"\u2284","nsubE":"\u2AC5\u0338","nsube":"\u2288","nsubset":"\u2282\u20D2","nsubseteq":"\u2288","nsubseteqq":"\u2AC5\u0338","nsucc":"\u2281","nsucceq":"\u2AB0\u0338","nsup":"\u2285","nsupE":"\u2AC6\u0338","nsupe":"\u2289","nsupset":"\u2283\u20D2","nsupseteq":"\u2289","nsupseteqq":"\u2AC6\u0338","ntgl":"\u2279","Ntilde":"\u00D1","ntilde":"\u00F1","ntlg":"\u2278","ntriangleleft":"\u22EA","ntrianglelefteq":"\u22EC","ntriangleright":"\u22EB","ntrianglerighteq":"\u22ED","Nu":"\u039D","nu":"\u03BD","num":"#","numero":"\u2116","numsp":"\u2007","nvap":"\u224D\u20D2","nvdash":"\u22AC","nvDash":"\u22AD","nVdash":"\u22AE","nVDash":"\u22AF","nvge":"\u2265\u20D2","nvgt":">\u20D2","nvHarr":"\u2904","nvinfin":"\u29DE","nvlArr":"\u2902","nvle":"\u2264\u20D2","nvlt":"<\u20D2","nvltrie":"\u22B4\u20D2","nvrArr":"\u2903","nvrtrie":"\u22B5\u20D2","nvsim":"\u223C\u20D2","nwarhk":"\u2923","nwarr":"\u2196","nwArr":"\u21D6","nwarrow":"\u2196","nwnear":"\u2927","Oacute":"\u00D3","oacute":"\u00F3","oast":"\u229B","Ocirc":"\u00D4","ocirc":"\u00F4","ocir":"\u229A","Ocy":"\u041E","ocy":"\u043E","odash":"\u229D","Odblac":"\u0150","odblac":"\u0151","odiv":"\u2A38","odot":"\u2299","odsold":"\u29BC","OElig":"\u0152","oelig":"\u0153","ofcir":"\u29BF","Ofr":"\uD835\uDD12","ofr":"\uD835\uDD2C","ogon":"\u02DB","Ograve":"\u00D2","ograve":"\u00F2","ogt":"\u29C1","ohbar":"\u29B5","ohm":"\u03A9","oint":"\u222E","olarr":"\u21BA","olcir":"\u29BE","olcross":"\u29BB","oline":"\u203E","olt":"\u29C0","Omacr":"\u014C","omacr":"\u014D","Omega":"\u03A9","omega":"\u03C9","Omicron":"\u039F","omicron":"\u03BF","omid":"\u29B6","ominus":"\u2296","Oopf":"\uD835\uDD46","oopf":"\uD835\uDD60","opar":"\u29B7","OpenCurlyDoubleQuote":"\u201C","OpenCurlyQuote":"\u2018","operp":"\u29B9","oplus":"\u2295","orarr":"\u21BB","Or":"\u2A54","or":"\u2228","ord":"\u2A5D","order":"\u2134","orderof":"\u2134","ordf":"\u00AA","ordm":"\u00BA","origof":"\u22B6","oror":"\u2A56","orslope":"\u2A57","orv":"\u2A5B","oS":"\u24C8","Oscr":"\uD835\uDCAA","oscr":"\u2134","Oslash":"\u00D8","oslash":"\u00F8","osol":"\u2298","Otilde":"\u00D5","otilde":"\u00F5","otimesas":"\u2A36","Otimes":"\u2A37","otimes":"\u2297","Ouml":"\u00D6","ouml":"\u00F6","ovbar":"\u233D","OverBar":"\u203E","OverBrace":"\u23DE","OverBracket":"\u23B4","OverParenthesis":"\u23DC","para":"\u00B6","parallel":"\u2225","par":"\u2225","parsim":"\u2AF3","parsl":"\u2AFD","part":"\u2202","PartialD":"\u2202","Pcy":"\u041F","pcy":"\u043F","percnt":"%","period":".","permil":"\u2030","perp":"\u22A5","pertenk":"\u2031","Pfr":"\uD835\uDD13","pfr":"\uD835\uDD2D","Phi":"\u03A6","phi":"\u03C6","phiv":"\u03D5","phmmat":"\u2133","phone":"\u260E","Pi":"\u03A0","pi":"\u03C0","pitchfork":"\u22D4","piv":"\u03D6","planck":"\u210F","planckh":"\u210E","plankv":"\u210F","plusacir":"\u2A23","plusb":"\u229E","pluscir":"\u2A22","plus":"+","plusdo":"\u2214","plusdu":"\u2A25","pluse":"\u2A72","PlusMinus":"\u00B1","plusmn":"\u00B1","plussim":"\u2A26","plustwo":"\u2A27","pm":"\u00B1","Poincareplane":"\u210C","pointint":"\u2A15","popf":"\uD835\uDD61","Popf":"\u2119","pound":"\u00A3","prap":"\u2AB7","Pr":"\u2ABB","pr":"\u227A","prcue":"\u227C","precapprox":"\u2AB7","prec":"\u227A","preccurlyeq":"\u227C","Precedes":"\u227A","PrecedesEqual":"\u2AAF","PrecedesSlantEqual":"\u227C","PrecedesTilde":"\u227E","preceq":"\u2AAF","precnapprox":"\u2AB9","precneqq":"\u2AB5","precnsim":"\u22E8","pre":"\u2AAF","prE":"\u2AB3","precsim":"\u227E","prime":"\u2032","Prime":"\u2033","primes":"\u2119","prnap":"\u2AB9","prnE":"\u2AB5","prnsim":"\u22E8","prod":"\u220F","Product":"\u220F","profalar":"\u232E","profline":"\u2312","profsurf":"\u2313","prop":"\u221D","Proportional":"\u221D","Proportion":"\u2237","propto":"\u221D","prsim":"\u227E","prurel":"\u22B0","Pscr":"\uD835\uDCAB","pscr":"\uD835\uDCC5","Psi":"\u03A8","psi":"\u03C8","puncsp":"\u2008","Qfr":"\uD835\uDD14","qfr":"\uD835\uDD2E","qint":"\u2A0C","qopf":"\uD835\uDD62","Qopf":"\u211A","qprime":"\u2057","Qscr":"\uD835\uDCAC","qscr":"\uD835\uDCC6","quaternions":"\u210D","quatint":"\u2A16","quest":"?","questeq":"\u225F","quot":"\"","QUOT":"\"","rAarr":"\u21DB","race":"\u223D\u0331","Racute":"\u0154","racute":"\u0155","radic":"\u221A","raemptyv":"\u29B3","rang":"\u27E9","Rang":"\u27EB","rangd":"\u2992","range":"\u29A5","rangle":"\u27E9","raquo":"\u00BB","rarrap":"\u2975","rarrb":"\u21E5","rarrbfs":"\u2920","rarrc":"\u2933","rarr":"\u2192","Rarr":"\u21A0","rArr":"\u21D2","rarrfs":"\u291E","rarrhk":"\u21AA","rarrlp":"\u21AC","rarrpl":"\u2945","rarrsim":"\u2974","Rarrtl":"\u2916","rarrtl":"\u21A3","rarrw":"\u219D","ratail":"\u291A","rAtail":"\u291C","ratio":"\u2236","rationals":"\u211A","rbarr":"\u290D","rBarr":"\u290F","RBarr":"\u2910","rbbrk":"\u2773","rbrace":"}","rbrack":"]","rbrke":"\u298C","rbrksld":"\u298E","rbrkslu":"\u2990","Rcaron":"\u0158","rcaron":"\u0159","Rcedil":"\u0156","rcedil":"\u0157","rceil":"\u2309","rcub":"}","Rcy":"\u0420","rcy":"\u0440","rdca":"\u2937","rdldhar":"\u2969","rdquo":"\u201D","rdquor":"\u201D","rdsh":"\u21B3","real":"\u211C","realine":"\u211B","realpart":"\u211C","reals":"\u211D","Re":"\u211C","rect":"\u25AD","reg":"\u00AE","REG":"\u00AE","ReverseElement":"\u220B","ReverseEquilibrium":"\u21CB","ReverseUpEquilibrium":"\u296F","rfisht":"\u297D","rfloor":"\u230B","rfr":"\uD835\uDD2F","Rfr":"\u211C","rHar":"\u2964","rhard":"\u21C1","rharu":"\u21C0","rharul":"\u296C","Rho":"\u03A1","rho":"\u03C1","rhov":"\u03F1","RightAngleBracket":"\u27E9","RightArrowBar":"\u21E5","rightarrow":"\u2192","RightArrow":"\u2192","Rightarrow":"\u21D2","RightArrowLeftArrow":"\u21C4","rightarrowtail":"\u21A3","RightCeiling":"\u2309","RightDoubleBracket":"\u27E7","RightDownTeeVector":"\u295D","RightDownVectorBar":"\u2955","RightDownVector":"\u21C2","RightFloor":"\u230B","rightharpoondown":"\u21C1","rightharpoonup":"\u21C0","rightleftarrows":"\u21C4","rightleftharpoons":"\u21CC","rightrightarrows":"\u21C9","rightsquigarrow":"\u219D","RightTeeArrow":"\u21A6","RightTee":"\u22A2","RightTeeVector":"\u295B","rightthreetimes":"\u22CC","RightTriangleBar":"\u29D0","RightTriangle":"\u22B3","RightTriangleEqual":"\u22B5","RightUpDownVector":"\u294F","RightUpTeeVector":"\u295C","RightUpVectorBar":"\u2954","RightUpVector":"\u21BE","RightVectorBar":"\u2953","RightVector":"\u21C0","ring":"\u02DA","risingdotseq":"\u2253","rlarr":"\u21C4","rlhar":"\u21CC","rlm":"\u200F","rmoustache":"\u23B1","rmoust":"\u23B1","rnmid":"\u2AEE","roang":"\u27ED","roarr":"\u21FE","robrk":"\u27E7","ropar":"\u2986","ropf":"\uD835\uDD63","Ropf":"\u211D","roplus":"\u2A2E","rotimes":"\u2A35","RoundImplies":"\u2970","rpar":")","rpargt":"\u2994","rppolint":"\u2A12","rrarr":"\u21C9","Rrightarrow":"\u21DB","rsaquo":"\u203A","rscr":"\uD835\uDCC7","Rscr":"\u211B","rsh":"\u21B1","Rsh":"\u21B1","rsqb":"]","rsquo":"\u2019","rsquor":"\u2019","rthree":"\u22CC","rtimes":"\u22CA","rtri":"\u25B9","rtrie":"\u22B5","rtrif":"\u25B8","rtriltri":"\u29CE","RuleDelayed":"\u29F4","ruluhar":"\u2968","rx":"\u211E","Sacute":"\u015A","sacute":"\u015B","sbquo":"\u201A","scap":"\u2AB8","Scaron":"\u0160","scaron":"\u0161","Sc":"\u2ABC","sc":"\u227B","sccue":"\u227D","sce":"\u2AB0","scE":"\u2AB4","Scedil":"\u015E","scedil":"\u015F","Scirc":"\u015C","scirc":"\u015D","scnap":"\u2ABA","scnE":"\u2AB6","scnsim":"\u22E9","scpolint":"\u2A13","scsim":"\u227F","Scy":"\u0421","scy":"\u0441","sdotb":"\u22A1","sdot":"\u22C5","sdote":"\u2A66","searhk":"\u2925","searr":"\u2198","seArr":"\u21D8","searrow":"\u2198","sect":"\u00A7","semi":";","seswar":"\u2929","setminus":"\u2216","setmn":"\u2216","sext":"\u2736","Sfr":"\uD835\uDD16","sfr":"\uD835\uDD30","sfrown":"\u2322","sharp":"\u266F","SHCHcy":"\u0429","shchcy":"\u0449","SHcy":"\u0428","shcy":"\u0448","ShortDownArrow":"\u2193","ShortLeftArrow":"\u2190","shortmid":"\u2223","shortparallel":"\u2225","ShortRightArrow":"\u2192","ShortUpArrow":"\u2191","shy":"\u00AD","Sigma":"\u03A3","sigma":"\u03C3","sigmaf":"\u03C2","sigmav":"\u03C2","sim":"\u223C","simdot":"\u2A6A","sime":"\u2243","simeq":"\u2243","simg":"\u2A9E","simgE":"\u2AA0","siml":"\u2A9D","simlE":"\u2A9F","simne":"\u2246","simplus":"\u2A24","simrarr":"\u2972","slarr":"\u2190","SmallCircle":"\u2218","smallsetminus":"\u2216","smashp":"\u2A33","smeparsl":"\u29E4","smid":"\u2223","smile":"\u2323","smt":"\u2AAA","smte":"\u2AAC","smtes":"\u2AAC\uFE00","SOFTcy":"\u042C","softcy":"\u044C","solbar":"\u233F","solb":"\u29C4","sol":"/","Sopf":"\uD835\uDD4A","sopf":"\uD835\uDD64","spades":"\u2660","spadesuit":"\u2660","spar":"\u2225","sqcap":"\u2293","sqcaps":"\u2293\uFE00","sqcup":"\u2294","sqcups":"\u2294\uFE00","Sqrt":"\u221A","sqsub":"\u228F","sqsube":"\u2291","sqsubset":"\u228F","sqsubseteq":"\u2291","sqsup":"\u2290","sqsupe":"\u2292","sqsupset":"\u2290","sqsupseteq":"\u2292","square":"\u25A1","Square":"\u25A1","SquareIntersection":"\u2293","SquareSubset":"\u228F","SquareSubsetEqual":"\u2291","SquareSuperset":"\u2290","SquareSupersetEqual":"\u2292","SquareUnion":"\u2294","squarf":"\u25AA","squ":"\u25A1","squf":"\u25AA","srarr":"\u2192","Sscr":"\uD835\uDCAE","sscr":"\uD835\uDCC8","ssetmn":"\u2216","ssmile":"\u2323","sstarf":"\u22C6","Star":"\u22C6","star":"\u2606","starf":"\u2605","straightepsilon":"\u03F5","straightphi":"\u03D5","strns":"\u00AF","sub":"\u2282","Sub":"\u22D0","subdot":"\u2ABD","subE":"\u2AC5","sube":"\u2286","subedot":"\u2AC3","submult":"\u2AC1","subnE":"\u2ACB","subne":"\u228A","subplus":"\u2ABF","subrarr":"\u2979","subset":"\u2282","Subset":"\u22D0","subseteq":"\u2286","subseteqq":"\u2AC5","SubsetEqual":"\u2286","subsetneq":"\u228A","subsetneqq":"\u2ACB","subsim":"\u2AC7","subsub":"\u2AD5","subsup":"\u2AD3","succapprox":"\u2AB8","succ":"\u227B","succcurlyeq":"\u227D","Succeeds":"\u227B","SucceedsEqual":"\u2AB0","SucceedsSlantEqual":"\u227D","SucceedsTilde":"\u227F","succeq":"\u2AB0","succnapprox":"\u2ABA","succneqq":"\u2AB6","succnsim":"\u22E9","succsim":"\u227F","SuchThat":"\u220B","sum":"\u2211","Sum":"\u2211","sung":"\u266A","sup1":"\u00B9","sup2":"\u00B2","sup3":"\u00B3","sup":"\u2283","Sup":"\u22D1","supdot":"\u2ABE","supdsub":"\u2AD8","supE":"\u2AC6","supe":"\u2287","supedot":"\u2AC4","Superset":"\u2283","SupersetEqual":"\u2287","suphsol":"\u27C9","suphsub":"\u2AD7","suplarr":"\u297B","supmult":"\u2AC2","supnE":"\u2ACC","supne":"\u228B","supplus":"\u2AC0","supset":"\u2283","Supset":"\u22D1","supseteq":"\u2287","supseteqq":"\u2AC6","supsetneq":"\u228B","supsetneqq":"\u2ACC","supsim":"\u2AC8","supsub":"\u2AD4","supsup":"\u2AD6","swarhk":"\u2926","swarr":"\u2199","swArr":"\u21D9","swarrow":"\u2199","swnwar":"\u292A","szlig":"\u00DF","Tab":"\t","target":"\u2316","Tau":"\u03A4","tau":"\u03C4","tbrk":"\u23B4","Tcaron":"\u0164","tcaron":"\u0165","Tcedil":"\u0162","tcedil":"\u0163","Tcy":"\u0422","tcy":"\u0442","tdot":"\u20DB","telrec":"\u2315","Tfr":"\uD835\uDD17","tfr":"\uD835\uDD31","there4":"\u2234","therefore":"\u2234","Therefore":"\u2234","Theta":"\u0398","theta":"\u03B8","thetasym":"\u03D1","thetav":"\u03D1","thickapprox":"\u2248","thicksim":"\u223C","ThickSpace":"\u205F\u200A","ThinSpace":"\u2009","thinsp":"\u2009","thkap":"\u2248","thksim":"\u223C","THORN":"\u00DE","thorn":"\u00FE","tilde":"\u02DC","Tilde":"\u223C","TildeEqual":"\u2243","TildeFullEqual":"\u2245","TildeTilde":"\u2248","timesbar":"\u2A31","timesb":"\u22A0","times":"\u00D7","timesd":"\u2A30","tint":"\u222D","toea":"\u2928","topbot":"\u2336","topcir":"\u2AF1","top":"\u22A4","Topf":"\uD835\uDD4B","topf":"\uD835\uDD65","topfork":"\u2ADA","tosa":"\u2929","tprime":"\u2034","trade":"\u2122","TRADE":"\u2122","triangle":"\u25B5","triangledown":"\u25BF","triangleleft":"\u25C3","trianglelefteq":"\u22B4","triangleq":"\u225C","triangleright":"\u25B9","trianglerighteq":"\u22B5","tridot":"\u25EC","trie":"\u225C","triminus":"\u2A3A","TripleDot":"\u20DB","triplus":"\u2A39","trisb":"\u29CD","tritime":"\u2A3B","trpezium":"\u23E2","Tscr":"\uD835\uDCAF","tscr":"\uD835\uDCC9","TScy":"\u0426","tscy":"\u0446","TSHcy":"\u040B","tshcy":"\u045B","Tstrok":"\u0166","tstrok":"\u0167","twixt":"\u226C","twoheadleftarrow":"\u219E","twoheadrightarrow":"\u21A0","Uacute":"\u00DA","uacute":"\u00FA","uarr":"\u2191","Uarr":"\u219F","uArr":"\u21D1","Uarrocir":"\u2949","Ubrcy":"\u040E","ubrcy":"\u045E","Ubreve":"\u016C","ubreve":"\u016D","Ucirc":"\u00DB","ucirc":"\u00FB","Ucy":"\u0423","ucy":"\u0443","udarr":"\u21C5","Udblac":"\u0170","udblac":"\u0171","udhar":"\u296E","ufisht":"\u297E","Ufr":"\uD835\uDD18","ufr":"\uD835\uDD32","Ugrave":"\u00D9","ugrave":"\u00F9","uHar":"\u2963","uharl":"\u21BF","uharr":"\u21BE","uhblk":"\u2580","ulcorn":"\u231C","ulcorner":"\u231C","ulcrop":"\u230F","ultri":"\u25F8","Umacr":"\u016A","umacr":"\u016B","uml":"\u00A8","UnderBar":"_","UnderBrace":"\u23DF","UnderBracket":"\u23B5","UnderParenthesis":"\u23DD","Union":"\u22C3","UnionPlus":"\u228E","Uogon":"\u0172","uogon":"\u0173","Uopf":"\uD835\uDD4C","uopf":"\uD835\uDD66","UpArrowBar":"\u2912","uparrow":"\u2191","UpArrow":"\u2191","Uparrow":"\u21D1","UpArrowDownArrow":"\u21C5","updownarrow":"\u2195","UpDownArrow":"\u2195","Updownarrow":"\u21D5","UpEquilibrium":"\u296E","upharpoonleft":"\u21BF","upharpoonright":"\u21BE","uplus":"\u228E","UpperLeftArrow":"\u2196","UpperRightArrow":"\u2197","upsi":"\u03C5","Upsi":"\u03D2","upsih":"\u03D2","Upsilon":"\u03A5","upsilon":"\u03C5","UpTeeArrow":"\u21A5","UpTee":"\u22A5","upuparrows":"\u21C8","urcorn":"\u231D","urcorner":"\u231D","urcrop":"\u230E","Uring":"\u016E","uring":"\u016F","urtri":"\u25F9","Uscr":"\uD835\uDCB0","uscr":"\uD835\uDCCA","utdot":"\u22F0","Utilde":"\u0168","utilde":"\u0169","utri":"\u25B5","utrif":"\u25B4","uuarr":"\u21C8","Uuml":"\u00DC","uuml":"\u00FC","uwangle":"\u29A7","vangrt":"\u299C","varepsilon":"\u03F5","varkappa":"\u03F0","varnothing":"\u2205","varphi":"\u03D5","varpi":"\u03D6","varpropto":"\u221D","varr":"\u2195","vArr":"\u21D5","varrho":"\u03F1","varsigma":"\u03C2","varsubsetneq":"\u228A\uFE00","varsubsetneqq":"\u2ACB\uFE00","varsupsetneq":"\u228B\uFE00","varsupsetneqq":"\u2ACC\uFE00","vartheta":"\u03D1","vartriangleleft":"\u22B2","vartriangleright":"\u22B3","vBar":"\u2AE8","Vbar":"\u2AEB","vBarv":"\u2AE9","Vcy":"\u0412","vcy":"\u0432","vdash":"\u22A2","vDash":"\u22A8","Vdash":"\u22A9","VDash":"\u22AB","Vdashl":"\u2AE6","veebar":"\u22BB","vee":"\u2228","Vee":"\u22C1","veeeq":"\u225A","vellip":"\u22EE","verbar":"|","Verbar":"\u2016","vert":"|","Vert":"\u2016","VerticalBar":"\u2223","VerticalLine":"|","VerticalSeparator":"\u2758","VerticalTilde":"\u2240","VeryThinSpace":"\u200A","Vfr":"\uD835\uDD19","vfr":"\uD835\uDD33","vltri":"\u22B2","vnsub":"\u2282\u20D2","vnsup":"\u2283\u20D2","Vopf":"\uD835\uDD4D","vopf":"\uD835\uDD67","vprop":"\u221D","vrtri":"\u22B3","Vscr":"\uD835\uDCB1","vscr":"\uD835\uDCCB","vsubnE":"\u2ACB\uFE00","vsubne":"\u228A\uFE00","vsupnE":"\u2ACC\uFE00","vsupne":"\u228B\uFE00","Vvdash":"\u22AA","vzigzag":"\u299A","Wcirc":"\u0174","wcirc":"\u0175","wedbar":"\u2A5F","wedge":"\u2227","Wedge":"\u22C0","wedgeq":"\u2259","weierp":"\u2118","Wfr":"\uD835\uDD1A","wfr":"\uD835\uDD34","Wopf":"\uD835\uDD4E","wopf":"\uD835\uDD68","wp":"\u2118","wr":"\u2240","wreath":"\u2240","Wscr":"\uD835\uDCB2","wscr":"\uD835\uDCCC","xcap":"\u22C2","xcirc":"\u25EF","xcup":"\u22C3","xdtri":"\u25BD","Xfr":"\uD835\uDD1B","xfr":"\uD835\uDD35","xharr":"\u27F7","xhArr":"\u27FA","Xi":"\u039E","xi":"\u03BE","xlarr":"\u27F5","xlArr":"\u27F8","xmap":"\u27FC","xnis":"\u22FB","xodot":"\u2A00","Xopf":"\uD835\uDD4F","xopf":"\uD835\uDD69","xoplus":"\u2A01","xotime":"\u2A02","xrarr":"\u27F6","xrArr":"\u27F9","Xscr":"\uD835\uDCB3","xscr":"\uD835\uDCCD","xsqcup":"\u2A06","xuplus":"\u2A04","xutri":"\u25B3","xvee":"\u22C1","xwedge":"\u22C0","Yacute":"\u00DD","yacute":"\u00FD","YAcy":"\u042F","yacy":"\u044F","Ycirc":"\u0176","ycirc":"\u0177","Ycy":"\u042B","ycy":"\u044B","yen":"\u00A5","Yfr":"\uD835\uDD1C","yfr":"\uD835\uDD36","YIcy":"\u0407","yicy":"\u0457","Yopf":"\uD835\uDD50","yopf":"\uD835\uDD6A","Yscr":"\uD835\uDCB4","yscr":"\uD835\uDCCE","YUcy":"\u042E","yucy":"\u044E","yuml":"\u00FF","Yuml":"\u0178","Zacute":"\u0179","zacute":"\u017A","Zcaron":"\u017D","zcaron":"\u017E","Zcy":"\u0417","zcy":"\u0437","Zdot":"\u017B","zdot":"\u017C","zeetrf":"\u2128","ZeroWidthSpace":"\u200B","Zeta":"\u0396","zeta":"\u03B6","zfr":"\uD835\uDD37","Zfr":"\u2128","ZHcy":"\u0416","zhcy":"\u0436","zigrarr":"\u21DD","zopf":"\uD835\uDD6B","Zopf":"\u2124","Zscr":"\uD835\uDCB5","zscr":"\uD835\uDCCF","zwj":"\u200D","zwnj":"\u200C"}
-},{}],357:[function(require,module,exports){
+},{}],290:[function(require,module,exports){
 module.exports={"Aacute":"\u00C1","aacute":"\u00E1","Acirc":"\u00C2","acirc":"\u00E2","acute":"\u00B4","AElig":"\u00C6","aelig":"\u00E6","Agrave":"\u00C0","agrave":"\u00E0","amp":"&","AMP":"&","Aring":"\u00C5","aring":"\u00E5","Atilde":"\u00C3","atilde":"\u00E3","Auml":"\u00C4","auml":"\u00E4","brvbar":"\u00A6","Ccedil":"\u00C7","ccedil":"\u00E7","cedil":"\u00B8","cent":"\u00A2","copy":"\u00A9","COPY":"\u00A9","curren":"\u00A4","deg":"\u00B0","divide":"\u00F7","Eacute":"\u00C9","eacute":"\u00E9","Ecirc":"\u00CA","ecirc":"\u00EA","Egrave":"\u00C8","egrave":"\u00E8","ETH":"\u00D0","eth":"\u00F0","Euml":"\u00CB","euml":"\u00EB","frac12":"\u00BD","frac14":"\u00BC","frac34":"\u00BE","gt":">","GT":">","Iacute":"\u00CD","iacute":"\u00ED","Icirc":"\u00CE","icirc":"\u00EE","iexcl":"\u00A1","Igrave":"\u00CC","igrave":"\u00EC","iquest":"\u00BF","Iuml":"\u00CF","iuml":"\u00EF","laquo":"\u00AB","lt":"<","LT":"<","macr":"\u00AF","micro":"\u00B5","middot":"\u00B7","nbsp":"\u00A0","not":"\u00AC","Ntilde":"\u00D1","ntilde":"\u00F1","Oacute":"\u00D3","oacute":"\u00F3","Ocirc":"\u00D4","ocirc":"\u00F4","Ograve":"\u00D2","ograve":"\u00F2","ordf":"\u00AA","ordm":"\u00BA","Oslash":"\u00D8","oslash":"\u00F8","Otilde":"\u00D5","otilde":"\u00F5","Ouml":"\u00D6","ouml":"\u00F6","para":"\u00B6","plusmn":"\u00B1","pound":"\u00A3","quot":"\"","QUOT":"\"","raquo":"\u00BB","reg":"\u00AE","REG":"\u00AE","sect":"\u00A7","shy":"\u00AD","sup1":"\u00B9","sup2":"\u00B2","sup3":"\u00B3","szlig":"\u00DF","THORN":"\u00DE","thorn":"\u00FE","times":"\u00D7","Uacute":"\u00DA","uacute":"\u00FA","Ucirc":"\u00DB","ucirc":"\u00FB","Ugrave":"\u00D9","ugrave":"\u00F9","uml":"\u00A8","Uuml":"\u00DC","uuml":"\u00FC","Yacute":"\u00DD","yacute":"\u00FD","yen":"\u00A5","yuml":"\u00FF"}
-},{}],358:[function(require,module,exports){
+},{}],291:[function(require,module,exports){
 module.exports={"amp":"&","apos":"'","gt":">","lt":"<","quot":"\""}
 
-},{}],359:[function(require,module,exports){
+},{}],292:[function(require,module,exports){
 (function (Buffer){
 'use strict'
 var Transform = require('stream').Transform
@@ -49597,9 +37765,9 @@ HashBase.prototype._digest = function () {
 module.exports = HashBase
 
 }).call(this,require("buffer").Buffer)
-},{"buffer":188,"inherits":360,"stream":264}],360:[function(require,module,exports){
-arguments[4][101][0].apply(exports,arguments)
-},{"dup":101}],361:[function(require,module,exports){
+},{"buffer":134,"inherits":293,"stream":205}],293:[function(require,module,exports){
+arguments[4][54][0].apply(exports,arguments)
+},{"dup":54}],294:[function(require,module,exports){
 (function(){
 
   function hasProp(obj, path) {
@@ -49658,7 +37826,7 @@ arguments[4][101][0].apply(exports,arguments)
 
 })();
 
-},{}],362:[function(require,module,exports){
+},{}],295:[function(require,module,exports){
 module.exports = CollectingHandler;
 
 function CollectingHandler(cbs){
@@ -49715,7 +37883,7 @@ CollectingHandler.prototype.restart = function(){
 	}
 };
 
-},{"./":369}],363:[function(require,module,exports){
+},{"./":302}],296:[function(require,module,exports){
 var index = require("./index.js"),
     DomHandler = index.DomHandler,
     DomUtils = index.DomUtils;
@@ -49812,7 +37980,7 @@ FeedHandler.prototype.onend = function(){
 
 module.exports = FeedHandler;
 
-},{"./index.js":369,"inherits":370}],364:[function(require,module,exports){
+},{"./index.js":302,"inherits":303}],297:[function(require,module,exports){
 var Tokenizer = require("./Tokenizer.js");
 
 /*
@@ -50167,7 +38335,7 @@ Parser.prototype.done = Parser.prototype.end;
 
 module.exports = Parser;
 
-},{"./Tokenizer.js":367,"events":209,"inherits":370}],365:[function(require,module,exports){
+},{"./Tokenizer.js":300,"events":154,"inherits":303}],298:[function(require,module,exports){
 module.exports = ProxyHandler;
 
 function ProxyHandler(cbs){
@@ -50195,7 +38363,7 @@ Object.keys(EVENTS).forEach(function(name){
 		throw Error("wrong number of arguments");
 	}
 });
-},{"./":369}],366:[function(require,module,exports){
+},{"./":302}],299:[function(require,module,exports){
 module.exports = Stream;
 
 var Parser = require("./WritableStream.js");
@@ -50231,7 +38399,7 @@ Object.keys(EVENTS).forEach(function(name){
 		throw Error("wrong number of arguments!");
 	}
 });
-},{"../":369,"./WritableStream.js":368,"inherits":370}],367:[function(require,module,exports){
+},{"../":302,"./WritableStream.js":301,"inherits":303}],300:[function(require,module,exports){
 module.exports = Tokenizer;
 
 var decodeCodePoint = require("entities/lib/decode_codepoint.js"),
@@ -51139,7 +39307,7 @@ Tokenizer.prototype._emitPartial = function(value){
 	}
 };
 
-},{"entities/lib/decode_codepoint.js":353,"entities/maps/entities.json":356,"entities/maps/legacy.json":357,"entities/maps/xml.json":358}],368:[function(require,module,exports){
+},{"entities/lib/decode_codepoint.js":286,"entities/maps/entities.json":289,"entities/maps/legacy.json":290,"entities/maps/xml.json":291}],301:[function(require,module,exports){
 module.exports = Stream;
 
 var Parser = require("./Parser.js"),
@@ -51165,7 +39333,7 @@ WritableStream.prototype._write = function(chunk, encoding, cb){
 	this._parser.write(chunk);
 	cb();
 };
-},{"./Parser.js":364,"buffer":188,"inherits":370,"readable-stream":160,"stream":264,"string_decoder":269}],369:[function(require,module,exports){
+},{"./Parser.js":297,"buffer":134,"inherits":303,"readable-stream":106,"stream":205,"string_decoder":206}],302:[function(require,module,exports){
 var Parser = require("./Parser.js"),
     DomHandler = require("domhandler");
 
@@ -51235,9 +39403,9 @@ module.exports = {
 	}
 };
 
-},{"./CollectingHandler.js":362,"./FeedHandler.js":363,"./Parser.js":364,"./ProxyHandler.js":365,"./Stream.js":366,"./Tokenizer.js":367,"./WritableStream.js":368,"domelementtype":301,"domhandler":302,"domutils":305}],370:[function(require,module,exports){
-arguments[4][101][0].apply(exports,arguments)
-},{"dup":101}],371:[function(require,module,exports){
+},{"./CollectingHandler.js":295,"./FeedHandler.js":296,"./Parser.js":297,"./ProxyHandler.js":298,"./Stream.js":299,"./Tokenizer.js":300,"./WritableStream.js":301,"domelementtype":234,"domhandler":235,"domutils":238}],303:[function(require,module,exports){
+arguments[4][54][0].apply(exports,arguments)
+},{"dup":54}],304:[function(require,module,exports){
 // the whatwg-fetch polyfill installs the fetch() function
 // on the global object (window or self)
 //
@@ -51245,7 +39413,7 @@ arguments[4][101][0].apply(exports,arguments)
 require('whatwg-fetch');
 module.exports = self.fetch.bind(self);
 
-},{"whatwg-fetch":372}],372:[function(require,module,exports){
+},{"whatwg-fetch":305}],305:[function(require,module,exports){
 (function(self) {
   'use strict';
 
@@ -51708,13 +39876,7 @@ module.exports = self.fetch.bind(self);
   self.fetch.polyfill = true
 })(typeof self !== 'undefined' ? self : this);
 
-},{}],373:[function(require,module,exports){
-arguments[4][79][0].apply(exports,arguments)
-},{"./lib/parse":374,"./lib/stringify":375,"dup":79}],374:[function(require,module,exports){
-arguments[4][80][0].apply(exports,arguments)
-},{"dup":80}],375:[function(require,module,exports){
-arguments[4][81][0].apply(exports,arguments)
-},{"dup":81}],376:[function(require,module,exports){
+},{}],306:[function(require,module,exports){
 (function (Buffer){
 'use strict';
 
@@ -51852,7 +40014,7 @@ function joseToDer(signature, alg) {
     return signature;
 }
 }).call(this,require("buffer").Buffer)
-},{"asn1.js":384,"buffer":188}],377:[function(require,module,exports){
+},{"asn1.js":314,"buffer":134}],307:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -51868,7 +40030,7 @@ var cryptoClients = {
 
 exports.SECP256K1Client = _secp256k.SECP256K1Client;
 exports.cryptoClients = cryptoClients;
-},{"./secp256k1":378}],378:[function(require,module,exports){
+},{"./secp256k1":308}],308:[function(require,module,exports){
 (function (Buffer){
 'use strict';
 
@@ -52003,7 +40165,7 @@ SECP256K1Client.keyEncoder = new _keyEncoder2.default({
   curve: SECP256K1Client.ec
 });
 }).call(this,require("buffer").Buffer)
-},{"../errors":380,"./ecdsaSigFormatter":376,"buffer":188,"crypto":198,"elliptic":317,"key-encoder":416,"validator":488}],379:[function(require,module,exports){
+},{"../errors":310,"./ecdsaSigFormatter":306,"buffer":134,"crypto":143,"elliptic":250,"key-encoder":346,"validator":407}],309:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -52038,7 +40200,7 @@ function decodeToken(token) {
     signature: signature
   };
 }
-},{"./errors":380,"base64url":400}],380:[function(require,module,exports){
+},{"./errors":310,"base64url":330}],310:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -52082,7 +40244,7 @@ var InvalidTokenError = exports.InvalidTokenError = function (_Error2) {
 
   return InvalidTokenError;
 }(Error);
-},{}],381:[function(require,module,exports){
+},{}],311:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -52151,7 +40313,7 @@ Object.defineProperty(exports, 'cryptoClients', {
     return _cryptoClients.cryptoClients;
   }
 });
-},{"./cryptoClients":377,"./decode":379,"./errors":380,"./signer":382,"./verifier":383}],382:[function(require,module,exports){
+},{"./cryptoClients":307,"./decode":309,"./errors":310,"./signer":312,"./verifier":313}],312:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -52241,7 +40403,7 @@ var TokenSigner = exports.TokenSigner = function () {
 
     return TokenSigner;
 }();
-},{"./cryptoClients":377,"./decode":379,"base64url":400}],383:[function(require,module,exports){
+},{"./cryptoClients":307,"./decode":309,"base64url":330}],313:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -52304,35 +40466,35 @@ var TokenVerifier = exports.TokenVerifier = function () {
 
     return TokenVerifier;
 }();
-},{"./cryptoClients":377,"./decode":379,"base64url":400}],384:[function(require,module,exports){
-arguments[4][142][0].apply(exports,arguments)
-},{"./asn1/api":385,"./asn1/base":387,"./asn1/constants":391,"./asn1/decoders":393,"./asn1/encoders":396,"bn.js":401,"dup":142}],385:[function(require,module,exports){
-arguments[4][143][0].apply(exports,arguments)
-},{"../asn1":384,"dup":143,"inherits":415,"vm":277}],386:[function(require,module,exports){
-arguments[4][144][0].apply(exports,arguments)
-},{"../base":387,"buffer":188,"dup":144,"inherits":415}],387:[function(require,module,exports){
-arguments[4][145][0].apply(exports,arguments)
-},{"./buffer":386,"./node":388,"./reporter":389,"dup":145}],388:[function(require,module,exports){
-arguments[4][146][0].apply(exports,arguments)
-},{"../base":387,"dup":146,"minimalistic-assert":451}],389:[function(require,module,exports){
-arguments[4][147][0].apply(exports,arguments)
-},{"dup":147,"inherits":415}],390:[function(require,module,exports){
-arguments[4][148][0].apply(exports,arguments)
-},{"../constants":391,"dup":148}],391:[function(require,module,exports){
-arguments[4][149][0].apply(exports,arguments)
-},{"./der":390,"dup":149}],392:[function(require,module,exports){
-arguments[4][150][0].apply(exports,arguments)
-},{"../../asn1":384,"dup":150,"inherits":415}],393:[function(require,module,exports){
-arguments[4][151][0].apply(exports,arguments)
-},{"./der":392,"./pem":394,"dup":151}],394:[function(require,module,exports){
-arguments[4][152][0].apply(exports,arguments)
-},{"./der":392,"buffer":188,"dup":152,"inherits":415}],395:[function(require,module,exports){
-arguments[4][153][0].apply(exports,arguments)
-},{"../../asn1":384,"buffer":188,"dup":153,"inherits":415}],396:[function(require,module,exports){
-arguments[4][154][0].apply(exports,arguments)
-},{"./der":395,"./pem":397,"dup":154}],397:[function(require,module,exports){
-arguments[4][155][0].apply(exports,arguments)
-},{"./der":395,"dup":155,"inherits":415}],398:[function(require,module,exports){
+},{"./cryptoClients":307,"./decode":309,"base64url":330}],314:[function(require,module,exports){
+arguments[4][88][0].apply(exports,arguments)
+},{"./asn1/api":315,"./asn1/base":317,"./asn1/constants":321,"./asn1/decoders":323,"./asn1/encoders":326,"bn.js":331,"dup":88}],315:[function(require,module,exports){
+arguments[4][89][0].apply(exports,arguments)
+},{"../asn1":314,"dup":89,"inherits":345,"vm":211}],316:[function(require,module,exports){
+arguments[4][90][0].apply(exports,arguments)
+},{"../base":317,"buffer":134,"dup":90,"inherits":345}],317:[function(require,module,exports){
+arguments[4][91][0].apply(exports,arguments)
+},{"./buffer":316,"./node":318,"./reporter":319,"dup":91}],318:[function(require,module,exports){
+arguments[4][92][0].apply(exports,arguments)
+},{"../base":317,"dup":92,"minimalistic-assert":381}],319:[function(require,module,exports){
+arguments[4][93][0].apply(exports,arguments)
+},{"dup":93,"inherits":345}],320:[function(require,module,exports){
+arguments[4][94][0].apply(exports,arguments)
+},{"../constants":321,"dup":94}],321:[function(require,module,exports){
+arguments[4][95][0].apply(exports,arguments)
+},{"./der":320,"dup":95}],322:[function(require,module,exports){
+arguments[4][96][0].apply(exports,arguments)
+},{"../../asn1":314,"dup":96,"inherits":345}],323:[function(require,module,exports){
+arguments[4][97][0].apply(exports,arguments)
+},{"./der":322,"./pem":324,"dup":97}],324:[function(require,module,exports){
+arguments[4][98][0].apply(exports,arguments)
+},{"./der":322,"buffer":134,"dup":98,"inherits":345}],325:[function(require,module,exports){
+arguments[4][99][0].apply(exports,arguments)
+},{"../../asn1":314,"buffer":134,"dup":99,"inherits":345}],326:[function(require,module,exports){
+arguments[4][100][0].apply(exports,arguments)
+},{"./der":325,"./pem":327,"dup":100}],327:[function(require,module,exports){
+arguments[4][101][0].apply(exports,arguments)
+},{"./der":325,"dup":101,"inherits":345}],328:[function(require,module,exports){
 (function (Buffer){
 "use strict";
 var pad_string_1 = require("./pad-string");
@@ -52373,7 +40535,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.default = base64url;
 
 }).call(this,require("buffer").Buffer)
-},{"./pad-string":399,"buffer":188}],399:[function(require,module,exports){
+},{"./pad-string":329,"buffer":134}],329:[function(require,module,exports){
 (function (Buffer){
 "use strict";
 function padString(input) {
@@ -52397,45 +40559,45 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.default = padString;
 
 }).call(this,require("buffer").Buffer)
-},{"buffer":188}],400:[function(require,module,exports){
+},{"buffer":134}],330:[function(require,module,exports){
 module.exports = require('./dist/base64url').default;
 module.exports.default = module.exports;
 
-},{"./dist/base64url":398}],401:[function(require,module,exports){
-arguments[4][158][0].apply(exports,arguments)
-},{"buffer":160,"dup":158}],402:[function(require,module,exports){
-arguments[4][159][0].apply(exports,arguments)
-},{"crypto":160,"dup":159}],403:[function(require,module,exports){
-arguments[4][334][0].apply(exports,arguments)
-},{"./hash/common":404,"./hash/hmac":405,"./hash/ripemd":406,"./hash/sha":407,"./hash/utils":414,"dup":334}],404:[function(require,module,exports){
-arguments[4][335][0].apply(exports,arguments)
-},{"./utils":414,"dup":335,"minimalistic-assert":451}],405:[function(require,module,exports){
-arguments[4][336][0].apply(exports,arguments)
-},{"./utils":414,"dup":336,"minimalistic-assert":451}],406:[function(require,module,exports){
-arguments[4][337][0].apply(exports,arguments)
-},{"./common":404,"./utils":414,"dup":337}],407:[function(require,module,exports){
-arguments[4][338][0].apply(exports,arguments)
-},{"./sha/1":408,"./sha/224":409,"./sha/256":410,"./sha/384":411,"./sha/512":412,"dup":338}],408:[function(require,module,exports){
-arguments[4][339][0].apply(exports,arguments)
-},{"../common":404,"../utils":414,"./common":413,"dup":339}],409:[function(require,module,exports){
-arguments[4][340][0].apply(exports,arguments)
-},{"../utils":414,"./256":410,"dup":340}],410:[function(require,module,exports){
-arguments[4][341][0].apply(exports,arguments)
-},{"../common":404,"../utils":414,"./common":413,"dup":341,"minimalistic-assert":451}],411:[function(require,module,exports){
-arguments[4][342][0].apply(exports,arguments)
-},{"../utils":414,"./512":412,"dup":342}],412:[function(require,module,exports){
-arguments[4][343][0].apply(exports,arguments)
-},{"../common":404,"../utils":414,"dup":343,"minimalistic-assert":451}],413:[function(require,module,exports){
-arguments[4][344][0].apply(exports,arguments)
-},{"../utils":414,"dup":344}],414:[function(require,module,exports){
-arguments[4][345][0].apply(exports,arguments)
-},{"dup":345,"inherits":415,"minimalistic-assert":451}],415:[function(require,module,exports){
-arguments[4][101][0].apply(exports,arguments)
-},{"dup":101}],416:[function(require,module,exports){
+},{"./dist/base64url":328}],331:[function(require,module,exports){
+arguments[4][104][0].apply(exports,arguments)
+},{"buffer":106,"dup":104}],332:[function(require,module,exports){
+arguments[4][105][0].apply(exports,arguments)
+},{"crypto":106,"dup":105}],333:[function(require,module,exports){
+arguments[4][267][0].apply(exports,arguments)
+},{"./hash/common":334,"./hash/hmac":335,"./hash/ripemd":336,"./hash/sha":337,"./hash/utils":344,"dup":267}],334:[function(require,module,exports){
+arguments[4][268][0].apply(exports,arguments)
+},{"./utils":344,"dup":268,"minimalistic-assert":381}],335:[function(require,module,exports){
+arguments[4][269][0].apply(exports,arguments)
+},{"./utils":344,"dup":269,"minimalistic-assert":381}],336:[function(require,module,exports){
+arguments[4][270][0].apply(exports,arguments)
+},{"./common":334,"./utils":344,"dup":270}],337:[function(require,module,exports){
+arguments[4][271][0].apply(exports,arguments)
+},{"./sha/1":338,"./sha/224":339,"./sha/256":340,"./sha/384":341,"./sha/512":342,"dup":271}],338:[function(require,module,exports){
+arguments[4][272][0].apply(exports,arguments)
+},{"../common":334,"../utils":344,"./common":343,"dup":272}],339:[function(require,module,exports){
+arguments[4][273][0].apply(exports,arguments)
+},{"../utils":344,"./256":340,"dup":273}],340:[function(require,module,exports){
+arguments[4][274][0].apply(exports,arguments)
+},{"../common":334,"../utils":344,"./common":343,"dup":274,"minimalistic-assert":381}],341:[function(require,module,exports){
+arguments[4][275][0].apply(exports,arguments)
+},{"../utils":344,"./512":342,"dup":275}],342:[function(require,module,exports){
+arguments[4][276][0].apply(exports,arguments)
+},{"../common":334,"../utils":344,"dup":276,"minimalistic-assert":381}],343:[function(require,module,exports){
+arguments[4][277][0].apply(exports,arguments)
+},{"../utils":344,"dup":277}],344:[function(require,module,exports){
+arguments[4][278][0].apply(exports,arguments)
+},{"dup":278,"inherits":345,"minimalistic-assert":381}],345:[function(require,module,exports){
+arguments[4][54][0].apply(exports,arguments)
+},{"dup":54}],346:[function(require,module,exports){
 'use strict'
 
 module.exports = require('./lib/key-encoder')
-},{"./lib/key-encoder":417}],417:[function(require,module,exports){
+},{"./lib/key-encoder":347}],347:[function(require,module,exports){
 (function (Buffer){
 'use strict'
 
@@ -52601,9 +40763,9 @@ KeyEncoder.prototype.encodePublic = function(publicKey, originalFormat, destinat
 
 module.exports = KeyEncoder
 }).call(this,require("buffer").Buffer)
-},{"asn1.js":418,"bn.js":433,"buffer":188,"elliptic":434}],418:[function(require,module,exports){
-arguments[4][142][0].apply(exports,arguments)
-},{"./asn1/api":419,"./asn1/base":421,"./asn1/constants":425,"./asn1/decoders":427,"./asn1/encoders":430,"bn.js":432,"dup":142}],419:[function(require,module,exports){
+},{"asn1.js":348,"bn.js":363,"buffer":134,"elliptic":364}],348:[function(require,module,exports){
+arguments[4][88][0].apply(exports,arguments)
+},{"./asn1/api":349,"./asn1/base":351,"./asn1/constants":355,"./asn1/decoders":357,"./asn1/encoders":360,"bn.js":362,"dup":88}],349:[function(require,module,exports){
 var asn1 = require('../asn1');
 var inherits = require('inherits');
 
@@ -52664,11 +40826,11 @@ Entity.prototype.encode = function encode(data, enc, /* internal */ reporter) {
   return this._getEncoder(enc).encode(data, reporter);
 };
 
-},{"../asn1":418,"inherits":415,"vm":277}],420:[function(require,module,exports){
-arguments[4][144][0].apply(exports,arguments)
-},{"../base":421,"buffer":188,"dup":144,"inherits":415}],421:[function(require,module,exports){
-arguments[4][145][0].apply(exports,arguments)
-},{"./buffer":420,"./node":422,"./reporter":423,"dup":145}],422:[function(require,module,exports){
+},{"../asn1":348,"inherits":345,"vm":211}],350:[function(require,module,exports){
+arguments[4][90][0].apply(exports,arguments)
+},{"../base":351,"buffer":134,"dup":90,"inherits":345}],351:[function(require,module,exports){
+arguments[4][91][0].apply(exports,arguments)
+},{"./buffer":350,"./node":352,"./reporter":353,"dup":91}],352:[function(require,module,exports){
 var Reporter = require('../base').Reporter;
 var EncoderBuffer = require('../base').EncoderBuffer;
 var assert = require('minimalistic-assert');
@@ -53268,7 +41430,7 @@ Node.prototype._encodePrimitive = function encodePrimitive(tag, data) {
     throw new Error('Unsupported tag: ' + tag);
 };
 
-},{"../base":421,"minimalistic-assert":451}],423:[function(require,module,exports){
+},{"../base":351,"minimalistic-assert":381}],353:[function(require,module,exports){
 var inherits = require('inherits');
 
 function Reporter(options) {
@@ -53372,11 +41534,11 @@ ReporterError.prototype.rethrow = function rethrow(msg) {
   return this;
 };
 
-},{"inherits":415}],424:[function(require,module,exports){
-arguments[4][148][0].apply(exports,arguments)
-},{"../constants":425,"dup":148}],425:[function(require,module,exports){
-arguments[4][149][0].apply(exports,arguments)
-},{"./der":424,"dup":149}],426:[function(require,module,exports){
+},{"inherits":345}],354:[function(require,module,exports){
+arguments[4][94][0].apply(exports,arguments)
+},{"../constants":355,"dup":94}],355:[function(require,module,exports){
+arguments[4][95][0].apply(exports,arguments)
+},{"./der":354,"dup":95}],356:[function(require,module,exports){
 var inherits = require('inherits');
 
 var asn1 = require('../../asn1');
@@ -53669,9 +41831,9 @@ function derDecodeLen(buf, primitive, fail) {
   return len;
 }
 
-},{"../../asn1":418,"inherits":415}],427:[function(require,module,exports){
-arguments[4][151][0].apply(exports,arguments)
-},{"./der":426,"./pem":428,"dup":151}],428:[function(require,module,exports){
+},{"../../asn1":348,"inherits":345}],357:[function(require,module,exports){
+arguments[4][97][0].apply(exports,arguments)
+},{"./der":356,"./pem":358,"dup":97}],358:[function(require,module,exports){
 var inherits = require('inherits');
 var Buffer = require('buffer').Buffer;
 
@@ -53723,7 +41885,7 @@ PEMDecoder.prototype.decode = function decode(data, options) {
   return DERDecoder.prototype.decode.call(this, input, options);
 };
 
-},{"../../asn1":418,"./der":426,"buffer":188,"inherits":415}],429:[function(require,module,exports){
+},{"../../asn1":348,"./der":356,"buffer":134,"inherits":345}],359:[function(require,module,exports){
 var inherits = require('inherits');
 var Buffer = require('buffer').Buffer;
 
@@ -53997,9 +42159,9 @@ function encodeTag(tag, primitive, cls, reporter) {
   return res;
 }
 
-},{"../../asn1":418,"buffer":188,"inherits":415}],430:[function(require,module,exports){
-arguments[4][154][0].apply(exports,arguments)
-},{"./der":429,"./pem":431,"dup":154}],431:[function(require,module,exports){
+},{"../../asn1":348,"buffer":134,"inherits":345}],360:[function(require,module,exports){
+arguments[4][100][0].apply(exports,arguments)
+},{"./der":359,"./pem":361,"dup":100}],361:[function(require,module,exports){
 var inherits = require('inherits');
 var Buffer = require('buffer').Buffer;
 
@@ -54024,7 +42186,7 @@ PEMEncoder.prototype.encode = function encode(data, options) {
   return out.join('\n');
 };
 
-},{"../../asn1":418,"./der":429,"buffer":188,"inherits":415}],432:[function(require,module,exports){
+},{"../../asn1":348,"./der":359,"buffer":134,"inherits":345}],362:[function(require,module,exports){
 (function (module, exports) {
 
 'use strict';
@@ -56344,7 +44506,7 @@ Mont.prototype.invm = function invm(a) {
 
 })(typeof module === 'undefined' || module, this);
 
-},{}],433:[function(require,module,exports){
+},{}],363:[function(require,module,exports){
 (function (module, exports) {
 
 'use strict';
@@ -58793,7 +46955,7 @@ Mont.prototype.invm = function invm(a) {
 
 })(typeof module === 'undefined' || module, this);
 
-},{}],434:[function(require,module,exports){
+},{}],364:[function(require,module,exports){
 'use strict';
 
 var elliptic = exports;
@@ -58809,7 +46971,7 @@ elliptic.curves = require('./elliptic/curves');
 elliptic.ec = require('./elliptic/ec');
 elliptic.eddsa = require('./elliptic/eddsa');
 
-},{"../package.json":450,"./elliptic/curve":437,"./elliptic/curves":440,"./elliptic/ec":441,"./elliptic/eddsa":444,"./elliptic/hmac-drbg":447,"./elliptic/utils":449,"brorand":402}],435:[function(require,module,exports){
+},{"../package.json":380,"./elliptic/curve":367,"./elliptic/curves":370,"./elliptic/ec":371,"./elliptic/eddsa":374,"./elliptic/hmac-drbg":377,"./elliptic/utils":379,"brorand":332}],365:[function(require,module,exports){
 'use strict';
 
 var bn = require('bn.js');
@@ -59162,7 +47324,7 @@ BasePoint.prototype.dblp = function dblp(k) {
   return r;
 };
 
-},{"../../elliptic":434,"bn.js":433}],436:[function(require,module,exports){
+},{"../../elliptic":364,"bn.js":363}],366:[function(require,module,exports){
 'use strict';
 
 var curve = require('../curve');
@@ -59570,9 +47732,9 @@ Point.prototype.eq = function eq(other) {
 Point.prototype.toP = Point.prototype.normalize;
 Point.prototype.mixedAdd = Point.prototype.add;
 
-},{"../../elliptic":434,"../curve":437,"bn.js":433,"inherits":415}],437:[function(require,module,exports){
-arguments[4][320][0].apply(exports,arguments)
-},{"./base":435,"./edwards":436,"./mont":438,"./short":439,"dup":320}],438:[function(require,module,exports){
+},{"../../elliptic":364,"../curve":367,"bn.js":363,"inherits":345}],367:[function(require,module,exports){
+arguments[4][253][0].apply(exports,arguments)
+},{"./base":365,"./edwards":366,"./mont":368,"./short":369,"dup":253}],368:[function(require,module,exports){
 'use strict';
 
 var curve = require('../curve');
@@ -59750,7 +47912,7 @@ Point.prototype.getX = function getX() {
   return this.x.fromRed();
 };
 
-},{"../../elliptic":434,"../curve":437,"bn.js":433,"inherits":415}],439:[function(require,module,exports){
+},{"../../elliptic":364,"../curve":367,"bn.js":363,"inherits":345}],369:[function(require,module,exports){
 'use strict';
 
 var curve = require('../curve');
@@ -60659,7 +48821,7 @@ JPoint.prototype.isInfinity = function isInfinity() {
   return this.z.cmpn(0) === 0;
 };
 
-},{"../../elliptic":434,"../curve":437,"bn.js":433,"inherits":415}],440:[function(require,module,exports){
+},{"../../elliptic":364,"../curve":367,"bn.js":363,"inherits":345}],370:[function(require,module,exports){
 'use strict';
 
 var curves = exports;
@@ -60866,7 +49028,7 @@ defineCurve('secp256k1', {
   ]
 });
 
-},{"../elliptic":434,"./precomputed/secp256k1":448,"hash.js":403}],441:[function(require,module,exports){
+},{"../elliptic":364,"./precomputed/secp256k1":378,"hash.js":333}],371:[function(require,module,exports){
 'use strict';
 
 var bn = require('bn.js');
@@ -61078,7 +49240,7 @@ EC.prototype.getKeyRecoveryParam = function(e, signature, Q, enc) {
   throw new Error('Unable to find valid recovery factor');
 };
 
-},{"../../elliptic":434,"./key":442,"./signature":443,"bn.js":433}],442:[function(require,module,exports){
+},{"../../elliptic":364,"./key":372,"./signature":373,"bn.js":363}],372:[function(require,module,exports){
 'use strict';
 
 var bn = require('bn.js');
@@ -61187,7 +49349,7 @@ KeyPair.prototype.inspect = function inspect() {
          ' pub: ' + (this.pub && this.pub.inspect()) + ' >';
 };
 
-},{"bn.js":433}],443:[function(require,module,exports){
+},{"bn.js":363}],373:[function(require,module,exports){
 'use strict';
 
 var bn = require('bn.js');
@@ -61324,9 +49486,9 @@ Signature.prototype.toDER = function toDER(enc) {
   return utils.encode(res, enc);
 };
 
-},{"../../elliptic":434,"bn.js":433}],444:[function(require,module,exports){
-arguments[4][327][0].apply(exports,arguments)
-},{"../../elliptic":434,"./key":445,"./signature":446,"dup":327,"hash.js":403}],445:[function(require,module,exports){
+},{"../../elliptic":364,"bn.js":363}],374:[function(require,module,exports){
+arguments[4][260][0].apply(exports,arguments)
+},{"../../elliptic":364,"./key":375,"./signature":376,"dup":260,"hash.js":333}],375:[function(require,module,exports){
 'use strict';
 
 var elliptic = require('../../elliptic');
@@ -61424,7 +49586,7 @@ KeyPair.prototype.getPublic = function getPublic(enc) {
 
 module.exports = KeyPair;
 
-},{"../../elliptic":434}],446:[function(require,module,exports){
+},{"../../elliptic":364}],376:[function(require,module,exports){
 'use strict';
 
 var bn = require('bn.js');
@@ -61492,7 +49654,7 @@ Signature.prototype.toHex = function toHex() {
 
 module.exports = Signature;
 
-},{"../../elliptic":434,"bn.js":433}],447:[function(require,module,exports){
+},{"../../elliptic":364,"bn.js":363}],377:[function(require,module,exports){
 'use strict';
 
 var hash = require('hash.js');
@@ -61608,9 +49770,9 @@ HmacDRBG.prototype.generate = function generate(len, enc, add, addEnc) {
   return utils.encode(res, enc);
 };
 
-},{"../elliptic":434,"hash.js":403}],448:[function(require,module,exports){
-arguments[4][330][0].apply(exports,arguments)
-},{"dup":330}],449:[function(require,module,exports){
+},{"../elliptic":364,"hash.js":333}],378:[function(require,module,exports){
+arguments[4][263][0].apply(exports,arguments)
+},{"dup":263}],379:[function(require,module,exports){
 'use strict';
 
 var utils = exports;
@@ -61785,31 +49947,36 @@ function intFromLE(bytes) {
 utils.intFromLE = intFromLE;
 
 
-},{"bn.js":433}],450:[function(require,module,exports){
+},{"bn.js":363}],380:[function(require,module,exports){
 module.exports={
-  "_from": "elliptic@^5.1.0",
+  "_args": [
+    [
+      "elliptic@5.2.1",
+      "/home/aaron/devel/blockstack.js"
+    ]
+  ],
+  "_from": "elliptic@5.2.1",
   "_id": "elliptic@5.2.1",
   "_inBundle": false,
   "_integrity": "sha1-+ilLZWPG3bybo9yFlGh66ECFjxA=",
   "_location": "/jsontokens/key-encoder/elliptic",
   "_phantomChildren": {},
   "_requested": {
-    "type": "range",
+    "type": "version",
     "registry": true,
-    "raw": "elliptic@^5.1.0",
+    "raw": "elliptic@5.2.1",
     "name": "elliptic",
     "escapedName": "elliptic",
-    "rawSpec": "^5.1.0",
+    "rawSpec": "5.2.1",
     "saveSpec": null,
-    "fetchSpec": "^5.1.0"
+    "fetchSpec": "5.2.1"
   },
   "_requiredBy": [
     "/jsontokens/key-encoder"
   ],
   "_resolved": "https://registry.npmjs.org/elliptic/-/elliptic-5.2.1.tgz",
-  "_shasum": "fa294b6563c6ddbc9ba3dc8594687ae840858f10",
-  "_spec": "elliptic@^5.1.0",
-  "_where": "/Users/larry/git/blockstack.js/node_modules/jsontokens/node_modules/key-encoder",
+  "_spec": "5.2.1",
+  "_where": "/home/aaron/devel/blockstack.js",
   "author": {
     "name": "Fedor Indutny",
     "email": "fedor@indutny.com"
@@ -61817,14 +49984,12 @@ module.exports={
   "bugs": {
     "url": "https://github.com/indutny/elliptic/issues"
   },
-  "bundleDependencies": false,
   "dependencies": {
     "bn.js": "^3.1.1",
     "brorand": "^1.0.1",
     "hash.js": "^1.0.0",
     "inherits": "^2.0.1"
   },
-  "deprecated": false,
   "description": "EC cryptography",
   "devDependencies": {
     "browserify": "^3.44.2",
@@ -61856,9 +50021,9 @@ module.exports={
   "version": "5.2.1"
 }
 
-},{}],451:[function(require,module,exports){
-arguments[4][217][0].apply(exports,arguments)
-},{"dup":217}],452:[function(require,module,exports){
+},{}],381:[function(require,module,exports){
+arguments[4][162][0].apply(exports,arguments)
+},{"dup":162}],382:[function(require,module,exports){
 /**
  * lodash (Custom Build) <https://lodash.com/>
  * Build: `lodash modularize exports="npm" -o ./`
@@ -62486,7 +50651,7 @@ function keysIn(object) {
 
 module.exports = assignIn;
 
-},{}],453:[function(require,module,exports){
+},{}],383:[function(require,module,exports){
 (function (global){
 /**
  * lodash (Custom Build) <https://lodash.com/>
@@ -63744,7 +51909,7 @@ bind.placeholder = {};
 module.exports = bind;
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],454:[function(require,module,exports){
+},{}],384:[function(require,module,exports){
 /**
  * lodash (Custom Build) <https://lodash.com/>
  * Build: `lodash modularize exports="npm" -o ./`
@@ -64414,7 +52579,7 @@ function keysIn(object) {
 
 module.exports = defaults;
 
-},{}],455:[function(require,module,exports){
+},{}],385:[function(require,module,exports){
 (function (global){
 /**
  * lodash (Custom Build) <https://lodash.com/>
@@ -66784,7 +54949,7 @@ function property(path) {
 module.exports = filter;
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],456:[function(require,module,exports){
+},{}],386:[function(require,module,exports){
 (function (global){
 /**
  * lodash (Custom Build) <https://lodash.com/>
@@ -67137,7 +55302,7 @@ function isObjectLike(value) {
 module.exports = flatten;
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],457:[function(require,module,exports){
+},{}],387:[function(require,module,exports){
 /**
  * lodash (Custom Build) <https://lodash.com/>
  * Build: `lodash modularize exports="npm" -o ./`
@@ -67704,7 +55869,7 @@ function identity(value) {
 
 module.exports = forEach;
 
-},{}],458:[function(require,module,exports){
+},{}],388:[function(require,module,exports){
 (function (global){
 /**
  * lodash (Custom Build) <https://lodash.com/>
@@ -70074,7 +58239,7 @@ function property(path) {
 module.exports = map;
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],459:[function(require,module,exports){
+},{}],389:[function(require,module,exports){
 (function (global){
 /**
  * lodash (Custom Build) <https://lodash.com/>
@@ -72285,7 +60450,7 @@ function stubFalse() {
 module.exports = merge;
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],460:[function(require,module,exports){
+},{}],390:[function(require,module,exports){
 (function (global){
 /**
  * lodash (Custom Build) <https://lodash.com/>
@@ -72792,7 +60957,7 @@ var pick = baseRest(function(object, props) {
 module.exports = pick;
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],461:[function(require,module,exports){
+},{}],391:[function(require,module,exports){
 (function (global){
 /**
  * lodash (Custom Build) <https://lodash.com/>
@@ -75168,7 +63333,7 @@ function property(path) {
 module.exports = reduce;
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],462:[function(require,module,exports){
+},{}],392:[function(require,module,exports){
 (function (global){
 /**
  * lodash (Custom Build) <https://lodash.com/>
@@ -77570,7 +65735,7 @@ function property(path) {
 module.exports = reject;
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],463:[function(require,module,exports){
+},{}],393:[function(require,module,exports){
 (function (global){
 /**
  * lodash (Custom Build) <https://lodash.com/>
@@ -79942,7 +68107,7 @@ function property(path) {
 module.exports = some;
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],464:[function(require,module,exports){
+},{}],394:[function(require,module,exports){
 (function (Buffer){
 'use strict'
 var inherits = require('inherits')
@@ -80091,7 +68256,7 @@ function fnI (a, b, c, d, m, k, s) {
 module.exports = MD5
 
 }).call(this,require("buffer").Buffer)
-},{"buffer":188,"hash-base":465,"inherits":466}],465:[function(require,module,exports){
+},{"buffer":134,"hash-base":395,"inherits":396}],395:[function(require,module,exports){
 'use strict'
 var Buffer = require('safe-buffer').Buffer
 var Transform = require('stream').Transform
@@ -80188,9 +68353,9 @@ HashBase.prototype._digest = function () {
 
 module.exports = HashBase
 
-},{"inherits":466,"safe-buffer":481,"stream":264}],466:[function(require,module,exports){
-arguments[4][101][0].apply(exports,arguments)
-},{"dup":101}],467:[function(require,module,exports){
+},{"inherits":396,"safe-buffer":403,"stream":205}],396:[function(require,module,exports){
+arguments[4][54][0].apply(exports,arguments)
+},{"dup":54}],397:[function(require,module,exports){
 module.exports = compile;
 
 var BaseFuncs = require("boolbase"),
@@ -80231,7 +68396,7 @@ function compile(parsed){
 		return pos <= b && pos % a === bMod;
 	};
 }
-},{"boolbase":141}],468:[function(require,module,exports){
+},{"boolbase":87}],398:[function(require,module,exports){
 var parse = require("./parse.js"),
     compile = require("./compile.js");
 
@@ -80241,7 +68406,7 @@ module.exports = function nthCheck(formula){
 
 module.exports.parse = parse;
 module.exports.compile = compile;
-},{"./compile.js":467,"./parse.js":469}],469:[function(require,module,exports){
+},{"./compile.js":397,"./parse.js":399}],399:[function(require,module,exports){
 module.exports = parse;
 
 //following http://www.w3.org/TR/css3-selectors/#nth-child-pseudo
@@ -80283,575 +68448,7 @@ function parse(formula){
 	}
 }
 
-},{}],470:[function(require,module,exports){
-'use strict';
-
-module.exports = require('./lib')
-
-},{"./lib":475}],471:[function(require,module,exports){
-'use strict';
-
-var asap = require('asap/raw');
-
-function noop() {}
-
-// States:
-//
-// 0 - pending
-// 1 - fulfilled with _value
-// 2 - rejected with _value
-// 3 - adopted the state of another promise, _value
-//
-// once the state is no longer pending (0) it is immutable
-
-// All `_` prefixed properties will be reduced to `_{random number}`
-// at build time to obfuscate them and discourage their use.
-// We don't use symbols or Object.defineProperty to fully hide them
-// because the performance isn't good enough.
-
-
-// to avoid using try/catch inside critical functions, we
-// extract them to here.
-var LAST_ERROR = null;
-var IS_ERROR = {};
-function getThen(obj) {
-  try {
-    return obj.then;
-  } catch (ex) {
-    LAST_ERROR = ex;
-    return IS_ERROR;
-  }
-}
-
-function tryCallOne(fn, a) {
-  try {
-    return fn(a);
-  } catch (ex) {
-    LAST_ERROR = ex;
-    return IS_ERROR;
-  }
-}
-function tryCallTwo(fn, a, b) {
-  try {
-    fn(a, b);
-  } catch (ex) {
-    LAST_ERROR = ex;
-    return IS_ERROR;
-  }
-}
-
-module.exports = Promise;
-
-function Promise(fn) {
-  if (typeof this !== 'object') {
-    throw new TypeError('Promises must be constructed via new');
-  }
-  if (typeof fn !== 'function') {
-    throw new TypeError('Promise constructor\'s argument is not a function');
-  }
-  this._40 = 0;
-  this._65 = 0;
-  this._55 = null;
-  this._72 = null;
-  if (fn === noop) return;
-  doResolve(fn, this);
-}
-Promise._37 = null;
-Promise._87 = null;
-Promise._61 = noop;
-
-Promise.prototype.then = function(onFulfilled, onRejected) {
-  if (this.constructor !== Promise) {
-    return safeThen(this, onFulfilled, onRejected);
-  }
-  var res = new Promise(noop);
-  handle(this, new Handler(onFulfilled, onRejected, res));
-  return res;
-};
-
-function safeThen(self, onFulfilled, onRejected) {
-  return new self.constructor(function (resolve, reject) {
-    var res = new Promise(noop);
-    res.then(resolve, reject);
-    handle(self, new Handler(onFulfilled, onRejected, res));
-  });
-}
-function handle(self, deferred) {
-  while (self._65 === 3) {
-    self = self._55;
-  }
-  if (Promise._37) {
-    Promise._37(self);
-  }
-  if (self._65 === 0) {
-    if (self._40 === 0) {
-      self._40 = 1;
-      self._72 = deferred;
-      return;
-    }
-    if (self._40 === 1) {
-      self._40 = 2;
-      self._72 = [self._72, deferred];
-      return;
-    }
-    self._72.push(deferred);
-    return;
-  }
-  handleResolved(self, deferred);
-}
-
-function handleResolved(self, deferred) {
-  asap(function() {
-    var cb = self._65 === 1 ? deferred.onFulfilled : deferred.onRejected;
-    if (cb === null) {
-      if (self._65 === 1) {
-        resolve(deferred.promise, self._55);
-      } else {
-        reject(deferred.promise, self._55);
-      }
-      return;
-    }
-    var ret = tryCallOne(cb, self._55);
-    if (ret === IS_ERROR) {
-      reject(deferred.promise, LAST_ERROR);
-    } else {
-      resolve(deferred.promise, ret);
-    }
-  });
-}
-function resolve(self, newValue) {
-  // Promise Resolution Procedure: https://github.com/promises-aplus/promises-spec#the-promise-resolution-procedure
-  if (newValue === self) {
-    return reject(
-      self,
-      new TypeError('A promise cannot be resolved with itself.')
-    );
-  }
-  if (
-    newValue &&
-    (typeof newValue === 'object' || typeof newValue === 'function')
-  ) {
-    var then = getThen(newValue);
-    if (then === IS_ERROR) {
-      return reject(self, LAST_ERROR);
-    }
-    if (
-      then === self.then &&
-      newValue instanceof Promise
-    ) {
-      self._65 = 3;
-      self._55 = newValue;
-      finale(self);
-      return;
-    } else if (typeof then === 'function') {
-      doResolve(then.bind(newValue), self);
-      return;
-    }
-  }
-  self._65 = 1;
-  self._55 = newValue;
-  finale(self);
-}
-
-function reject(self, newValue) {
-  self._65 = 2;
-  self._55 = newValue;
-  if (Promise._87) {
-    Promise._87(self, newValue);
-  }
-  finale(self);
-}
-function finale(self) {
-  if (self._40 === 1) {
-    handle(self, self._72);
-    self._72 = null;
-  }
-  if (self._40 === 2) {
-    for (var i = 0; i < self._72.length; i++) {
-      handle(self, self._72[i]);
-    }
-    self._72 = null;
-  }
-}
-
-function Handler(onFulfilled, onRejected, promise){
-  this.onFulfilled = typeof onFulfilled === 'function' ? onFulfilled : null;
-  this.onRejected = typeof onRejected === 'function' ? onRejected : null;
-  this.promise = promise;
-}
-
-/**
- * Take a potentially misbehaving resolver function and make sure
- * onFulfilled and onRejected are only called once.
- *
- * Makes no guarantees about asynchrony.
- */
-function doResolve(fn, promise) {
-  var done = false;
-  var res = tryCallTwo(fn, function (value) {
-    if (done) return;
-    done = true;
-    resolve(promise, value);
-  }, function (reason) {
-    if (done) return;
-    done = true;
-    reject(promise, reason);
-  });
-  if (!done && res === IS_ERROR) {
-    done = true;
-    reject(promise, LAST_ERROR);
-  }
-}
-
-},{"asap/raw":83}],472:[function(require,module,exports){
-'use strict';
-
-var Promise = require('./core.js');
-
-module.exports = Promise;
-Promise.prototype.done = function (onFulfilled, onRejected) {
-  var self = arguments.length ? this.then.apply(this, arguments) : this;
-  self.then(null, function (err) {
-    setTimeout(function () {
-      throw err;
-    }, 0);
-  });
-};
-
-},{"./core.js":471}],473:[function(require,module,exports){
-'use strict';
-
-//This file contains the ES6 extensions to the core Promises/A+ API
-
-var Promise = require('./core.js');
-
-module.exports = Promise;
-
-/* Static Functions */
-
-var TRUE = valuePromise(true);
-var FALSE = valuePromise(false);
-var NULL = valuePromise(null);
-var UNDEFINED = valuePromise(undefined);
-var ZERO = valuePromise(0);
-var EMPTYSTRING = valuePromise('');
-
-function valuePromise(value) {
-  var p = new Promise(Promise._61);
-  p._65 = 1;
-  p._55 = value;
-  return p;
-}
-Promise.resolve = function (value) {
-  if (value instanceof Promise) return value;
-
-  if (value === null) return NULL;
-  if (value === undefined) return UNDEFINED;
-  if (value === true) return TRUE;
-  if (value === false) return FALSE;
-  if (value === 0) return ZERO;
-  if (value === '') return EMPTYSTRING;
-
-  if (typeof value === 'object' || typeof value === 'function') {
-    try {
-      var then = value.then;
-      if (typeof then === 'function') {
-        return new Promise(then.bind(value));
-      }
-    } catch (ex) {
-      return new Promise(function (resolve, reject) {
-        reject(ex);
-      });
-    }
-  }
-  return valuePromise(value);
-};
-
-Promise.all = function (arr) {
-  var args = Array.prototype.slice.call(arr);
-
-  return new Promise(function (resolve, reject) {
-    if (args.length === 0) return resolve([]);
-    var remaining = args.length;
-    function res(i, val) {
-      if (val && (typeof val === 'object' || typeof val === 'function')) {
-        if (val instanceof Promise && val.then === Promise.prototype.then) {
-          while (val._65 === 3) {
-            val = val._55;
-          }
-          if (val._65 === 1) return res(i, val._55);
-          if (val._65 === 2) reject(val._55);
-          val.then(function (val) {
-            res(i, val);
-          }, reject);
-          return;
-        } else {
-          var then = val.then;
-          if (typeof then === 'function') {
-            var p = new Promise(then.bind(val));
-            p.then(function (val) {
-              res(i, val);
-            }, reject);
-            return;
-          }
-        }
-      }
-      args[i] = val;
-      if (--remaining === 0) {
-        resolve(args);
-      }
-    }
-    for (var i = 0; i < args.length; i++) {
-      res(i, args[i]);
-    }
-  });
-};
-
-Promise.reject = function (value) {
-  return new Promise(function (resolve, reject) {
-    reject(value);
-  });
-};
-
-Promise.race = function (values) {
-  return new Promise(function (resolve, reject) {
-    values.forEach(function(value){
-      Promise.resolve(value).then(resolve, reject);
-    });
-  });
-};
-
-/* Prototype Methods */
-
-Promise.prototype['catch'] = function (onRejected) {
-  return this.then(null, onRejected);
-};
-
-},{"./core.js":471}],474:[function(require,module,exports){
-'use strict';
-
-var Promise = require('./core.js');
-
-module.exports = Promise;
-Promise.prototype['finally'] = function (f) {
-  return this.then(function (value) {
-    return Promise.resolve(f()).then(function () {
-      return value;
-    });
-  }, function (err) {
-    return Promise.resolve(f()).then(function () {
-      throw err;
-    });
-  });
-};
-
-},{"./core.js":471}],475:[function(require,module,exports){
-'use strict';
-
-module.exports = require('./core.js');
-require('./done.js');
-require('./finally.js');
-require('./es6-extensions.js');
-require('./node-extensions.js');
-require('./synchronous.js');
-
-},{"./core.js":471,"./done.js":472,"./es6-extensions.js":473,"./finally.js":474,"./node-extensions.js":476,"./synchronous.js":477}],476:[function(require,module,exports){
-'use strict';
-
-// This file contains then/promise specific extensions that are only useful
-// for node.js interop
-
-var Promise = require('./core.js');
-var asap = require('asap');
-
-module.exports = Promise;
-
-/* Static Functions */
-
-Promise.denodeify = function (fn, argumentCount) {
-  if (
-    typeof argumentCount === 'number' && argumentCount !== Infinity
-  ) {
-    return denodeifyWithCount(fn, argumentCount);
-  } else {
-    return denodeifyWithoutCount(fn);
-  }
-};
-
-var callbackFn = (
-  'function (err, res) {' +
-  'if (err) { rj(err); } else { rs(res); }' +
-  '}'
-);
-function denodeifyWithCount(fn, argumentCount) {
-  var args = [];
-  for (var i = 0; i < argumentCount; i++) {
-    args.push('a' + i);
-  }
-  var body = [
-    'return function (' + args.join(',') + ') {',
-    'var self = this;',
-    'return new Promise(function (rs, rj) {',
-    'var res = fn.call(',
-    ['self'].concat(args).concat([callbackFn]).join(','),
-    ');',
-    'if (res &&',
-    '(typeof res === "object" || typeof res === "function") &&',
-    'typeof res.then === "function"',
-    ') {rs(res);}',
-    '});',
-    '};'
-  ].join('');
-  return Function(['Promise', 'fn'], body)(Promise, fn);
-}
-function denodeifyWithoutCount(fn) {
-  var fnLength = Math.max(fn.length - 1, 3);
-  var args = [];
-  for (var i = 0; i < fnLength; i++) {
-    args.push('a' + i);
-  }
-  var body = [
-    'return function (' + args.join(',') + ') {',
-    'var self = this;',
-    'var args;',
-    'var argLength = arguments.length;',
-    'if (arguments.length > ' + fnLength + ') {',
-    'args = new Array(arguments.length + 1);',
-    'for (var i = 0; i < arguments.length; i++) {',
-    'args[i] = arguments[i];',
-    '}',
-    '}',
-    'return new Promise(function (rs, rj) {',
-    'var cb = ' + callbackFn + ';',
-    'var res;',
-    'switch (argLength) {',
-    args.concat(['extra']).map(function (_, index) {
-      return (
-        'case ' + (index) + ':' +
-        'res = fn.call(' + ['self'].concat(args.slice(0, index)).concat('cb').join(',') + ');' +
-        'break;'
-      );
-    }).join(''),
-    'default:',
-    'args[argLength] = cb;',
-    'res = fn.apply(self, args);',
-    '}',
-    
-    'if (res &&',
-    '(typeof res === "object" || typeof res === "function") &&',
-    'typeof res.then === "function"',
-    ') {rs(res);}',
-    '});',
-    '};'
-  ].join('');
-
-  return Function(
-    ['Promise', 'fn'],
-    body
-  )(Promise, fn);
-}
-
-Promise.nodeify = function (fn) {
-  return function () {
-    var args = Array.prototype.slice.call(arguments);
-    var callback =
-      typeof args[args.length - 1] === 'function' ? args.pop() : null;
-    var ctx = this;
-    try {
-      return fn.apply(this, arguments).nodeify(callback, ctx);
-    } catch (ex) {
-      if (callback === null || typeof callback == 'undefined') {
-        return new Promise(function (resolve, reject) {
-          reject(ex);
-        });
-      } else {
-        asap(function () {
-          callback.call(ctx, ex);
-        })
-      }
-    }
-  }
-};
-
-Promise.prototype.nodeify = function (callback, ctx) {
-  if (typeof callback != 'function') return this;
-
-  this.then(function (value) {
-    asap(function () {
-      callback.call(ctx, null, value);
-    });
-  }, function (err) {
-    asap(function () {
-      callback.call(ctx, err);
-    });
-  });
-};
-
-},{"./core.js":471,"asap":82}],477:[function(require,module,exports){
-'use strict';
-
-var Promise = require('./core.js');
-
-module.exports = Promise;
-Promise.enableSynchronous = function () {
-  Promise.prototype.isPending = function() {
-    return this.getState() == 0;
-  };
-
-  Promise.prototype.isFulfilled = function() {
-    return this.getState() == 1;
-  };
-
-  Promise.prototype.isRejected = function() {
-    return this.getState() == 2;
-  };
-
-  Promise.prototype.getValue = function () {
-    if (this._65 === 3) {
-      return this._55.getValue();
-    }
-
-    if (!this.isFulfilled()) {
-      throw new Error('Cannot get a value of an unfulfilled promise.');
-    }
-
-    return this._55;
-  };
-
-  Promise.prototype.getReason = function () {
-    if (this._65 === 3) {
-      return this._55.getReason();
-    }
-
-    if (!this.isRejected()) {
-      throw new Error('Cannot get a rejection reason of a non-rejected promise.');
-    }
-
-    return this._55;
-  };
-
-  Promise.prototype.getState = function () {
-    if (this._65 === 3) {
-      return this._55.getState();
-    }
-    if (this._65 === -1 || this._65 === -2) {
-      return 0;
-    }
-
-    return this._65;
-  };
-};
-
-Promise.disableSynchronous = function() {
-  Promise.prototype.isPending = undefined;
-  Promise.prototype.isFulfilled = undefined;
-  Promise.prototype.isRejected = undefined;
-  Promise.prototype.getValue = undefined;
-  Promise.prototype.getReason = undefined;
-  Promise.prototype.getState = undefined;
-};
-
-},{"./core.js":471}],478:[function(require,module,exports){
+},{}],400:[function(require,module,exports){
 'use strict';
 var strictUriEncode = require('strict-uri-encode');
 var objectAssign = require('object-assign');
@@ -81058,7 +68655,7 @@ exports.stringify = function (obj, opts) {
 	}).join('&') : '';
 };
 
-},{"object-assign":479,"strict-uri-encode":480}],479:[function(require,module,exports){
+},{"object-assign":401,"strict-uri-encode":402}],401:[function(require,module,exports){
 /*
 object-assign
 (c) Sindre Sorhus
@@ -81150,7 +68747,7 @@ module.exports = shouldUseNative() ? Object.assign : function (target, source) {
 	return to;
 };
 
-},{}],480:[function(require,module,exports){
+},{}],402:[function(require,module,exports){
 'use strict';
 module.exports = function (str) {
 	return encodeURIComponent(str).replace(/[!'()*]/g, function (c) {
@@ -81158,7 +68755,7 @@ module.exports = function (str) {
 	});
 };
 
-},{}],481:[function(require,module,exports){
+},{}],403:[function(require,module,exports){
 /* eslint-disable node/no-deprecated-api */
 var buffer = require('buffer')
 var Buffer = buffer.Buffer
@@ -81222,10 +68819,10 @@ SafeBuffer.allocUnsafeSlow = function (size) {
   return buffer.SlowBuffer(size)
 }
 
-},{"buffer":188}],482:[function(require,module,exports){
+},{"buffer":134}],404:[function(require,module,exports){
 module.exports = require('./lib/schema-inspector');
 
-},{"./lib/schema-inspector":483}],483:[function(require,module,exports){
+},{"./lib/schema-inspector":405}],405:[function(require,module,exports){
 /*
  * This module is intended to be executed both on client side and server side.
  * No error should be thrown. (soft error handling)
@@ -82804,7 +70401,7 @@ module.exports = require('./lib/schema-inspector');
 	};
 })();
 
-},{"async":484}],484:[function(require,module,exports){
+},{"async":406}],406:[function(require,module,exports){
 (function (process,global){
 /*!
  * async
@@ -84073,100 +71670,7 @@ module.exports = require('./lib/schema-inspector');
 }());
 
 }).call(this,require('_process'),typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"_process":229}],485:[function(require,module,exports){
-/**
- * Convert array of 16 byte values to UUID string format of the form:
- * XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
- */
-var byteToHex = [];
-for (var i = 0; i < 256; ++i) {
-  byteToHex[i] = (i + 0x100).toString(16).substr(1);
-}
-
-function bytesToUuid(buf, offset) {
-  var i = offset || 0;
-  var bth = byteToHex;
-  return bth[buf[i++]] + bth[buf[i++]] +
-          bth[buf[i++]] + bth[buf[i++]] + '-' +
-          bth[buf[i++]] + bth[buf[i++]] + '-' +
-          bth[buf[i++]] + bth[buf[i++]] + '-' +
-          bth[buf[i++]] + bth[buf[i++]] + '-' +
-          bth[buf[i++]] + bth[buf[i++]] +
-          bth[buf[i++]] + bth[buf[i++]] +
-          bth[buf[i++]] + bth[buf[i++]];
-}
-
-module.exports = bytesToUuid;
-
-},{}],486:[function(require,module,exports){
-(function (global){
-// Unique ID creation requires a high quality random # generator.  In the
-// browser this is a little complicated due to unknown quality of Math.random()
-// and inconsistent support for the `crypto` API.  We do the best we can via
-// feature-detection
-var rng;
-
-var crypto = global.crypto || global.msCrypto; // for IE 11
-if (crypto && crypto.getRandomValues) {
-  // WHATWG crypto RNG - http://wiki.whatwg.org/wiki/Crypto
-  var rnds8 = new Uint8Array(16); // eslint-disable-line no-undef
-  rng = function whatwgRNG() {
-    crypto.getRandomValues(rnds8);
-    return rnds8;
-  };
-}
-
-if (!rng) {
-  // Math.random()-based (RNG)
-  //
-  // If all else fails, use Math.random().  It's fast, but is of unspecified
-  // quality.
-  var rnds = new Array(16);
-  rng = function() {
-    for (var i = 0, r; i < 16; i++) {
-      if ((i & 0x03) === 0) r = Math.random() * 0x100000000;
-      rnds[i] = r >>> ((i & 0x03) << 3) & 0xff;
-    }
-
-    return rnds;
-  };
-}
-
-module.exports = rng;
-
-}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],487:[function(require,module,exports){
-var rng = require('./lib/rng');
-var bytesToUuid = require('./lib/bytesToUuid');
-
-function v4(options, buf, offset) {
-  var i = buf && offset || 0;
-
-  if (typeof(options) == 'string') {
-    buf = options == 'binary' ? new Array(16) : null;
-    options = null;
-  }
-  options = options || {};
-
-  var rnds = options.random || (options.rng || rng)();
-
-  // Per 4.4, set bits for version and `clock_seq_hi_and_reserved`
-  rnds[6] = (rnds[6] & 0x0f) | 0x40;
-  rnds[8] = (rnds[8] & 0x3f) | 0x80;
-
-  // Copy bytes to buffer, if provided
-  if (buf) {
-    for (var ii = 0; ii < 16; ++ii) {
-      buf[i + ii] = rnds[ii];
-    }
-  }
-
-  return buf || bytesToUuid(rnds);
-}
-
-module.exports = v4;
-
-},{"./lib/bytesToUuid":485,"./lib/rng":486}],488:[function(require,module,exports){
+},{"_process":174}],407:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -84488,7 +71992,7 @@ var validator = {
 
 exports.default = validator;
 module.exports = exports['default'];
-},{"./lib/blacklist":490,"./lib/contains":491,"./lib/equals":492,"./lib/escape":493,"./lib/isAfter":494,"./lib/isAlpha":495,"./lib/isAlphanumeric":496,"./lib/isAscii":497,"./lib/isBase64":498,"./lib/isBefore":499,"./lib/isBoolean":500,"./lib/isByteLength":501,"./lib/isCreditCard":502,"./lib/isCurrency":503,"./lib/isDataURI":504,"./lib/isDecimal":505,"./lib/isDivisibleBy":506,"./lib/isEmail":507,"./lib/isEmpty":508,"./lib/isFQDN":509,"./lib/isFloat":510,"./lib/isFullWidth":511,"./lib/isHalfWidth":512,"./lib/isHexColor":513,"./lib/isHexadecimal":514,"./lib/isIP":515,"./lib/isISBN":516,"./lib/isISIN":517,"./lib/isISO8601":518,"./lib/isISRC":519,"./lib/isISSN":520,"./lib/isIn":521,"./lib/isInt":522,"./lib/isJSON":523,"./lib/isLength":524,"./lib/isLowercase":525,"./lib/isMACAddress":526,"./lib/isMD5":527,"./lib/isMobilePhone":528,"./lib/isMongoId":529,"./lib/isMultibyte":530,"./lib/isNumeric":531,"./lib/isSurrogatePair":532,"./lib/isURL":533,"./lib/isUUID":534,"./lib/isUppercase":535,"./lib/isVariableWidth":536,"./lib/isWhitelisted":537,"./lib/ltrim":538,"./lib/matches":539,"./lib/normalizeEmail":540,"./lib/rtrim":541,"./lib/stripLow":542,"./lib/toBoolean":543,"./lib/toDate":544,"./lib/toFloat":545,"./lib/toInt":546,"./lib/trim":547,"./lib/unescape":548,"./lib/util/toString":551,"./lib/whitelist":552}],489:[function(require,module,exports){
+},{"./lib/blacklist":409,"./lib/contains":410,"./lib/equals":411,"./lib/escape":412,"./lib/isAfter":413,"./lib/isAlpha":414,"./lib/isAlphanumeric":415,"./lib/isAscii":416,"./lib/isBase64":417,"./lib/isBefore":418,"./lib/isBoolean":419,"./lib/isByteLength":420,"./lib/isCreditCard":421,"./lib/isCurrency":422,"./lib/isDataURI":423,"./lib/isDecimal":424,"./lib/isDivisibleBy":425,"./lib/isEmail":426,"./lib/isEmpty":427,"./lib/isFQDN":428,"./lib/isFloat":429,"./lib/isFullWidth":430,"./lib/isHalfWidth":431,"./lib/isHexColor":432,"./lib/isHexadecimal":433,"./lib/isIP":434,"./lib/isISBN":435,"./lib/isISIN":436,"./lib/isISO8601":437,"./lib/isISRC":438,"./lib/isISSN":439,"./lib/isIn":440,"./lib/isInt":441,"./lib/isJSON":442,"./lib/isLength":443,"./lib/isLowercase":444,"./lib/isMACAddress":445,"./lib/isMD5":446,"./lib/isMobilePhone":447,"./lib/isMongoId":448,"./lib/isMultibyte":449,"./lib/isNumeric":450,"./lib/isSurrogatePair":451,"./lib/isURL":452,"./lib/isUUID":453,"./lib/isUppercase":454,"./lib/isVariableWidth":455,"./lib/isWhitelisted":456,"./lib/ltrim":457,"./lib/matches":458,"./lib/normalizeEmail":459,"./lib/rtrim":460,"./lib/stripLow":461,"./lib/toBoolean":462,"./lib/toDate":463,"./lib/toFloat":464,"./lib/toInt":465,"./lib/trim":466,"./lib/unescape":467,"./lib/util/toString":470,"./lib/whitelist":471}],408:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -84551,7 +72055,7 @@ for (var _locale, _i = 0; _i < arabicLocales.length; _i++) {
   alpha[_locale] = alpha.ar;
   alphanumeric[_locale] = alphanumeric.ar;
 }
-},{}],490:[function(require,module,exports){
+},{}],409:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -84570,7 +72074,7 @@ function blacklist(str, chars) {
   return str.replace(new RegExp('[' + chars + ']+', 'g'), '');
 }
 module.exports = exports['default'];
-},{"./util/assertString":549}],491:[function(require,module,exports){
+},{"./util/assertString":468}],410:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -84593,7 +72097,7 @@ function contains(str, elem) {
   return str.indexOf((0, _toString2.default)(elem)) >= 0;
 }
 module.exports = exports['default'];
-},{"./util/assertString":549,"./util/toString":551}],492:[function(require,module,exports){
+},{"./util/assertString":468,"./util/toString":470}],411:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -84612,7 +72116,7 @@ function equals(str, comparison) {
   return str === comparison;
 }
 module.exports = exports['default'];
-},{"./util/assertString":549}],493:[function(require,module,exports){
+},{"./util/assertString":468}],412:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -84631,7 +72135,7 @@ function escape(str) {
   return str.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/'/g, '&#x27;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/\//g, '&#x2F;').replace(/\\/g, '&#x5C;').replace(/`/g, '&#96;');
 }
 module.exports = exports['default'];
-},{"./util/assertString":549}],494:[function(require,module,exports){
+},{"./util/assertString":468}],413:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -84658,7 +72162,7 @@ function isAfter(str) {
   return !!(original && comparison && original > comparison);
 }
 module.exports = exports['default'];
-},{"./toDate":544,"./util/assertString":549}],495:[function(require,module,exports){
+},{"./toDate":463,"./util/assertString":468}],414:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -84684,7 +72188,7 @@ function isAlpha(str) {
   throw new Error('Invalid locale \'' + locale + '\'');
 }
 module.exports = exports['default'];
-},{"./alpha":489,"./util/assertString":549}],496:[function(require,module,exports){
+},{"./alpha":408,"./util/assertString":468}],415:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -84710,7 +72214,7 @@ function isAlphanumeric(str) {
   throw new Error('Invalid locale \'' + locale + '\'');
 }
 module.exports = exports['default'];
-},{"./alpha":489,"./util/assertString":549}],497:[function(require,module,exports){
+},{"./alpha":408,"./util/assertString":468}],416:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -84733,7 +72237,7 @@ function isAscii(str) {
   return ascii.test(str);
 }
 module.exports = exports['default'];
-},{"./util/assertString":549}],498:[function(require,module,exports){
+},{"./util/assertString":468}],417:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -84759,7 +72263,7 @@ function isBase64(str) {
   return firstPaddingChar === -1 || firstPaddingChar === len - 1 || firstPaddingChar === len - 2 && str[len - 1] === '=';
 }
 module.exports = exports['default'];
-},{"./util/assertString":549}],499:[function(require,module,exports){
+},{"./util/assertString":468}],418:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -84786,7 +72290,7 @@ function isBefore(str) {
   return !!(original && comparison && original < comparison);
 }
 module.exports = exports['default'];
-},{"./toDate":544,"./util/assertString":549}],500:[function(require,module,exports){
+},{"./toDate":463,"./util/assertString":468}],419:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -84805,7 +72309,7 @@ function isBoolean(str) {
   return ['true', 'false', '1', '0'].indexOf(str) >= 0;
 }
 module.exports = exports['default'];
-},{"./util/assertString":549}],501:[function(require,module,exports){
+},{"./util/assertString":468}],420:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -84839,7 +72343,7 @@ function isByteLength(str, options) {
   return len >= min && (typeof max === 'undefined' || len <= max);
 }
 module.exports = exports['default'];
-},{"./util/assertString":549}],502:[function(require,module,exports){
+},{"./util/assertString":468}],421:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -84885,7 +72389,7 @@ function isCreditCard(str) {
   return !!(sum % 10 === 0 ? sanitized : false);
 }
 module.exports = exports['default'];
-},{"./util/assertString":549}],503:[function(require,module,exports){
+},{"./util/assertString":468}],422:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -84971,7 +72475,7 @@ function isCurrency(str, options) {
   return currencyRegex(options).test(str);
 }
 module.exports = exports['default'];
-},{"./util/assertString":549,"./util/merge":550}],504:[function(require,module,exports){
+},{"./util/assertString":468,"./util/merge":469}],423:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -84992,7 +72496,7 @@ function isDataURI(str) {
   return dataURI.test(str);
 }
 module.exports = exports['default'];
-},{"./util/assertString":549}],505:[function(require,module,exports){
+},{"./util/assertString":468}],424:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -85013,7 +72517,7 @@ function isDecimal(str) {
   return str !== '' && decimal.test(str);
 }
 module.exports = exports['default'];
-},{"./util/assertString":549}],506:[function(require,module,exports){
+},{"./util/assertString":468}],425:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -85036,7 +72540,7 @@ function isDivisibleBy(str, num) {
   return (0, _toFloat2.default)(str) % parseInt(num, 10) === 0;
 }
 module.exports = exports['default'];
-},{"./toFloat":545,"./util/assertString":549}],507:[function(require,module,exports){
+},{"./toFloat":464,"./util/assertString":468}],426:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -85126,7 +72630,7 @@ function isEmail(str, options) {
   return true;
 }
 module.exports = exports['default'];
-},{"./isByteLength":501,"./isFQDN":509,"./util/assertString":549,"./util/merge":550}],508:[function(require,module,exports){
+},{"./isByteLength":420,"./isFQDN":428,"./util/assertString":468,"./util/merge":469}],427:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -85145,7 +72649,7 @@ function isEmpty(str) {
   return str.length === 0;
 }
 module.exports = exports['default'];
-},{"./util/assertString":549}],509:[function(require,module,exports){
+},{"./util/assertString":468}],428:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -85207,7 +72711,7 @@ function isFDQN(str, options) {
   return true;
 }
 module.exports = exports['default'];
-},{"./util/assertString":549,"./util/merge":550}],510:[function(require,module,exports){
+},{"./util/assertString":468,"./util/merge":469}],429:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -85232,7 +72736,7 @@ function isFloat(str, options) {
   return float.test(str) && (!options.hasOwnProperty('min') || str >= options.min) && (!options.hasOwnProperty('max') || str <= options.max) && (!options.hasOwnProperty('lt') || str < options.lt) && (!options.hasOwnProperty('gt') || str > options.gt);
 }
 module.exports = exports['default'];
-},{"./util/assertString":549}],511:[function(require,module,exports){
+},{"./util/assertString":468}],430:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -85253,7 +72757,7 @@ function isFullWidth(str) {
   (0, _assertString2.default)(str);
   return fullWidth.test(str);
 }
-},{"./util/assertString":549}],512:[function(require,module,exports){
+},{"./util/assertString":468}],431:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -85274,7 +72778,7 @@ function isHalfWidth(str) {
   (0, _assertString2.default)(str);
   return halfWidth.test(str);
 }
-},{"./util/assertString":549}],513:[function(require,module,exports){
+},{"./util/assertString":468}],432:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -85295,7 +72799,7 @@ function isHexColor(str) {
   return hexcolor.test(str);
 }
 module.exports = exports['default'];
-},{"./util/assertString":549}],514:[function(require,module,exports){
+},{"./util/assertString":468}],433:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -85316,7 +72820,7 @@ function isHexadecimal(str) {
   return hexadecimal.test(str);
 }
 module.exports = exports['default'];
-},{"./util/assertString":549}],515:[function(require,module,exports){
+},{"./util/assertString":468}],434:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -85398,7 +72902,7 @@ function isIP(str) {
   return false;
 }
 module.exports = exports['default'];
-},{"./util/assertString":549}],516:[function(require,module,exports){
+},{"./util/assertString":468}],435:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -85456,7 +72960,7 @@ function isISBN(str) {
   return false;
 }
 module.exports = exports['default'];
-},{"./util/assertString":549}],517:[function(require,module,exports){
+},{"./util/assertString":468}],436:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -85505,7 +73009,7 @@ function isISIN(str) {
   return parseInt(str.substr(str.length - 1), 10) === (10000 - sum) % 10;
 }
 module.exports = exports['default'];
-},{"./util/assertString":549}],518:[function(require,module,exports){
+},{"./util/assertString":468}],437:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -85528,7 +73032,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 // from http://goo.gl/0ejHHW
 var iso8601 = exports.iso8601 = /^([\+-]?\d{4}(?!\d{2}\b))((-?)((0[1-9]|1[0-2])(\3([12]\d|0[1-9]|3[01]))?|W([0-4]\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\d|[12]\d{2}|3([0-5]\d|6[1-6])))([T\s]((([01]\d|2[0-3])((:?)[0-5]\d)?|24:?00)([\.,]\d+(?!:))?)?(\17[0-5]\d([\.,]\d+)?)?([zZ]|([\+-])([01]\d|2[0-3]):?([0-5]\d)?)?)?)?$/;
 /* eslint-enable max-len */
-},{"./util/assertString":549}],519:[function(require,module,exports){
+},{"./util/assertString":468}],438:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -85550,7 +73054,7 @@ function isISRC(str) {
   return isrc.test(str);
 }
 module.exports = exports['default'];
-},{"./util/assertString":549}],520:[function(require,module,exports){
+},{"./util/assertString":468}],439:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -85609,7 +73113,7 @@ function isISSN(str) {
   return checksum % 11 === 0;
 }
 module.exports = exports['default'];
-},{"./util/assertString":549}],521:[function(require,module,exports){
+},{"./util/assertString":468}],440:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -85649,7 +73153,7 @@ function isIn(str, options) {
   return false;
 }
 module.exports = exports['default'];
-},{"./util/assertString":549,"./util/toString":551}],522:[function(require,module,exports){
+},{"./util/assertString":468,"./util/toString":470}],441:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -85683,7 +73187,7 @@ function isInt(str, options) {
   return regex.test(str) && minCheckPassed && maxCheckPassed && ltCheckPassed && gtCheckPassed;
 }
 module.exports = exports['default'];
-},{"./util/assertString":549}],523:[function(require,module,exports){
+},{"./util/assertString":468}],442:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -85709,7 +73213,7 @@ function isJSON(str) {
   return false;
 }
 module.exports = exports['default'];
-},{"./util/assertString":549}],524:[function(require,module,exports){
+},{"./util/assertString":468}],443:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -85744,7 +73248,7 @@ function isLength(str, options) {
   return len >= min && (typeof max === 'undefined' || len <= max);
 }
 module.exports = exports['default'];
-},{"./util/assertString":549}],525:[function(require,module,exports){
+},{"./util/assertString":468}],444:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -85763,7 +73267,7 @@ function isLowercase(str) {
   return str === str.toLowerCase();
 }
 module.exports = exports['default'];
-},{"./util/assertString":549}],526:[function(require,module,exports){
+},{"./util/assertString":468}],445:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -85784,7 +73288,7 @@ function isMACAddress(str) {
   return macAddress.test(str);
 }
 module.exports = exports['default'];
-},{"./util/assertString":549}],527:[function(require,module,exports){
+},{"./util/assertString":468}],446:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -85805,7 +73309,7 @@ function isMD5(str) {
   return md5.test(str);
 }
 module.exports = exports['default'];
-},{"./util/assertString":549}],528:[function(require,module,exports){
+},{"./util/assertString":468}],447:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -85887,7 +73391,7 @@ function isMobilePhone(str, locale) {
   return false;
 }
 module.exports = exports['default'];
-},{"./util/assertString":549}],529:[function(require,module,exports){
+},{"./util/assertString":468}],448:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -85910,7 +73414,7 @@ function isMongoId(str) {
   return (0, _isHexadecimal2.default)(str) && str.length === 24;
 }
 module.exports = exports['default'];
-},{"./isHexadecimal":514,"./util/assertString":549}],530:[function(require,module,exports){
+},{"./isHexadecimal":433,"./util/assertString":468}],449:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -85933,7 +73437,7 @@ function isMultibyte(str) {
   return multibyte.test(str);
 }
 module.exports = exports['default'];
-},{"./util/assertString":549}],531:[function(require,module,exports){
+},{"./util/assertString":468}],450:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -85954,7 +73458,7 @@ function isNumeric(str) {
   return numeric.test(str);
 }
 module.exports = exports['default'];
-},{"./util/assertString":549}],532:[function(require,module,exports){
+},{"./util/assertString":468}],451:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -85975,7 +73479,7 @@ function isSurrogatePair(str) {
   return surrogatePair.test(str);
 }
 module.exports = exports['default'];
-},{"./util/assertString":549}],533:[function(require,module,exports){
+},{"./util/assertString":468}],452:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -86119,7 +73623,7 @@ function isURL(url, options) {
   return true;
 }
 module.exports = exports['default'];
-},{"./isFQDN":509,"./isIP":515,"./util/assertString":549,"./util/merge":550}],534:[function(require,module,exports){
+},{"./isFQDN":428,"./isIP":434,"./util/assertString":468,"./util/merge":469}],453:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -86148,7 +73652,7 @@ function isUUID(str) {
   return pattern && pattern.test(str);
 }
 module.exports = exports['default'];
-},{"./util/assertString":549}],535:[function(require,module,exports){
+},{"./util/assertString":468}],454:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -86167,7 +73671,7 @@ function isUppercase(str) {
   return str === str.toUpperCase();
 }
 module.exports = exports['default'];
-},{"./util/assertString":549}],536:[function(require,module,exports){
+},{"./util/assertString":468}],455:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -86190,7 +73694,7 @@ function isVariableWidth(str) {
   return _isFullWidth.fullWidth.test(str) && _isHalfWidth.halfWidth.test(str);
 }
 module.exports = exports['default'];
-},{"./isFullWidth":511,"./isHalfWidth":512,"./util/assertString":549}],537:[function(require,module,exports){
+},{"./isFullWidth":430,"./isHalfWidth":431,"./util/assertString":468}],456:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -86214,7 +73718,7 @@ function isWhitelisted(str, chars) {
   return true;
 }
 module.exports = exports['default'];
-},{"./util/assertString":549}],538:[function(require,module,exports){
+},{"./util/assertString":468}],457:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -86234,7 +73738,7 @@ function ltrim(str, chars) {
   return str.replace(pattern, '');
 }
 module.exports = exports['default'];
-},{"./util/assertString":549}],539:[function(require,module,exports){
+},{"./util/assertString":468}],458:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -86256,7 +73760,7 @@ function matches(str, pattern, modifiers) {
   return pattern.test(str);
 }
 module.exports = exports['default'];
-},{"./util/assertString":549}],540:[function(require,module,exports){
+},{"./util/assertString":468}],459:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -86394,7 +73898,7 @@ function normalizeEmail(email, options) {
   return parts.join('@');
 }
 module.exports = exports['default'];
-},{"./isEmail":507,"./util/merge":550}],541:[function(require,module,exports){
+},{"./isEmail":426,"./util/merge":469}],460:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -86420,7 +73924,7 @@ function rtrim(str, chars) {
   return idx < str.length ? str.substr(0, idx + 1) : str;
 }
 module.exports = exports['default'];
-},{"./util/assertString":549}],542:[function(require,module,exports){
+},{"./util/assertString":468}],461:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -86444,7 +73948,7 @@ function stripLow(str, keep_new_lines) {
   return (0, _blacklist2.default)(str, chars);
 }
 module.exports = exports['default'];
-},{"./blacklist":490,"./util/assertString":549}],543:[function(require,module,exports){
+},{"./blacklist":409,"./util/assertString":468}],462:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -86466,7 +73970,7 @@ function toBoolean(str, strict) {
   return str !== '0' && str !== 'false' && str !== '';
 }
 module.exports = exports['default'];
-},{"./util/assertString":549}],544:[function(require,module,exports){
+},{"./util/assertString":468}],463:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -86486,7 +73990,7 @@ function toDate(date) {
   return !isNaN(date) ? new Date(date) : null;
 }
 module.exports = exports['default'];
-},{"./util/assertString":549}],545:[function(require,module,exports){
+},{"./util/assertString":468}],464:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -86505,7 +74009,7 @@ function toFloat(str) {
   return parseFloat(str);
 }
 module.exports = exports['default'];
-},{"./util/assertString":549}],546:[function(require,module,exports){
+},{"./util/assertString":468}],465:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -86524,7 +74028,7 @@ function toInt(str, radix) {
   return parseInt(str, radix || 10);
 }
 module.exports = exports['default'];
-},{"./util/assertString":549}],547:[function(require,module,exports){
+},{"./util/assertString":468}],466:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -86546,7 +74050,7 @@ function trim(str, chars) {
   return (0, _rtrim2.default)((0, _ltrim2.default)(str, chars), chars);
 }
 module.exports = exports['default'];
-},{"./ltrim":538,"./rtrim":541}],548:[function(require,module,exports){
+},{"./ltrim":457,"./rtrim":460}],467:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -86565,7 +74069,7 @@ function unescape(str) {
   return str.replace(/&amp;/g, '&').replace(/&quot;/g, '"').replace(/&#x27;/g, "'").replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&#x2F;/g, '/').replace(/&#96;/g, '`');
 }
 module.exports = exports['default'];
-},{"./util/assertString":549}],549:[function(require,module,exports){
+},{"./util/assertString":468}],468:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -86580,7 +74084,7 @@ function assertString(input) {
   }
 }
 module.exports = exports['default'];
-},{}],550:[function(require,module,exports){
+},{}],469:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -86599,7 +74103,7 @@ function merge() {
   return obj;
 }
 module.exports = exports['default'];
-},{}],551:[function(require,module,exports){
+},{}],470:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -86622,7 +74126,7 @@ function toString(input) {
   return String(input);
 }
 module.exports = exports['default'];
-},{}],552:[function(require,module,exports){
+},{}],471:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -86641,7 +74145,7 @@ function whitelist(str, chars) {
   return str.replace(new RegExp('[^' + chars + ']+', 'g'), '');
 }
 module.exports = exports['default'];
-},{"./util/assertString":549}],553:[function(require,module,exports){
+},{"./util/assertString":468}],472:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -86674,7 +74178,7 @@ Object.defineProperty(exports, 'ZoneFile', {
     return _zoneFile.ZoneFile;
   }
 });
-},{"./makeZoneFile":554,"./parseZoneFile":555,"./zoneFile":556}],554:[function(require,module,exports){
+},{"./makeZoneFile":473,"./parseZoneFile":474,"./zoneFile":475}],473:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -86843,7 +74347,7 @@ var processValues = function processValues(jsonZoneFile, template) {
     template = template.replace('{datetime}', new Date().toISOString());
     return template.replace('{time}', Math.round(Date.now() / 1000));
 };
-},{"./zoneFileTemplate":557}],555:[function(require,module,exports){
+},{"./zoneFileTemplate":476}],474:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -87099,7 +74603,7 @@ var parseURI = function parseURI(rr) {
     if (!isNaN(rrTokens[1])) result.ttl = parseInt(rrTokens[1], 10);
     return result;
 };
-},{}],556:[function(require,module,exports){
+},{}],475:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -87142,7 +74646,7 @@ var ZoneFile = exports.ZoneFile = function () {
 
   return ZoneFile;
 }();
-},{"./makeZoneFile":554,"./parseZoneFile":555}],557:[function(require,module,exports){
+},{"./makeZoneFile":473,"./parseZoneFile":474}],476:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {

--- a/dist/blockstack.js
+++ b/dist/blockstack.js
@@ -3560,6 +3560,9 @@ function getFile(path) {
   return (0, _hub.getOrSetLocalGaiaHubConnection)().then(function (gaiaHubConfig) {
     return fetch((0, _hub.getFullReadUrl)(path, gaiaHubConfig));
   }).then(function (response) {
+    if (response.status !== 200) {
+      throw new Error('getFile ' + path + ' failed with HTTP status ' + response.status);
+    }
     var contentType = response.headers.get('Content-Type');
     if (contentType === null || decrypt || contentType.startsWith('text') || contentType === 'application/json') {
       return response.text();

--- a/docs.json
+++ b/docs.json
@@ -457,22 +457,22 @@
     ],
     "loc": {
       "start": {
-        "line": 86,
+        "line": 87,
         "column": 0
       },
       "end": {
-        "line": 108,
+        "line": 109,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 109,
+          "line": 110,
           "column": 0
         },
         "end": {
-          "line": 115,
+          "line": 116,
           "column": 1
         }
       },
@@ -790,22 +790,22 @@
     ],
     "loc": {
       "start": {
-        "line": 126,
+        "line": 127,
         "column": 0
       },
       "end": {
-        "line": 129,
+        "line": 130,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 130,
+          "line": 131,
           "column": 0
         },
         "end": {
-          "line": 132,
+          "line": 133,
           "column": 1
         }
       },
@@ -1044,22 +1044,22 @@
     ],
     "loc": {
       "start": {
-        "line": 135,
+        "line": 136,
         "column": 0
       },
       "end": {
-        "line": 144,
+        "line": 145,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 145,
+          "line": 146,
           "column": 0
         },
         "end": {
-          "line": 223,
+          "line": 224,
           "column": 1
         }
       },
@@ -1321,22 +1321,22 @@
     ],
     "loc": {
       "start": {
-        "line": 225,
+        "line": 226,
         "column": 0
       },
       "end": {
-        "line": 228,
+        "line": 229,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 229,
+          "line": 230,
           "column": 0
         },
         "end": {
-          "line": 231,
+          "line": 232,
           "column": 1
         }
       },
@@ -1493,22 +1493,22 @@
     ],
     "loc": {
       "start": {
-        "line": 44,
+        "line": 45,
         "column": 0
       },
       "end": {
-        "line": 47,
+        "line": 48,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 48,
+          "line": 49,
           "column": 0
         },
         "end": {
-          "line": 50,
+          "line": 51,
           "column": 1
         }
       },
@@ -1730,22 +1730,22 @@
     ],
     "loc": {
       "start": {
-        "line": 233,
+        "line": 234,
         "column": 0
       },
       "end": {
-        "line": 237,
+        "line": 238,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 238,
+          "line": 239,
           "column": 0
         },
         "end": {
-          "line": 245,
+          "line": 246,
           "column": 1
         }
       },
@@ -2021,7 +2021,7 @@
           "column": 0
         },
         "end": {
-          "line": 73,
+          "line": 74,
           "column": 1
         }
       },
@@ -2697,22 +2697,22 @@
     ],
     "loc": {
       "start": {
-        "line": 52,
+        "line": 53,
         "column": 0
       },
       "end": {
-        "line": 63,
+        "line": 64,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 64,
+          "line": 65,
           "column": 0
         },
         "end": {
-          "line": 84,
+          "line": 85,
           "column": 1
         }
       },
@@ -2979,22 +2979,22 @@
     ],
     "loc": {
       "start": {
-        "line": 117,
+        "line": 118,
         "column": 0
       },
       "end": {
-        "line": 120,
+        "line": 121,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 121,
+          "line": 122,
           "column": 0
         },
         "end": {
-          "line": 124,
+          "line": 125,
           "column": 1
         }
       },
@@ -7133,22 +7133,22 @@
     ],
     "loc": {
       "start": {
-        "line": 67,
+        "line": 68,
         "column": 0
       },
       "end": {
-        "line": 72,
+        "line": 73,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 73,
+          "line": 74,
           "column": 0
         },
         "end": {
-          "line": 80,
+          "line": 91,
           "column": 1
         }
       },

--- a/docs.json
+++ b/docs.json
@@ -5769,7 +5769,7 @@
           "column": 0
         },
         "end": {
-          "line": 30,
+          "line": 39,
           "column": 1
         }
       },
@@ -6093,22 +6093,22 @@
     ],
     "loc": {
       "start": {
-        "line": 32,
+        "line": 41,
         "column": 0
       },
       "end": {
-        "line": 39,
+        "line": 48,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 40,
+          "line": 49,
           "column": 0
         },
         "end": {
-          "line": 49,
+          "line": 63,
           "column": 1
         }
       },
@@ -7315,22 +7315,22 @@
     ],
     "loc": {
       "start": {
-        "line": 51,
+        "line": 65,
         "column": 0
       },
       "end": {
-        "line": 56,
+        "line": 70,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 57,
+          "line": 71,
           "column": 0
         },
         "end": {
-          "line": 59,
+          "line": 73,
           "column": 1
         }
       },

--- a/docs.json
+++ b/docs.json
@@ -476,7 +476,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/auth/authApp.js"
+      "file": "/home/aaron/devel/blockstack.js/src/auth/authApp.js"
     },
     "augments": [],
     "examples": [],
@@ -809,7 +809,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/auth/authApp.js"
+      "file": "/home/aaron/devel/blockstack.js/src/auth/authApp.js"
     },
     "augments": [],
     "examples": [],
@@ -1059,11 +1059,11 @@
           "column": 0
         },
         "end": {
-          "line": 207,
+          "line": 221,
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/auth/authApp.js"
+      "file": "/home/aaron/devel/blockstack.js/src/auth/authApp.js"
     },
     "augments": [],
     "examples": [],
@@ -1321,26 +1321,26 @@
     ],
     "loc": {
       "start": {
-        "line": 209,
+        "line": 223,
         "column": 0
       },
       "end": {
-        "line": 212,
+        "line": 226,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 213,
+          "line": 227,
           "column": 0
         },
         "end": {
-          "line": 215,
+          "line": 229,
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/auth/authApp.js"
+      "file": "/home/aaron/devel/blockstack.js/src/auth/authApp.js"
     },
     "augments": [],
     "examples": [],
@@ -1512,7 +1512,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/auth/authApp.js"
+      "file": "/home/aaron/devel/blockstack.js/src/auth/authApp.js"
     },
     "augments": [],
     "examples": [],
@@ -1730,26 +1730,26 @@
     ],
     "loc": {
       "start": {
-        "line": 217,
+        "line": 231,
         "column": 0
       },
       "end": {
-        "line": 221,
+        "line": 235,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 222,
+          "line": 236,
           "column": 0
         },
         "end": {
-          "line": 228,
+          "line": 242,
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/auth/authApp.js"
+      "file": "/home/aaron/devel/blockstack.js/src/auth/authApp.js"
     },
     "augments": [],
     "examples": [],
@@ -2025,7 +2025,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/auth/authMessages.js"
+      "file": "/home/aaron/devel/blockstack.js/src/auth/authMessages.js"
     },
     "augments": [],
     "examples": [],
@@ -2716,7 +2716,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/auth/authApp.js"
+      "file": "/home/aaron/devel/blockstack.js/src/auth/authApp.js"
     },
     "augments": [],
     "examples": [],
@@ -2998,7 +2998,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/auth/authApp.js"
+      "file": "/home/aaron/devel/blockstack.js/src/auth/authApp.js"
     },
     "augments": [],
     "examples": [],
@@ -3379,7 +3379,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/profiles/profileTokens.js"
+      "file": "/home/aaron/devel/blockstack.js/src/profiles/profileTokens.js"
     },
     "augments": [],
     "examples": [],
@@ -3765,7 +3765,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/profiles/profileTokens.js"
+      "file": "/home/aaron/devel/blockstack.js/src/profiles/profileTokens.js"
     },
     "augments": [],
     "examples": [],
@@ -4120,7 +4120,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/profiles/profileTokens.js"
+      "file": "/home/aaron/devel/blockstack.js/src/profiles/profileTokens.js"
     },
     "augments": [],
     "examples": [],
@@ -4754,7 +4754,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/profiles/profileTokens.js"
+      "file": "/home/aaron/devel/blockstack.js/src/profiles/profileTokens.js"
     },
     "augments": [],
     "examples": [],
@@ -5150,7 +5150,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/profiles/profileProofs.js"
+      "file": "/home/aaron/devel/blockstack.js/src/profiles/profileProofs.js"
     },
     "augments": [],
     "examples": [],
@@ -5754,26 +5754,26 @@
     ],
     "loc": {
       "start": {
-        "line": 9,
+        "line": 10,
         "column": 0
       },
       "end": {
-        "line": 15,
+        "line": 16,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 16,
+          "line": 17,
           "column": 0
         },
         "end": {
-          "line": 27,
+          "line": 30,
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/storage/index.js"
+      "file": "/home/aaron/devel/blockstack.js/src/storage/index.js"
     },
     "augments": [],
     "examples": [],
@@ -6093,26 +6093,26 @@
     ],
     "loc": {
       "start": {
-        "line": 29,
+        "line": 32,
         "column": 0
       },
       "end": {
-        "line": 36,
+        "line": 39,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 37,
+          "line": 40,
           "column": 0
         },
         "end": {
-          "line": 45,
+          "line": 49,
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/storage/index.js"
+      "file": "/home/aaron/devel/blockstack.js/src/storage/index.js"
     },
     "augments": [],
     "examples": [],
@@ -6511,7 +6511,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/encryption.js"
+      "file": "/home/aaron/devel/blockstack.js/src/encryption.js"
     },
     "augments": [],
     "examples": [],
@@ -6843,7 +6843,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/encryption.js"
+      "file": "/home/aaron/devel/blockstack.js/src/encryption.js"
     },
     "augments": [],
     "examples": [],
@@ -7060,5 +7060,431 @@
       }
     ],
     "namespace": "decryptECIES"
+  },
+  {
+    "description": {
+      "type": "root",
+      "children": [
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "These two functions are app-specific connections to gaia hub,\n  they read the user data object for information on setting up\n  a hub connection, and store the hub config to localstorage",
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1,
+                  "offset": 0
+                },
+                "end": {
+                  "line": 3,
+                  "column": 61,
+                  "offset": 185
+                },
+                "indent": [
+                  1,
+                  1
+                ]
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 3,
+              "column": 61,
+              "offset": 185
+            },
+            "indent": [
+              1,
+              1
+            ]
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 1,
+          "column": 1,
+          "offset": 0
+        },
+        "end": {
+          "line": 3,
+          "column": 61,
+          "offset": 185
+        }
+      }
+    },
+    "tags": [
+      {
+        "title": "returns",
+        "description": "that resolves to the new gaia hub connection",
+        "lineNumber": 4,
+        "type": {
+          "type": "NameExpression",
+          "name": "Promise"
+        }
+      }
+    ],
+    "loc": {
+      "start": {
+        "line": 67,
+        "column": 0
+      },
+      "end": {
+        "line": 72,
+        "column": 3
+      }
+    },
+    "context": {
+      "loc": {
+        "start": {
+          "line": 73,
+          "column": 0
+        },
+        "end": {
+          "line": 80,
+          "column": 1
+        }
+      },
+      "file": "/home/aaron/devel/blockstack.js/src/storage/hub.js"
+    },
+    "augments": [],
+    "examples": [],
+    "params": [],
+    "properties": [],
+    "returns": [
+      {
+        "description": {
+          "type": "root",
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "that resolves to the new gaia hub connection",
+                  "position": {
+                    "start": {
+                      "line": 1,
+                      "column": 1,
+                      "offset": 0
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 45,
+                      "offset": 44
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1,
+                  "offset": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 45,
+                  "offset": 44
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 45,
+              "offset": 44
+            }
+          }
+        },
+        "title": "returns",
+        "type": {
+          "type": "NameExpression",
+          "name": "Promise"
+        }
+      }
+    ],
+    "sees": [],
+    "throws": [],
+    "todos": [],
+    "name": "setLocalGaiaHubConnection",
+    "kind": "function",
+    "members": {
+      "global": [],
+      "inner": [],
+      "instance": [],
+      "events": [],
+      "static": []
+    },
+    "path": [
+      {
+        "name": "setLocalGaiaHubConnection",
+        "kind": "function"
+      }
+    ],
+    "namespace": "setLocalGaiaHubConnection"
+  },
+  {
+    "description": {
+      "type": "root",
+      "children": [
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "Deletes the specified file from the app's data store.",
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1,
+                  "offset": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 54,
+                  "offset": 53
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 54,
+              "offset": 53
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 1,
+          "column": 1,
+          "offset": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 54,
+          "offset": 53
+        }
+      }
+    },
+    "tags": [
+      {
+        "title": "param",
+        "description": "the path to the file to delete",
+        "lineNumber": 2,
+        "type": {
+          "type": "NameExpression",
+          "name": "String"
+        },
+        "name": "path"
+      },
+      {
+        "title": "returns",
+        "description": "that resolves when the file has been removed\nor rejects with an error",
+        "lineNumber": 3,
+        "type": {
+          "type": "NameExpression",
+          "name": "Promise"
+        }
+      }
+    ],
+    "loc": {
+      "start": {
+        "line": 51,
+        "column": 0
+      },
+      "end": {
+        "line": 56,
+        "column": 3
+      }
+    },
+    "context": {
+      "loc": {
+        "start": {
+          "line": 57,
+          "column": 0
+        },
+        "end": {
+          "line": 59,
+          "column": 1
+        }
+      },
+      "file": "/home/aaron/devel/blockstack.js/src/storage/index.js"
+    },
+    "augments": [],
+    "examples": [],
+    "params": [
+      {
+        "title": "param",
+        "name": "path",
+        "lineNumber": 2,
+        "description": {
+          "type": "root",
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "the path to the file to delete",
+                  "position": {
+                    "start": {
+                      "line": 1,
+                      "column": 1,
+                      "offset": 0
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 31,
+                      "offset": 30
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1,
+                  "offset": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 31,
+                  "offset": 30
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 31,
+              "offset": 30
+            }
+          }
+        },
+        "type": {
+          "type": "NameExpression",
+          "name": "String"
+        }
+      }
+    ],
+    "properties": [],
+    "returns": [
+      {
+        "description": {
+          "type": "root",
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "that resolves when the file has been removed\nor rejects with an error",
+                  "position": {
+                    "start": {
+                      "line": 1,
+                      "column": 1,
+                      "offset": 0
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 25,
+                      "offset": 69
+                    },
+                    "indent": [
+                      1
+                    ]
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1,
+                  "offset": 0
+                },
+                "end": {
+                  "line": 2,
+                  "column": 25,
+                  "offset": 69
+                },
+                "indent": [
+                  1
+                ]
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 2,
+              "column": 25,
+              "offset": 69
+            }
+          }
+        },
+        "title": "returns",
+        "type": {
+          "type": "NameExpression",
+          "name": "Promise"
+        }
+      }
+    ],
+    "sees": [],
+    "throws": [],
+    "todos": [],
+    "name": "deleteFile",
+    "kind": "function",
+    "members": {
+      "global": [],
+      "inner": [],
+      "instance": [],
+      "events": [],
+      "static": []
+    },
+    "path": [
+      {
+        "name": "deleteFile",
+        "kind": "function"
+      }
+    ],
+    "namespace": "deleteFile"
   }
 ]

--- a/docs.json
+++ b/docs.json
@@ -5769,7 +5769,7 @@
           "column": 0
         },
         "end": {
-          "line": 39,
+          "line": 42,
           "column": 1
         }
       },
@@ -6093,22 +6093,22 @@
     ],
     "loc": {
       "start": {
-        "line": 41,
+        "line": 44,
         "column": 0
       },
       "end": {
-        "line": 48,
+        "line": 51,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 49,
+          "line": 52,
           "column": 0
         },
         "end": {
-          "line": 63,
+          "line": 66,
           "column": 1
         }
       },
@@ -7315,22 +7315,22 @@
     ],
     "loc": {
       "start": {
-        "line": 65,
+        "line": 68,
         "column": 0
       },
       "end": {
-        "line": 70,
+        "line": 73,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 71,
+          "line": 74,
           "column": 0
         },
         "end": {
-          "line": 73,
+          "line": 76,
           "column": 1
         }
       },

--- a/docs.json
+++ b/docs.json
@@ -457,22 +457,22 @@
     ],
     "loc": {
       "start": {
-        "line": 84,
+        "line": 86,
         "column": 0
       },
       "end": {
-        "line": 106,
+        "line": 108,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 107,
+          "line": 109,
           "column": 0
         },
         "end": {
-          "line": 113,
+          "line": 115,
           "column": 1
         }
       },
@@ -790,22 +790,22 @@
     ],
     "loc": {
       "start": {
-        "line": 124,
+        "line": 126,
         "column": 0
       },
       "end": {
-        "line": 127,
+        "line": 129,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 128,
+          "line": 130,
           "column": 0
         },
         "end": {
-          "line": 130,
+          "line": 132,
           "column": 1
         }
       },
@@ -1044,22 +1044,22 @@
     ],
     "loc": {
       "start": {
-        "line": 133,
+        "line": 135,
         "column": 0
       },
       "end": {
-        "line": 142,
+        "line": 144,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 143,
+          "line": 145,
           "column": 0
         },
         "end": {
-          "line": 221,
+          "line": 223,
           "column": 1
         }
       },
@@ -1321,22 +1321,22 @@
     ],
     "loc": {
       "start": {
-        "line": 223,
+        "line": 225,
         "column": 0
       },
       "end": {
-        "line": 226,
+        "line": 228,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 227,
+          "line": 229,
           "column": 0
         },
         "end": {
-          "line": 229,
+          "line": 231,
           "column": 1
         }
       },
@@ -1493,22 +1493,22 @@
     ],
     "loc": {
       "start": {
-        "line": 42,
+        "line": 44,
         "column": 0
       },
       "end": {
-        "line": 45,
+        "line": 47,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 46,
+          "line": 48,
           "column": 0
         },
         "end": {
-          "line": 48,
+          "line": 50,
           "column": 1
         }
       },
@@ -1730,22 +1730,22 @@
     ],
     "loc": {
       "start": {
-        "line": 231,
+        "line": 233,
         "column": 0
       },
       "end": {
-        "line": 235,
+        "line": 237,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 236,
+          "line": 238,
           "column": 0
         },
         "end": {
-          "line": 242,
+          "line": 245,
           "column": 1
         }
       },
@@ -2697,22 +2697,22 @@
     ],
     "loc": {
       "start": {
-        "line": 50,
+        "line": 52,
         "column": 0
       },
       "end": {
-        "line": 61,
+        "line": 63,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 62,
+          "line": 64,
           "column": 0
         },
         "end": {
-          "line": 82,
+          "line": 84,
           "column": 1
         }
       },
@@ -2979,22 +2979,22 @@
     ],
     "loc": {
       "start": {
-        "line": 115,
+        "line": 117,
         "column": 0
       },
       "end": {
-        "line": 118,
+        "line": 120,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 119,
+          "line": 121,
           "column": 0
         },
         "end": {
-          "line": 122,
+          "line": 124,
           "column": 1
         }
       },
@@ -7486,5 +7486,320 @@
       }
     ],
     "namespace": "deleteFile"
+  },
+  {
+    "description": {
+      "type": "root",
+      "children": [
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "Versioning",
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1,
+                  "offset": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 11,
+                  "offset": 10
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 11,
+              "offset": 10
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 1,
+          "column": 1,
+          "offset": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 11,
+          "offset": 10
+        }
+      }
+    },
+    "tags": [
+      {
+        "title": "param",
+        "description": "the left half of the version inequality",
+        "lineNumber": 2,
+        "type": {
+          "type": "NameExpression",
+          "name": "string"
+        },
+        "name": "v1"
+      },
+      {
+        "title": "param",
+        "description": "right half of the version inequality",
+        "lineNumber": 3,
+        "type": {
+          "type": "NameExpression",
+          "name": "string"
+        },
+        "name": "v2"
+      },
+      {
+        "title": "returns",
+        "description": "iff v1 >= v2",
+        "lineNumber": 4,
+        "type": {
+          "type": "NameExpression",
+          "name": "bool"
+        }
+      }
+    ],
+    "loc": {
+      "start": {
+        "line": 47,
+        "column": 0
+      },
+      "end": {
+        "line": 52,
+        "column": 3
+      }
+    },
+    "context": {
+      "loc": {
+        "start": {
+          "line": 53,
+          "column": 0
+        },
+        "end": {
+          "line": 66,
+          "column": 1
+        }
+      },
+      "file": "/home/aaron/devel/blockstack.js/src/utils.js"
+    },
+    "augments": [],
+    "examples": [],
+    "params": [
+      {
+        "title": "param",
+        "name": "v1",
+        "lineNumber": 2,
+        "description": {
+          "type": "root",
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "the left half of the version inequality",
+                  "position": {
+                    "start": {
+                      "line": 1,
+                      "column": 1,
+                      "offset": 0
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 40,
+                      "offset": 39
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1,
+                  "offset": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 40,
+                  "offset": 39
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 40,
+              "offset": 39
+            }
+          }
+        },
+        "type": {
+          "type": "NameExpression",
+          "name": "string"
+        }
+      },
+      {
+        "title": "param",
+        "name": "v2",
+        "lineNumber": 3,
+        "description": {
+          "type": "root",
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "right half of the version inequality",
+                  "position": {
+                    "start": {
+                      "line": 1,
+                      "column": 1,
+                      "offset": 0
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 37,
+                      "offset": 36
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1,
+                  "offset": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 37,
+                  "offset": 36
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 37,
+              "offset": 36
+            }
+          }
+        },
+        "type": {
+          "type": "NameExpression",
+          "name": "string"
+        }
+      }
+    ],
+    "properties": [],
+    "returns": [
+      {
+        "description": {
+          "type": "root",
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "iff v1 >= v2",
+                  "position": {
+                    "start": {
+                      "line": 1,
+                      "column": 1,
+                      "offset": 0
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 13,
+                      "offset": 12
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1,
+                  "offset": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 13,
+                  "offset": 12
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 13,
+              "offset": 12
+            }
+          }
+        },
+        "title": "returns",
+        "type": {
+          "type": "NameExpression",
+          "name": "bool"
+        }
+      }
+    ],
+    "sees": [],
+    "throws": [],
+    "todos": [],
+    "name": "isLaterVersion",
+    "kind": "function",
+    "members": {
+      "global": [],
+      "inner": [],
+      "instance": [],
+      "events": [],
+      "static": []
+    },
+    "path": [
+      {
+        "name": "isLaterVersion",
+        "kind": "function"
+      }
+    ],
+    "namespace": "isLaterVersion"
   }
 ]

--- a/docs/index.html
+++ b/docs/index.html
@@ -253,6 +253,16 @@
                 
                 </li>
               
+                
+                <li><a
+                  href='#islaterversion'
+                  class="">
+                  isLaterVersion
+                  
+                </a>
+                
+                </li>
+              
             </ul>
           </div>
           <div class='mt1 h6 quiet'>
@@ -1899,6 +1909,84 @@ a hub connection, and store the hub config to localstorage</p>
       <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
         that resolves when the file has been removed
 or rejects with an error
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+            <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='islaterversion'>
+      isLaterVersion
+    </h3>
+    
+    
+  </div>
+  
+
+  <p>Versioning</p>
+
+
+  <div class='pre p1 fill-light mt0'>isLaterVersion(v1: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, v2: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): bool</div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>v1</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+	    the left half of the version inequality
+
+          </div>
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>v2</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+	    right half of the version inequality
+
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code>bool</code>:
+        iff v1 >= v2
 
       
     

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset='utf-8' />
-  <title>blockstack 0.13.7 | Documentation</title>
+  <title>blockstack 0.13.8 | Documentation</title>
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <link href='assets/bass.css' type='text/css' rel='stylesheet' />
   <link href='assets/style.css' type='text/css' rel='stylesheet' />
@@ -14,7 +14,7 @@
       <div class='fixed xs-hide fix-3 overflow-auto max-height-100'>
         <div class='py1 px2'>
           <h3 class='mb0 no-anchor'>blockstack</h3>
-          <div class='mb1'><code>0.13.7</code></div>
+          <div class='mb1'><code>0.13.8</code></div>
           <input
             placeholder='Filter'
             id='filter-input'
@@ -228,6 +228,26 @@
                   href='#decryptecies'
                   class="">
                   decryptECIES
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#setlocalgaiahubconnection'
+                  class="">
+                  setLocalGaiaHubConnection
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#deletefile'
+                  class="">
+                  deleteFile
                   
                 </a>
                 
@@ -1752,6 +1772,133 @@ wasString (boolean indicating with or not to return a buffer or string on decryp
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="https://nodejs.org/api/buffer.html">Buffer</a></code>:
         plaintext, or false if error
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+            <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='setlocalgaiahubconnection'>
+      setLocalGaiaHubConnection
+    </h3>
+    
+    
+  </div>
+  
+
+  <p>These two functions are app-specific connections to gaia hub,
+they read the user data object for information on setting up
+a hub connection, and store the hub config to localstorage</p>
+
+
+  <div class='pre p1 fill-light mt0'>setLocalGaiaHubConnection(): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
+        that resolves to the new gaia hub connection
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+            <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='deletefile'>
+      deleteFile
+    </h3>
+    
+    
+  </div>
+  
+
+  <p>Deletes the specified file from the app's data store.</p>
+
+
+  <div class='pre p1 fill-light mt0'>deleteFile(path: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>path</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)</code>
+	    the path to the file to delete
+
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
+        that resolves when the file has been removed
+or rejects with an error
 
       
     

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "blockstack",
-  "version": "0.13.7",
+  "version": "0.13.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -468,7 +468,6 @@
           "requires": {
             "anymatch": "1.3.2",
             "async-each": "1.0.1",
-            "fsevents": "1.1.3",
             "glob-parent": "2.0.0",
             "inherits": "2.0.3",
             "is-binary-path": "1.0.1",
@@ -2724,7 +2723,7 @@
     "base": {
       "version": "0.11.2",
       "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
-      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
       "dev": true,
       "requires": {
         "cache-base": "1.0.1",
@@ -4173,7 +4172,7 @@
     "cache-base": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
-      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
       "dev": true,
       "requires": {
         "collection-visit": "1.0.0",
@@ -4298,7 +4297,6 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
-        "fsevents": "1.1.3",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -4332,7 +4330,7 @@
         "is-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
           "dev": true,
           "requires": {
             "is-accessor-descriptor": "0.1.6",
@@ -4349,7 +4347,7 @@
         "kind-of": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
           "dev": true
         }
       }
@@ -4424,7 +4422,7 @@
     "color-convert": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "integrity": "sha1-wSYRB66y8pTr/+ye2eytUppgl+0=",
       "dev": true,
       "requires": {
         "color-name": "1.1.3"
@@ -6743,910 +6741,6 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "fsevents": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
-      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "nan": "2.8.0",
-        "node-pre-gyp": "0.6.39"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ajv": {
-          "version": "4.11.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "aproba": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.2.9"
-          }
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "balanced-match": {
-          "version": "0.4.2",
-          "bundled": true,
-          "dev": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "block-stream": {
-          "version": "0.0.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.3"
-          }
-        },
-        "boom": {
-          "version": "2.10.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "brace-expansion": {
-          "version": "1.1.7",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "balanced-match": "0.4.2",
-            "concat-map": "0.0.1"
-          }
-        },
-        "buffer-shims": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "co": {
-          "version": "4.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "boom": "2.10.1"
-          }
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "debug": {
-          "version": "2.6.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "deep-extend": {
-          "version": "0.4.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "detect-libc": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "extend": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "extsprintf": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.15"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "fstream": {
-          "version": "1.0.11",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.1"
-          }
-        },
-        "fstream-ignore": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "fstream": "1.0.11",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4"
-          }
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aproba": "1.1.1",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
-          }
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "bundled": true,
-          "dev": true
-        },
-        "har-schema": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "har-validator": {
-          "version": "4.2.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "bundled": true,
-          "dev": true
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.0",
-            "sshpk": "1.13.0"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "ini": {
-          "version": "1.3.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jodid25519": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsonify": "0.0.0"
-          }
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jsonify": {
-          "version": "0.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jsprim": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.0.2",
-            "json-schema": "0.2.3",
-            "verror": "1.3.6"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "mime-db": {
-          "version": "1.27.0",
-          "bundled": true,
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.1.15",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "mime-db": "1.27.0"
-          }
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true,
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "node-pre-gyp": {
-          "version": "0.6.39",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "detect-libc": "1.0.2",
-            "hawk": "3.1.3",
-            "mkdirp": "0.5.1",
-            "nopt": "4.0.1",
-            "npmlog": "4.1.0",
-            "rc": "1.2.1",
-            "request": "2.81.0",
-            "rimraf": "2.6.1",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "tar-pack": "3.4.0"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1.1.0",
-            "osenv": "0.1.4"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "osenv": {
-          "version": "0.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "performance-now": {
-          "version": "0.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "bundled": true,
-          "dev": true
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "qs": {
-          "version": "6.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "rc": {
-          "version": "1.2.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.2.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "buffer-shims": "1.0.0",
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "1.0.1",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "request": {
-          "version": "2.81.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.15",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.0.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.0.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "glob": "7.1.2"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "semver": {
-          "version": "5.3.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "sshpk": {
-          "version": "1.13.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jodid25519": "1.0.2",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "tar": {
-          "version": "2.2.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
-          }
-        },
-        "tar-pack": {
-          "version": "3.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "debug": "2.6.8",
-            "fstream": "1.0.11",
-            "fstream-ignore": "1.0.5",
-            "once": "1.4.0",
-            "readable-stream": "2.2.9",
-            "rimraf": "2.6.1",
-            "tar": "2.2.1",
-            "uid-number": "0.0.6"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.3.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "punycode": "1.4.1"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "uid-number": {
-          "version": "0.0.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "uuid": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "verror": {
-          "version": "1.3.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "extsprintf": "1.0.2"
-          }
-        },
-        "wide-align": {
-          "version": "1.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "string-width": "1.0.2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        }
-      }
-    },
     "get-caller-file": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
@@ -8457,7 +7551,7 @@
     "is-descriptor": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.1.tgz",
-      "integrity": "sha512-G3fFVFTqfaqu7r4YuSBHKBAuOaLz8Sy7ekklUpFEliaLMP1Y2ZjoN9jS62YWCAPQrQpMUQSitRlrzibbuCZjdA==",
+      "integrity": "sha1-LGAjWZveLenV0si5qdlAggNrbvI=",
       "dev": true,
       "requires": {
         "is-accessor-descriptor": "0.1.6",
@@ -8468,7 +7562,7 @@
         "kind-of": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
           "dev": true
         }
       }
@@ -8571,7 +7665,7 @@
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
       "dev": true,
       "requires": {
         "isobject": "3.0.1"
@@ -9445,17 +8539,10 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
-    "nan": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
-      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
-      "dev": true,
-      "optional": true
-    },
     "nanomatch": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.5.tgz",
-      "integrity": "sha512-ZHJamn1utzcUvW8Bais+Kk7pobp6dKmUEKOSQ/HI2glGwOMA/GvjRRKlLyORBUrdRXnwTU/6LIBcW7jYSlutgg==",
+      "integrity": "sha1-XJqwJHXHZnYnVzGwvwpzlcYkqcQ=",
       "dev": true,
       "requires": {
         "arr-diff": "4.0.0",
@@ -9486,7 +8573,7 @@
         "kind-of": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
           "dev": true
         }
       }
@@ -9605,7 +8692,7 @@
         "is-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
           "dev": true,
           "requires": {
             "is-accessor-descriptor": "0.1.6",
@@ -9616,7 +8703,7 @@
             "kind-of": {
               "version": "5.1.0",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
               "dev": true
             }
           }
@@ -10519,7 +9606,7 @@
     "set-value": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "integrity": "sha1-ca5KiPD+77v1LR6mBPP7MV67YnQ=",
       "dev": true,
       "requires": {
         "extend-shallow": "2.0.1",
@@ -10584,7 +9671,7 @@
         "is-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
           "dev": true,
           "requires": {
             "is-accessor-descriptor": "0.1.6",
@@ -10595,7 +9682,7 @@
         "kind-of": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
           "dev": true
         }
       }
@@ -10603,7 +9690,7 @@
     "snapdragon-node": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
-      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
       "dev": true,
       "requires": {
         "define-property": "1.0.0",
@@ -10622,7 +9709,7 @@
     "snapdragon-util": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
-      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
       "dev": true,
       "requires": {
         "kind-of": "3.2.2"
@@ -10645,7 +9732,7 @@
     "source-map-resolve": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
-      "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
+      "integrity": "sha1-etD1k/IoFZjoVN+A8ZquS5LXoRo=",
       "dev": true,
       "requires": {
         "atob": "2.0.3",
@@ -10703,7 +9790,7 @@
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
-      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
       "dev": true,
       "requires": {
         "extend-shallow": "3.0.1"
@@ -10712,7 +9799,7 @@
         "extend-shallow": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.1.tgz",
-          "integrity": "sha512-Fg1xXAv+qXKdwHiJFMcZSqsMcbPlkzsZtf8KkLJ2fqnP+lqg2RjEKgDcSfO9CO1+p4LZKgApDBUUUqKaaRhwZQ==",
+          "integrity": "sha1-S22MSbFH/uAp3J65SErbdw9omEQ=",
           "dev": true,
           "requires": {
             "is-extendable": "1.0.1"
@@ -10721,7 +9808,7 @@
         "is-extendable": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
           "dev": true,
           "requires": {
             "is-plain-object": "2.0.4"
@@ -10777,7 +9864,7 @@
         "is-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
           "dev": true,
           "requires": {
             "is-accessor-descriptor": "0.1.6",
@@ -10788,7 +9875,7 @@
         "kind-of": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
           "dev": true
         }
       }
@@ -11348,7 +10435,7 @@
         "is-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
           "dev": true,
           "requires": {
             "is-accessor-descriptor": "0.1.6",
@@ -11359,7 +10446,7 @@
         "kind-of": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
           "dev": true
         }
       }
@@ -11665,7 +10752,7 @@
         "is-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
           "dev": true,
           "requires": {
             "is-accessor-descriptor": "0.1.6",
@@ -11682,7 +10769,7 @@
         "kind-of": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blockstack",
-  "version": "0.13.7",
+  "version": "0.13.8",
   "description": "The Blockstack Javascript library for identity and authentication.",
   "main": "lib/index",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -69,6 +69,9 @@
     },
     {
       "name": "Jude Nelson"
+    },
+    {
+      "name": "Aaron Blankstein"
     }
   ],
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "ajv": "^4.11.5",
     "bigi": "^1.4.2",
     "bitcoinjs-lib": "^2.3.0",
-    "blockstack-storage": "0.2.11",
     "cheerio": "^0.22.0",
     "custom-protocol-detection-blockstack": "1.1.3",
     "ecurve": "^1.0.5",

--- a/src/auth/authApp.js
+++ b/src/auth/authApp.js
@@ -8,6 +8,7 @@ import { makeECPrivateKey } from '../index'
 import { decryptPrivateKey } from './authMessages'
 import { BLOCKSTACK_APP_PRIVATE_KEY_LABEL,
          BLOCKSTACK_STORAGE_LABEL,
+         BLOCKSTACK_DEFAULT_GAIA_HUB_URL,
          DEFAULT_BLOCKSTACK_HOST,
          DEFAULT_SCOPE } from './authConstants'
 
@@ -172,7 +173,7 @@ export function handlePendingSignIn(nameLookupURL: string = 'https://core.blocks
             }
           }
         }
-        let hubUrl = 'https://hub.blockstack.org'
+        let hubUrl = BLOCKSTACK_DEFAULT_GAIA_HUB_URL
         if (isLaterVersion(tokenPayload.version, '1.2.0') &&
             tokenPayload.hubUrl !== null && tokenPayload.hubUrl !== undefined) {
           hubUrl = tokenPayload.hubUrl

--- a/src/auth/authApp.js
+++ b/src/auth/authApp.js
@@ -158,11 +158,11 @@ export function handlePendingSignIn(nameLookupURL: string = 'https://core.blocks
               try {
                 appPrivateKey = decryptPrivateKey(transitKey, appPrivateKey)
               } catch (e) {
-                console.log('Failed decryption of appPrivateKey, will try to use appPrivateKey as given')
+                console.log('Failed decryption of appPrivateKey, will try to use as given')
               }
             }
             if (coreSessionToken !== undefined && coreSessionToken !== null) {
-              try{
+              try {
                 coreSessionToken = decryptPrivateKey(transitKey, coreSessionToken)
               } catch (e) {
                 console.log('Failed decryption of coreSessionToken, will try to use as given')

--- a/src/auth/authApp.js
+++ b/src/auth/authApp.js
@@ -3,7 +3,7 @@ import queryString from 'query-string'
 import { decodeToken } from 'jsontokens'
 import { makeAuthRequest, verifyAuthResponse } from './index'
 import protocolCheck from 'custom-protocol-detection-blockstack'
-import { BLOCKSTACK_HANDLER } from '../utils'
+import { BLOCKSTACK_HANDLER, isLaterVersionString } from '../utils'
 import { makeECPrivateKey } from '../index'
 import { decryptPrivateKey } from './authMessages'
 import { BLOCKSTACK_APP_PRIVATE_KEY_LABEL,
@@ -151,7 +151,7 @@ export function handlePendingSignIn(nameLookupURL: string = 'https://core.blocks
         // TODO: real version handling
         let appPrivateKey = tokenPayload.private_key
         let coreSessionToken = tokenPayload.core_token
-        if (tokenPayload.version === '1.1.0') {
+        if (isLaterVersionString(tokenPayload.version, '1.1.0')) {
           const transitKey = getTransitKey()
           if (transitKey !== undefined && transitKey != null) {
             if (appPrivateKey !== undefined && appPrivateKey !== null) {
@@ -162,13 +162,19 @@ export function handlePendingSignIn(nameLookupURL: string = 'https://core.blocks
             }
           }
         }
+        let hubUrl = 'https://hub.blockstack.org'
+        if (isLaterVersionString(tokenPayload.version, '1.2.0') &&
+            tokenPayload.hubUrl !== null) {
+          hubUrl = tokenPayload.hubUrl
+        }
 
         const userData = {
           username: tokenPayload.username,
           profile: tokenPayload.profile,
           appPrivateKey,
           coreSessionToken,
-          authResponseToken
+          authResponseToken,
+          hubUrl
         }
         const profileURL = tokenPayload.profile_url
         if ((userData.profile === null ||

--- a/src/auth/authApp.js
+++ b/src/auth/authApp.js
@@ -155,16 +155,24 @@ export function handlePendingSignIn(nameLookupURL: string = 'https://core.blocks
           const transitKey = getTransitKey()
           if (transitKey !== undefined && transitKey != null) {
             if (appPrivateKey !== undefined && appPrivateKey !== null) {
-              appPrivateKey = decryptPrivateKey(transitKey, appPrivateKey)
+              try {
+                appPrivateKey = decryptPrivateKey(transitKey, appPrivateKey)
+              } catch (e) {
+                console.log('Failed decryption of appPrivateKey, will try to use appPrivateKey as given')
+              }
             }
             if (coreSessionToken !== undefined && coreSessionToken !== null) {
-              coreSessionToken = decryptPrivateKey(transitKey, coreSessionToken)
+              try{
+                coreSessionToken = decryptPrivateKey(transitKey, coreSessionToken)
+              } catch (e) {
+                console.log('Failed decryption of coreSessionToken, will try to use as given')
+              }
             }
           }
         }
         let hubUrl = 'https://hub.blockstack.org'
         if (isLaterVersionString(tokenPayload.version, '1.2.0') &&
-            tokenPayload.hubUrl !== null) {
+            tokenPayload.hubUrl !== null && tokenPayload.hubUrl !== undefined) {
           hubUrl = tokenPayload.hubUrl
         }
 

--- a/src/auth/authApp.js
+++ b/src/auth/authApp.js
@@ -3,13 +3,15 @@ import queryString from 'query-string'
 import { decodeToken } from 'jsontokens'
 import { makeAuthRequest, verifyAuthResponse } from './index'
 import protocolCheck from 'custom-protocol-detection-blockstack'
-import { BLOCKSTACK_HANDLER, isLaterVersionString } from '../utils'
+import { BLOCKSTACK_HANDLER, isLaterVersion } from '../utils'
 import { makeECPrivateKey } from '../index'
 import { decryptPrivateKey } from './authMessages'
 import { BLOCKSTACK_APP_PRIVATE_KEY_LABEL,
          BLOCKSTACK_STORAGE_LABEL,
          DEFAULT_BLOCKSTACK_HOST,
          DEFAULT_SCOPE } from './authConstants'
+
+import { BLOCKSTACK_GAIA_HUB_LABEL } from '../storage'
 
 import { extractProfile } from '../profiles'
 
@@ -151,7 +153,7 @@ export function handlePendingSignIn(nameLookupURL: string = 'https://core.blocks
         // TODO: real version handling
         let appPrivateKey = tokenPayload.private_key
         let coreSessionToken = tokenPayload.core_token
-        if (isLaterVersionString(tokenPayload.version, '1.1.0')) {
+        if (isLaterVersion(tokenPayload.version, '1.1.0')) {
           const transitKey = getTransitKey()
           if (transitKey !== undefined && transitKey != null) {
             if (appPrivateKey !== undefined && appPrivateKey !== null) {
@@ -171,7 +173,7 @@ export function handlePendingSignIn(nameLookupURL: string = 'https://core.blocks
           }
         }
         let hubUrl = 'https://hub.blockstack.org'
-        if (isLaterVersionString(tokenPayload.version, '1.2.0') &&
+        if (isLaterVersion(tokenPayload.version, '1.2.0') &&
             tokenPayload.hubUrl !== null && tokenPayload.hubUrl !== undefined) {
           hubUrl = tokenPayload.hubUrl
         }
@@ -235,6 +237,7 @@ export function loadUserData() {
  */
 export function signUserOut(redirectURL: ?string = null) {
   window.localStorage.removeItem(BLOCKSTACK_STORAGE_LABEL)
+  window.localStorage.removeItem(BLOCKSTACK_GAIA_HUB_LABEL)
 
   if (redirectURL !== null) {
     window.location = redirectURL

--- a/src/auth/authConstants.js
+++ b/src/auth/authConstants.js
@@ -3,3 +3,4 @@ export const BLOCKSTACK_STORAGE_LABEL = 'blockstack'
 export const DEFAULT_BLOCKSTACK_HOST = 'https://blockstack.org/auth'
 export const DEFAULT_SCOPE = ['store_write']
 export const BLOCKSTACK_APP_PRIVATE_KEY_LABEL = 'blockstack-transit-private-key'
+export const BLOCKSTACK_DEFAULT_GAIA_HUB_URL = 'https://hub.blockstack.org'

--- a/src/auth/authMessages.js
+++ b/src/auth/authMessages.js
@@ -17,7 +17,7 @@ import {
 
 import { encryptECIES, decryptECIES } from '../encryption'
 
-const VERSION = '1.1.0'
+const VERSION = '1.2.0'
 
 type AuthMetadata = {
   email: ?string,
@@ -93,7 +93,8 @@ export function makeAuthResponse(privateKey: string,
                                  coreToken: ?string = null,
                                  appPrivateKey: ?string = null,
                                  expiresAt: number = nextMonth().getTime(),
-                                 transitPublicKey: ?string = null): string {
+                                 transitPublicKey: ?string = null,
+                                 hubUrl: ?string = null): string {
   /* Convert the private key to a public key to an issuer */
   const publicKey = SECP256K1Client.derivePublicKey(privateKey)
   const address = publicKeyToAddress(publicKey)
@@ -113,6 +114,7 @@ export function makeAuthResponse(privateKey: string,
     additionalProperties = {
       email: metadata.email ? metadata.email : null,
       profile_url: metadata.profileUrl ? metadata.profileUrl : null,
+      hubUrl,
       version: VERSION
     }
   } else {

--- a/src/auth/authMessages.js
+++ b/src/auth/authMessages.js
@@ -17,7 +17,7 @@ import {
 
 import { encryptECIES, decryptECIES } from '../encryption'
 
-const VERSION = '1.2.0'
+const VERSION = '1.1.0'
 
 type AuthMetadata = {
   email: ?string,
@@ -54,6 +54,7 @@ export function makeAuthRequest(transitPrivateKey: string = generateAndStoreTran
     redirect_uri: redirectURI,
     version: VERSION,
     do_not_include_profile: true,
+    suppports_hub_url: true,
     scopes
   }
 

--- a/src/auth/authMessages.js
+++ b/src/auth/authMessages.js
@@ -54,7 +54,7 @@ export function makeAuthRequest(transitPrivateKey: string = generateAndStoreTran
     redirect_uri: redirectURI,
     version: VERSION,
     do_not_include_profile: true,
-    suppports_hub_url: true,
+    supports_hub_url: true,
     scopes
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ export {
   getEntropy, makeECPrivateKey, publicKeyToAddress, getPublicKeyFromPrivate
 } from './keys'
 export {
-  nextYear, nextMonth, nextHour, makeUUID4, hasprop, updateQueryStringParameter
+  nextYear, nextMonth, nextHour, makeUUID4, hasprop, updateQueryStringParameter,
+  isLaterVersion
 } from './utils'
 export { decodeToken } from 'jsontokens'

--- a/src/storage/hub.js
+++ b/src/storage/hub.js
@@ -7,7 +7,7 @@ export const BLOCKSTACK_GAIA_HUB_LABEL = 'blockstack-gaia-hub-config'
 
 export type GaiaHubConfig = {
   address: string,
-  url_prefix: string, // aaron: investigate if I can rename this field
+  url_prefix: string,
   token: string,
   server: string
 }

--- a/src/storage/hub.js
+++ b/src/storage/hub.js
@@ -2,6 +2,7 @@ import bitcoin from 'bitcoinjs-lib'
 import bigi from 'bigi'
 
 import { loadUserData } from '../auth/authApp'
+import { BLOCKSTACK_DEFAULT_GAIA_HUB_URL, BLOCKSTACK_STORAGE_LABEL } from '../auth/authConstants'
 
 export const BLOCKSTACK_GAIA_HUB_LABEL = 'blockstack-gaia-hub-config'
 
@@ -71,7 +72,17 @@ export function connectToGaiaHub(gaiaHubUrl: string, challengeSignerHex: string)
  * @returns {Promise} that resolves to the new gaia hub connection
  */
 export function setLocalGaiaHubConnection(): Promise<*> {
-  const userData = loadUserData()
+  let userData = loadUserData()
+
+  if (!userData.hubUrl) {
+    userData.hubUrl = BLOCKSTACK_DEFAULT_GAIA_HUB_URL
+
+    window.localStorage.setItem(
+      BLOCKSTACK_STORAGE_LABEL, JSON.stringify(userData))
+
+    userData = loadUserData()
+  }
+
   return connectToGaiaHub(userData.hubUrl, userData.appPrivateKey)
     .then((gaiaConfig) => {
       localStorage.setItem(BLOCKSTACK_GAIA_HUB_LABEL, JSON.stringify(gaiaConfig))

--- a/src/storage/hub.js
+++ b/src/storage/hub.js
@@ -33,6 +33,11 @@ export function uploadToGaiaHub(filename: string, contents: any,
 }
 
 
+export function getFullReadUrl(filename: string,
+                               hubConfig: GaiaHubConfig): string {
+  return `${hubConfig.url_prefix}${hubConfig.address}/${filename}`
+}
+
 export function connectToGaiaHub(gaiaHubUrl: string, challengeSignerHex: string): Promise<*> {
   console.log(`connectToGaiaHub: ${gaiaHubUrl}/hub_info`)
   const challengeSigner = new bitcoin.ECPair(
@@ -67,15 +72,15 @@ export function connectToGaiaHub(gaiaHubUrl: string, challengeSignerHex: string)
  */
 export function setLocalGaiaHubConnection(): Promise<*> {
   const userData = loadUserData()
-  return connectToGaiaHub(userData.gaiaHubUrl, userData.appPrivateKey)
+  return connectToGaiaHub(userData.hubUrl, userData.appPrivateKey)
     .then((gaiaConfig) => {
-      localStorage.setItem(BLOCKSTACK_GAIA_HUB_LABEL, gaiaConfig)
+      localStorage.setItem(BLOCKSTACK_GAIA_HUB_LABEL, JSON.stringify(gaiaConfig))
       return gaiaConfig
     })
 }
 
 export function getOrSetLocalGaiaHubConnection(): Promise<*> {
-  const hubConfig = localStorage.getItem(BLOCKSTACK_GAIA_HUB_LABEL)
+  const hubConfig = JSON.parse(localStorage.getItem(BLOCKSTACK_GAIA_HUB_LABEL))
   if (hubConfig !== null) {
     return new Promise((resolve) => resolve(hubConfig))
   } else {

--- a/src/storage/hub.js
+++ b/src/storage/hub.js
@@ -1,0 +1,84 @@
+import bitcoin from 'bitcoinjs-lib'
+import bigi from 'bigi'
+
+import { loadUserData } from '../auth/authApp'
+
+export const BLOCKSTACK_GAIA_HUB_LABEL = 'blockstack-gaia-hub-config'
+
+export type GaiaHubConfig = {
+  address: string,
+  url_prefix: string, // aaron: investigate if I can rename this field
+  token: string,
+  server: string
+}
+
+export function uploadToGaiaHub(filename: string, contents: any,
+                                hubConfig: GaiaHubConfig,
+                                contentType: string = 'application/octet-stream'): Promise<*> {
+  return new Promise((resolve) => {
+    console.log(`uploadToGaiaHub: uploading ${filename} to ${hubConfig.server}`)
+    return fetch(`${hubConfig.server}/store/${hubConfig.address}/${filename}`,
+          { method: 'POST',
+            headers: {
+              'Content-Type': contentType,
+              Authorization: `bearer ${hubConfig.token}`
+            },
+            body: contents })
+      .then((response) => response.text())
+      .then((responseText) => JSON.parse(responseText))
+      .then((responseJSON) => {
+        resolve(responseJSON.publicURL)
+      })
+  })
+}
+
+
+export function connectToGaiaHub(gaiaHubUrl: string, challengeSignerHex: string): Promise<*> {
+  console.log(`connectToGaiaHub: ${gaiaHubUrl}/hub_info`)
+  const challengeSigner = new bitcoin.ECPair(
+    bigi.fromHex(challengeSignerHex))
+  return new Promise((resolve) => {
+    fetch(`${gaiaHubUrl}/hub_info`)
+      .then((response) => response.text())
+      .then((responseText) => JSON.parse(responseText))
+      .then((responseJSON) => {
+        const readURL = responseJSON.read_url_prefix
+        const challenge = responseJSON.challenge_text
+        const digest = bitcoin.crypto.sha256(challenge)
+        const signature = challengeSigner.sign(digest)
+              .toDER().toString('hex')
+        const publickey = challengeSigner.getPublicKeyBuffer()
+              .toString('hex')
+        const token = new Buffer(JSON.stringify(
+          { publickey, signature })).toString('base64')
+        const address = challengeSigner.getAddress()
+        resolve({ url_prefix: readURL,
+                  address,
+                  token,
+                  server: gaiaHubUrl }
+               ) }) })
+}
+
+/**
+ * These two functions are app-specific connections to gaia hub,
+ *   they read the user data object for information on setting up
+ *   a hub connection, and store the hub config to localstorage
+ * @returns {Promise} that resolves to the new gaia hub connection
+ */
+export function setLocalGaiaHubConnection(): Promise<*> {
+  const userData = loadUserData()
+  return connectToGaiaHub(userData.gaiaHubUrl, userData.appPrivateKey)
+    .then((gaiaConfig) => {
+      localStorage.setItem(BLOCKSTACK_GAIA_HUB_LABEL, gaiaConfig)
+      return gaiaConfig
+    })
+}
+
+export function getOrSetLocalGaiaHubConnection(): Promise<*> {
+  const hubConfig = localStorage.getItem(BLOCKSTACK_GAIA_HUB_LABEL)
+  if (hubConfig !== null) {
+    return new Promise((resolve) => resolve(hubConfig))
+  } else {
+    return setLocalGaiaHubConnection()
+  }
+}

--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { getOrSetLocalGaiaHubConnection,
+import { getOrSetLocalGaiaHubConnection, getFullReadUrl,
          connectToGaiaHub, uploadToGaiaHub } from './hub'
 
 import { encryptECIES, decryptECIES } from '../encryption'
@@ -16,7 +16,8 @@ import { getPublicKeyFromPrivate } from '../keys'
  */
 export function getFile(path: string, decrypt: boolean = false) {
   return getOrSetLocalGaiaHubConnection()
-    .then((gaiaHubConfig) => fetch(`${gaiaHubConfig.url_prefix}${path}`))
+    .then((gaiaHubConfig) => fetch(getFullReadUrl(path, gaiaHubConfig)))
+    .then((response) => response.text())
     .then((storedContents) => {
       if (decrypt) {
         const privateKey = loadUserData().appPrivateKey

--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { getOrSetLocalGaiaHubConnection, getFullReadUrl,
+import { getOrSetLocalGaiaHubConnection, getFullReadUrl, GaiaHubConfig,
          connectToGaiaHub, uploadToGaiaHub, BLOCKSTACK_GAIA_HUB_LABEL } from './hub'
 
 import { encryptECIES, decryptECIES } from '../encryption'
@@ -72,5 +72,5 @@ export function deleteFile(path: string) {
   throw new Error(`Delete of ${path} not supported by gaia hubs`)
 }
 
-export { connectToGaiaHub, uploadToGaiaHub, BLOCKSTACK_GAIA_HUB_LABEL }
+export { connectToGaiaHub, uploadToGaiaHub, BLOCKSTACK_GAIA_HUB_LABEL, GaiaHubConfig }
 

--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -19,7 +19,12 @@ export function getFile(path: string, decrypt: boolean = false) {
     .then((gaiaHubConfig) => fetch(getFullReadUrl(path, gaiaHubConfig)))
     .then((response) => {
       if (response.status !== 200) {
-        throw new Error(`getFile ${path} failed with HTTP status ${response.status}`)
+        if (response.status === 404) {
+          console.log(`getFile ${path} returned 404, returning null`)
+          return null
+        } else {
+          throw new Error(`getFile ${path} failed with HTTP status ${response.status}`)
+        }
       }
       const contentType = response.headers.get('Content-Type')
       if (contentType === null || decrypt ||

--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -18,6 +18,9 @@ export function getFile(path: string, decrypt: boolean = false) {
   return getOrSetLocalGaiaHubConnection()
     .then((gaiaHubConfig) => fetch(getFullReadUrl(path, gaiaHubConfig)))
     .then((response) => {
+      if (response.status !== 200) {
+        throw new Error(`getFile ${path} failed with HTTP status ${response.status}`)
+      }
       const contentType = response.headers.get('Content-Type')
       if (contentType === null || decrypt ||
           contentType.startsWith('text') ||

--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import { getOrSetLocalGaiaHubConnection, getFullReadUrl,
-         connectToGaiaHub, uploadToGaiaHub } from './hub'
+         connectToGaiaHub, uploadToGaiaHub, BLOCKSTACK_GAIA_HUB_LABEL } from './hub'
 
 import { encryptECIES, decryptECIES } from '../encryption'
 import { loadUserData } from '../auth'
@@ -72,5 +72,5 @@ export function deleteFile(path: string) {
   throw new Error(`Delete of ${path} not supported by gaia hubs`)
 }
 
-export { connectToGaiaHub, uploadToGaiaHub }
+export { connectToGaiaHub, uploadToGaiaHub, BLOCKSTACK_GAIA_HUB_LABEL }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -45,6 +45,28 @@ export function updateQueryStringParameter(uri: string, key: string, value: stri
 }
 
 /**
+ * Versioning
+ * @param {string} v1 - the left half of the version inequality
+ * @param {string} v2 - right half of the version inequality
+ * @returns {bool} iff v1 >= v2
+ * @private
+ */
+export function isLaterVersionString(v1: string, v2: string) {
+  const v1tuple = v1.split('.').map(x => parseInt(x, 10))
+  const v2tuple = v2.split('.').map(x => parseInt(x, 10))
+
+  for (let index = 0; index < v2.length; index++) {
+    if (index >= v1.length) {
+      v2tuple.push(0)
+    }
+    if (v1tuple[index] < v2tuple[index]) {
+      return false
+    }
+  }
+  return true
+}
+
+/**
  * UUIDs
  * @private
  */

--- a/src/utils.js
+++ b/src/utils.js
@@ -49,9 +49,8 @@ export function updateQueryStringParameter(uri: string, key: string, value: stri
  * @param {string} v1 - the left half of the version inequality
  * @param {string} v2 - right half of the version inequality
  * @returns {bool} iff v1 >= v2
- * @private
  */
-export function isLaterVersionString(v1: string, v2: string) {
+export function isLaterVersion(v1: string, v2: string) {
   const v1tuple = v1.split('.').map(x => parseInt(x, 10))
   const v2tuple = v2.split('.').map(x => parseInt(x, 10))
 

--- a/tests/unitTests/src/index.js
+++ b/tests/unitTests/src/index.js
@@ -3,6 +3,7 @@ import { runProfilesUnitTests } from './unitTestsProfiles'
 import { runProofsUnitTests }   from './unitTestsProofs'
 import { runUtilsTests }        from './unitTestsUtils'
 import { runEncryptionTests }   from './unitTestsEncryption'
+import { runStorageTests }      from './unitTestsStorage'
 
 // Utils tests
 runUtilsTests()
@@ -18,3 +19,6 @@ runProofsUnitTests()
 
 // Encryption Tests
 runEncryptionTests()
+
+// Storage Tests
+runStorageTests()

--- a/tests/unitTests/src/unitTestsStorage.js
+++ b/tests/unitTests/src/unitTestsStorage.js
@@ -1,0 +1,75 @@
+import test from 'tape'
+import FetchMock from 'fetch-mock'
+
+import bitcoin from 'bitcoinjs-lib'
+
+import { uploadToGaiaHub, getFullReadUrl, connectToGaiaHub } from '../../../lib/storage/hub'
+
+export function runStorageTests() {
+
+  test('uploadToGaiaHub', (t) => {
+    t.plan(2)
+
+    const config = { address: '19MoWG8u88L6t766j7Vne21Mg4wHsCQ7vk',
+                   url_prefix: 'gaia.testblockstack.org',
+                   token: '',
+                   server: 'hub.testblockstack.org' }
+
+    FetchMock.post(`${config.server}/store/${config.address}/foo.json`,
+                   JSON.stringify({publicURL: '${config.url_prefix}/${config.address}/foo.json'}))
+
+    uploadToGaiaHub('foo.json', 'foo the bar', config)
+      .then((url) => {
+        t.ok(url, 'URL returned')
+        t.equal(url, '${config.url_prefix}/${config.address}/foo.json')
+      })
+  })
+
+  test('getFullReadUrl', (t) => {
+    t.plan(1)
+
+    const config = { address: '19MoWG8u88L6t766j7Vne21Mg4wHsCQ7vk',
+                   url_prefix: 'gaia.testblockstack.org',
+                   token: '',
+                   server: 'hub.testblockstack.org' }
+
+    const outUrl = getFullReadUrl('foo.json', config)
+    t.equal(`${config.url_prefix}${config.address}/foo.json`, outUrl)
+  })
+
+  test('connectToGaiaHub', (t) => {
+    t.plan(5)
+
+    const hubServer = 'hub.testblockstack.org'
+
+    const hubInfo = {
+      read_url_prefix: 'gaia.testblockstack.org',
+      challenge_text: 'please-sign',
+    }
+
+    const privateKey = 'a5c61c6ca7b3e7e55edee68566aeab22e4da26baa285c7bd10e8d2218aa3b229'
+    const address = '1NZNxhoxobqwsNvTb16pdeiqvFvce3Yg8U'
+    const publicKey = '027d28f9951ce46538951e3697c62588a87f1f1f295de4a14fdd4c780fc52cfe69'
+
+    FetchMock.get(`${hubServer}/hub_info`,
+                   JSON.stringify(hubInfo))
+
+    connectToGaiaHub(hubServer, privateKey)
+      .then((config) => {
+        t.ok(config, 'Config returned by connectToGaiaHub()')
+        t.equal(hubInfo.read_url_prefix, config.url_prefix)
+        t.equal(address, config.address)
+        t.equal(hubServer, config.server)
+
+        const verificationKey = bitcoin.ECPair.fromPublicKeyBuffer(Buffer.from(publicKey, 'hex'))
+
+        const decoded = JSON.parse(Buffer.from(config.token, 'base64').toString())
+        const signature = bitcoin.ECSignature.fromDER(Buffer.from(
+          decoded.signature, 'hex'))
+
+        t.ok(verificationKey.verify(
+          bitcoin.crypto.sha256(hubInfo.challenge_text), signature), 'Verified token')
+      })
+  })
+
+}


### PR DESCRIPTION
This PR implements:

#309 Pass gaia hub root url as part of generating an authentication response
#310 Move gaia hub bearer token generation code from browser into blockstack.js  
#311 Implement direct-to-hub gaia hub storage client

In general, the way it works, is:

1. it bumps the version on the Auth Request
2. tries to read the hubURL from the Auth Response. if it cannot, it defaults to `hub.blockstack.org`
3. stores a user's hubConfig to localStorage

This PR includes a _new_ interface as well, that people may want to advise on. Now that we have a bumped version for the auth request, we need to actually do semantic version checks on those requests. To do this, I added a `isLaterVersion` function to `src/utils.js`

Testing this doesn't require an updated browser (if you use an old browser, the sign in process in the browser will still do the datastore setup and core session token generation even though the app won't use either)

Improvements this should give us:
1. Faster and more reliable writes/reads (and the errors should be more understandable)
2. URLs which match files (i.e., if you putFile(todos.json), the stored file is a `gaia.blockstack.org/hub/<app-addr>/todos.json`
3. Ability to serve applications which use storage over HTTPS (no longer making requests to localhost means no longer having mixed-content errors).

Once the blockstack-browser updates are live, we'll also be able to use storage from the next Windows native build and webapp builds.
