### PR TITLE
Improved Stability in the Buffers used in Encryption

### DIFF
--- a/dist/blockstack.js
+++ b/dist/blockstack.js
@@ -1110,7 +1110,9 @@ function getHexFromBN(bnInput) {
     return hexOut;
   } else if (hexOut.length < 64) {
     // pad with leading zeros
-    return hexOut.padStart(64, '0');
+    // the padStart function would require node 9
+    var padding = '0'.repeat(64 - hexOut.length);
+    return '' + padding + hexOut;
   } else {
     throw new Error('Generated a > 32-byte BN for encryption. Failing.');
   }

--- a/dist/blockstack.js
+++ b/dist/blockstack.js
@@ -1057,6 +1057,7 @@ export function getPublicKeyOrAddressFromDID(decentralizedID) {
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+exports.getHexFromBN = getHexFromBN;
 exports.encryptECIES = encryptECIES;
 exports.decryptECIES = decryptECIES;
 
@@ -1107,8 +1108,11 @@ function getHexFromBN(bnInput) {
 
   if (hexOut.length === 64) {
     return hexOut;
+  } else if (hexOut.length < 64) {
+    // pad with leading zeros
+    return hexOut.padStart(64, '0');
   } else {
-    return '0' + hexOut;
+    throw new Error('Generated a > 32-byte BN for encryption. Failing.');
   }
 }
 
@@ -5347,7 +5351,7 @@ module.exports={
   "_args": [
     [
       "bigi@1.4.2",
-      "/Users/larry/git/blockstack.js"
+      "/home/aaron/devel/blockstack.js"
     ]
   ],
   "_from": "bigi@1.4.2",
@@ -5373,7 +5377,7 @@ module.exports={
   ],
   "_resolved": "https://registry.npmjs.org/bigi/-/bigi-1.4.2.tgz",
   "_spec": "1.4.2",
-  "_where": "/Users/larry/git/blockstack.js",
+  "_where": "/home/aaron/devel/blockstack.js",
   "bugs": {
     "url": "https://github.com/cryptocoinjs/bigi/issues"
   },
@@ -29172,29 +29176,34 @@ exports.isHtml = function(str) {
 
 },{"./parse":219,"dom-serializer":232}],222:[function(require,module,exports){
 module.exports={
-  "_from": "cheerio@^0.22.0",
+  "_args": [
+    [
+      "cheerio@0.22.0",
+      "/home/aaron/devel/blockstack.js"
+    ]
+  ],
+  "_from": "cheerio@0.22.0",
   "_id": "cheerio@0.22.0",
   "_inBundle": false,
   "_integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
   "_location": "/cheerio",
   "_phantomChildren": {},
   "_requested": {
-    "type": "range",
+    "type": "version",
     "registry": true,
-    "raw": "cheerio@^0.22.0",
+    "raw": "cheerio@0.22.0",
     "name": "cheerio",
     "escapedName": "cheerio",
-    "rawSpec": "^0.22.0",
+    "rawSpec": "0.22.0",
     "saveSpec": null,
-    "fetchSpec": "^0.22.0"
+    "fetchSpec": "0.22.0"
   },
   "_requiredBy": [
     "/"
   ],
   "_resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
-  "_shasum": "a9baa860a3f9b595a6b81b1a86873121ed3a269e",
-  "_spec": "cheerio@^0.22.0",
-  "_where": "/Users/larry/git/blockstack.js",
+  "_spec": "0.22.0",
+  "_where": "/home/aaron/devel/blockstack.js",
   "author": {
     "name": "Matt Mueller",
     "email": "mattmuelle@gmail.com",
@@ -29203,7 +29212,6 @@ module.exports={
   "bugs": {
     "url": "https://github.com/cheeriojs/cheerio/issues"
   },
-  "bundleDependencies": false,
   "dependencies": {
     "css-select": "~1.2.0",
     "dom-serializer": "~0.1.0",
@@ -29222,7 +29230,6 @@ module.exports={
     "lodash.reject": "^4.4.0",
     "lodash.some": "^4.4.0"
   },
-  "deprecated": false,
   "description": "Tiny, fast, and elegant implementation of core jQuery designed specifically for the server",
   "devDependencies": {
     "benchmark": "^2.1.0",
@@ -37421,21 +37428,27 @@ utils.encode = function encode(arr, enc) {
 
 },{}],283:[function(require,module,exports){
 module.exports={
-  "_from": "elliptic@^6.4.0",
+  "_args": [
+    [
+      "elliptic@6.4.0",
+      "/home/aaron/devel/blockstack.js"
+    ]
+  ],
+  "_from": "elliptic@6.4.0",
   "_id": "elliptic@6.4.0",
   "_inBundle": false,
   "_integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
   "_location": "/elliptic",
   "_phantomChildren": {},
   "_requested": {
-    "type": "range",
+    "type": "version",
     "registry": true,
-    "raw": "elliptic@^6.4.0",
+    "raw": "elliptic@6.4.0",
     "name": "elliptic",
     "escapedName": "elliptic",
-    "rawSpec": "^6.4.0",
+    "rawSpec": "6.4.0",
     "saveSpec": null,
-    "fetchSpec": "^6.4.0"
+    "fetchSpec": "6.4.0"
   },
   "_requiredBy": [
     "/",
@@ -37445,9 +37458,8 @@ module.exports={
     "/jsontokens"
   ],
   "_resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
-  "_shasum": "cac9af8762c85836187003c8dfe193e5e2eae5df",
-  "_spec": "elliptic@^6.4.0",
-  "_where": "/Users/larry/git/blockstack.js",
+  "_spec": "6.4.0",
+  "_where": "/home/aaron/devel/blockstack.js",
   "author": {
     "name": "Fedor Indutny",
     "email": "fedor@indutny.com"
@@ -37455,7 +37467,6 @@ module.exports={
   "bugs": {
     "url": "https://github.com/indutny/elliptic/issues"
   },
-  "bundleDependencies": false,
   "dependencies": {
     "bn.js": "^4.4.0",
     "brorand": "^1.0.1",
@@ -37465,7 +37476,6 @@ module.exports={
     "minimalistic-assert": "^1.0.0",
     "minimalistic-crypto-utils": "^1.0.0"
   },
-  "deprecated": false,
   "description": "EC cryptography",
   "devDependencies": {
     "brfs": "^1.4.3",
@@ -50002,29 +50012,34 @@ utils.intFromLE = intFromLE;
 
 },{"bn.js":363}],380:[function(require,module,exports){
 module.exports={
-  "_from": "elliptic@^5.1.0",
+  "_args": [
+    [
+      "elliptic@5.2.1",
+      "/home/aaron/devel/blockstack.js"
+    ]
+  ],
+  "_from": "elliptic@5.2.1",
   "_id": "elliptic@5.2.1",
   "_inBundle": false,
   "_integrity": "sha1-+ilLZWPG3bybo9yFlGh66ECFjxA=",
   "_location": "/jsontokens/key-encoder/elliptic",
   "_phantomChildren": {},
   "_requested": {
-    "type": "range",
+    "type": "version",
     "registry": true,
-    "raw": "elliptic@^5.1.0",
+    "raw": "elliptic@5.2.1",
     "name": "elliptic",
     "escapedName": "elliptic",
-    "rawSpec": "^5.1.0",
+    "rawSpec": "5.2.1",
     "saveSpec": null,
-    "fetchSpec": "^5.1.0"
+    "fetchSpec": "5.2.1"
   },
   "_requiredBy": [
     "/jsontokens/key-encoder"
   ],
   "_resolved": "https://registry.npmjs.org/elliptic/-/elliptic-5.2.1.tgz",
-  "_shasum": "fa294b6563c6ddbc9ba3dc8594687ae840858f10",
-  "_spec": "elliptic@^5.1.0",
-  "_where": "/Users/larry/git/blockstack.js/node_modules/jsontokens/node_modules/key-encoder",
+  "_spec": "5.2.1",
+  "_where": "/home/aaron/devel/blockstack.js",
   "author": {
     "name": "Fedor Indutny",
     "email": "fedor@indutny.com"
@@ -50032,14 +50047,12 @@ module.exports={
   "bugs": {
     "url": "https://github.com/indutny/elliptic/issues"
   },
-  "bundleDependencies": false,
   "dependencies": {
     "bn.js": "^3.1.1",
     "brorand": "^1.0.1",
     "hash.js": "^1.0.0",
     "inherits": "^2.0.1"
   },
-  "deprecated": false,
   "description": "EC cryptography",
   "devDependencies": {
     "browserify": "^3.44.2",

--- a/src/encryption.js
+++ b/src/encryption.js
@@ -42,7 +42,9 @@ export function getHexFromBN(bnInput: Object) {
     return hexOut
   } else if (hexOut.length < 64) {
     // pad with leading zeros
-    return hexOut.padStart(64, '0')
+    // the padStart function would require node 9
+    const padding = '0'.repeat(64 - hexOut.length)
+    return `${padding}${hexOut}`
   } else {
     throw new Error('Generated a > 32-byte BN for encryption. Failing.')
   }

--- a/src/encryption.js
+++ b/src/encryption.js
@@ -35,13 +35,16 @@ function sharedSecretToKeys(sharedSecret : Buffer) {
            hmacKey: hashedSecret.slice(32) }
 }
 
-function getHexFromBN(bnInput: Object) {
+export function getHexFromBN(bnInput: Object) {
   const hexOut = bnInput.toString('hex')
 
   if (hexOut.length === 64) {
     return hexOut
+  } else if (hexOut.length < 64) {
+    // pad with leading zeros
+    return hexOut.padStart(64, '0')
   } else {
-    return `0${hexOut}`
+    throw new Error('Generated a > 32-byte BN for encryption. Failing.')
   }
 }
 


### PR DESCRIPTION
Turns out, the quick fix for the buffers used in encryption wasn't a _forever_ fix, because the binary-normal form library used by elliptic, can in fact return many different kinds of interestingly formatted hex string (basically, it doesn't pad), so the quick patch of just prepending a `0` was limited. Anyways, now I just pad the hex string to 64 characters. This _should_ resolve all those bad hex string TypeErrors that the library was giving before.

Added a unit test which derives 2 BNs known to produce 62 and 63 length hex strings, and checks to make sure that they are getting padded correctly. Prior versions will fail that test.

One note for the future -- I ended up changing around my padding function because node 6 doesn't have `padStart`, we should think about a policy going forward for language version support. Do we want to just support NodeJS LTS + Stable?