### PR TITLE
Remove deprecated crypto

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "blockstack-storage": "0.2.11",
     "cheerio": "^0.22.0",
     "custom-protocol-detection-blockstack": "1.1.3",
-    "crypto": "^0.0.3",
     "ecurve": "^1.0.5",
     "elliptic": "^6.4.0",
     "es6-promise": "^4.1.0",


### PR DESCRIPTION
Per issue #305 and #308, we shouldn't be listing the `crypto` library in our package.json anymore.

This is included by default in nodejs now, and so simply deleting it from the package.json works -- even with webpack.