### PR TITLE
Compatibility update to PR #314

### DIFF
--- a/src/auth/authApp.js
+++ b/src/auth/authApp.js
@@ -8,6 +8,7 @@ import { makeECPrivateKey } from '../index'
 import { decryptPrivateKey } from './authMessages'
 import { BLOCKSTACK_APP_PRIVATE_KEY_LABEL,
          BLOCKSTACK_STORAGE_LABEL,
+         BLOCKSTACK_DEFAULT_GAIA_HUB_URL,
          DEFAULT_BLOCKSTACK_HOST,
          DEFAULT_SCOPE } from './authConstants'
 
@@ -172,7 +173,7 @@ export function handlePendingSignIn(nameLookupURL: string = 'https://core.blocks
             }
           }
         }
-        let hubUrl = 'https://hub.blockstack.org'
+        let hubUrl = BLOCKSTACK_DEFAULT_GAIA_HUB_URL
         if (isLaterVersion(tokenPayload.version, '1.2.0') &&
             tokenPayload.hubUrl !== null && tokenPayload.hubUrl !== undefined) {
           hubUrl = tokenPayload.hubUrl

--- a/src/auth/authConstants.js
+++ b/src/auth/authConstants.js
@@ -3,3 +3,4 @@ export const BLOCKSTACK_STORAGE_LABEL = 'blockstack'
 export const DEFAULT_BLOCKSTACK_HOST = 'https://blockstack.org/auth'
 export const DEFAULT_SCOPE = ['store_write']
 export const BLOCKSTACK_APP_PRIVATE_KEY_LABEL = 'blockstack-transit-private-key'
+export const BLOCKSTACK_DEFAULT_GAIA_HUB_URL = 'https://hub.blockstack.org'

--- a/src/storage/hub.js
+++ b/src/storage/hub.js
@@ -2,6 +2,7 @@ import bitcoin from 'bitcoinjs-lib'
 import bigi from 'bigi'
 
 import { loadUserData } from '../auth/authApp'
+import { BLOCKSTACK_DEFAULT_GAIA_HUB_URL, BLOCKSTACK_STORAGE_LABEL } from '../auth/authConstants'
 
 export const BLOCKSTACK_GAIA_HUB_LABEL = 'blockstack-gaia-hub-config'
 
@@ -71,7 +72,17 @@ export function connectToGaiaHub(gaiaHubUrl: string, challengeSignerHex: string)
  * @returns {Promise} that resolves to the new gaia hub connection
  */
 export function setLocalGaiaHubConnection(): Promise<*> {
-  const userData = loadUserData()
+  let userData = loadUserData()
+
+  if (!userData.hubUrl) {
+    userData.hubUrl = BLOCKSTACK_DEFAULT_GAIA_HUB_URL
+
+    window.localStorage.setItem(
+      BLOCKSTACK_STORAGE_LABEL, JSON.stringify(userData))
+
+    userData = loadUserData()
+  }
+
   return connectToGaiaHub(userData.hubUrl, userData.appPrivateKey)
     .then((gaiaConfig) => {
       localStorage.setItem(BLOCKSTACK_GAIA_HUB_LABEL, JSON.stringify(gaiaConfig))


### PR DESCRIPTION
Add functionality to `direct-gaia-hub` feature (PR #314) so users won't need to relog into apps on blockstack.js version update.


### Commits 
* Add a check inside of `setLocalGaiaHubConnection` to make sure `hubUrl` is contained in `userData`
** This change makes it so that after upgrading to the new `direct-gaia-hub` feature users will not need to
log out and back into a blockstack app to use the new Gaia Hub functionality.