### PR TITLE
Fix null handling problems with encryption

### DIFF
--- a/dist/blockstack.js
+++ b/dist/blockstack.js
@@ -5347,7 +5347,7 @@ module.exports={
   "_args": [
     [
       "bigi@1.4.2",
-      "/home/aaron/devel/blockstack.js"
+      "/Users/larry/git/blockstack.js"
     ]
   ],
   "_from": "bigi@1.4.2",
@@ -5373,7 +5373,7 @@ module.exports={
   ],
   "_resolved": "https://registry.npmjs.org/bigi/-/bigi-1.4.2.tgz",
   "_spec": "1.4.2",
-  "_where": "/home/aaron/devel/blockstack.js",
+  "_where": "/Users/larry/git/blockstack.js",
   "bugs": {
     "url": "https://github.com/cryptocoinjs/bigi/issues"
   },
@@ -29172,34 +29172,29 @@ exports.isHtml = function(str) {
 
 },{"./parse":219,"dom-serializer":232}],222:[function(require,module,exports){
 module.exports={
-  "_args": [
-    [
-      "cheerio@0.22.0",
-      "/home/aaron/devel/blockstack.js"
-    ]
-  ],
-  "_from": "cheerio@0.22.0",
+  "_from": "cheerio@^0.22.0",
   "_id": "cheerio@0.22.0",
   "_inBundle": false,
   "_integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
   "_location": "/cheerio",
   "_phantomChildren": {},
   "_requested": {
-    "type": "version",
+    "type": "range",
     "registry": true,
-    "raw": "cheerio@0.22.0",
+    "raw": "cheerio@^0.22.0",
     "name": "cheerio",
     "escapedName": "cheerio",
-    "rawSpec": "0.22.0",
+    "rawSpec": "^0.22.0",
     "saveSpec": null,
-    "fetchSpec": "0.22.0"
+    "fetchSpec": "^0.22.0"
   },
   "_requiredBy": [
     "/"
   ],
   "_resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
-  "_spec": "0.22.0",
-  "_where": "/home/aaron/devel/blockstack.js",
+  "_shasum": "a9baa860a3f9b595a6b81b1a86873121ed3a269e",
+  "_spec": "cheerio@^0.22.0",
+  "_where": "/Users/larry/git/blockstack.js",
   "author": {
     "name": "Matt Mueller",
     "email": "mattmuelle@gmail.com",
@@ -29208,6 +29203,7 @@ module.exports={
   "bugs": {
     "url": "https://github.com/cheeriojs/cheerio/issues"
   },
+  "bundleDependencies": false,
   "dependencies": {
     "css-select": "~1.2.0",
     "dom-serializer": "~0.1.0",
@@ -29226,6 +29222,7 @@ module.exports={
     "lodash.reject": "^4.4.0",
     "lodash.some": "^4.4.0"
   },
+  "deprecated": false,
   "description": "Tiny, fast, and elegant implementation of core jQuery designed specifically for the server",
   "devDependencies": {
     "benchmark": "^2.1.0",
@@ -37424,27 +37421,21 @@ utils.encode = function encode(arr, enc) {
 
 },{}],283:[function(require,module,exports){
 module.exports={
-  "_args": [
-    [
-      "elliptic@6.4.0",
-      "/home/aaron/devel/blockstack.js"
-    ]
-  ],
-  "_from": "elliptic@6.4.0",
+  "_from": "elliptic@^6.4.0",
   "_id": "elliptic@6.4.0",
   "_inBundle": false,
   "_integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
   "_location": "/elliptic",
   "_phantomChildren": {},
   "_requested": {
-    "type": "version",
+    "type": "range",
     "registry": true,
-    "raw": "elliptic@6.4.0",
+    "raw": "elliptic@^6.4.0",
     "name": "elliptic",
     "escapedName": "elliptic",
-    "rawSpec": "6.4.0",
+    "rawSpec": "^6.4.0",
     "saveSpec": null,
-    "fetchSpec": "6.4.0"
+    "fetchSpec": "^6.4.0"
   },
   "_requiredBy": [
     "/",
@@ -37454,8 +37445,9 @@ module.exports={
     "/jsontokens"
   ],
   "_resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
-  "_spec": "6.4.0",
-  "_where": "/home/aaron/devel/blockstack.js",
+  "_shasum": "cac9af8762c85836187003c8dfe193e5e2eae5df",
+  "_spec": "elliptic@^6.4.0",
+  "_where": "/Users/larry/git/blockstack.js",
   "author": {
     "name": "Fedor Indutny",
     "email": "fedor@indutny.com"
@@ -37463,6 +37455,7 @@ module.exports={
   "bugs": {
     "url": "https://github.com/indutny/elliptic/issues"
   },
+  "bundleDependencies": false,
   "dependencies": {
     "bn.js": "^4.4.0",
     "brorand": "^1.0.1",
@@ -37472,6 +37465,7 @@ module.exports={
     "minimalistic-assert": "^1.0.0",
     "minimalistic-crypto-utils": "^1.0.0"
   },
+  "deprecated": false,
   "description": "EC cryptography",
   "devDependencies": {
     "brfs": "^1.4.3",
@@ -50008,34 +50002,29 @@ utils.intFromLE = intFromLE;
 
 },{"bn.js":363}],380:[function(require,module,exports){
 module.exports={
-  "_args": [
-    [
-      "elliptic@5.2.1",
-      "/home/aaron/devel/blockstack.js"
-    ]
-  ],
-  "_from": "elliptic@5.2.1",
+  "_from": "elliptic@^5.1.0",
   "_id": "elliptic@5.2.1",
   "_inBundle": false,
   "_integrity": "sha1-+ilLZWPG3bybo9yFlGh66ECFjxA=",
   "_location": "/jsontokens/key-encoder/elliptic",
   "_phantomChildren": {},
   "_requested": {
-    "type": "version",
+    "type": "range",
     "registry": true,
-    "raw": "elliptic@5.2.1",
+    "raw": "elliptic@^5.1.0",
     "name": "elliptic",
     "escapedName": "elliptic",
-    "rawSpec": "5.2.1",
+    "rawSpec": "^5.1.0",
     "saveSpec": null,
-    "fetchSpec": "5.2.1"
+    "fetchSpec": "^5.1.0"
   },
   "_requiredBy": [
     "/jsontokens/key-encoder"
   ],
   "_resolved": "https://registry.npmjs.org/elliptic/-/elliptic-5.2.1.tgz",
-  "_spec": "5.2.1",
-  "_where": "/home/aaron/devel/blockstack.js",
+  "_shasum": "fa294b6563c6ddbc9ba3dc8594687ae840858f10",
+  "_spec": "elliptic@^5.1.0",
+  "_where": "/Users/larry/git/blockstack.js/node_modules/jsontokens/node_modules/key-encoder",
   "author": {
     "name": "Fedor Indutny",
     "email": "fedor@indutny.com"
@@ -50043,12 +50032,14 @@ module.exports={
   "bugs": {
     "url": "https://github.com/indutny/elliptic/issues"
   },
+  "bundleDependencies": false,
   "dependencies": {
     "bn.js": "^3.1.1",
     "brorand": "^1.0.1",
     "hash.js": "^1.0.0",
     "inherits": "^2.0.1"
   },
+  "deprecated": false,
   "description": "EC cryptography",
   "devDependencies": {
     "browserify": "^3.44.2",

--- a/dist/blockstack.js
+++ b/dist/blockstack.js
@@ -3592,7 +3592,7 @@ function getFile(path) {
       return response.arrayBuffer();
     }
   }).then(function (storedContents) {
-    if (decrypt) {
+    if (decrypt && storedContents !== null) {
       var privateKey = (0, _auth.loadUserData)().appPrivateKey;
       var cipherObject = JSON.parse(storedContents);
       return (0, _encryption.decryptECIES)(privateKey, cipherObject);
@@ -5347,7 +5347,7 @@ module.exports={
   "_args": [
     [
       "bigi@1.4.2",
-      "/Users/larry/git/blockstack.js"
+      "/home/aaron/devel/blockstack.js"
     ]
   ],
   "_from": "bigi@1.4.2",
@@ -5373,7 +5373,7 @@ module.exports={
   ],
   "_resolved": "https://registry.npmjs.org/bigi/-/bigi-1.4.2.tgz",
   "_spec": "1.4.2",
-  "_where": "/Users/larry/git/blockstack.js",
+  "_where": "/home/aaron/devel/blockstack.js",
   "bugs": {
     "url": "https://github.com/cryptocoinjs/bigi/issues"
   },
@@ -29172,29 +29172,34 @@ exports.isHtml = function(str) {
 
 },{"./parse":219,"dom-serializer":232}],222:[function(require,module,exports){
 module.exports={
-  "_from": "cheerio@^0.22.0",
+  "_args": [
+    [
+      "cheerio@0.22.0",
+      "/home/aaron/devel/blockstack.js"
+    ]
+  ],
+  "_from": "cheerio@0.22.0",
   "_id": "cheerio@0.22.0",
   "_inBundle": false,
   "_integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
   "_location": "/cheerio",
   "_phantomChildren": {},
   "_requested": {
-    "type": "range",
+    "type": "version",
     "registry": true,
-    "raw": "cheerio@^0.22.0",
+    "raw": "cheerio@0.22.0",
     "name": "cheerio",
     "escapedName": "cheerio",
-    "rawSpec": "^0.22.0",
+    "rawSpec": "0.22.0",
     "saveSpec": null,
-    "fetchSpec": "^0.22.0"
+    "fetchSpec": "0.22.0"
   },
   "_requiredBy": [
     "/"
   ],
   "_resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
-  "_shasum": "a9baa860a3f9b595a6b81b1a86873121ed3a269e",
-  "_spec": "cheerio@^0.22.0",
-  "_where": "/Users/larry/git/blockstack.js",
+  "_spec": "0.22.0",
+  "_where": "/home/aaron/devel/blockstack.js",
   "author": {
     "name": "Matt Mueller",
     "email": "mattmuelle@gmail.com",
@@ -29203,7 +29208,6 @@ module.exports={
   "bugs": {
     "url": "https://github.com/cheeriojs/cheerio/issues"
   },
-  "bundleDependencies": false,
   "dependencies": {
     "css-select": "~1.2.0",
     "dom-serializer": "~0.1.0",
@@ -29222,7 +29226,6 @@ module.exports={
     "lodash.reject": "^4.4.0",
     "lodash.some": "^4.4.0"
   },
-  "deprecated": false,
   "description": "Tiny, fast, and elegant implementation of core jQuery designed specifically for the server",
   "devDependencies": {
     "benchmark": "^2.1.0",
@@ -37421,21 +37424,27 @@ utils.encode = function encode(arr, enc) {
 
 },{}],283:[function(require,module,exports){
 module.exports={
-  "_from": "elliptic@^6.4.0",
+  "_args": [
+    [
+      "elliptic@6.4.0",
+      "/home/aaron/devel/blockstack.js"
+    ]
+  ],
+  "_from": "elliptic@6.4.0",
   "_id": "elliptic@6.4.0",
   "_inBundle": false,
   "_integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
   "_location": "/elliptic",
   "_phantomChildren": {},
   "_requested": {
-    "type": "range",
+    "type": "version",
     "registry": true,
-    "raw": "elliptic@^6.4.0",
+    "raw": "elliptic@6.4.0",
     "name": "elliptic",
     "escapedName": "elliptic",
-    "rawSpec": "^6.4.0",
+    "rawSpec": "6.4.0",
     "saveSpec": null,
-    "fetchSpec": "^6.4.0"
+    "fetchSpec": "6.4.0"
   },
   "_requiredBy": [
     "/",
@@ -37445,9 +37454,8 @@ module.exports={
     "/jsontokens"
   ],
   "_resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
-  "_shasum": "cac9af8762c85836187003c8dfe193e5e2eae5df",
-  "_spec": "elliptic@^6.4.0",
-  "_where": "/Users/larry/git/blockstack.js",
+  "_spec": "6.4.0",
+  "_where": "/home/aaron/devel/blockstack.js",
   "author": {
     "name": "Fedor Indutny",
     "email": "fedor@indutny.com"
@@ -37455,7 +37463,6 @@ module.exports={
   "bugs": {
     "url": "https://github.com/indutny/elliptic/issues"
   },
-  "bundleDependencies": false,
   "dependencies": {
     "bn.js": "^4.4.0",
     "brorand": "^1.0.1",
@@ -37465,7 +37472,6 @@ module.exports={
     "minimalistic-assert": "^1.0.0",
     "minimalistic-crypto-utils": "^1.0.0"
   },
-  "deprecated": false,
   "description": "EC cryptography",
   "devDependencies": {
     "brfs": "^1.4.3",
@@ -50002,29 +50008,34 @@ utils.intFromLE = intFromLE;
 
 },{"bn.js":363}],380:[function(require,module,exports){
 module.exports={
-  "_from": "elliptic@^5.1.0",
+  "_args": [
+    [
+      "elliptic@5.2.1",
+      "/home/aaron/devel/blockstack.js"
+    ]
+  ],
+  "_from": "elliptic@5.2.1",
   "_id": "elliptic@5.2.1",
   "_inBundle": false,
   "_integrity": "sha1-+ilLZWPG3bybo9yFlGh66ECFjxA=",
   "_location": "/jsontokens/key-encoder/elliptic",
   "_phantomChildren": {},
   "_requested": {
-    "type": "range",
+    "type": "version",
     "registry": true,
-    "raw": "elliptic@^5.1.0",
+    "raw": "elliptic@5.2.1",
     "name": "elliptic",
     "escapedName": "elliptic",
-    "rawSpec": "^5.1.0",
+    "rawSpec": "5.2.1",
     "saveSpec": null,
-    "fetchSpec": "^5.1.0"
+    "fetchSpec": "5.2.1"
   },
   "_requiredBy": [
     "/jsontokens/key-encoder"
   ],
   "_resolved": "https://registry.npmjs.org/elliptic/-/elliptic-5.2.1.tgz",
-  "_shasum": "fa294b6563c6ddbc9ba3dc8594687ae840858f10",
-  "_spec": "elliptic@^5.1.0",
-  "_where": "/Users/larry/git/blockstack.js/node_modules/jsontokens/node_modules/key-encoder",
+  "_spec": "5.2.1",
+  "_where": "/home/aaron/devel/blockstack.js",
   "author": {
     "name": "Fedor Indutny",
     "email": "fedor@indutny.com"
@@ -50032,14 +50043,12 @@ module.exports={
   "bugs": {
     "url": "https://github.com/indutny/elliptic/issues"
   },
-  "bundleDependencies": false,
   "dependencies": {
     "bn.js": "^3.1.1",
     "brorand": "^1.0.1",
     "hash.js": "^1.0.0",
     "inherits": "^2.0.1"
   },
-  "deprecated": false,
   "description": "EC cryptography",
   "devDependencies": {
     "browserify": "^3.44.2",

--- a/docs.json
+++ b/docs.json
@@ -476,7 +476,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/auth/authApp.js"
+      "file": "/home/aaron/devel/blockstack.js/src/auth/authApp.js"
     },
     "augments": [],
     "examples": [],
@@ -809,7 +809,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/auth/authApp.js"
+      "file": "/home/aaron/devel/blockstack.js/src/auth/authApp.js"
     },
     "augments": [],
     "examples": [],
@@ -1063,7 +1063,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/auth/authApp.js"
+      "file": "/home/aaron/devel/blockstack.js/src/auth/authApp.js"
     },
     "augments": [],
     "examples": [],
@@ -1340,7 +1340,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/auth/authApp.js"
+      "file": "/home/aaron/devel/blockstack.js/src/auth/authApp.js"
     },
     "augments": [],
     "examples": [],
@@ -1512,7 +1512,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/auth/authApp.js"
+      "file": "/home/aaron/devel/blockstack.js/src/auth/authApp.js"
     },
     "augments": [],
     "examples": [],
@@ -1749,7 +1749,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/auth/authApp.js"
+      "file": "/home/aaron/devel/blockstack.js/src/auth/authApp.js"
     },
     "augments": [],
     "examples": [],
@@ -2025,7 +2025,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/auth/authMessages.js"
+      "file": "/home/aaron/devel/blockstack.js/src/auth/authMessages.js"
     },
     "augments": [],
     "examples": [],
@@ -2716,7 +2716,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/auth/authApp.js"
+      "file": "/home/aaron/devel/blockstack.js/src/auth/authApp.js"
     },
     "augments": [],
     "examples": [],
@@ -2998,7 +2998,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/auth/authApp.js"
+      "file": "/home/aaron/devel/blockstack.js/src/auth/authApp.js"
     },
     "augments": [],
     "examples": [],
@@ -3379,7 +3379,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/profiles/profileTokens.js"
+      "file": "/home/aaron/devel/blockstack.js/src/profiles/profileTokens.js"
     },
     "augments": [],
     "examples": [],
@@ -3765,7 +3765,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/profiles/profileTokens.js"
+      "file": "/home/aaron/devel/blockstack.js/src/profiles/profileTokens.js"
     },
     "augments": [],
     "examples": [],
@@ -4120,7 +4120,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/profiles/profileTokens.js"
+      "file": "/home/aaron/devel/blockstack.js/src/profiles/profileTokens.js"
     },
     "augments": [],
     "examples": [],
@@ -4754,7 +4754,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/profiles/profileTokens.js"
+      "file": "/home/aaron/devel/blockstack.js/src/profiles/profileTokens.js"
     },
     "augments": [],
     "examples": [],
@@ -5150,7 +5150,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/profiles/profileProofs.js"
+      "file": "/home/aaron/devel/blockstack.js/src/profiles/profileProofs.js"
     },
     "augments": [],
     "examples": [],
@@ -5773,7 +5773,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/storage/index.js"
+      "file": "/home/aaron/devel/blockstack.js/src/storage/index.js"
     },
     "augments": [],
     "examples": [],
@@ -6112,7 +6112,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/storage/index.js"
+      "file": "/home/aaron/devel/blockstack.js/src/storage/index.js"
     },
     "augments": [],
     "examples": [],
@@ -6511,7 +6511,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/encryption.js"
+      "file": "/home/aaron/devel/blockstack.js/src/encryption.js"
     },
     "augments": [],
     "examples": [],
@@ -6843,7 +6843,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/encryption.js"
+      "file": "/home/aaron/devel/blockstack.js/src/encryption.js"
     },
     "augments": [],
     "examples": [],
@@ -7152,7 +7152,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/storage/hub.js"
+      "file": "/home/aaron/devel/blockstack.js/src/storage/hub.js"
     },
     "augments": [],
     "examples": [],
@@ -7334,7 +7334,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/storage/index.js"
+      "file": "/home/aaron/devel/blockstack.js/src/storage/index.js"
     },
     "augments": [],
     "examples": [],
@@ -7592,7 +7592,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/utils.js"
+      "file": "/home/aaron/devel/blockstack.js/src/utils.js"
     },
     "augments": [],
     "examples": [],

--- a/docs.json
+++ b/docs.json
@@ -476,7 +476,7 @@
           "column": 1
         }
       },
-      "file": "/home/aaron/devel/blockstack.js/src/auth/authApp.js"
+      "file": "/Users/larry/git/blockstack.js/src/auth/authApp.js"
     },
     "augments": [],
     "examples": [],
@@ -809,7 +809,7 @@
           "column": 1
         }
       },
-      "file": "/home/aaron/devel/blockstack.js/src/auth/authApp.js"
+      "file": "/Users/larry/git/blockstack.js/src/auth/authApp.js"
     },
     "augments": [],
     "examples": [],
@@ -1063,7 +1063,7 @@
           "column": 1
         }
       },
-      "file": "/home/aaron/devel/blockstack.js/src/auth/authApp.js"
+      "file": "/Users/larry/git/blockstack.js/src/auth/authApp.js"
     },
     "augments": [],
     "examples": [],
@@ -1340,7 +1340,7 @@
           "column": 1
         }
       },
-      "file": "/home/aaron/devel/blockstack.js/src/auth/authApp.js"
+      "file": "/Users/larry/git/blockstack.js/src/auth/authApp.js"
     },
     "augments": [],
     "examples": [],
@@ -1512,7 +1512,7 @@
           "column": 1
         }
       },
-      "file": "/home/aaron/devel/blockstack.js/src/auth/authApp.js"
+      "file": "/Users/larry/git/blockstack.js/src/auth/authApp.js"
     },
     "augments": [],
     "examples": [],
@@ -1749,7 +1749,7 @@
           "column": 1
         }
       },
-      "file": "/home/aaron/devel/blockstack.js/src/auth/authApp.js"
+      "file": "/Users/larry/git/blockstack.js/src/auth/authApp.js"
     },
     "augments": [],
     "examples": [],
@@ -2025,7 +2025,7 @@
           "column": 1
         }
       },
-      "file": "/home/aaron/devel/blockstack.js/src/auth/authMessages.js"
+      "file": "/Users/larry/git/blockstack.js/src/auth/authMessages.js"
     },
     "augments": [],
     "examples": [],
@@ -2716,7 +2716,7 @@
           "column": 1
         }
       },
-      "file": "/home/aaron/devel/blockstack.js/src/auth/authApp.js"
+      "file": "/Users/larry/git/blockstack.js/src/auth/authApp.js"
     },
     "augments": [],
     "examples": [],
@@ -2998,7 +2998,7 @@
           "column": 1
         }
       },
-      "file": "/home/aaron/devel/blockstack.js/src/auth/authApp.js"
+      "file": "/Users/larry/git/blockstack.js/src/auth/authApp.js"
     },
     "augments": [],
     "examples": [],
@@ -3379,7 +3379,7 @@
           "column": 1
         }
       },
-      "file": "/home/aaron/devel/blockstack.js/src/profiles/profileTokens.js"
+      "file": "/Users/larry/git/blockstack.js/src/profiles/profileTokens.js"
     },
     "augments": [],
     "examples": [],
@@ -3765,7 +3765,7 @@
           "column": 1
         }
       },
-      "file": "/home/aaron/devel/blockstack.js/src/profiles/profileTokens.js"
+      "file": "/Users/larry/git/blockstack.js/src/profiles/profileTokens.js"
     },
     "augments": [],
     "examples": [],
@@ -4120,7 +4120,7 @@
           "column": 1
         }
       },
-      "file": "/home/aaron/devel/blockstack.js/src/profiles/profileTokens.js"
+      "file": "/Users/larry/git/blockstack.js/src/profiles/profileTokens.js"
     },
     "augments": [],
     "examples": [],
@@ -4754,7 +4754,7 @@
           "column": 1
         }
       },
-      "file": "/home/aaron/devel/blockstack.js/src/profiles/profileTokens.js"
+      "file": "/Users/larry/git/blockstack.js/src/profiles/profileTokens.js"
     },
     "augments": [],
     "examples": [],
@@ -5150,7 +5150,7 @@
           "column": 1
         }
       },
-      "file": "/home/aaron/devel/blockstack.js/src/profiles/profileProofs.js"
+      "file": "/Users/larry/git/blockstack.js/src/profiles/profileProofs.js"
     },
     "augments": [],
     "examples": [],
@@ -5773,7 +5773,7 @@
           "column": 1
         }
       },
-      "file": "/home/aaron/devel/blockstack.js/src/storage/index.js"
+      "file": "/Users/larry/git/blockstack.js/src/storage/index.js"
     },
     "augments": [],
     "examples": [],
@@ -6112,7 +6112,7 @@
           "column": 1
         }
       },
-      "file": "/home/aaron/devel/blockstack.js/src/storage/index.js"
+      "file": "/Users/larry/git/blockstack.js/src/storage/index.js"
     },
     "augments": [],
     "examples": [],
@@ -6511,7 +6511,7 @@
           "column": 1
         }
       },
-      "file": "/home/aaron/devel/blockstack.js/src/encryption.js"
+      "file": "/Users/larry/git/blockstack.js/src/encryption.js"
     },
     "augments": [],
     "examples": [],
@@ -6843,7 +6843,7 @@
           "column": 1
         }
       },
-      "file": "/home/aaron/devel/blockstack.js/src/encryption.js"
+      "file": "/Users/larry/git/blockstack.js/src/encryption.js"
     },
     "augments": [],
     "examples": [],
@@ -7152,7 +7152,7 @@
           "column": 1
         }
       },
-      "file": "/home/aaron/devel/blockstack.js/src/storage/hub.js"
+      "file": "/Users/larry/git/blockstack.js/src/storage/hub.js"
     },
     "augments": [],
     "examples": [],
@@ -7334,7 +7334,7 @@
           "column": 1
         }
       },
-      "file": "/home/aaron/devel/blockstack.js/src/storage/index.js"
+      "file": "/Users/larry/git/blockstack.js/src/storage/index.js"
     },
     "augments": [],
     "examples": [],
@@ -7592,7 +7592,7 @@
           "column": 1
         }
       },
-      "file": "/home/aaron/devel/blockstack.js/src/utils.js"
+      "file": "/Users/larry/git/blockstack.js/src/utils.js"
     },
     "augments": [],
     "examples": [],

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset='utf-8' />
-  <title>blockstack 0.14.0 | Documentation</title>
+  <title>blockstack 0.14.1 | Documentation</title>
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <link href='assets/bass.css' type='text/css' rel='stylesheet' />
   <link href='assets/style.css' type='text/css' rel='stylesheet' />
@@ -14,7 +14,7 @@
       <div class='fixed xs-hide fix-3 overflow-auto max-height-100'>
         <div class='py1 px2'>
           <h3 class='mb0 no-anchor'>blockstack</h3>
-          <div class='mb1'><code>0.14.0</code></div>
+          <div class='mb1'><code>0.14.1</code></div>
           <input
             placeholder='Filter'
             id='filter-input'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "blockstack",
-  "version": "0.13.8",
+  "version": "0.14.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -468,919 +468,12 @@
           "requires": {
             "anymatch": "1.3.2",
             "async-each": "1.0.1",
-            "fsevents": "1.1.3",
             "glob-parent": "2.0.0",
             "inherits": "2.0.3",
             "is-binary-path": "1.0.1",
             "is-glob": "2.0.1",
             "path-is-absolute": "1.0.1",
             "readdirp": "2.1.0"
-          },
-          "dependencies": {
-            "fsevents": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
-              "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "nan": "2.8.0",
-                "node-pre-gyp": "0.6.39"
-              },
-              "dependencies": {
-                "abbrev": {
-                  "version": "1.1.0",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                },
-                "ajv": {
-                  "version": "4.11.8",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "co": "4.6.0",
-                    "json-stable-stringify": "1.0.1"
-                  }
-                },
-                "ansi-regex": {
-                  "version": "2.1.1",
-                  "bundled": true,
-                  "dev": true
-                },
-                "aproba": {
-                  "version": "1.1.1",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                },
-                "are-we-there-yet": {
-                  "version": "1.1.4",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "delegates": "1.0.0",
-                    "readable-stream": "2.2.9"
-                  }
-                },
-                "asn1": {
-                  "version": "0.2.3",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                },
-                "assert-plus": {
-                  "version": "0.2.0",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                },
-                "asynckit": {
-                  "version": "0.4.0",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                },
-                "aws-sign2": {
-                  "version": "0.6.0",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                },
-                "aws4": {
-                  "version": "1.6.0",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                },
-                "balanced-match": {
-                  "version": "0.4.2",
-                  "bundled": true,
-                  "dev": true
-                },
-                "bcrypt-pbkdf": {
-                  "version": "1.0.1",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "tweetnacl": "0.14.5"
-                  }
-                },
-                "block-stream": {
-                  "version": "0.0.9",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "inherits": "2.0.3"
-                  }
-                },
-                "boom": {
-                  "version": "2.10.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "hoek": "2.16.3"
-                  }
-                },
-                "brace-expansion": {
-                  "version": "1.1.7",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "balanced-match": "0.4.2",
-                    "concat-map": "0.0.1"
-                  }
-                },
-                "buffer-shims": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "dev": true
-                },
-                "caseless": {
-                  "version": "0.12.0",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                },
-                "co": {
-                  "version": "4.6.0",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                },
-                "code-point-at": {
-                  "version": "1.1.0",
-                  "bundled": true,
-                  "dev": true
-                },
-                "combined-stream": {
-                  "version": "1.0.5",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "delayed-stream": "1.0.0"
-                  }
-                },
-                "concat-map": {
-                  "version": "0.0.1",
-                  "bundled": true,
-                  "dev": true
-                },
-                "console-control-strings": {
-                  "version": "1.1.0",
-                  "bundled": true,
-                  "dev": true
-                },
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "dev": true
-                },
-                "cryptiles": {
-                  "version": "2.0.5",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "boom": "2.10.1"
-                  }
-                },
-                "dashdash": {
-                  "version": "1.14.1",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "assert-plus": "1.0.0"
-                  },
-                  "dependencies": {
-                    "assert-plus": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "dev": true,
-                      "optional": true
-                    }
-                  }
-                },
-                "debug": {
-                  "version": "2.6.8",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "ms": "2.0.0"
-                  }
-                },
-                "deep-extend": {
-                  "version": "0.4.2",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                },
-                "delayed-stream": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "dev": true
-                },
-                "delegates": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                },
-                "detect-libc": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                },
-                "ecc-jsbn": {
-                  "version": "0.1.1",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "jsbn": "0.1.1"
-                  }
-                },
-                "extend": {
-                  "version": "3.0.1",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                },
-                "extsprintf": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "dev": true
-                },
-                "forever-agent": {
-                  "version": "0.6.1",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                },
-                "form-data": {
-                  "version": "2.1.4",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "asynckit": "0.4.0",
-                    "combined-stream": "1.0.5",
-                    "mime-types": "2.1.15"
-                  }
-                },
-                "fs.realpath": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "dev": true
-                },
-                "fstream": {
-                  "version": "1.0.11",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "graceful-fs": "4.1.11",
-                    "inherits": "2.0.3",
-                    "mkdirp": "0.5.1",
-                    "rimraf": "2.6.1"
-                  }
-                },
-                "fstream-ignore": {
-                  "version": "1.0.5",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "fstream": "1.0.11",
-                    "inherits": "2.0.3",
-                    "minimatch": "3.0.4"
-                  }
-                },
-                "gauge": {
-                  "version": "2.7.4",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "aproba": "1.1.1",
-                    "console-control-strings": "1.1.0",
-                    "has-unicode": "2.0.1",
-                    "object-assign": "4.1.1",
-                    "signal-exit": "3.0.2",
-                    "string-width": "1.0.2",
-                    "strip-ansi": "3.0.1",
-                    "wide-align": "1.1.2"
-                  }
-                },
-                "getpass": {
-                  "version": "0.1.7",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "assert-plus": "1.0.0"
-                  },
-                  "dependencies": {
-                    "assert-plus": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "dev": true,
-                      "optional": true
-                    }
-                  }
-                },
-                "glob": {
-                  "version": "7.1.2",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "fs.realpath": "1.0.0",
-                    "inflight": "1.0.6",
-                    "inherits": "2.0.3",
-                    "minimatch": "3.0.4",
-                    "once": "1.4.0",
-                    "path-is-absolute": "1.0.1"
-                  }
-                },
-                "graceful-fs": {
-                  "version": "4.1.11",
-                  "bundled": true,
-                  "dev": true
-                },
-                "har-schema": {
-                  "version": "1.0.5",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                },
-                "har-validator": {
-                  "version": "4.2.1",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "ajv": "4.11.8",
-                    "har-schema": "1.0.5"
-                  }
-                },
-                "has-unicode": {
-                  "version": "2.0.1",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                },
-                "hawk": {
-                  "version": "3.1.3",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "boom": "2.10.1",
-                    "cryptiles": "2.0.5",
-                    "hoek": "2.16.3",
-                    "sntp": "1.0.9"
-                  }
-                },
-                "hoek": {
-                  "version": "2.16.3",
-                  "bundled": true,
-                  "dev": true
-                },
-                "http-signature": {
-                  "version": "1.1.1",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "assert-plus": "0.2.0",
-                    "jsprim": "1.4.0",
-                    "sshpk": "1.13.0"
-                  }
-                },
-                "inflight": {
-                  "version": "1.0.6",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "once": "1.4.0",
-                    "wrappy": "1.0.2"
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.3",
-                  "bundled": true,
-                  "dev": true
-                },
-                "ini": {
-                  "version": "1.3.4",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                },
-                "is-fullwidth-code-point": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "number-is-nan": "1.0.1"
-                  }
-                },
-                "is-typedarray": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                },
-                "isarray": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "dev": true
-                },
-                "isstream": {
-                  "version": "0.1.2",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                },
-                "jodid25519": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "jsbn": "0.1.1"
-                  }
-                },
-                "jsbn": {
-                  "version": "0.1.1",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                },
-                "json-schema": {
-                  "version": "0.2.3",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                },
-                "json-stable-stringify": {
-                  "version": "1.0.1",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "jsonify": "0.0.0"
-                  }
-                },
-                "json-stringify-safe": {
-                  "version": "5.0.1",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                },
-                "jsonify": {
-                  "version": "0.0.0",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                },
-                "jsprim": {
-                  "version": "1.4.0",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "assert-plus": "1.0.0",
-                    "extsprintf": "1.0.2",
-                    "json-schema": "0.2.3",
-                    "verror": "1.3.6"
-                  },
-                  "dependencies": {
-                    "assert-plus": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "dev": true,
-                      "optional": true
-                    }
-                  }
-                },
-                "mime-db": {
-                  "version": "1.27.0",
-                  "bundled": true,
-                  "dev": true
-                },
-                "mime-types": {
-                  "version": "2.1.15",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "mime-db": "1.27.0"
-                  }
-                },
-                "minimatch": {
-                  "version": "3.0.4",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "brace-expansion": "1.1.7"
-                  }
-                },
-                "minimist": {
-                  "version": "0.0.8",
-                  "bundled": true,
-                  "dev": true
-                },
-                "mkdirp": {
-                  "version": "0.5.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "minimist": "0.0.8"
-                  }
-                },
-                "ms": {
-                  "version": "2.0.0",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                },
-                "node-pre-gyp": {
-                  "version": "0.6.39",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "detect-libc": "1.0.2",
-                    "hawk": "3.1.3",
-                    "mkdirp": "0.5.1",
-                    "nopt": "4.0.1",
-                    "npmlog": "4.1.0",
-                    "rc": "1.2.1",
-                    "request": "2.81.0",
-                    "rimraf": "2.6.1",
-                    "semver": "5.3.0",
-                    "tar": "2.2.1",
-                    "tar-pack": "3.4.0"
-                  }
-                },
-                "nopt": {
-                  "version": "4.0.1",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "abbrev": "1.1.0",
-                    "osenv": "0.1.4"
-                  }
-                },
-                "npmlog": {
-                  "version": "4.1.0",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "are-we-there-yet": "1.1.4",
-                    "console-control-strings": "1.1.0",
-                    "gauge": "2.7.4",
-                    "set-blocking": "2.0.0"
-                  }
-                },
-                "number-is-nan": {
-                  "version": "1.0.1",
-                  "bundled": true,
-                  "dev": true
-                },
-                "oauth-sign": {
-                  "version": "0.8.2",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                },
-                "object-assign": {
-                  "version": "4.1.1",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                },
-                "once": {
-                  "version": "1.4.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "wrappy": "1.0.2"
-                  }
-                },
-                "os-homedir": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                },
-                "os-tmpdir": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                },
-                "osenv": {
-                  "version": "0.1.4",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "os-homedir": "1.0.2",
-                    "os-tmpdir": "1.0.2"
-                  }
-                },
-                "path-is-absolute": {
-                  "version": "1.0.1",
-                  "bundled": true,
-                  "dev": true
-                },
-                "performance-now": {
-                  "version": "0.2.0",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                },
-                "process-nextick-args": {
-                  "version": "1.0.7",
-                  "bundled": true,
-                  "dev": true
-                },
-                "punycode": {
-                  "version": "1.4.1",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                },
-                "qs": {
-                  "version": "6.4.0",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                },
-                "rc": {
-                  "version": "1.2.1",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "deep-extend": "0.4.2",
-                    "ini": "1.3.4",
-                    "minimist": "1.2.0",
-                    "strip-json-comments": "2.0.1"
-                  },
-                  "dependencies": {
-                    "minimist": {
-                      "version": "1.2.0",
-                      "bundled": true,
-                      "dev": true,
-                      "optional": true
-                    }
-                  }
-                },
-                "readable-stream": {
-                  "version": "2.2.9",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "buffer-shims": "1.0.0",
-                    "core-util-is": "1.0.2",
-                    "inherits": "2.0.3",
-                    "isarray": "1.0.0",
-                    "process-nextick-args": "1.0.7",
-                    "string_decoder": "1.0.1",
-                    "util-deprecate": "1.0.2"
-                  }
-                },
-                "request": {
-                  "version": "2.81.0",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "aws-sign2": "0.6.0",
-                    "aws4": "1.6.0",
-                    "caseless": "0.12.0",
-                    "combined-stream": "1.0.5",
-                    "extend": "3.0.1",
-                    "forever-agent": "0.6.1",
-                    "form-data": "2.1.4",
-                    "har-validator": "4.2.1",
-                    "hawk": "3.1.3",
-                    "http-signature": "1.1.1",
-                    "is-typedarray": "1.0.0",
-                    "isstream": "0.1.2",
-                    "json-stringify-safe": "5.0.1",
-                    "mime-types": "2.1.15",
-                    "oauth-sign": "0.8.2",
-                    "performance-now": "0.2.0",
-                    "qs": "6.4.0",
-                    "safe-buffer": "5.0.1",
-                    "stringstream": "0.0.5",
-                    "tough-cookie": "2.3.2",
-                    "tunnel-agent": "0.6.0",
-                    "uuid": "3.0.1"
-                  }
-                },
-                "rimraf": {
-                  "version": "2.6.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "glob": "7.1.2"
-                  }
-                },
-                "safe-buffer": {
-                  "version": "5.0.1",
-                  "bundled": true,
-                  "dev": true
-                },
-                "semver": {
-                  "version": "5.3.0",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                },
-                "set-blocking": {
-                  "version": "2.0.0",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                },
-                "signal-exit": {
-                  "version": "3.0.2",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                },
-                "sntp": {
-                  "version": "1.0.9",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "hoek": "2.16.3"
-                  }
-                },
-                "sshpk": {
-                  "version": "1.13.0",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "asn1": "0.2.3",
-                    "assert-plus": "1.0.0",
-                    "bcrypt-pbkdf": "1.0.1",
-                    "dashdash": "1.14.1",
-                    "ecc-jsbn": "0.1.1",
-                    "getpass": "0.1.7",
-                    "jodid25519": "1.0.2",
-                    "jsbn": "0.1.1",
-                    "tweetnacl": "0.14.5"
-                  },
-                  "dependencies": {
-                    "assert-plus": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "dev": true,
-                      "optional": true
-                    }
-                  }
-                },
-                "string-width": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "code-point-at": "1.1.0",
-                    "is-fullwidth-code-point": "1.0.0",
-                    "strip-ansi": "3.0.1"
-                  }
-                },
-                "string_decoder": {
-                  "version": "1.0.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "safe-buffer": "5.0.1"
-                  }
-                },
-                "stringstream": {
-                  "version": "0.0.5",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                },
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "ansi-regex": "2.1.1"
-                  }
-                },
-                "strip-json-comments": {
-                  "version": "2.0.1",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                },
-                "tar": {
-                  "version": "2.2.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "block-stream": "0.0.9",
-                    "fstream": "1.0.11",
-                    "inherits": "2.0.3"
-                  }
-                },
-                "tar-pack": {
-                  "version": "3.4.0",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "debug": "2.6.8",
-                    "fstream": "1.0.11",
-                    "fstream-ignore": "1.0.5",
-                    "once": "1.4.0",
-                    "readable-stream": "2.2.9",
-                    "rimraf": "2.6.1",
-                    "tar": "2.2.1",
-                    "uid-number": "0.0.6"
-                  }
-                },
-                "tough-cookie": {
-                  "version": "2.3.2",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "punycode": "1.4.1"
-                  }
-                },
-                "tunnel-agent": {
-                  "version": "0.6.0",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "safe-buffer": "5.0.1"
-                  }
-                },
-                "tweetnacl": {
-                  "version": "0.14.5",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                },
-                "uid-number": {
-                  "version": "0.0.6",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "dev": true
-                },
-                "uuid": {
-                  "version": "3.0.1",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                },
-                "verror": {
-                  "version": "1.3.6",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "extsprintf": "1.0.2"
-                  }
-                },
-                "wide-align": {
-                  "version": "1.1.2",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "string-width": "1.0.2"
-                  }
-                },
-                "wrappy": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            }
           }
         },
         "concat-map": {
@@ -3630,7 +2723,7 @@
     "base": {
       "version": "0.11.2",
       "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
-      "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "dev": true,
       "requires": {
         "cache-base": "1.0.1",
@@ -5066,7 +4159,7 @@
     "cache-base": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
-      "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "dev": true,
       "requires": {
         "collection-visit": "1.0.0",
@@ -5191,7 +4284,6 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
-        "fsevents": "1.1.3",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -5225,7 +4317,7 @@
         "is-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
             "is-accessor-descriptor": "0.1.6",
@@ -5242,7 +4334,7 @@
         "kind-of": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
           "dev": true
         }
       }
@@ -5317,7 +4409,7 @@
     "color-convert": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha1-wSYRB66y8pTr/+ye2eytUppgl+0=",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "dev": true,
       "requires": {
         "color-name": "1.1.3"
@@ -5724,6 +4816,12 @@
           "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
         }
       }
+    },
+    "dom-walk": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
+      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg=",
+      "dev": true
     },
     "domelementtype": {
       "version": "1.3.0",
@@ -7636,910 +6734,6 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "fsevents": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
-      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "nan": "2.8.0",
-        "node-pre-gyp": "0.6.39"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ajv": {
-          "version": "4.11.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "aproba": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.2.9"
-          }
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "balanced-match": {
-          "version": "0.4.2",
-          "bundled": true,
-          "dev": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "block-stream": {
-          "version": "0.0.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.3"
-          }
-        },
-        "boom": {
-          "version": "2.10.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "brace-expansion": {
-          "version": "1.1.7",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "balanced-match": "0.4.2",
-            "concat-map": "0.0.1"
-          }
-        },
-        "buffer-shims": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "co": {
-          "version": "4.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "boom": "2.10.1"
-          }
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "debug": {
-          "version": "2.6.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "deep-extend": {
-          "version": "0.4.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "detect-libc": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "extend": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "extsprintf": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.15"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "fstream": {
-          "version": "1.0.11",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.1"
-          }
-        },
-        "fstream-ignore": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "fstream": "1.0.11",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4"
-          }
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aproba": "1.1.1",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
-          }
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "bundled": true,
-          "dev": true
-        },
-        "har-schema": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "har-validator": {
-          "version": "4.2.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "bundled": true,
-          "dev": true
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.0",
-            "sshpk": "1.13.0"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "ini": {
-          "version": "1.3.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jodid25519": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsonify": "0.0.0"
-          }
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jsonify": {
-          "version": "0.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jsprim": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.0.2",
-            "json-schema": "0.2.3",
-            "verror": "1.3.6"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "mime-db": {
-          "version": "1.27.0",
-          "bundled": true,
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.1.15",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "mime-db": "1.27.0"
-          }
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true,
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "node-pre-gyp": {
-          "version": "0.6.39",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "detect-libc": "1.0.2",
-            "hawk": "3.1.3",
-            "mkdirp": "0.5.1",
-            "nopt": "4.0.1",
-            "npmlog": "4.1.0",
-            "rc": "1.2.1",
-            "request": "2.81.0",
-            "rimraf": "2.6.1",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "tar-pack": "3.4.0"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1.1.0",
-            "osenv": "0.1.4"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "osenv": {
-          "version": "0.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "performance-now": {
-          "version": "0.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "bundled": true,
-          "dev": true
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "qs": {
-          "version": "6.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "rc": {
-          "version": "1.2.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.2.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "buffer-shims": "1.0.0",
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "1.0.1",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "request": {
-          "version": "2.81.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.15",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.0.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.0.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "glob": "7.1.2"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "semver": {
-          "version": "5.3.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "sshpk": {
-          "version": "1.13.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jodid25519": "1.0.2",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "tar": {
-          "version": "2.2.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
-          }
-        },
-        "tar-pack": {
-          "version": "3.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "debug": "2.6.8",
-            "fstream": "1.0.11",
-            "fstream-ignore": "1.0.5",
-            "once": "1.4.0",
-            "readable-stream": "2.2.9",
-            "rimraf": "2.6.1",
-            "tar": "2.2.1",
-            "uid-number": "0.0.6"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.3.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "punycode": "1.4.1"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "uid-number": {
-          "version": "0.0.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "uuid": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "verror": {
-          "version": "1.3.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "extsprintf": "1.0.2"
-          }
-        },
-        "wide-align": {
-          "version": "1.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "string-width": "1.0.2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        }
-      }
-    },
     "get-caller-file": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
@@ -8766,6 +6960,16 @@
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
       "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
       "dev": true
+    },
+    "global": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
+      "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
+      "dev": true,
+      "requires": {
+        "min-document": "2.19.0",
+        "process": "0.5.2"
+      }
     },
     "globals": {
       "version": "9.18.0",
@@ -9350,7 +7554,7 @@
     "is-descriptor": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.1.tgz",
-      "integrity": "sha1-LGAjWZveLenV0si5qdlAggNrbvI=",
+      "integrity": "sha512-G3fFVFTqfaqu7r4YuSBHKBAuOaLz8Sy7ekklUpFEliaLMP1Y2ZjoN9jS62YWCAPQrQpMUQSitRlrzibbuCZjdA==",
       "dev": true,
       "requires": {
         "is-accessor-descriptor": "0.1.6",
@@ -9361,7 +7565,7 @@
         "kind-of": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
           "dev": true
         }
       }
@@ -9464,7 +7668,7 @@
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
       "requires": {
         "isobject": "3.0.1"
@@ -10298,6 +8502,15 @@
         "mime-db": "1.30.0"
       }
     },
+    "min-document": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+      "dev": true,
+      "requires": {
+        "dom-walk": "0.1.1"
+      }
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -10332,23 +8545,34 @@
         "minimist": "0.0.8"
       }
     },
+    "mock-local-storage": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/mock-local-storage/-/mock-local-storage-1.0.5.tgz",
+      "integrity": "sha1-iZ/zAAJ87+1HgW5txTm7BZ/M5Ik=",
+      "dev": true,
+      "requires": {
+        "core-js": "0.8.4",
+        "global": "4.3.2"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "0.8.4",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-0.8.4.tgz",
+          "integrity": "sha1-wiZl8eDRucPF4bCNq9HxCGleT88=",
+          "dev": true
+        }
+      }
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
-    "nan": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
-      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
-      "dev": true,
-      "optional": true
-    },
     "nanomatch": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.5.tgz",
-      "integrity": "sha1-XJqwJHXHZnYnVzGwvwpzlcYkqcQ=",
+      "integrity": "sha512-ZHJamn1utzcUvW8Bais+Kk7pobp6dKmUEKOSQ/HI2glGwOMA/GvjRRKlLyORBUrdRXnwTU/6LIBcW7jYSlutgg==",
       "dev": true,
       "requires": {
         "arr-diff": "4.0.0",
@@ -10379,7 +8603,7 @@
         "kind-of": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
           "dev": true
         }
       }
@@ -10498,7 +8722,7 @@
         "is-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
             "is-accessor-descriptor": "0.1.6",
@@ -10509,7 +8733,7 @@
             "kind-of": {
               "version": "5.1.0",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-              "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
               "dev": true
             }
           }
@@ -10898,6 +9122,12 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
       "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+      "dev": true
+    },
+    "process": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+      "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8=",
       "dev": true
     },
     "process-nextick-args": {
@@ -11412,7 +9642,7 @@
     "set-value": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-      "integrity": "sha1-ca5KiPD+77v1LR6mBPP7MV67YnQ=",
+      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "dev": true,
       "requires": {
         "extend-shallow": "2.0.1",
@@ -11477,7 +9707,7 @@
         "is-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
             "is-accessor-descriptor": "0.1.6",
@@ -11488,7 +9718,7 @@
         "kind-of": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
           "dev": true
         }
       }
@@ -11496,7 +9726,7 @@
     "snapdragon-node": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
-      "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "dev": true,
       "requires": {
         "define-property": "1.0.0",
@@ -11515,7 +9745,7 @@
     "snapdragon-util": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
-      "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "dev": true,
       "requires": {
         "kind-of": "3.2.2"
@@ -11538,7 +9768,7 @@
     "source-map-resolve": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
-      "integrity": "sha1-etD1k/IoFZjoVN+A8ZquS5LXoRo=",
+      "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
       "dev": true,
       "requires": {
         "atob": "2.0.3",
@@ -11596,7 +9826,7 @@
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
-      "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "dev": true,
       "requires": {
         "extend-shallow": "3.0.1"
@@ -11605,7 +9835,7 @@
         "extend-shallow": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.1.tgz",
-          "integrity": "sha1-S22MSbFH/uAp3J65SErbdw9omEQ=",
+          "integrity": "sha512-Fg1xXAv+qXKdwHiJFMcZSqsMcbPlkzsZtf8KkLJ2fqnP+lqg2RjEKgDcSfO9CO1+p4LZKgApDBUUUqKaaRhwZQ==",
           "dev": true,
           "requires": {
             "is-extendable": "1.0.1"
@@ -11614,7 +9844,7 @@
         "is-extendable": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-          "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
             "is-plain-object": "2.0.4"
@@ -11670,7 +9900,7 @@
         "is-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
             "is-accessor-descriptor": "0.1.6",
@@ -11681,7 +9911,7 @@
         "kind-of": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
           "dev": true
         }
       }
@@ -12241,7 +10471,7 @@
         "is-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
             "is-accessor-descriptor": "0.1.6",
@@ -12252,7 +10482,7 @@
         "kind-of": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
           "dev": true
         }
       }
@@ -12558,7 +10788,7 @@
         "is-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
             "is-accessor-descriptor": "0.1.6",
@@ -12575,7 +10805,7 @@
         "kind-of": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blockstack",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "The Blockstack Javascript library for identity and authentication.",
   "main": "lib/index",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "fetch-mock": "^5.5.0",
     "flow-bin": "^0.49.1",
     "node-fetch": "^1.6.3",
+    "mock-local-storage": "^1.0.5",
     "opn": "^4.0.2",
     "tape": "^4.6.3",
     "tape-promise": "^2.0.1"

--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -36,7 +36,7 @@ export function getFile(path: string, decrypt: boolean = false) {
       }
     })
     .then((storedContents) => {
-      if (decrypt) {
+      if (decrypt && storedContents !== null) {
         const privateKey = loadUserData().appPrivateKey
         const cipherObject = JSON.parse(storedContents)
         return decryptECIES(privateKey, cipherObject)


### PR DESCRIPTION
Simple fix for Issue #320 -- if the return file is `null` (happens on 404), don't try to decrypt it, just return `null`.