### PR TITLE
Send bitcoind credentials in request header for local regtest environment

### DIFF
--- a/dist/blockstack.js
+++ b/dist/blockstack.js
@@ -1277,115 +1277,47 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
-
-var _get = function get(object, property, receiver) { if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { return get(parent, property, receiver); } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } };
-
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-var ERROR_CODES = exports.ERROR_CODES = {
-  MISSING_PARAMETER: 'missing_parameter',
-  REMOTE_SERVICE_ERROR: 'remote_service_error',
-  UNKNOWN: 'unknown'
-};
+var MissingParametersError = exports.MissingParametersError = function (_Error) {
+  _inherits(MissingParametersError, _Error);
 
-Object.freeze(ERROR_CODES);
+  function MissingParametersError() {
+    var message = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : '';
 
-var BlockstackError = exports.BlockstackError = function (_Error) {
-  _inherits(BlockstackError, _Error);
+    _classCallCheck(this, MissingParametersError);
 
-  function BlockstackError(error) {
-    _classCallCheck(this, BlockstackError);
+    var _this = _possibleConstructorReturn(this, (MissingParametersError.__proto__ || Object.getPrototypeOf(MissingParametersError)).call(this));
 
-    var _this = _possibleConstructorReturn(this, (BlockstackError.__proto__ || Object.getPrototypeOf(BlockstackError)).call(this, error.message));
-
-    _this.code = error.code;
-    _this.parameter = error.parameter ? error.parameter : null;
+    _this.name = 'MissingParametersError';
+    _this.message = message;
     return _this;
   }
 
-  _createClass(BlockstackError, [{
-    key: 'toString',
-    value: function toString() {
-      return _get(BlockstackError.prototype.__proto__ || Object.getPrototypeOf(BlockstackError.prototype), 'toString', this).call(this) + '\n    code: ' + this.code + ' param: ' + (this.parameter ? this.parameter : 'n/a');
-    }
-  }]);
-
-  return BlockstackError;
+  return MissingParametersError;
 }(Error);
 
-var InvalidParameterError = exports.InvalidParameterError = function (_BlockstackError) {
-  _inherits(InvalidParameterError, _BlockstackError);
-
-  function InvalidParameterError(parameter) {
-    var message = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : '';
-
-    _classCallCheck(this, InvalidParameterError);
-
-    var _this2 = _possibleConstructorReturn(this, (InvalidParameterError.__proto__ || Object.getPrototypeOf(InvalidParameterError)).call(this, { code: 'missing_parameter', message: message, parameter: '' }));
-
-    _this2.name = 'MissingParametersError';
-    return _this2;
-  }
-
-  return InvalidParameterError;
-}(BlockstackError);
-
-var MissingParameterError = exports.MissingParameterError = function (_BlockstackError2) {
-  _inherits(MissingParameterError, _BlockstackError2);
-
-  function MissingParameterError(parameter) {
-    var message = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : '';
-
-    _classCallCheck(this, MissingParameterError);
-
-    var _this3 = _possibleConstructorReturn(this, (MissingParameterError.__proto__ || Object.getPrototypeOf(MissingParameterError)).call(this, { code: ERROR_CODES.MISSING_PARAMETER, message: message, parameter: parameter }));
-
-    _this3.name = 'MissingParametersError';
-    return _this3;
-  }
-
-  return MissingParameterError;
-}(BlockstackError);
-
-var RemoteServiceError = exports.RemoteServiceError = function (_BlockstackError3) {
-  _inherits(RemoteServiceError, _BlockstackError3);
-
-  function RemoteServiceError(response) {
-    var message = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : '';
-
-    _classCallCheck(this, RemoteServiceError);
-
-    var _this4 = _possibleConstructorReturn(this, (RemoteServiceError.__proto__ || Object.getPrototypeOf(RemoteServiceError)).call(this, { code: ERROR_CODES.REMOTE_SERVICE_ERROR, message: message }));
-
-    _this4.response = response;
-    return _this4;
-  }
-
-  return RemoteServiceError;
-}(BlockstackError);
-
-var InvalidDIDError = exports.InvalidDIDError = function (_BlockstackError4) {
-  _inherits(InvalidDIDError, _BlockstackError4);
+var InvalidDIDError = exports.InvalidDIDError = function (_Error2) {
+  _inherits(InvalidDIDError, _Error2);
 
   function InvalidDIDError() {
     var message = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : '';
 
     _classCallCheck(this, InvalidDIDError);
 
-    var _this5 = _possibleConstructorReturn(this, (InvalidDIDError.__proto__ || Object.getPrototypeOf(InvalidDIDError)).call(this, { code: 'invalid_did_error', message: message, param: '' }));
+    var _this2 = _possibleConstructorReturn(this, (InvalidDIDError.__proto__ || Object.getPrototypeOf(InvalidDIDError)).call(this));
 
-    _this5.name = 'InvalidDIDError';
-    _this5.message = message;
-    return _this5;
+    _this2.name = 'InvalidDIDError';
+    _this2.message = message;
+    return _this2;
   }
 
   return InvalidDIDError;
-}(BlockstackError);
+}(Error);
 },{}],12:[function(require,module,exports){
 'use strict';
 
@@ -1651,8 +1583,6 @@ var _formData = require('form-data');
 
 var _formData2 = _interopRequireDefault(_formData);
 
-var _errors = require('./errors');
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
@@ -1662,19 +1592,15 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 var SATOSHIS_PER_BTC = 1e8;
-var TX_BROADCAST_SERVICE_ZONE_FILE_ENDPOINT = 'zone-file';
-var TX_BROADCAST_SERVICE_REGISTRATION_ENDPOINT = 'registration';
-var TX_BROADCAST_SERVICE_TX_ENDPOINT = 'transaction';
 
 var BlockstackNetwork = function () {
-  function BlockstackNetwork(apiUrl, utxoProviderUrl, broadcastServiceUrl) {
-    var network = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : _bitcoinjsLib2.default.networks.bitcoin;
+  function BlockstackNetwork(apiUrl, utxoProviderUrl) {
+    var network = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : _bitcoinjsLib2.default.networks.bitcoin;
 
     _classCallCheck(this, BlockstackNetwork);
 
     this.blockstackAPIUrl = apiUrl;
     this.utxoProviderUrl = utxoProviderUrl;
-    this.broadcastServiceUrl = broadcastServiceUrl;
     this.layer1 = network;
 
     this.DUST_MINIMUM = 5500;
@@ -1774,252 +1700,22 @@ var BlockstackNetwork = function () {
         }
       });
     }
-
-    /**
-     * Performs a POST request to the given URL
-     * @param  {String} endpoint  the name of
-     * @param  {String} body [description]
-     * @return {Promise<Object|Error>} Returns a `Promise` that resolves to the object requested.
-     * In the event of an error, it rejects with:
-     * * a `RemoteServiceError` if there is a problem
-     * with the transaction broadcast service
-     * * `MissingParameterError` if you call the function without a required
-     * parameter
-     *
-     * @private
-     */
-
-  }, {
-    key: 'broadcastServiceFetchHelper',
-    value: function broadcastServiceFetchHelper(endpoint, body) {
-      var requestHeaders = {
-        Accept: 'application/json',
-        'Content-Type': 'application/json'
-      };
-
-      var options = {
-        method: 'POST',
-        headers: requestHeaders,
-        body: JSON.stringify(body)
-      };
-
-      var url = this.broadcastServiceUrl + '/v1/broadcast/' + endpoint;
-      return fetch(url, options).then(function (response) {
-        if (response.ok) {
-          return response.json();
-        } else {
-          throw new _errors.RemoteServiceError(response);
-        }
-      });
-    }
-
-    /**
-    * Broadcasts a signed bitcoin transaction to the network optionally waiting to broadcast the
-    * transaction until a second transaction has a certain number of confirmations.
-    *
-    * @param  {string} transaction the hex-encoded transaction to broadcast
-    * @param  {string} transactionToWatch the hex transaction id of the transaction to watch for
-    * the specified number of confirmations before broadcasting the `transaction`
-    * @param  {number} confirmations the number of confirmations `transactionToWatch` must have
-    * before broadcasting `transaction`.
-    * @return {Promise<Object|Error>} Returns a Promise that resolves to an object with a
-    * `transaction_hash` key containing the transaction hash of the broadcasted transaction.
-    *
-    * In the event of an error, it rejects with:
-    * * a `RemoteServiceError` if there is a problem
-    *   with the transaction broadcast service
-    * * `MissingParameterError` if you call the function without a required
-    *   parameter
-    */
-
   }, {
     key: 'broadcastTransaction',
     value: function broadcastTransaction(transaction) {
-      var transactionToWatch = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : null;
-      var confirmations = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 6;
-
-      if (!transaction) {
-        var error = new _errors.MissingParameterError('transaction');
-        return Promise.reject(error);
-      }
-
-      if (!confirmations && confirmations !== 0) {
-        var _error = new _errors.MissingParameterError('confirmations');
-        return Promise.reject(_error);
-      }
-
-      if (transactionToWatch === null) {
-        var form = new _formData2.default();
-        form.append('tx', transaction);
-        return fetch(this.utxoProviderUrl + '/pushtx?cors=true', { method: 'POST',
-          body: form }).then(function (resp) {
-          var text = resp.text();
-          return text.then(function (respText) {
-            if (respText.toLowerCase().indexOf('transaction submitted') >= 0) {
-              var txHash = _bitcoinjsLib2.default.Transaction.fromHex(transaction).getHash().reverse().toString('hex'); // big_endian
-              return txHash;
-            } else {
-              throw new _errors.RemoteServiceError(resp, 'Broadcast transaction failed with message: ' + respText);
-            }
-          });
-        });
-      } else {
-        /*
-         * POST /v1/broadcast/transaction
-         * Request body:
-         * JSON.stringify({
-         *  transaction,
-         *  transactionToWatch,
-         *  confirmations
-         * })
-         */
-        var endpoint = TX_BROADCAST_SERVICE_TX_ENDPOINT;
-
-        var requestBody = {
-          transaction: transaction,
-          transactionToWatch: transactionToWatch,
-          confirmations: confirmations
-        };
-
-        return this.broadcastServiceFetchHelper(endpoint, requestBody);
-      }
-    }
-
-    /**
-     * Broadcasts a zone file to the Atlas network via the transaction broadcast service.
-     *
-     * @param  {String} zoneFile the zone file to be broadcast to the Atlas network
-     * @param  {String} transactionToWatch the hex transaction id of the transaction
-     * to watch for confirmation before broadcasting the zone file to the Atlas network
-     * @return {Promise<Object|Error>} Returns a Promise that resolves to an object with a
-     * `transaction_hash` key containing the transaction hash of the broadcasted transaction.
-     *
-     * In the event of an error, it rejects with:
-     * * a `RemoteServiceError` if there is a problem
-     *   with the transaction broadcast service
-     * * `MissingParameterError` if you call the function without a required
-     *   parameter
-     */
-
-  }, {
-    key: 'broadcastZoneFile',
-    value: function broadcastZoneFile(zoneFile) {
-      var transactionToWatch = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : null;
-
-      if (!zoneFile) {
-        return Promise.reject(new _errors.MissingParameterError('zoneFile'));
-      }
-
-      // TODO: validate zonefile
-
-      if (transactionToWatch) {
-        // broadcast via transaction broadcast service
-
-        /*
-         * POST /v1/broadcast/zone-file
-         * Request body:
-         * JSON.stringify({
-         *  zoneFile,
-         *  transactionToWatch
-         * })
-         */
-
-        var requestBody = {
-          zoneFile: zoneFile,
-          transactionToWatch: transactionToWatch
-        };
-
-        var endpoint = TX_BROADCAST_SERVICE_ZONE_FILE_ENDPOINT;
-
-        return this.broadcastServiceFetchHelper(endpoint, requestBody);
-      } else {
-        // broadcast via core endpoint
-
-        // zone file is two words but core's api treats it as one word 'zonefile'
-        var _requestBody = { zonefile: zoneFile };
-
-        return fetch(this.blockstackAPIUrl + '/v1/zonefile/', { method: 'POST',
-          body: JSON.stringify(_requestBody),
-          headers: {
-            'Content-Type': 'application/json'
-          }
-        }).then(function (resp) {
-          var json = resp.json();
-          return json.then(function (respObj) {
-            if (respObj.hasOwnProperty('error')) {
-              throw new _errors.RemoteServiceError(resp);
-            }
-            return respObj.servers;
-          });
-        });
-      }
-    }
-
-    /**
-     * Sends the preorder and registration transactions and zone file
-     * for a Blockstack name registration
-     * along with the to the transaction broadcast service.
-     *
-     * The transaction broadcast:
-     *
-     * * immediately broadcasts the preorder transaction
-     * * broadcasts the register transactions after the preorder transaction
-     * has an appropriate number of confirmations
-     * * broadcasts the zone file to the Atlas network after the register transaction
-     * has an appropriate number of confirmations
-     *
-     * @param  {String} preorderTransaction the hex-encoded, signed preorder transaction generated
-     * using the `makePreorder` function
-     * @param  {String} registerTransaction the hex-encoded, signed register transaction generated
-     * using the `makeRegister` function
-     * @param  {String} zoneFile the zone file to be broadcast to the Atlas network
-     * @return {Promise<Object|Error>} Returns a Promise that resolves to an object with a
-     * `transaction_hash` key containing the transaction hash of the broadcasted transaction.
-     *
-     * In the event of an error, it rejects with:
-     * * a `RemoteServiceError` if there is a problem
-     *   with the transaction broadcast service
-     * * `MissingParameterError` if you call the function without a required
-     *   parameter
-     */
-
-  }, {
-    key: 'broadcastNameRegistration',
-    value: function broadcastNameRegistration(preorderTransaction, registerTransaction, zoneFile) {
-      /*
-       * POST /v1/broadcast/registration
-       * Request body:
-       * JSON.stringify({
-       * preorderTransaction,
-       * registerTransaction,
-       * zoneFile
-       * })
-       */
-
-      if (!preorderTransaction) {
-        var error = new _errors.MissingParameterError('preorderTransaction');
-        return Promise.reject(error);
-      }
-
-      if (!registerTransaction) {
-        var _error2 = new _errors.MissingParameterError('registerTransaction');
-        return Promise.reject(_error2);
-      }
-
-      if (!zoneFile) {
-        var _error3 = new _errors.MissingParameterError('zoneFile');
-        return Promise.reject(_error3);
-      }
-
-      var requestBody = {
-        preorderTransaction: preorderTransaction,
-        registerTransaction: registerTransaction,
-        zoneFile: zoneFile
-      };
-
-      var endpoint = TX_BROADCAST_SERVICE_REGISTRATION_ENDPOINT;
-
-      return this.broadcastServiceFetchHelper(endpoint, requestBody);
+      var form = new _formData2.default();
+      form.append('tx', transaction);
+      return fetch(this.utxoProviderUrl + '/pushtx?cors=true', { method: 'POST',
+        body: form }).then(function (resp) {
+        return resp.text();
+      }).then(function (respText) {
+        if (respText.toLowerCase().indexOf('transaction submitted') >= 0) {
+          var txHash = _bitcoinjsLib2.default.Transaction.fromHex(transaction).getHash().reverse().toString('hex'); // big_endian
+          return txHash;
+        } else {
+          throw new Error('Broadcast transaction failed with message: ' + respText);
+        }
+      });
     }
   }, {
     key: 'getTransactionInfo',
@@ -2054,9 +1750,7 @@ var BlockstackNetwork = function () {
       return fetch(this.utxoProviderUrl + '/unspent?format=json&active=' + address).then(function (resp) {
         if (resp.status === 500) {
           console.log('DEBUG: UTXO provider 500 usually means no UTXOs: returning []');
-          return {
-            unspent_outputs: []
-          };
+          return [];
         } else {
           return resp.json();
         }
@@ -2150,6 +1844,24 @@ var BlockstackNetwork = function () {
       this.excludeUtxoSet = [];
     }
   }, {
+    key: 'publishZonefile',
+    value: function publishZonefile(zonefile) {
+      var arg = { zonefile: zonefile };
+      return fetch(this.blockstackAPIUrl + '/v1/zonefile/', { method: 'POST',
+        body: JSON.stringify(arg),
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }).then(function (resp) {
+        return resp.json();
+      }).then(function (respObj) {
+        if (respObj.hasOwnProperty('error')) {
+          throw new Error(respObj.error);
+        }
+        return respObj.servers;
+      });
+    }
+  }, {
     key: 'getConsensusHash',
     value: function getConsensusHash() {
       return fetch(this.blockstackAPIUrl + '/v1/blockchains/bitcoin/consensus').then(function (resp) {
@@ -2166,12 +1878,15 @@ var BlockstackNetwork = function () {
 var LocalRegtest = function (_BlockstackNetwork) {
   _inherits(LocalRegtest, _BlockstackNetwork);
 
-  function LocalRegtest(apiUrl, bitcoindUrl, broadcastServiceUrl) {
+  function LocalRegtest(apiUrl, bitcoindUrl) {
+    var bitcoindCredentials = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : null;
+
     _classCallCheck(this, LocalRegtest);
 
-    var _this5 = _possibleConstructorReturn(this, (LocalRegtest.__proto__ || Object.getPrototypeOf(LocalRegtest)).call(this, apiUrl, '', broadcastServiceUrl, _bitcoinjsLib2.default.networks.testnet));
+    var _this5 = _possibleConstructorReturn(this, (LocalRegtest.__proto__ || Object.getPrototypeOf(LocalRegtest)).call(this, apiUrl, '', _bitcoinjsLib2.default.networks.testnet));
 
     _this5.bitcoindUrl = bitcoindUrl;
+    _this5.bitcoindCredentials = bitcoindCredentials;
     return _this5;
   }
 
@@ -2186,7 +1901,11 @@ var LocalRegtest = function (_BlockstackNetwork) {
       var jsonRPC = { jsonrpc: '1.0',
         method: 'sendrawtransaction',
         params: [transaction] };
-      return fetch(this.bitcoindUrl, { method: 'POST', body: JSON.stringify(jsonRPC) }).then(function (resp) {
+      var authString = btoa(this.bitcoindCredentials.username + ':' + this.bitcoindCredentials.password);
+      var headers = new Headers({ Authorization: 'Basic ' + authString });
+      return fetch(this.bitcoindUrl, { method: 'POST',
+        body: JSON.stringify(jsonRPC),
+        headers: headers }).then(function (resp) {
         return resp.json();
       }).then(function (respObj) {
         return respObj.result;
@@ -2197,7 +1916,11 @@ var LocalRegtest = function (_BlockstackNetwork) {
     value: function getBlockHeight() {
       var jsonRPC = { jsonrpc: '1.0',
         method: 'getblockcount' };
-      return fetch(this.bitcoindUrl, { method: 'POST', body: JSON.stringify(jsonRPC) }).then(function (resp) {
+      var authString = btoa(this.bitcoindCredentials.username + ':' + this.bitcoindCredentials.password);
+      var headers = new Headers({ Authorization: 'Basic ' + authString });
+      return fetch(this.bitcoindUrl, { method: 'POST',
+        body: JSON.stringify(jsonRPC),
+        headers: headers }).then(function (resp) {
         return resp.json();
       }).then(function (respObj) {
         return respObj.result;
@@ -2211,7 +1934,11 @@ var LocalRegtest = function (_BlockstackNetwork) {
       var jsonRPC = { jsonrpc: '1.0',
         method: 'gettransaction',
         params: [txHash] };
-      return fetch(this.bitcoindUrl, { method: 'POST', body: JSON.stringify(jsonRPC) }).then(function (resp) {
+      var authString = btoa(this.bitcoindCredentials.username + ':' + this.bitcoindCredentials.password);
+      var headers = new Headers({ Authorization: 'Basic ' + authString });
+      return fetch(this.bitcoindUrl, { method: 'POST',
+        body: JSON.stringify(jsonRPC),
+        headers: headers }).then(function (resp) {
         return resp.json();
       }).then(function (respObj) {
         return respObj.result;
@@ -2221,8 +1948,10 @@ var LocalRegtest = function (_BlockstackNetwork) {
         var jsonRPCBlock = { jsonrpc: '1.0',
           method: 'getblockheader',
           params: [blockhash] };
+        headers.append('Authorization', 'Basic ' + authString);
         return fetch(_this6.bitcoindUrl, { method: 'POST',
-          body: JSON.stringify(jsonRPCBlock) });
+          body: JSON.stringify(jsonRPCBlock),
+          headers: headers });
       }).then(function (resp) {
         return resp.json();
       }).then(function (respObj) {
@@ -2240,9 +1969,15 @@ var LocalRegtest = function (_BlockstackNetwork) {
       var jsonRPCUnspent = { jsonrpc: '1.0',
         method: 'listunspent',
         params: [1, 9999999, [address]] };
+      var authString = btoa(this.bitcoindCredentials.username + ':' + this.bitcoindCredentials.password);
+      var headers = new Headers({ Authorization: 'Basic ' + authString });
 
-      return fetch(this.bitcoindUrl, { method: 'POST', body: JSON.stringify(jsonRPCImport) }).then(function () {
-        return fetch(_this7.bitcoindUrl, { method: 'POST', body: JSON.stringify(jsonRPCUnspent) });
+      return fetch(this.bitcoindUrl, { method: 'POST',
+        body: JSON.stringify(jsonRPCImport),
+        headers: headers }).then(function () {
+        return fetch(_this7.bitcoindUrl, { method: 'POST',
+          body: JSON.stringify(jsonRPCUnspent),
+          headers: headers });
       }).then(function (resp) {
         return resp.json();
       }).then(function (x) {
@@ -2261,14 +1996,14 @@ var LocalRegtest = function (_BlockstackNetwork) {
   return LocalRegtest;
 }(BlockstackNetwork);
 
-var LOCAL_REGTEST = new LocalRegtest('http://localhost:16268', 'http://blockstack:blockstacksystem@127.0.0.1:18332/', 'http://localhost:16269');
+var LOCAL_REGTEST = new LocalRegtest('http://localhost:6270', 'http://localhost:18332/', { username: 'blockstack', password: 'blockstacksystem' });
 
-var MAINNET_DEFAULT = new BlockstackNetwork('https://core.blockstack.org', 'https://blockchain.info', 'https://broadcast.blockstack.org');
+var MAINNET_DEFAULT = new BlockstackNetwork('https://core.blockstack.org', 'https://blockchain.info');
 
 var network = exports.network = { BlockstackNetwork: BlockstackNetwork, LocalRegtest: LocalRegtest,
   defaults: { LOCAL_REGTEST: LOCAL_REGTEST, MAINNET_DEFAULT: MAINNET_DEFAULT } };
 }).call(this,require("buffer").Buffer)
-},{"./errors":11,"bitcoinjs-lib":86,"buffer":142,"form-data":300}],15:[function(require,module,exports){
+},{"bitcoinjs-lib":86,"buffer":142,"form-data":300}],15:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -3435,12 +3170,12 @@ var _profileZoneFiles = require('./profileZoneFiles');
  * Look up a user profile by blockstack ID
  *
  * @param {string} username The Blockstack ID of the profile to look up
- * @param {string} [zoneFileLookupURL=https://core.blockstack.org/v1/names/] The URL
+ * @param {string} [zoneFileLookupURL=http://localhost:6270/v1/names/] The URL
  * to use for zonefile lookup 
  * @returns {Promise} that resolves to a profile object
  */
 function lookupProfile(username) {
-  var zoneFileLookupURL = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 'https://core.blockstack.org/v1/names/';
+  var zoneFileLookupURL = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 'http://localhost:6270/v1/names/';
 
   return new Promise(function (resolve, reject) {
     if (!username) {
@@ -5708,7 +5443,6 @@ function updateQueryStringParameter(uri, key, value) {
  * @param {string} v1 - the left half of the version inequality
  * @param {string} v2 - right half of the version inequality
  * @returns {bool} iff v1 >= v2
- * @private
  */
 function isLaterVersion(v1, v2) {
   var v1tuple = v1.split('.').map(function (x) {
@@ -7411,34 +7145,51 @@ module.exports = BigInteger
 module.exports={
   "_args": [
     [
-      "bigi@1.4.2",
-      "/Users/larry/git/blockstack.js"
+      {
+        "raw": "bigi@^1.4.0",
+        "scope": null,
+        "escapedName": "bigi",
+        "name": "bigi",
+        "rawSpec": "^1.4.0",
+        "spec": ">=1.4.0 <2.0.0",
+        "type": "range"
+      },
+      "/Users/Yukan/Desktop/work/blockstack/blockstack.js/node_modules/bitcoinjs-lib"
     ]
   ],
-  "_from": "bigi@1.4.2",
+  "_from": "bigi@>=1.4.0 <2.0.0",
   "_id": "bigi@1.4.2",
-  "_inBundle": false,
-  "_integrity": "sha1-nGZalfiLiwj8Bc/XMfVhhZ1yWCU=",
+  "_inCache": true,
   "_location": "/bigi",
+  "_nodeVersion": "6.1.0",
+  "_npmOperationalInternal": {
+    "host": "packages-12-west.internal.npmjs.com",
+    "tmp": "tmp/bigi-1.4.2.tgz_1469584192413_0.6801238611806184"
+  },
+  "_npmUser": {
+    "name": "jprichardson",
+    "email": "jprichardson@gmail.com"
+  },
+  "_npmVersion": "3.8.6",
   "_phantomChildren": {},
   "_requested": {
-    "type": "version",
-    "registry": true,
-    "raw": "bigi@1.4.2",
-    "name": "bigi",
+    "raw": "bigi@^1.4.0",
+    "scope": null,
     "escapedName": "bigi",
-    "rawSpec": "1.4.2",
-    "saveSpec": null,
-    "fetchSpec": "1.4.2"
+    "name": "bigi",
+    "rawSpec": "^1.4.0",
+    "spec": ">=1.4.0 <2.0.0",
+    "type": "range"
   },
   "_requiredBy": [
-    "/",
     "/bitcoinjs-lib",
     "/ecurve"
   ],
   "_resolved": "https://registry.npmjs.org/bigi/-/bigi-1.4.2.tgz",
-  "_spec": "1.4.2",
-  "_where": "/Users/larry/git/blockstack.js",
+  "_shasum": "9c665a95f88b8b08fc05cfd731f561859d725825",
+  "_shrinkwrap": null,
+  "_spec": "bigi@^1.4.0",
+  "_where": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/node_modules/bitcoinjs-lib",
   "bugs": {
     "url": "https://github.com/cryptocoinjs/bigi/issues"
   },
@@ -7451,6 +7202,12 @@ module.exports={
     "mocha": "^2.1.0",
     "mochify": "^2.1.0"
   },
+  "directories": {},
+  "dist": {
+    "shasum": "9c665a95f88b8b08fc05cfd731f561859d725825",
+    "tarball": "https://registry.npmjs.org/bigi/-/bigi-1.4.2.tgz"
+  },
+  "gitHead": "c25308081c896ff84702303722bf5ecd8b3f78e3",
   "homepage": "https://github.com/cryptocoinjs/bigi#readme",
   "keywords": [
     "cryptography",
@@ -7470,7 +7227,27 @@ module.exports={
     "float"
   ],
   "main": "./lib/index.js",
+  "maintainers": [
+    {
+      "name": "midnightlightning",
+      "email": "boydb@midnightdesign.ws"
+    },
+    {
+      "name": "sidazhang",
+      "email": "sidazhang89@gmail.com"
+    },
+    {
+      "name": "nadav",
+      "email": "npm@shesek.info"
+    },
+    {
+      "name": "jprichardson",
+      "email": "jprichardson@gmail.com"
+    }
+  ],
   "name": "bigi",
+  "optionalDependencies": {},
+  "readme": "ERROR: No README data found!",
   "repository": {
     "url": "git+https://github.com/cryptocoinjs/bigi.git",
     "type": "git"
@@ -31237,29 +31014,53 @@ exports.isHtml = function(str) {
 
 },{"./parse":227,"dom-serializer":240}],230:[function(require,module,exports){
 module.exports={
-  "_from": "cheerio@^0.22.0",
+  "_args": [
+    [
+      {
+        "raw": "cheerio@0.22.0",
+        "scope": null,
+        "escapedName": "cheerio",
+        "name": "cheerio",
+        "rawSpec": "0.22.0",
+        "spec": "0.22.0",
+        "type": "version"
+      },
+      "/Users/Yukan/Desktop/work/blockstack/blockstack.js"
+    ]
+  ],
+  "_from": "cheerio@0.22.0",
   "_id": "cheerio@0.22.0",
-  "_inBundle": false,
-  "_integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
+  "_inCache": true,
   "_location": "/cheerio",
+  "_nodeVersion": "6.2.2",
+  "_npmOperationalInternal": {
+    "host": "packages-12-west.internal.npmjs.com",
+    "tmp": "tmp/cheerio-0.22.0.tgz_1471954900169_0.12557715992443264"
+  },
+  "_npmUser": {
+    "name": "mattmueller",
+    "email": "mattmuelle@gmail.com"
+  },
+  "_npmVersion": "3.10.6",
   "_phantomChildren": {},
   "_requested": {
-    "type": "range",
-    "registry": true,
-    "raw": "cheerio@^0.22.0",
-    "name": "cheerio",
+    "raw": "cheerio@0.22.0",
+    "scope": null,
     "escapedName": "cheerio",
-    "rawSpec": "^0.22.0",
-    "saveSpec": null,
-    "fetchSpec": "^0.22.0"
+    "name": "cheerio",
+    "rawSpec": "0.22.0",
+    "spec": "0.22.0",
+    "type": "version"
   },
   "_requiredBy": [
+    "#USER",
     "/"
   ],
   "_resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
   "_shasum": "a9baa860a3f9b595a6b81b1a86873121ed3a269e",
-  "_spec": "cheerio@^0.22.0",
-  "_where": "/Users/larry/git/blockstack.js",
+  "_shrinkwrap": null,
+  "_spec": "cheerio@0.22.0",
+  "_where": "/Users/Yukan/Desktop/work/blockstack/blockstack.js",
   "author": {
     "name": "Matt Mueller",
     "email": "mattmuelle@gmail.com",
@@ -31268,7 +31069,6 @@ module.exports={
   "bugs": {
     "url": "https://github.com/cheeriojs/cheerio/issues"
   },
-  "bundleDependencies": false,
   "dependencies": {
     "css-select": "~1.2.0",
     "dom-serializer": "~0.1.0",
@@ -31287,7 +31087,6 @@ module.exports={
     "lodash.reject": "^4.4.0",
     "lodash.some": "^4.4.0"
   },
-  "deprecated": false,
   "description": "Tiny, fast, and elegant implementation of core jQuery designed specifically for the server",
   "devDependencies": {
     "benchmark": "^2.1.0",
@@ -31300,6 +31099,11 @@ module.exports={
     "mocha": "^2.5.3",
     "xyz": "~0.5.0"
   },
+  "directories": {},
+  "dist": {
+    "shasum": "a9baa860a3f9b595a6b81b1a86873121ed3a269e",
+    "tarball": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz"
+  },
   "engines": {
     "node": ">= 0.6"
   },
@@ -31307,6 +31111,7 @@ module.exports={
     "index.js",
     "lib"
   ],
+  "gitHead": "35c4917205dca9d08139c95419e2626c0689e38a",
   "homepage": "https://github.com/cheeriojs/cheerio#readme",
   "keywords": [
     "htmlparser",
@@ -31318,7 +31123,27 @@ module.exports={
   ],
   "license": "MIT",
   "main": "./index.js",
+  "maintainers": [
+    {
+      "name": "mattmueller",
+      "email": "mattmuelle@gmail.com"
+    },
+    {
+      "name": "davidchambers",
+      "email": "dc@davidchambers.me"
+    },
+    {
+      "name": "jugglinmike",
+      "email": "mike@mikepennisi.com"
+    },
+    {
+      "name": "feedic",
+      "email": "me@feedic.com"
+    }
+  ],
   "name": "cheerio",
+  "optionalDependencies": {},
+  "readme": "ERROR: No README data found!",
   "repository": {
     "type": "git",
     "url": "git://github.com/cheeriojs/cheerio.git"
@@ -39485,33 +39310,56 @@ utils.encode = function encode(arr, enc) {
 
 },{}],291:[function(require,module,exports){
 module.exports={
-  "_from": "elliptic@^6.4.0",
+  "_args": [
+    [
+      {
+        "raw": "elliptic@^6.4.0",
+        "scope": null,
+        "escapedName": "elliptic",
+        "name": "elliptic",
+        "rawSpec": "^6.4.0",
+        "spec": ">=6.4.0 <7.0.0",
+        "type": "range"
+      },
+      "/Users/Yukan/Desktop/work/blockstack/blockstack.js"
+    ]
+  ],
+  "_from": "elliptic@>=6.4.0 <7.0.0",
   "_id": "elliptic@6.4.0",
-  "_inBundle": false,
-  "_integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
+  "_inCache": true,
   "_location": "/elliptic",
+  "_nodeVersion": "7.0.0",
+  "_npmOperationalInternal": {
+    "host": "packages-18-east.internal.npmjs.com",
+    "tmp": "tmp/elliptic-6.4.0.tgz_1487798866428_0.30510620190761983"
+  },
+  "_npmUser": {
+    "name": "indutny",
+    "email": "fedor@indutny.com"
+  },
+  "_npmVersion": "3.10.8",
   "_phantomChildren": {},
   "_requested": {
-    "type": "range",
-    "registry": true,
     "raw": "elliptic@^6.4.0",
-    "name": "elliptic",
+    "scope": null,
     "escapedName": "elliptic",
+    "name": "elliptic",
     "rawSpec": "^6.4.0",
-    "saveSpec": null,
-    "fetchSpec": "^6.4.0"
+    "spec": ">=6.4.0 <7.0.0",
+    "type": "range"
   },
   "_requiredBy": [
     "/",
     "/blockstack-storage",
-    "/browserify/browserify-sign",
-    "/browserify/create-ecdh",
+    "/browserify-sign",
+    "/create-ecdh",
     "/jsontokens"
   ],
   "_resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
   "_shasum": "cac9af8762c85836187003c8dfe193e5e2eae5df",
+  "_shrinkwrap": null,
   "_spec": "elliptic@^6.4.0",
-  "_where": "/Users/larry/git/blockstack.js",
+  "_where": "/Users/Yukan/Desktop/work/blockstack/blockstack.js",
   "author": {
     "name": "Fedor Indutny",
     "email": "fedor@indutny.com"
@@ -39519,7 +39367,6 @@ module.exports={
   "bugs": {
     "url": "https://github.com/indutny/elliptic/issues"
   },
-  "bundleDependencies": false,
   "dependencies": {
     "bn.js": "^4.4.0",
     "brorand": "^1.0.1",
@@ -39529,7 +39376,6 @@ module.exports={
     "minimalistic-assert": "^1.0.0",
     "minimalistic-crypto-utils": "^1.0.0"
   },
-  "deprecated": false,
   "description": "EC cryptography",
   "devDependencies": {
     "brfs": "^1.4.3",
@@ -39547,9 +39393,15 @@ module.exports={
     "jshint": "^2.6.0",
     "mocha": "^2.1.0"
   },
+  "directories": {},
+  "dist": {
+    "shasum": "cac9af8762c85836187003c8dfe193e5e2eae5df",
+    "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz"
+  },
   "files": [
     "lib"
   ],
+  "gitHead": "6b0d2b76caae91471649c8e21f0b1d3ba0f96090",
   "homepage": "https://github.com/indutny/elliptic",
   "keywords": [
     "EC",
@@ -39559,7 +39411,15 @@ module.exports={
   ],
   "license": "MIT",
   "main": "lib/elliptic.js",
+  "maintainers": [
+    {
+      "name": "indutny",
+      "email": "fedor@indutny.com"
+    }
+  ],
   "name": "elliptic",
+  "optionalDependencies": {},
+  "readme": "ERROR: No README data found!",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/indutny/elliptic.git"
@@ -52072,29 +51932,34 @@ utils.intFromLE = intFromLE;
 
 },{"bn.js":373}],390:[function(require,module,exports){
 module.exports={
-  "_from": "elliptic@^5.1.0",
+  "_args": [
+    [
+      "elliptic@5.2.1",
+      "/Users/Yukan/Desktop/work/blockstack/blockstack.js"
+    ]
+  ],
+  "_from": "elliptic@5.2.1",
   "_id": "elliptic@5.2.1",
   "_inBundle": false,
   "_integrity": "sha1-+ilLZWPG3bybo9yFlGh66ECFjxA=",
   "_location": "/jsontokens/key-encoder/elliptic",
   "_phantomChildren": {},
   "_requested": {
-    "type": "range",
+    "type": "version",
     "registry": true,
-    "raw": "elliptic@^5.1.0",
+    "raw": "elliptic@5.2.1",
     "name": "elliptic",
     "escapedName": "elliptic",
-    "rawSpec": "^5.1.0",
+    "rawSpec": "5.2.1",
     "saveSpec": null,
-    "fetchSpec": "^5.1.0"
+    "fetchSpec": "5.2.1"
   },
   "_requiredBy": [
     "/jsontokens/key-encoder"
   ],
   "_resolved": "https://registry.npmjs.org/elliptic/-/elliptic-5.2.1.tgz",
-  "_shasum": "fa294b6563c6ddbc9ba3dc8594687ae840858f10",
-  "_spec": "elliptic@^5.1.0",
-  "_where": "/Users/larry/git/blockstack.js/node_modules/jsontokens/node_modules/key-encoder",
+  "_spec": "5.2.1",
+  "_where": "/Users/Yukan/Desktop/work/blockstack/blockstack.js",
   "author": {
     "name": "Fedor Indutny",
     "email": "fedor@indutny.com"
@@ -52102,14 +51967,12 @@ module.exports={
   "bugs": {
     "url": "https://github.com/indutny/elliptic/issues"
   },
-  "bundleDependencies": false,
   "dependencies": {
     "bn.js": "^3.1.1",
     "brorand": "^1.0.1",
     "hash.js": "^1.0.0",
     "inherits": "^2.0.1"
   },
-  "deprecated": false,
   "description": "EC cryptography",
   "devDependencies": {
     "browserify": "^3.44.2",

--- a/dist/blockstack.js
+++ b/dist/blockstack.js
@@ -1996,7 +1996,7 @@ var LocalRegtest = function (_BlockstackNetwork) {
   return LocalRegtest;
 }(BlockstackNetwork);
 
-var LOCAL_REGTEST = new LocalRegtest('http://localhost:6270', 'http://localhost:18332/', { username: 'blockstack', password: 'blockstacksystem' });
+var LOCAL_REGTEST = new LocalRegtest('http://localhost:16268', 'http://localhost:18332/', { username: 'blockstack', password: 'blockstacksystem' });
 
 var MAINNET_DEFAULT = new BlockstackNetwork('https://core.blockstack.org', 'https://blockchain.info');
 

--- a/dist/blockstack.js
+++ b/dist/blockstack.js
@@ -1277,47 +1277,115 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _get = function get(object, property, receiver) { if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { return get(parent, property, receiver); } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } };
+
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-var MissingParametersError = exports.MissingParametersError = function (_Error) {
-  _inherits(MissingParametersError, _Error);
+var ERROR_CODES = exports.ERROR_CODES = {
+  MISSING_PARAMETER: 'missing_parameter',
+  REMOTE_SERVICE_ERROR: 'remote_service_error',
+  UNKNOWN: 'unknown'
+};
 
-  function MissingParametersError() {
-    var message = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : '';
+Object.freeze(ERROR_CODES);
 
-    _classCallCheck(this, MissingParametersError);
+var BlockstackError = exports.BlockstackError = function (_Error) {
+  _inherits(BlockstackError, _Error);
 
-    var _this = _possibleConstructorReturn(this, (MissingParametersError.__proto__ || Object.getPrototypeOf(MissingParametersError)).call(this));
+  function BlockstackError(error) {
+    _classCallCheck(this, BlockstackError);
 
-    _this.name = 'MissingParametersError';
-    _this.message = message;
+    var _this = _possibleConstructorReturn(this, (BlockstackError.__proto__ || Object.getPrototypeOf(BlockstackError)).call(this, error.message));
+
+    _this.code = error.code;
+    _this.parameter = error.parameter ? error.parameter : null;
     return _this;
   }
 
-  return MissingParametersError;
+  _createClass(BlockstackError, [{
+    key: 'toString',
+    value: function toString() {
+      return _get(BlockstackError.prototype.__proto__ || Object.getPrototypeOf(BlockstackError.prototype), 'toString', this).call(this) + '\n    code: ' + this.code + ' param: ' + (this.parameter ? this.parameter : 'n/a');
+    }
+  }]);
+
+  return BlockstackError;
 }(Error);
 
-var InvalidDIDError = exports.InvalidDIDError = function (_Error2) {
-  _inherits(InvalidDIDError, _Error2);
+var InvalidParameterError = exports.InvalidParameterError = function (_BlockstackError) {
+  _inherits(InvalidParameterError, _BlockstackError);
+
+  function InvalidParameterError(parameter) {
+    var message = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : '';
+
+    _classCallCheck(this, InvalidParameterError);
+
+    var _this2 = _possibleConstructorReturn(this, (InvalidParameterError.__proto__ || Object.getPrototypeOf(InvalidParameterError)).call(this, { code: 'missing_parameter', message: message, parameter: '' }));
+
+    _this2.name = 'MissingParametersError';
+    return _this2;
+  }
+
+  return InvalidParameterError;
+}(BlockstackError);
+
+var MissingParameterError = exports.MissingParameterError = function (_BlockstackError2) {
+  _inherits(MissingParameterError, _BlockstackError2);
+
+  function MissingParameterError(parameter) {
+    var message = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : '';
+
+    _classCallCheck(this, MissingParameterError);
+
+    var _this3 = _possibleConstructorReturn(this, (MissingParameterError.__proto__ || Object.getPrototypeOf(MissingParameterError)).call(this, { code: ERROR_CODES.MISSING_PARAMETER, message: message, parameter: parameter }));
+
+    _this3.name = 'MissingParametersError';
+    return _this3;
+  }
+
+  return MissingParameterError;
+}(BlockstackError);
+
+var RemoteServiceError = exports.RemoteServiceError = function (_BlockstackError3) {
+  _inherits(RemoteServiceError, _BlockstackError3);
+
+  function RemoteServiceError(response) {
+    var message = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : '';
+
+    _classCallCheck(this, RemoteServiceError);
+
+    var _this4 = _possibleConstructorReturn(this, (RemoteServiceError.__proto__ || Object.getPrototypeOf(RemoteServiceError)).call(this, { code: ERROR_CODES.REMOTE_SERVICE_ERROR, message: message }));
+
+    _this4.response = response;
+    return _this4;
+  }
+
+  return RemoteServiceError;
+}(BlockstackError);
+
+var InvalidDIDError = exports.InvalidDIDError = function (_BlockstackError4) {
+  _inherits(InvalidDIDError, _BlockstackError4);
 
   function InvalidDIDError() {
     var message = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : '';
 
     _classCallCheck(this, InvalidDIDError);
 
-    var _this2 = _possibleConstructorReturn(this, (InvalidDIDError.__proto__ || Object.getPrototypeOf(InvalidDIDError)).call(this));
+    var _this5 = _possibleConstructorReturn(this, (InvalidDIDError.__proto__ || Object.getPrototypeOf(InvalidDIDError)).call(this, { code: 'invalid_did_error', message: message, param: '' }));
 
-    _this2.name = 'InvalidDIDError';
-    _this2.message = message;
-    return _this2;
+    _this5.name = 'InvalidDIDError';
+    _this5.message = message;
+    return _this5;
   }
 
   return InvalidDIDError;
-}(Error);
+}(BlockstackError);
 },{}],12:[function(require,module,exports){
 'use strict';
 
@@ -1583,6 +1651,8 @@ var _formData = require('form-data');
 
 var _formData2 = _interopRequireDefault(_formData);
 
+var _errors = require('./errors');
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
@@ -1592,15 +1662,19 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 var SATOSHIS_PER_BTC = 1e8;
+var TX_BROADCAST_SERVICE_ZONE_FILE_ENDPOINT = 'zone-file';
+var TX_BROADCAST_SERVICE_REGISTRATION_ENDPOINT = 'registration';
+var TX_BROADCAST_SERVICE_TX_ENDPOINT = 'transaction';
 
 var BlockstackNetwork = function () {
-  function BlockstackNetwork(apiUrl, utxoProviderUrl) {
-    var network = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : _bitcoinjsLib2.default.networks.bitcoin;
+  function BlockstackNetwork(apiUrl, utxoProviderUrl, broadcastServiceUrl) {
+    var network = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : _bitcoinjsLib2.default.networks.bitcoin;
 
     _classCallCheck(this, BlockstackNetwork);
 
     this.blockstackAPIUrl = apiUrl;
     this.utxoProviderUrl = utxoProviderUrl;
+    this.broadcastServiceUrl = broadcastServiceUrl;
     this.layer1 = network;
 
     this.DUST_MINIMUM = 5500;
@@ -1700,22 +1774,252 @@ var BlockstackNetwork = function () {
         }
       });
     }
+
+    /**
+     * Performs a POST request to the given URL
+     * @param  {String} endpoint  the name of
+     * @param  {String} body [description]
+     * @return {Promise<Object|Error>} Returns a `Promise` that resolves to the object requested.
+     * In the event of an error, it rejects with:
+     * * a `RemoteServiceError` if there is a problem
+     * with the transaction broadcast service
+     * * `MissingParameterError` if you call the function without a required
+     * parameter
+     *
+     * @private
+     */
+
+  }, {
+    key: 'broadcastServiceFetchHelper',
+    value: function broadcastServiceFetchHelper(endpoint, body) {
+      var requestHeaders = {
+        Accept: 'application/json',
+        'Content-Type': 'application/json'
+      };
+
+      var options = {
+        method: 'POST',
+        headers: requestHeaders,
+        body: JSON.stringify(body)
+      };
+
+      var url = this.broadcastServiceUrl + '/v1/broadcast/' + endpoint;
+      return fetch(url, options).then(function (response) {
+        if (response.ok) {
+          return response.json();
+        } else {
+          throw new _errors.RemoteServiceError(response);
+        }
+      });
+    }
+
+    /**
+    * Broadcasts a signed bitcoin transaction to the network optionally waiting to broadcast the
+    * transaction until a second transaction has a certain number of confirmations.
+    *
+    * @param  {string} transaction the hex-encoded transaction to broadcast
+    * @param  {string} transactionToWatch the hex transaction id of the transaction to watch for
+    * the specified number of confirmations before broadcasting the `transaction`
+    * @param  {number} confirmations the number of confirmations `transactionToWatch` must have
+    * before broadcasting `transaction`.
+    * @return {Promise<Object|Error>} Returns a Promise that resolves to an object with a
+    * `transaction_hash` key containing the transaction hash of the broadcasted transaction.
+    *
+    * In the event of an error, it rejects with:
+    * * a `RemoteServiceError` if there is a problem
+    *   with the transaction broadcast service
+    * * `MissingParameterError` if you call the function without a required
+    *   parameter
+    */
+
   }, {
     key: 'broadcastTransaction',
     value: function broadcastTransaction(transaction) {
-      var form = new _formData2.default();
-      form.append('tx', transaction);
-      return fetch(this.utxoProviderUrl + '/pushtx?cors=true', { method: 'POST',
-        body: form }).then(function (resp) {
-        return resp.text();
-      }).then(function (respText) {
-        if (respText.toLowerCase().indexOf('transaction submitted') >= 0) {
-          var txHash = _bitcoinjsLib2.default.Transaction.fromHex(transaction).getHash().reverse().toString('hex'); // big_endian
-          return txHash;
-        } else {
-          throw new Error('Broadcast transaction failed with message: ' + respText);
-        }
-      });
+      var transactionToWatch = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : null;
+      var confirmations = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 6;
+
+      if (!transaction) {
+        var error = new _errors.MissingParameterError('transaction');
+        return Promise.reject(error);
+      }
+
+      if (!confirmations && confirmations !== 0) {
+        var _error = new _errors.MissingParameterError('confirmations');
+        return Promise.reject(_error);
+      }
+
+      if (transactionToWatch === null) {
+        var form = new _formData2.default();
+        form.append('tx', transaction);
+        return fetch(this.utxoProviderUrl + '/pushtx?cors=true', { method: 'POST',
+          body: form }).then(function (resp) {
+          var text = resp.text();
+          return text.then(function (respText) {
+            if (respText.toLowerCase().indexOf('transaction submitted') >= 0) {
+              var txHash = _bitcoinjsLib2.default.Transaction.fromHex(transaction).getHash().reverse().toString('hex'); // big_endian
+              return txHash;
+            } else {
+              throw new _errors.RemoteServiceError(resp, 'Broadcast transaction failed with message: ' + respText);
+            }
+          });
+        });
+      } else {
+        /*
+         * POST /v1/broadcast/transaction
+         * Request body:
+         * JSON.stringify({
+         *  transaction,
+         *  transactionToWatch,
+         *  confirmations
+         * })
+         */
+        var endpoint = TX_BROADCAST_SERVICE_TX_ENDPOINT;
+
+        var requestBody = {
+          transaction: transaction,
+          transactionToWatch: transactionToWatch,
+          confirmations: confirmations
+        };
+
+        return this.broadcastServiceFetchHelper(endpoint, requestBody);
+      }
+    }
+
+    /**
+     * Broadcasts a zone file to the Atlas network via the transaction broadcast service.
+     *
+     * @param  {String} zoneFile the zone file to be broadcast to the Atlas network
+     * @param  {String} transactionToWatch the hex transaction id of the transaction
+     * to watch for confirmation before broadcasting the zone file to the Atlas network
+     * @return {Promise<Object|Error>} Returns a Promise that resolves to an object with a
+     * `transaction_hash` key containing the transaction hash of the broadcasted transaction.
+     *
+     * In the event of an error, it rejects with:
+     * * a `RemoteServiceError` if there is a problem
+     *   with the transaction broadcast service
+     * * `MissingParameterError` if you call the function without a required
+     *   parameter
+     */
+
+  }, {
+    key: 'broadcastZoneFile',
+    value: function broadcastZoneFile(zoneFile) {
+      var transactionToWatch = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : null;
+
+      if (!zoneFile) {
+        return Promise.reject(new _errors.MissingParameterError('zoneFile'));
+      }
+
+      // TODO: validate zonefile
+
+      if (transactionToWatch) {
+        // broadcast via transaction broadcast service
+
+        /*
+         * POST /v1/broadcast/zone-file
+         * Request body:
+         * JSON.stringify({
+         *  zoneFile,
+         *  transactionToWatch
+         * })
+         */
+
+        var requestBody = {
+          zoneFile: zoneFile,
+          transactionToWatch: transactionToWatch
+        };
+
+        var endpoint = TX_BROADCAST_SERVICE_ZONE_FILE_ENDPOINT;
+
+        return this.broadcastServiceFetchHelper(endpoint, requestBody);
+      } else {
+        // broadcast via core endpoint
+
+        // zone file is two words but core's api treats it as one word 'zonefile'
+        var _requestBody = { zonefile: zoneFile };
+
+        return fetch(this.blockstackAPIUrl + '/v1/zonefile/', { method: 'POST',
+          body: JSON.stringify(_requestBody),
+          headers: {
+            'Content-Type': 'application/json'
+          }
+        }).then(function (resp) {
+          var json = resp.json();
+          return json.then(function (respObj) {
+            if (respObj.hasOwnProperty('error')) {
+              throw new _errors.RemoteServiceError(resp);
+            }
+            return respObj.servers;
+          });
+        });
+      }
+    }
+
+    /**
+     * Sends the preorder and registration transactions and zone file
+     * for a Blockstack name registration
+     * along with the to the transaction broadcast service.
+     *
+     * The transaction broadcast:
+     *
+     * * immediately broadcasts the preorder transaction
+     * * broadcasts the register transactions after the preorder transaction
+     * has an appropriate number of confirmations
+     * * broadcasts the zone file to the Atlas network after the register transaction
+     * has an appropriate number of confirmations
+     *
+     * @param  {String} preorderTransaction the hex-encoded, signed preorder transaction generated
+     * using the `makePreorder` function
+     * @param  {String} registerTransaction the hex-encoded, signed register transaction generated
+     * using the `makeRegister` function
+     * @param  {String} zoneFile the zone file to be broadcast to the Atlas network
+     * @return {Promise<Object|Error>} Returns a Promise that resolves to an object with a
+     * `transaction_hash` key containing the transaction hash of the broadcasted transaction.
+     *
+     * In the event of an error, it rejects with:
+     * * a `RemoteServiceError` if there is a problem
+     *   with the transaction broadcast service
+     * * `MissingParameterError` if you call the function without a required
+     *   parameter
+     */
+
+  }, {
+    key: 'broadcastNameRegistration',
+    value: function broadcastNameRegistration(preorderTransaction, registerTransaction, zoneFile) {
+      /*
+       * POST /v1/broadcast/registration
+       * Request body:
+       * JSON.stringify({
+       * preorderTransaction,
+       * registerTransaction,
+       * zoneFile
+       * })
+       */
+
+      if (!preorderTransaction) {
+        var error = new _errors.MissingParameterError('preorderTransaction');
+        return Promise.reject(error);
+      }
+
+      if (!registerTransaction) {
+        var _error2 = new _errors.MissingParameterError('registerTransaction');
+        return Promise.reject(_error2);
+      }
+
+      if (!zoneFile) {
+        var _error3 = new _errors.MissingParameterError('zoneFile');
+        return Promise.reject(_error3);
+      }
+
+      var requestBody = {
+        preorderTransaction: preorderTransaction,
+        registerTransaction: registerTransaction,
+        zoneFile: zoneFile
+      };
+
+      var endpoint = TX_BROADCAST_SERVICE_REGISTRATION_ENDPOINT;
+
+      return this.broadcastServiceFetchHelper(endpoint, requestBody);
     }
   }, {
     key: 'getTransactionInfo',
@@ -1750,7 +2054,9 @@ var BlockstackNetwork = function () {
       return fetch(this.utxoProviderUrl + '/unspent?format=json&active=' + address).then(function (resp) {
         if (resp.status === 500) {
           console.log('DEBUG: UTXO provider 500 usually means no UTXOs: returning []');
-          return [];
+          return {
+            unspent_outputs: []
+          };
         } else {
           return resp.json();
         }
@@ -1844,24 +2150,6 @@ var BlockstackNetwork = function () {
       this.excludeUtxoSet = [];
     }
   }, {
-    key: 'publishZonefile',
-    value: function publishZonefile(zonefile) {
-      var arg = { zonefile: zonefile };
-      return fetch(this.blockstackAPIUrl + '/v1/zonefile/', { method: 'POST',
-        body: JSON.stringify(arg),
-        headers: {
-          'Content-Type': 'application/json'
-        }
-      }).then(function (resp) {
-        return resp.json();
-      }).then(function (respObj) {
-        if (respObj.hasOwnProperty('error')) {
-          throw new Error(respObj.error);
-        }
-        return respObj.servers;
-      });
-    }
-  }, {
     key: 'getConsensusHash',
     value: function getConsensusHash() {
       return fetch(this.blockstackAPIUrl + '/v1/blockchains/bitcoin/consensus').then(function (resp) {
@@ -1878,15 +2166,15 @@ var BlockstackNetwork = function () {
 var LocalRegtest = function (_BlockstackNetwork) {
   _inherits(LocalRegtest, _BlockstackNetwork);
 
-  function LocalRegtest(apiUrl, bitcoindUrl) {
-    var bitcoindCredentials = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : null;
+  function LocalRegtest(apiUrl, bitcoindUrl, broadcastServiceUrl) {
+    var bitcoindCredentials = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : null;
 
     _classCallCheck(this, LocalRegtest);
 
-    var _this5 = _possibleConstructorReturn(this, (LocalRegtest.__proto__ || Object.getPrototypeOf(LocalRegtest)).call(this, apiUrl, '', _bitcoinjsLib2.default.networks.testnet));
+    var _this5 = _possibleConstructorReturn(this, (LocalRegtest.__proto__ || Object.getPrototypeOf(LocalRegtest)).call(this, apiUrl, '', broadcastServiceUrl, _bitcoinjsLib2.default.networks.testnet));
 
     _this5.bitcoindUrl = bitcoindUrl;
-    _this5.bitcoindCredentials = bitcoindCredentials;
+    _this5.bitcoindCredentials = Object.assign({}, bitcoindCredentials);
     return _this5;
   }
 
@@ -1996,14 +2284,14 @@ var LocalRegtest = function (_BlockstackNetwork) {
   return LocalRegtest;
 }(BlockstackNetwork);
 
-var LOCAL_REGTEST = new LocalRegtest('http://localhost:16268', 'http://localhost:18332/', { username: 'blockstack', password: 'blockstacksystem' });
+var LOCAL_REGTEST = new LocalRegtest('http://localhost:16268', 'http://localhost:18332/', 'http://localhost:16269', { username: 'blockstack', password: 'blockstacksystem' });
 
-var MAINNET_DEFAULT = new BlockstackNetwork('https://core.blockstack.org', 'https://blockchain.info');
+var MAINNET_DEFAULT = new BlockstackNetwork('https://core.blockstack.org', 'https://blockchain.info', 'https://broadcast.blockstack.org');
 
 var network = exports.network = { BlockstackNetwork: BlockstackNetwork, LocalRegtest: LocalRegtest,
   defaults: { LOCAL_REGTEST: LOCAL_REGTEST, MAINNET_DEFAULT: MAINNET_DEFAULT } };
 }).call(this,require("buffer").Buffer)
-},{"bitcoinjs-lib":86,"buffer":142,"form-data":300}],15:[function(require,module,exports){
+},{"./errors":11,"bitcoinjs-lib":86,"buffer":142,"form-data":300}],15:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -3170,12 +3458,12 @@ var _profileZoneFiles = require('./profileZoneFiles');
  * Look up a user profile by blockstack ID
  *
  * @param {string} username The Blockstack ID of the profile to look up
- * @param {string} [zoneFileLookupURL=http://localhost:6270/v1/names/] The URL
+ * @param {string} [zoneFileLookupURL=https://core.blockstack.org/v1/names/] The URL
  * to use for zonefile lookup 
  * @returns {Promise} that resolves to a profile object
  */
 function lookupProfile(username) {
-  var zoneFileLookupURL = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 'http://localhost:6270/v1/names/';
+  var zoneFileLookupURL = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 'https://core.blockstack.org/v1/names/';
 
   return new Promise(function (resolve, reject) {
     if (!username) {
@@ -5443,6 +5731,7 @@ function updateQueryStringParameter(uri, key, value) {
  * @param {string} v1 - the left half of the version inequality
  * @param {string} v2 - right half of the version inequality
  * @returns {bool} iff v1 >= v2
+ * @private
  */
 function isLaterVersion(v1, v2) {
   var v1tuple = v1.split('.').map(function (x) {

--- a/docs.json
+++ b/docs.json
@@ -3103,6 +3103,325 @@
     "namespace": "getAuthResponseToken"
   },
   {
+    "description": {
+      "type": "root",
+      "children": [
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "Verify the authentication response is valid",
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1,
+                  "offset": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 44,
+                  "offset": 43
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 44,
+              "offset": 43
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 1,
+          "column": 1,
+          "offset": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 44,
+          "offset": 43
+        }
+      }
+    },
+    "tags": [
+      {
+        "title": "param",
+        "description": "the authentication response token",
+        "lineNumber": 2,
+        "type": {
+          "type": "NameExpression",
+          "name": "String"
+        },
+        "name": "token"
+      },
+      {
+        "title": "param",
+        "description": "the url use to verify owner of a username",
+        "lineNumber": 3,
+        "type": {
+          "type": "NameExpression",
+          "name": "String"
+        },
+        "name": "nameLookupURL"
+      },
+      {
+        "title": "return",
+        "description": "that resolves to true if auth response\nis valid and false if it does not",
+        "lineNumber": 4,
+        "type": {
+          "type": "NameExpression",
+          "name": "Promise"
+        }
+      }
+    ],
+    "loc": {
+      "start": {
+        "line": 190,
+        "column": 0
+      },
+      "end": {
+        "line": 196,
+        "column": 3
+      }
+    },
+    "context": {
+      "loc": {
+        "start": {
+          "line": 197,
+          "column": 0
+        },
+        "end": {
+          "line": 213,
+          "column": 1
+        }
+      },
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/auth/authVerification.js"
+    },
+    "augments": [],
+    "examples": [],
+    "params": [
+      {
+        "title": "param",
+        "name": "token",
+        "lineNumber": 2,
+        "description": {
+          "type": "root",
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "the authentication response token",
+                  "position": {
+                    "start": {
+                      "line": 1,
+                      "column": 1,
+                      "offset": 0
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 34,
+                      "offset": 33
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1,
+                  "offset": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 34,
+                  "offset": 33
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 34,
+              "offset": 33
+            }
+          }
+        },
+        "type": {
+          "type": "NameExpression",
+          "name": "String"
+        }
+      },
+      {
+        "title": "param",
+        "name": "nameLookupURL",
+        "lineNumber": 3,
+        "description": {
+          "type": "root",
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "the url use to verify owner of a username",
+                  "position": {
+                    "start": {
+                      "line": 1,
+                      "column": 1,
+                      "offset": 0
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 42,
+                      "offset": 41
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1,
+                  "offset": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 42,
+                  "offset": 41
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 42,
+              "offset": 41
+            }
+          }
+        },
+        "type": {
+          "type": "NameExpression",
+          "name": "String"
+        }
+      }
+    ],
+    "properties": [],
+    "returns": [
+      {
+        "description": {
+          "type": "root",
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "that resolves to true if auth response\nis valid and false if it does not",
+                  "position": {
+                    "start": {
+                      "line": 1,
+                      "column": 1,
+                      "offset": 0
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 34,
+                      "offset": 72
+                    },
+                    "indent": [
+                      1
+                    ]
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1,
+                  "offset": 0
+                },
+                "end": {
+                  "line": 2,
+                  "column": 34,
+                  "offset": 72
+                },
+                "indent": [
+                  1
+                ]
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 2,
+              "column": 34,
+              "offset": 72
+            }
+          }
+        },
+        "title": "returns",
+        "type": {
+          "type": "NameExpression",
+          "name": "Promise"
+        }
+      }
+    ],
+    "sees": [],
+    "throws": [],
+    "todos": [],
+    "name": "verifyAuthResponse",
+    "kind": "function",
+    "members": {
+      "global": [],
+      "inner": [],
+      "instance": [],
+      "events": [],
+      "static": []
+    },
+    "path": [
+      {
+        "name": "verifyAuthResponse",
+        "kind": "function"
+      }
+    ],
+    "namespace": "verifyAuthResponse"
+  },
+  {
     "name": "Profiles",
     "description": {
       "type": "root",
@@ -5498,7 +5817,7 @@
           }
         },
         "name": "zoneFileLookupURL",
-        "default": "http://localhost:6270/v1/names/"
+        "default": "https://core.blockstack.org/v1/names/"
       },
       {
         "title": "returns",
@@ -5661,7 +5980,7 @@
           "type": "NameExpression",
           "name": "string"
         },
-        "default": "http://localhost:6270/v1/names/"
+        "default": "https://core.blockstack.org/v1/names/"
       }
     ],
     "properties": [],
@@ -7120,6 +7439,254 @@
           "children": [
             {
               "type": "text",
+              "value": "Deletes the specified file from the app's data store.",
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1,
+                  "offset": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 54,
+                  "offset": 53
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 54,
+              "offset": 53
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 1,
+          "column": 1,
+          "offset": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 54,
+          "offset": 53
+        }
+      }
+    },
+    "tags": [
+      {
+        "title": "param",
+        "description": "the path to the file to delete",
+        "lineNumber": 2,
+        "type": {
+          "type": "NameExpression",
+          "name": "String"
+        },
+        "name": "path"
+      },
+      {
+        "title": "returns",
+        "description": "that resolves when the file has been removed\nor rejects with an error",
+        "lineNumber": 3,
+        "type": {
+          "type": "NameExpression",
+          "name": "Promise"
+        }
+      }
+    ],
+    "loc": {
+      "start": {
+        "line": 157,
+        "column": 0
+      },
+      "end": {
+        "line": 162,
+        "column": 3
+      }
+    },
+    "context": {
+      "loc": {
+        "start": {
+          "line": 163,
+          "column": 0
+        },
+        "end": {
+          "line": 165,
+          "column": 1
+        }
+      },
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/storage/index.js"
+    },
+    "augments": [],
+    "examples": [],
+    "params": [
+      {
+        "title": "param",
+        "name": "path",
+        "lineNumber": 2,
+        "description": {
+          "type": "root",
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "the path to the file to delete",
+                  "position": {
+                    "start": {
+                      "line": 1,
+                      "column": 1,
+                      "offset": 0
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 31,
+                      "offset": 30
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1,
+                  "offset": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 31,
+                  "offset": 30
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 31,
+              "offset": 30
+            }
+          }
+        },
+        "type": {
+          "type": "NameExpression",
+          "name": "String"
+        }
+      }
+    ],
+    "properties": [],
+    "returns": [
+      {
+        "description": {
+          "type": "root",
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "that resolves when the file has been removed\nor rejects with an error",
+                  "position": {
+                    "start": {
+                      "line": 1,
+                      "column": 1,
+                      "offset": 0
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 25,
+                      "offset": 69
+                    },
+                    "indent": [
+                      1
+                    ]
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1,
+                  "offset": 0
+                },
+                "end": {
+                  "line": 2,
+                  "column": 25,
+                  "offset": 69
+                },
+                "indent": [
+                  1
+                ]
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 2,
+              "column": 25,
+              "offset": 69
+            }
+          }
+        },
+        "title": "returns",
+        "type": {
+          "type": "NameExpression",
+          "name": "Promise"
+        }
+      }
+    ],
+    "sees": [],
+    "throws": [],
+    "todos": [],
+    "name": "deleteFile",
+    "kind": "function",
+    "members": {
+      "global": [],
+      "inner": [],
+      "instance": [],
+      "events": [],
+      "static": []
+    },
+    "path": [
+      {
+        "name": "deleteFile",
+        "kind": "function"
+      }
+    ],
+    "namespace": "deleteFile"
+  },
+  {
+    "description": {
+      "type": "root",
+      "children": [
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
               "value": "Get the app storage bucket URL",
               "position": {
                 "start": {
@@ -7901,6 +8468,7 @@
     "namespace": "getUserAppFileUrl"
   },
   {
+    "name": "Blockchain",
     "description": {
       "type": "root",
       "children": [
@@ -7909,7 +8477,7 @@
           "children": [
             {
               "type": "text",
-              "value": "Verify the authentication response is valid",
+              "value": "Generate and broadcast Blockstack blockchain transactions.",
               "position": {
                 "start": {
                   "line": 1,
@@ -7918,8 +8486,8 @@
                 },
                 "end": {
                   "line": 1,
-                  "column": 44,
-                  "offset": 43
+                  "column": 59,
+                  "offset": 58
                 },
                 "indent": []
               }
@@ -7933,8 +8501,8 @@
             },
             "end": {
               "line": 1,
-              "column": 44,
-              "offset": 43
+              "column": 59,
+              "offset": 58
             },
             "indent": []
           }
@@ -7947,221 +8515,38 @@
           "offset": 0
         },
         "end": {
-          "line": 1,
-          "column": 44,
-          "offset": 43
+          "line": 2,
+          "column": 1,
+          "offset": 59
         }
       }
     },
-    "tags": [
+    "kind": "note",
+    "members": {
+      "global": [],
+      "inner": [],
+      "instance": [],
+      "events": [],
+      "static": []
+    },
+    "path": [
       {
-        "title": "param",
-        "description": "the authentication response token",
-        "lineNumber": 2,
-        "type": {
-          "type": "NameExpression",
-          "name": "String"
-        },
-        "name": "token"
-      },
-      {
-        "title": "param",
-        "description": "the url use to verify owner of a username",
-        "lineNumber": 3,
-        "type": {
-          "type": "NameExpression",
-          "name": "String"
-        },
-        "name": "nameLookupURL"
-      },
-      {
-        "title": "return",
-        "description": "that resolves to true if auth response\nis valid and false if it does not",
-        "lineNumber": 4,
-        "type": {
-          "type": "NameExpression",
-          "name": "Promise"
-        }
+        "name": "Blockchain",
+        "kind": "note"
       }
     ],
-    "loc": {
-      "start": {
-        "line": 190,
-        "column": 0
-      },
-      "end": {
-        "line": 196,
-        "column": 3
-      }
-    },
-    "context": {
-      "loc": {
-        "start": {
-          "line": 197,
-          "column": 0
-        },
-        "end": {
-          "line": 213,
-          "column": 1
-        }
-      },
-      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/auth/authVerification.js"
-    },
-    "augments": [],
-    "examples": [],
-    "params": [
-      {
-        "title": "param",
-        "name": "token",
-        "lineNumber": 2,
-        "description": {
-          "type": "root",
+    "namespace": "Blockchain"
+  },
+  {
+    "description": {
+      "type": "root",
+      "children": [
+        {
+          "type": "paragraph",
           "children": [
             {
-              "type": "paragraph",
-              "children": [
-                {
-                  "type": "text",
-                  "value": "the authentication response token",
-                  "position": {
-                    "start": {
-                      "line": 1,
-                      "column": 1,
-                      "offset": 0
-                    },
-                    "end": {
-                      "line": 1,
-                      "column": 34,
-                      "offset": 33
-                    },
-                    "indent": []
-                  }
-                }
-              ],
-              "position": {
-                "start": {
-                  "line": 1,
-                  "column": 1,
-                  "offset": 0
-                },
-                "end": {
-                  "line": 1,
-                  "column": 34,
-                  "offset": 33
-                },
-                "indent": []
-              }
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 1,
-              "column": 1,
-              "offset": 0
-            },
-            "end": {
-              "line": 1,
-              "column": 34,
-              "offset": 33
-            }
-          }
-        },
-        "type": {
-          "type": "NameExpression",
-          "name": "String"
-        }
-      },
-      {
-        "title": "param",
-        "name": "nameLookupURL",
-        "lineNumber": 3,
-        "description": {
-          "type": "root",
-          "children": [
-            {
-              "type": "paragraph",
-              "children": [
-                {
-                  "type": "text",
-                  "value": "the url use to verify owner of a username",
-                  "position": {
-                    "start": {
-                      "line": 1,
-                      "column": 1,
-                      "offset": 0
-                    },
-                    "end": {
-                      "line": 1,
-                      "column": 42,
-                      "offset": 41
-                    },
-                    "indent": []
-                  }
-                }
-              ],
-              "position": {
-                "start": {
-                  "line": 1,
-                  "column": 1,
-                  "offset": 0
-                },
-                "end": {
-                  "line": 1,
-                  "column": 42,
-                  "offset": 41
-                },
-                "indent": []
-              }
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 1,
-              "column": 1,
-              "offset": 0
-            },
-            "end": {
-              "line": 1,
-              "column": 42,
-              "offset": 41
-            }
-          }
-        },
-        "type": {
-          "type": "NameExpression",
-          "name": "String"
-        }
-      }
-    ],
-    "properties": [],
-    "returns": [
-      {
-        "description": {
-          "type": "root",
-          "children": [
-            {
-              "type": "paragraph",
-              "children": [
-                {
-                  "type": "text",
-                  "value": "that resolves to true if auth response\nis valid and false if it does not",
-                  "position": {
-                    "start": {
-                      "line": 1,
-                      "column": 1,
-                      "offset": 0
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 34,
-                      "offset": 72
-                    },
-                    "indent": [
-                      1
-                    ]
-                  }
-                }
-              ],
+              "type": "text",
+              "value": "Broadcasts a signed bitcoin transaction to the network optionally waiting to broadcast the\ntransaction until a second transaction has a certain number of confirmations.",
               "position": {
                 "start": {
                   "line": 1,
@@ -8170,8 +8555,8 @@
                 },
                 "end": {
                   "line": 2,
-                  "column": 34,
-                  "offset": 72
+                  "column": 78,
+                  "offset": 168
                 },
                 "indent": [
                   1
@@ -8187,75 +8572,12 @@
             },
             "end": {
               "line": 2,
-              "column": 34,
-              "offset": 72
-            }
-          }
-        },
-        "title": "returns",
-        "type": {
-          "type": "NameExpression",
-          "name": "Promise"
-        }
-      }
-    ],
-    "sees": [],
-    "throws": [],
-    "todos": [],
-    "name": "verifyAuthResponse",
-    "kind": "function",
-    "members": {
-      "global": [],
-      "inner": [],
-      "instance": [],
-      "events": [],
-      "static": []
-    },
-    "path": [
-      {
-        "name": "verifyAuthResponse",
-        "kind": "function"
-      }
-    ],
-    "namespace": "verifyAuthResponse"
-  },
-  {
-    "description": {
-      "type": "root",
-      "children": [
-        {
-          "type": "paragraph",
-          "children": [
-            {
-              "type": "text",
-              "value": "Deletes the specified file from the app's data store.",
-              "position": {
-                "start": {
-                  "line": 1,
-                  "column": 1,
-                  "offset": 0
-                },
-                "end": {
-                  "line": 1,
-                  "column": 54,
-                  "offset": 53
-                },
-                "indent": []
-              }
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 1,
-              "column": 1,
-              "offset": 0
+              "column": 78,
+              "offset": 168
             },
-            "end": {
-              "line": 1,
-              "column": 54,
-              "offset": 53
-            },
-            "indent": []
+            "indent": [
+              1
+            ]
           }
         }
       ],
@@ -8266,63 +8588,101 @@
           "offset": 0
         },
         "end": {
-          "line": 1,
-          "column": 54,
-          "offset": 53
+          "line": 2,
+          "column": 78,
+          "offset": 168
         }
       }
     },
     "tags": [
       {
         "title": "param",
-        "description": "the path to the file to delete",
-        "lineNumber": 2,
+        "description": "the hex-encoded transaction to broadcast",
+        "lineNumber": 4,
         "type": {
           "type": "NameExpression",
-          "name": "String"
+          "name": "string"
         },
-        "name": "path"
+        "name": "transaction"
       },
       {
-        "title": "returns",
-        "description": "that resolves when the file has been removed\nor rejects with an error",
-        "lineNumber": 3,
+        "title": "param",
+        "description": "the hex transaction id of the transaction to watch for\nthe specified number of confirmations before broadcasting the `transaction`",
+        "lineNumber": 5,
         "type": {
           "type": "NameExpression",
-          "name": "Promise"
+          "name": "string"
+        },
+        "name": "transactionToWatch"
+      },
+      {
+        "title": "param",
+        "description": "the number of confirmations `transactionToWatch` must have\nbefore broadcasting `transaction`.",
+        "lineNumber": 7,
+        "type": {
+          "type": "NameExpression",
+          "name": "number"
+        },
+        "name": "confirmations"
+      },
+      {
+        "title": "return",
+        "description": "Returns a Promise that resolves to an object with a\n`transaction_hash` key containing the transaction hash of the broadcasted transaction.\n\nIn the event of an error, it rejects with:\n* a `RemoteServiceError` if there is a problem\n  with the transaction broadcast service\n* `MissingParameterError` if you call the function without a required\n  parameter",
+        "lineNumber": 9,
+        "type": {
+          "type": "TypeApplication",
+          "expression": {
+            "type": "NameExpression",
+            "name": "Promise"
+          },
+          "applications": [
+            {
+              "type": "UnionType",
+              "elements": [
+                {
+                  "type": "NameExpression",
+                  "name": "Object"
+                },
+                {
+                  "type": "NameExpression",
+                  "name": "Error"
+                }
+              ]
+            }
+          ]
         }
       }
     ],
     "loc": {
       "start": {
-        "line": 157,
-        "column": 0
+        "line": 149,
+        "column": 2
       },
       "end": {
-        "line": 162,
-        "column": 3
+        "line": 166,
+        "column": 4
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 163,
-          "column": 0
+          "line": 167,
+          "column": 2
         },
         "end": {
-          "line": 165,
-          "column": 1
+          "line": 222,
+          "column": 3
         }
       },
-      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/storage/index.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/network.js"
     },
     "augments": [],
     "examples": [],
     "params": [
       {
         "title": "param",
-        "name": "path",
-        "lineNumber": 2,
+        "name": "transaction",
+        "lineNumber": 4,
         "description": {
           "type": "root",
           "children": [
@@ -8331,7 +8691,7 @@
               "children": [
                 {
                   "type": "text",
-                  "value": "the path to the file to delete",
+                  "value": "the hex-encoded transaction to broadcast",
                   "position": {
                     "start": {
                       "line": 1,
@@ -8340,8 +8700,8 @@
                     },
                     "end": {
                       "line": 1,
-                      "column": 31,
-                      "offset": 30
+                      "column": 41,
+                      "offset": 40
                     },
                     "indent": []
                   }
@@ -8355,8 +8715,8 @@
                 },
                 "end": {
                   "line": 1,
-                  "column": 31,
-                  "offset": 30
+                  "column": 41,
+                  "offset": 40
                 },
                 "indent": []
               }
@@ -8370,15 +8730,232 @@
             },
             "end": {
               "line": 1,
-              "column": 31,
-              "offset": 30
+              "column": 41,
+              "offset": 40
             }
           }
         },
         "type": {
           "type": "NameExpression",
-          "name": "String"
+          "name": "string"
         }
+      },
+      {
+        "title": "param",
+        "name": "transactionToWatch",
+        "lineNumber": 5,
+        "description": {
+          "type": "root",
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "the hex transaction id of the transaction to watch for\nthe specified number of confirmations before broadcasting the ",
+                  "position": {
+                    "start": {
+                      "line": 1,
+                      "column": 1,
+                      "offset": 0
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 63,
+                      "offset": 117
+                    },
+                    "indent": [
+                      1
+                    ]
+                  }
+                },
+                {
+                  "type": "inlineCode",
+                  "value": "transaction",
+                  "position": {
+                    "start": {
+                      "line": 2,
+                      "column": 63,
+                      "offset": 117
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 76,
+                      "offset": 130
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1,
+                  "offset": 0
+                },
+                "end": {
+                  "line": 2,
+                  "column": 76,
+                  "offset": 130
+                },
+                "indent": [
+                  1
+                ]
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 2,
+              "column": 76,
+              "offset": 130
+            }
+          }
+        },
+        "type": {
+          "type": "NameExpression",
+          "name": "string"
+        },
+        "default": "null"
+      },
+      {
+        "title": "param",
+        "name": "confirmations",
+        "lineNumber": 7,
+        "description": {
+          "type": "root",
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "the number of confirmations ",
+                  "position": {
+                    "start": {
+                      "line": 1,
+                      "column": 1,
+                      "offset": 0
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 29,
+                      "offset": 28
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "inlineCode",
+                  "value": "transactionToWatch",
+                  "position": {
+                    "start": {
+                      "line": 1,
+                      "column": 29,
+                      "offset": 28
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 49,
+                      "offset": 48
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": " must have\nbefore broadcasting ",
+                  "position": {
+                    "start": {
+                      "line": 1,
+                      "column": 49,
+                      "offset": 48
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 21,
+                      "offset": 79
+                    },
+                    "indent": [
+                      1
+                    ]
+                  }
+                },
+                {
+                  "type": "inlineCode",
+                  "value": "transaction",
+                  "position": {
+                    "start": {
+                      "line": 2,
+                      "column": 21,
+                      "offset": 79
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 34,
+                      "offset": 92
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": ".",
+                  "position": {
+                    "start": {
+                      "line": 2,
+                      "column": 34,
+                      "offset": 92
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 35,
+                      "offset": 93
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1,
+                  "offset": 0
+                },
+                "end": {
+                  "line": 2,
+                  "column": 35,
+                  "offset": 93
+                },
+                "indent": [
+                  1
+                ]
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 2,
+              "column": 35,
+              "offset": 93
+            }
+          }
+        },
+        "type": {
+          "type": "NameExpression",
+          "name": "number"
+        },
+        "default": "6"
       }
     ],
     "properties": [],
@@ -8392,21 +8969,1442 @@
               "children": [
                 {
                   "type": "text",
-                  "value": "that resolves when the file has been removed\nor rejects with an error",
+                  "value": "Returns a Promise that resolves to an object with a\n",
                   "position": {
                     "start": {
                       "line": 1,
                       "column": 1,
                       "offset": 0
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 1,
+                      "offset": 52
+                    },
+                    "indent": [
+                      1
+                    ]
+                  }
+                },
+                {
+                  "type": "inlineCode",
+                  "value": "transaction_hash",
+                  "position": {
+                    "start": {
+                      "line": 2,
+                      "column": 1,
+                      "offset": 52
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 19,
+                      "offset": 70
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": " key containing the transaction hash of the broadcasted transaction.",
+                  "position": {
+                    "start": {
+                      "line": 2,
+                      "column": 19,
+                      "offset": 70
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 87,
+                      "offset": 138
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1,
+                  "offset": 0
+                },
+                "end": {
+                  "line": 2,
+                  "column": 87,
+                  "offset": 138
+                },
+                "indent": [
+                  1
+                ]
+              }
+            },
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "In the event of an error, it rejects with:",
+                  "position": {
+                    "start": {
+                      "line": 4,
+                      "column": 1,
+                      "offset": 140
+                    },
+                    "end": {
+                      "line": 4,
+                      "column": 43,
+                      "offset": 182
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 4,
+                  "column": 1,
+                  "offset": 140
+                },
+                "end": {
+                  "line": 4,
+                  "column": 43,
+                  "offset": 182
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "list",
+              "ordered": false,
+              "start": null,
+              "loose": false,
+              "children": [
+                {
+                  "type": "listItem",
+                  "loose": false,
+                  "checked": null,
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "text",
+                          "value": "a ",
+                          "position": {
+                            "start": {
+                              "line": 5,
+                              "column": 3,
+                              "offset": 185
+                            },
+                            "end": {
+                              "line": 5,
+                              "column": 5,
+                              "offset": 187
+                            },
+                            "indent": []
+                          }
+                        },
+                        {
+                          "type": "inlineCode",
+                          "value": "RemoteServiceError",
+                          "position": {
+                            "start": {
+                              "line": 5,
+                              "column": 5,
+                              "offset": 187
+                            },
+                            "end": {
+                              "line": 5,
+                              "column": 25,
+                              "offset": 207
+                            },
+                            "indent": []
+                          }
+                        },
+                        {
+                          "type": "text",
+                          "value": " if there is a problem\nwith the transaction broadcast service",
+                          "position": {
+                            "start": {
+                              "line": 5,
+                              "column": 25,
+                              "offset": 207
+                            },
+                            "end": {
+                              "line": 6,
+                              "column": 41,
+                              "offset": 270
+                            },
+                            "indent": [
+                              3
+                            ]
+                          }
+                        }
+                      ],
+                      "position": {
+                        "start": {
+                          "line": 5,
+                          "column": 3,
+                          "offset": 185
+                        },
+                        "end": {
+                          "line": 6,
+                          "column": 41,
+                          "offset": 270
+                        },
+                        "indent": [
+                          3
+                        ]
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 5,
+                      "column": 1,
+                      "offset": 183
+                    },
+                    "end": {
+                      "line": 6,
+                      "column": 41,
+                      "offset": 270
+                    },
+                    "indent": [
+                      1
+                    ]
+                  }
+                },
+                {
+                  "type": "listItem",
+                  "loose": false,
+                  "checked": null,
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "inlineCode",
+                          "value": "MissingParameterError",
+                          "position": {
+                            "start": {
+                              "line": 7,
+                              "column": 3,
+                              "offset": 273
+                            },
+                            "end": {
+                              "line": 7,
+                              "column": 26,
+                              "offset": 296
+                            },
+                            "indent": []
+                          }
+                        },
+                        {
+                          "type": "text",
+                          "value": " if you call the function without a required\nparameter",
+                          "position": {
+                            "start": {
+                              "line": 7,
+                              "column": 26,
+                              "offset": 296
+                            },
+                            "end": {
+                              "line": 8,
+                              "column": 12,
+                              "offset": 352
+                            },
+                            "indent": [
+                              3
+                            ]
+                          }
+                        }
+                      ],
+                      "position": {
+                        "start": {
+                          "line": 7,
+                          "column": 3,
+                          "offset": 273
+                        },
+                        "end": {
+                          "line": 8,
+                          "column": 12,
+                          "offset": 352
+                        },
+                        "indent": [
+                          3
+                        ]
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 7,
+                      "column": 1,
+                      "offset": 271
+                    },
+                    "end": {
+                      "line": 8,
+                      "column": 12,
+                      "offset": 352
+                    },
+                    "indent": [
+                      1
+                    ]
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 5,
+                  "column": 1,
+                  "offset": 183
+                },
+                "end": {
+                  "line": 8,
+                  "column": 12,
+                  "offset": 352
+                },
+                "indent": [
+                  1,
+                  1,
+                  1
+                ]
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 8,
+              "column": 12,
+              "offset": 352
+            }
+          }
+        },
+        "title": "returns",
+        "type": {
+          "type": "TypeApplication",
+          "expression": {
+            "type": "NameExpression",
+            "name": "Promise"
+          },
+          "applications": [
+            {
+              "type": "UnionType",
+              "elements": [
+                {
+                  "type": "NameExpression",
+                  "name": "Object"
+                },
+                {
+                  "type": "NameExpression",
+                  "name": "Error"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ],
+    "sees": [],
+    "throws": [],
+    "todos": [],
+    "name": "broadcastTransaction",
+    "kind": "function",
+    "memberof": "BlockstackNetwork",
+    "scope": "instance",
+    "members": {
+      "global": [],
+      "inner": [],
+      "instance": [],
+      "events": [],
+      "static": []
+    },
+    "path": [
+      {
+        "name": "broadcastTransaction",
+        "kind": "function",
+        "scope": "instance"
+      }
+    ],
+    "namespace": "#broadcastTransaction"
+  },
+  {
+    "description": {
+      "type": "root",
+      "children": [
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "Broadcasts a zone file to the Atlas network via the transaction broadcast service.",
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1,
+                  "offset": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 83,
+                  "offset": 82
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 83,
+              "offset": 82
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 1,
+          "column": 1,
+          "offset": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 83,
+          "offset": 82
+        }
+      }
+    },
+    "tags": [
+      {
+        "title": "param",
+        "description": "the zone file to be broadcast to the Atlas network",
+        "lineNumber": 3,
+        "type": {
+          "type": "NameExpression",
+          "name": "String"
+        },
+        "name": "zoneFile"
+      },
+      {
+        "title": "param",
+        "description": "the hex transaction id of the transaction\nto watch for confirmation before broadcasting the zone file to the Atlas network",
+        "lineNumber": 4,
+        "type": {
+          "type": "NameExpression",
+          "name": "String"
+        },
+        "name": "transactionToWatch"
+      },
+      {
+        "title": "return",
+        "description": "Returns a Promise that resolves to an object with a\n`transaction_hash` key containing the transaction hash of the broadcasted transaction.\n\nIn the event of an error, it rejects with:\n* a `RemoteServiceError` if there is a problem\n  with the transaction broadcast service\n* `MissingParameterError` if you call the function without a required\n  parameter",
+        "lineNumber": 6,
+        "type": {
+          "type": "TypeApplication",
+          "expression": {
+            "type": "NameExpression",
+            "name": "Promise"
+          },
+          "applications": [
+            {
+              "type": "UnionType",
+              "elements": [
+                {
+                  "type": "NameExpression",
+                  "name": "Object"
+                },
+                {
+                  "type": "NameExpression",
+                  "name": "Error"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ],
+    "loc": {
+      "start": {
+        "line": 224,
+        "column": 2
+      },
+      "end": {
+        "line": 238,
+        "column": 5
+      }
+    },
+    "context": {
+      "loc": {
+        "start": {
+          "line": 239,
+          "column": 2
+        },
+        "end": {
+          "line": 291,
+          "column": 3
+        }
+      },
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/network.js"
+    },
+    "augments": [],
+    "examples": [],
+    "params": [
+      {
+        "title": "param",
+        "name": "zoneFile",
+        "lineNumber": 3,
+        "description": {
+          "type": "root",
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "the zone file to be broadcast to the Atlas network",
+                  "position": {
+                    "start": {
+                      "line": 1,
+                      "column": 1,
+                      "offset": 0
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 51,
+                      "offset": 50
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1,
+                  "offset": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 51,
+                  "offset": 50
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 51,
+              "offset": 50
+            }
+          }
+        },
+        "type": {
+          "type": "NameExpression",
+          "name": "String"
+        }
+      },
+      {
+        "title": "param",
+        "name": "transactionToWatch",
+        "lineNumber": 4,
+        "description": {
+          "type": "root",
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "the hex transaction id of the transaction\nto watch for confirmation before broadcasting the zone file to the Atlas network",
+                  "position": {
+                    "start": {
+                      "line": 1,
+                      "column": 1,
+                      "offset": 0
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 81,
+                      "offset": 122
+                    },
+                    "indent": [
+                      1
+                    ]
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1,
+                  "offset": 0
+                },
+                "end": {
+                  "line": 2,
+                  "column": 81,
+                  "offset": 122
+                },
+                "indent": [
+                  1
+                ]
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 2,
+              "column": 81,
+              "offset": 122
+            }
+          }
+        },
+        "type": {
+          "type": "NameExpression",
+          "name": "String"
+        },
+        "default": "null"
+      }
+    ],
+    "properties": [],
+    "returns": [
+      {
+        "description": {
+          "type": "root",
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Returns a Promise that resolves to an object with a\n",
+                  "position": {
+                    "start": {
+                      "line": 1,
+                      "column": 1,
+                      "offset": 0
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 1,
+                      "offset": 52
+                    },
+                    "indent": [
+                      1
+                    ]
+                  }
+                },
+                {
+                  "type": "inlineCode",
+                  "value": "transaction_hash",
+                  "position": {
+                    "start": {
+                      "line": 2,
+                      "column": 1,
+                      "offset": 52
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 19,
+                      "offset": 70
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": " key containing the transaction hash of the broadcasted transaction.",
+                  "position": {
+                    "start": {
+                      "line": 2,
+                      "column": 19,
+                      "offset": 70
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 87,
+                      "offset": 138
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1,
+                  "offset": 0
+                },
+                "end": {
+                  "line": 2,
+                  "column": 87,
+                  "offset": 138
+                },
+                "indent": [
+                  1
+                ]
+              }
+            },
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "In the event of an error, it rejects with:",
+                  "position": {
+                    "start": {
+                      "line": 4,
+                      "column": 1,
+                      "offset": 140
+                    },
+                    "end": {
+                      "line": 4,
+                      "column": 43,
+                      "offset": 182
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 4,
+                  "column": 1,
+                  "offset": 140
+                },
+                "end": {
+                  "line": 4,
+                  "column": 43,
+                  "offset": 182
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "list",
+              "ordered": false,
+              "start": null,
+              "loose": false,
+              "children": [
+                {
+                  "type": "listItem",
+                  "loose": false,
+                  "checked": null,
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "text",
+                          "value": "a ",
+                          "position": {
+                            "start": {
+                              "line": 5,
+                              "column": 3,
+                              "offset": 185
+                            },
+                            "end": {
+                              "line": 5,
+                              "column": 5,
+                              "offset": 187
+                            },
+                            "indent": []
+                          }
+                        },
+                        {
+                          "type": "inlineCode",
+                          "value": "RemoteServiceError",
+                          "position": {
+                            "start": {
+                              "line": 5,
+                              "column": 5,
+                              "offset": 187
+                            },
+                            "end": {
+                              "line": 5,
+                              "column": 25,
+                              "offset": 207
+                            },
+                            "indent": []
+                          }
+                        },
+                        {
+                          "type": "text",
+                          "value": " if there is a problem\nwith the transaction broadcast service",
+                          "position": {
+                            "start": {
+                              "line": 5,
+                              "column": 25,
+                              "offset": 207
+                            },
+                            "end": {
+                              "line": 6,
+                              "column": 41,
+                              "offset": 270
+                            },
+                            "indent": [
+                              3
+                            ]
+                          }
+                        }
+                      ],
+                      "position": {
+                        "start": {
+                          "line": 5,
+                          "column": 3,
+                          "offset": 185
+                        },
+                        "end": {
+                          "line": 6,
+                          "column": 41,
+                          "offset": 270
+                        },
+                        "indent": [
+                          3
+                        ]
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 5,
+                      "column": 1,
+                      "offset": 183
+                    },
+                    "end": {
+                      "line": 6,
+                      "column": 41,
+                      "offset": 270
+                    },
+                    "indent": [
+                      1
+                    ]
+                  }
+                },
+                {
+                  "type": "listItem",
+                  "loose": false,
+                  "checked": null,
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "inlineCode",
+                          "value": "MissingParameterError",
+                          "position": {
+                            "start": {
+                              "line": 7,
+                              "column": 3,
+                              "offset": 273
+                            },
+                            "end": {
+                              "line": 7,
+                              "column": 26,
+                              "offset": 296
+                            },
+                            "indent": []
+                          }
+                        },
+                        {
+                          "type": "text",
+                          "value": " if you call the function without a required\nparameter",
+                          "position": {
+                            "start": {
+                              "line": 7,
+                              "column": 26,
+                              "offset": 296
+                            },
+                            "end": {
+                              "line": 8,
+                              "column": 12,
+                              "offset": 352
+                            },
+                            "indent": [
+                              3
+                            ]
+                          }
+                        }
+                      ],
+                      "position": {
+                        "start": {
+                          "line": 7,
+                          "column": 3,
+                          "offset": 273
+                        },
+                        "end": {
+                          "line": 8,
+                          "column": 12,
+                          "offset": 352
+                        },
+                        "indent": [
+                          3
+                        ]
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 7,
+                      "column": 1,
+                      "offset": 271
+                    },
+                    "end": {
+                      "line": 8,
+                      "column": 12,
+                      "offset": 352
+                    },
+                    "indent": [
+                      1
+                    ]
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 5,
+                  "column": 1,
+                  "offset": 183
+                },
+                "end": {
+                  "line": 8,
+                  "column": 12,
+                  "offset": 352
+                },
+                "indent": [
+                  1,
+                  1,
+                  1
+                ]
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 8,
+              "column": 12,
+              "offset": 352
+            }
+          }
+        },
+        "title": "returns",
+        "type": {
+          "type": "TypeApplication",
+          "expression": {
+            "type": "NameExpression",
+            "name": "Promise"
+          },
+          "applications": [
+            {
+              "type": "UnionType",
+              "elements": [
+                {
+                  "type": "NameExpression",
+                  "name": "Object"
+                },
+                {
+                  "type": "NameExpression",
+                  "name": "Error"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ],
+    "sees": [],
+    "throws": [],
+    "todos": [],
+    "name": "broadcastZoneFile",
+    "kind": "function",
+    "memberof": "BlockstackNetwork",
+    "scope": "instance",
+    "members": {
+      "global": [],
+      "inner": [],
+      "instance": [],
+      "events": [],
+      "static": []
+    },
+    "path": [
+      {
+        "name": "broadcastZoneFile",
+        "kind": "function",
+        "scope": "instance"
+      }
+    ],
+    "namespace": "#broadcastZoneFile"
+  },
+  {
+    "description": {
+      "type": "root",
+      "children": [
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "Sends the preorder and registration transactions and zone file\nfor a Blockstack name registration\nalong with the to the transaction broadcast service.",
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1,
+                  "offset": 0
+                },
+                "end": {
+                  "line": 3,
+                  "column": 53,
+                  "offset": 150
+                },
+                "indent": [
+                  1,
+                  1
+                ]
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 3,
+              "column": 53,
+              "offset": 150
+            },
+            "indent": [
+              1,
+              1
+            ]
+          }
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "The transaction broadcast:",
+              "position": {
+                "start": {
+                  "line": 5,
+                  "column": 1,
+                  "offset": 152
+                },
+                "end": {
+                  "line": 5,
+                  "column": 27,
+                  "offset": 178
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 5,
+              "column": 1,
+              "offset": 152
+            },
+            "end": {
+              "line": 5,
+              "column": 27,
+              "offset": 178
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "list",
+          "ordered": false,
+          "start": null,
+          "loose": false,
+          "children": [
+            {
+              "type": "listItem",
+              "loose": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "immediately broadcasts the preorder transaction",
+                      "position": {
+                        "start": {
+                          "line": 7,
+                          "column": 3,
+                          "offset": 182
+                        },
+                        "end": {
+                          "line": 7,
+                          "column": 50,
+                          "offset": 229
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 7,
+                      "column": 3,
+                      "offset": 182
+                    },
+                    "end": {
+                      "line": 7,
+                      "column": 50,
+                      "offset": 229
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 7,
+                  "column": 1,
+                  "offset": 180
+                },
+                "end": {
+                  "line": 7,
+                  "column": 50,
+                  "offset": 229
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "listItem",
+              "loose": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "broadcasts the register transactions after the preorder transaction\nhas an appropriate number of confirmations",
+                      "position": {
+                        "start": {
+                          "line": 8,
+                          "column": 3,
+                          "offset": 232
+                        },
+                        "end": {
+                          "line": 9,
+                          "column": 43,
+                          "offset": 342
+                        },
+                        "indent": [
+                          1
+                        ]
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 8,
+                      "column": 3,
+                      "offset": 232
+                    },
+                    "end": {
+                      "line": 9,
+                      "column": 43,
+                      "offset": 342
+                    },
+                    "indent": [
+                      1
+                    ]
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 8,
+                  "column": 1,
+                  "offset": 230
+                },
+                "end": {
+                  "line": 9,
+                  "column": 43,
+                  "offset": 342
+                },
+                "indent": [
+                  1
+                ]
+              }
+            },
+            {
+              "type": "listItem",
+              "loose": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "broadcasts the zone file to the Atlas network after the register transaction\nhas an appropriate number of confirmations",
+                      "position": {
+                        "start": {
+                          "line": 10,
+                          "column": 3,
+                          "offset": 345
+                        },
+                        "end": {
+                          "line": 11,
+                          "column": 43,
+                          "offset": 464
+                        },
+                        "indent": [
+                          1
+                        ]
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 10,
+                      "column": 3,
+                      "offset": 345
+                    },
+                    "end": {
+                      "line": 11,
+                      "column": 43,
+                      "offset": 464
+                    },
+                    "indent": [
+                      1
+                    ]
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 10,
+                  "column": 1,
+                  "offset": 343
+                },
+                "end": {
+                  "line": 11,
+                  "column": 43,
+                  "offset": 464
+                },
+                "indent": [
+                  1
+                ]
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 7,
+              "column": 1,
+              "offset": 180
+            },
+            "end": {
+              "line": 11,
+              "column": 43,
+              "offset": 464
+            },
+            "indent": [
+              1,
+              1,
+              1,
+              1
+            ]
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 1,
+          "column": 1,
+          "offset": 0
+        },
+        "end": {
+          "line": 11,
+          "column": 43,
+          "offset": 464
+        }
+      }
+    },
+    "tags": [
+      {
+        "title": "param",
+        "description": "the hex-encoded, signed preorder transaction generated\nusing the `makePreorder` function",
+        "lineNumber": 13,
+        "type": {
+          "type": "NameExpression",
+          "name": "String"
+        },
+        "name": "preorderTransaction"
+      },
+      {
+        "title": "param",
+        "description": "the hex-encoded, signed register transaction generated\nusing the `makeRegister` function",
+        "lineNumber": 15,
+        "type": {
+          "type": "NameExpression",
+          "name": "String"
+        },
+        "name": "registerTransaction"
+      },
+      {
+        "title": "param",
+        "description": "the zone file to be broadcast to the Atlas network",
+        "lineNumber": 17,
+        "type": {
+          "type": "NameExpression",
+          "name": "String"
+        },
+        "name": "zoneFile"
+      },
+      {
+        "title": "return",
+        "description": "Returns a Promise that resolves to an object with a\n`transaction_hash` key containing the transaction hash of the broadcasted transaction.\n\nIn the event of an error, it rejects with:\n* a `RemoteServiceError` if there is a problem\n  with the transaction broadcast service\n* `MissingParameterError` if you call the function without a required\n  parameter",
+        "lineNumber": 18,
+        "type": {
+          "type": "TypeApplication",
+          "expression": {
+            "type": "NameExpression",
+            "name": "Promise"
+          },
+          "applications": [
+            {
+              "type": "UnionType",
+              "elements": [
+                {
+                  "type": "NameExpression",
+                  "name": "Object"
+                },
+                {
+                  "type": "NameExpression",
+                  "name": "Error"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ],
+    "loc": {
+      "start": {
+        "line": 293,
+        "column": 2
+      },
+      "end": {
+        "line": 319,
+        "column": 5
+      }
+    },
+    "context": {
+      "loc": {
+        "start": {
+          "line": 320,
+          "column": 2
+        },
+        "end": {
+          "line": 357,
+          "column": 3
+        }
+      },
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/network.js"
+    },
+    "augments": [],
+    "examples": [],
+    "params": [
+      {
+        "title": "param",
+        "name": "preorderTransaction",
+        "lineNumber": 13,
+        "description": {
+          "type": "root",
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "the hex-encoded, signed preorder transaction generated\nusing the ",
+                  "position": {
+                    "start": {
+                      "line": 1,
+                      "column": 1,
+                      "offset": 0
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 11,
+                      "offset": 65
+                    },
+                    "indent": [
+                      1
+                    ]
+                  }
+                },
+                {
+                  "type": "inlineCode",
+                  "value": "makePreorder",
+                  "position": {
+                    "start": {
+                      "line": 2,
+                      "column": 11,
+                      "offset": 65
                     },
                     "end": {
                       "line": 2,
                       "column": 25,
-                      "offset": 69
+                      "offset": 79
                     },
-                    "indent": [
-                      1
-                    ]
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": " function",
+                  "position": {
+                    "start": {
+                      "line": 2,
+                      "column": 25,
+                      "offset": 79
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 34,
+                      "offset": 88
+                    },
+                    "indent": []
                   }
                 }
               ],
@@ -8418,8 +10416,8 @@
                 },
                 "end": {
                   "line": 2,
-                  "column": 25,
-                  "offset": 69
+                  "column": 34,
+                  "offset": 88
                 },
                 "indent": [
                   1
@@ -8435,48 +10433,80 @@
             },
             "end": {
               "line": 2,
-              "column": 25,
-              "offset": 69
+              "column": 34,
+              "offset": 88
             }
           }
         },
-        "title": "returns",
         "type": {
           "type": "NameExpression",
-          "name": "Promise"
+          "name": "String"
         }
-      }
-    ],
-    "sees": [],
-    "throws": [],
-    "todos": [],
-    "name": "deleteFile",
-    "kind": "function",
-    "members": {
-      "global": [],
-      "inner": [],
-      "instance": [],
-      "events": [],
-      "static": []
-    },
-    "path": [
+      },
       {
-        "name": "deleteFile",
-        "kind": "function"
-      }
-    ],
-    "namespace": "deleteFile"
-  },
-  {
-    "description": {
-      "type": "root",
-      "children": [
-        {
-          "type": "paragraph",
+        "title": "param",
+        "name": "registerTransaction",
+        "lineNumber": 15,
+        "description": {
+          "type": "root",
           "children": [
             {
-              "type": "text",
-              "value": "Versioning",
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "the hex-encoded, signed register transaction generated\nusing the ",
+                  "position": {
+                    "start": {
+                      "line": 1,
+                      "column": 1,
+                      "offset": 0
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 11,
+                      "offset": 65
+                    },
+                    "indent": [
+                      1
+                    ]
+                  }
+                },
+                {
+                  "type": "inlineCode",
+                  "value": "makeRegister",
+                  "position": {
+                    "start": {
+                      "line": 2,
+                      "column": 11,
+                      "offset": 65
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 25,
+                      "offset": 79
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": " function",
+                  "position": {
+                    "start": {
+                      "line": 2,
+                      "column": 25,
+                      "offset": 79
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 34,
+                      "offset": 88
+                    },
+                    "indent": []
+                  }
+                }
+              ],
               "position": {
                 "start": {
                   "line": 1,
@@ -8484,11 +10514,13 @@
                   "offset": 0
                 },
                 "end": {
-                  "line": 1,
-                  "column": 11,
-                  "offset": 10
+                  "line": 2,
+                  "column": 34,
+                  "offset": 88
                 },
-                "indent": []
+                "indent": [
+                  1
+                ]
               }
             }
           ],
@@ -8499,88 +10531,21 @@
               "offset": 0
             },
             "end": {
-              "line": 1,
-              "column": 11,
-              "offset": 10
-            },
-            "indent": []
+              "line": 2,
+              "column": 34,
+              "offset": 88
+            }
           }
-        }
-      ],
-      "position": {
-        "start": {
-          "line": 1,
-          "column": 1,
-          "offset": 0
         },
-        "end": {
-          "line": 1,
-          "column": 11,
-          "offset": 10
-        }
-      }
-    },
-    "tags": [
-      {
-        "title": "param",
-        "description": "the left half of the version inequality",
-        "lineNumber": 2,
         "type": {
           "type": "NameExpression",
-          "name": "string"
-        },
-        "name": "v1"
+          "name": "String"
+        }
       },
       {
         "title": "param",
-        "description": "right half of the version inequality",
-        "lineNumber": 3,
-        "type": {
-          "type": "NameExpression",
-          "name": "string"
-        },
-        "name": "v2"
-      },
-      {
-        "title": "returns",
-        "description": "iff v1 >= v2",
-        "lineNumber": 4,
-        "type": {
-          "type": "NameExpression",
-          "name": "bool"
-        }
-      }
-    ],
-    "loc": {
-      "start": {
-        "line": 52,
-        "column": 0
-      },
-      "end": {
-        "line": 57,
-        "column": 3
-      }
-    },
-    "context": {
-      "loc": {
-        "start": {
-          "line": 58,
-          "column": 0
-        },
-        "end": {
-          "line": 71,
-          "column": 1
-        }
-      },
-      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/utils.js"
-    },
-    "augments": [],
-    "examples": [],
-    "params": [
-      {
-        "title": "param",
-        "name": "v1",
-        "lineNumber": 2,
+        "name": "zoneFile",
+        "lineNumber": 17,
         "description": {
           "type": "root",
           "children": [
@@ -8589,7 +10554,7 @@
               "children": [
                 {
                   "type": "text",
-                  "value": "the left half of the version inequality",
+                  "value": "the zone file to be broadcast to the Atlas network",
                   "position": {
                     "start": {
                       "line": 1,
@@ -8598,8 +10563,8 @@
                     },
                     "end": {
                       "line": 1,
-                      "column": 40,
-                      "offset": 39
+                      "column": 51,
+                      "offset": 50
                     },
                     "indent": []
                   }
@@ -8613,8 +10578,8 @@
                 },
                 "end": {
                   "line": 1,
-                  "column": 40,
-                  "offset": 39
+                  "column": 51,
+                  "offset": 50
                 },
                 "indent": []
               }
@@ -8628,75 +10593,14 @@
             },
             "end": {
               "line": 1,
-              "column": 40,
-              "offset": 39
+              "column": 51,
+              "offset": 50
             }
           }
         },
         "type": {
           "type": "NameExpression",
-          "name": "string"
-        }
-      },
-      {
-        "title": "param",
-        "name": "v2",
-        "lineNumber": 3,
-        "description": {
-          "type": "root",
-          "children": [
-            {
-              "type": "paragraph",
-              "children": [
-                {
-                  "type": "text",
-                  "value": "right half of the version inequality",
-                  "position": {
-                    "start": {
-                      "line": 1,
-                      "column": 1,
-                      "offset": 0
-                    },
-                    "end": {
-                      "line": 1,
-                      "column": 37,
-                      "offset": 36
-                    },
-                    "indent": []
-                  }
-                }
-              ],
-              "position": {
-                "start": {
-                  "line": 1,
-                  "column": 1,
-                  "offset": 0
-                },
-                "end": {
-                  "line": 1,
-                  "column": 37,
-                  "offset": 36
-                },
-                "indent": []
-              }
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 1,
-              "column": 1,
-              "offset": 0
-            },
-            "end": {
-              "line": 1,
-              "column": 37,
-              "offset": 36
-            }
-          }
-        },
-        "type": {
-          "type": "NameExpression",
-          "name": "string"
+          "name": "String"
         }
       }
     ],
@@ -8711,7 +10615,7 @@
               "children": [
                 {
                   "type": "text",
-                  "value": "iff v1 >= v2",
+                  "value": "Returns a Promise that resolves to an object with a\n",
                   "position": {
                     "start": {
                       "line": 1,
@@ -8719,9 +10623,45 @@
                       "offset": 0
                     },
                     "end": {
-                      "line": 1,
-                      "column": 13,
-                      "offset": 12
+                      "line": 2,
+                      "column": 1,
+                      "offset": 52
+                    },
+                    "indent": [
+                      1
+                    ]
+                  }
+                },
+                {
+                  "type": "inlineCode",
+                  "value": "transaction_hash",
+                  "position": {
+                    "start": {
+                      "line": 2,
+                      "column": 1,
+                      "offset": 52
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 19,
+                      "offset": 70
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": " key containing the transaction hash of the broadcasted transaction.",
+                  "position": {
+                    "start": {
+                      "line": 2,
+                      "column": 19,
+                      "offset": 70
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 87,
+                      "offset": 138
                     },
                     "indent": []
                   }
@@ -8734,11 +10674,246 @@
                   "offset": 0
                 },
                 "end": {
-                  "line": 1,
-                  "column": 13,
-                  "offset": 12
+                  "line": 2,
+                  "column": 87,
+                  "offset": 138
+                },
+                "indent": [
+                  1
+                ]
+              }
+            },
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "In the event of an error, it rejects with:",
+                  "position": {
+                    "start": {
+                      "line": 4,
+                      "column": 1,
+                      "offset": 140
+                    },
+                    "end": {
+                      "line": 4,
+                      "column": 43,
+                      "offset": 182
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 4,
+                  "column": 1,
+                  "offset": 140
+                },
+                "end": {
+                  "line": 4,
+                  "column": 43,
+                  "offset": 182
                 },
                 "indent": []
+              }
+            },
+            {
+              "type": "list",
+              "ordered": false,
+              "start": null,
+              "loose": false,
+              "children": [
+                {
+                  "type": "listItem",
+                  "loose": false,
+                  "checked": null,
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "text",
+                          "value": "a ",
+                          "position": {
+                            "start": {
+                              "line": 5,
+                              "column": 3,
+                              "offset": 185
+                            },
+                            "end": {
+                              "line": 5,
+                              "column": 5,
+                              "offset": 187
+                            },
+                            "indent": []
+                          }
+                        },
+                        {
+                          "type": "inlineCode",
+                          "value": "RemoteServiceError",
+                          "position": {
+                            "start": {
+                              "line": 5,
+                              "column": 5,
+                              "offset": 187
+                            },
+                            "end": {
+                              "line": 5,
+                              "column": 25,
+                              "offset": 207
+                            },
+                            "indent": []
+                          }
+                        },
+                        {
+                          "type": "text",
+                          "value": " if there is a problem\nwith the transaction broadcast service",
+                          "position": {
+                            "start": {
+                              "line": 5,
+                              "column": 25,
+                              "offset": 207
+                            },
+                            "end": {
+                              "line": 6,
+                              "column": 41,
+                              "offset": 270
+                            },
+                            "indent": [
+                              3
+                            ]
+                          }
+                        }
+                      ],
+                      "position": {
+                        "start": {
+                          "line": 5,
+                          "column": 3,
+                          "offset": 185
+                        },
+                        "end": {
+                          "line": 6,
+                          "column": 41,
+                          "offset": 270
+                        },
+                        "indent": [
+                          3
+                        ]
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 5,
+                      "column": 1,
+                      "offset": 183
+                    },
+                    "end": {
+                      "line": 6,
+                      "column": 41,
+                      "offset": 270
+                    },
+                    "indent": [
+                      1
+                    ]
+                  }
+                },
+                {
+                  "type": "listItem",
+                  "loose": false,
+                  "checked": null,
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "inlineCode",
+                          "value": "MissingParameterError",
+                          "position": {
+                            "start": {
+                              "line": 7,
+                              "column": 3,
+                              "offset": 273
+                            },
+                            "end": {
+                              "line": 7,
+                              "column": 26,
+                              "offset": 296
+                            },
+                            "indent": []
+                          }
+                        },
+                        {
+                          "type": "text",
+                          "value": " if you call the function without a required\nparameter",
+                          "position": {
+                            "start": {
+                              "line": 7,
+                              "column": 26,
+                              "offset": 296
+                            },
+                            "end": {
+                              "line": 8,
+                              "column": 12,
+                              "offset": 352
+                            },
+                            "indent": [
+                              3
+                            ]
+                          }
+                        }
+                      ],
+                      "position": {
+                        "start": {
+                          "line": 7,
+                          "column": 3,
+                          "offset": 273
+                        },
+                        "end": {
+                          "line": 8,
+                          "column": 12,
+                          "offset": 352
+                        },
+                        "indent": [
+                          3
+                        ]
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 7,
+                      "column": 1,
+                      "offset": 271
+                    },
+                    "end": {
+                      "line": 8,
+                      "column": 12,
+                      "offset": 352
+                    },
+                    "indent": [
+                      1
+                    ]
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 5,
+                  "column": 1,
+                  "offset": 183
+                },
+                "end": {
+                  "line": 8,
+                  "column": 12,
+                  "offset": 352
+                },
+                "indent": [
+                  1,
+                  1,
+                  1
+                ]
               }
             }
           ],
@@ -8749,24 +10924,44 @@
               "offset": 0
             },
             "end": {
-              "line": 1,
-              "column": 13,
-              "offset": 12
+              "line": 8,
+              "column": 12,
+              "offset": 352
             }
           }
         },
         "title": "returns",
         "type": {
-          "type": "NameExpression",
-          "name": "bool"
+          "type": "TypeApplication",
+          "expression": {
+            "type": "NameExpression",
+            "name": "Promise"
+          },
+          "applications": [
+            {
+              "type": "UnionType",
+              "elements": [
+                {
+                  "type": "NameExpression",
+                  "name": "Object"
+                },
+                {
+                  "type": "NameExpression",
+                  "name": "Error"
+                }
+              ]
+            }
+          ]
         }
       }
     ],
     "sees": [],
     "throws": [],
     "todos": [],
-    "name": "isLaterVersion",
+    "name": "broadcastNameRegistration",
     "kind": "function",
+    "memberof": "BlockstackNetwork",
+    "scope": "instance",
     "members": {
       "global": [],
       "inner": [],
@@ -8776,10 +10971,11 @@
     },
     "path": [
       {
-        "name": "isLaterVersion",
-        "kind": "function"
+        "name": "broadcastNameRegistration",
+        "kind": "function",
+        "scope": "instance"
       }
     ],
-    "namespace": "isLaterVersion"
+    "namespace": "#broadcastNameRegistration"
   }
 ]

--- a/docs.json
+++ b/docs.json
@@ -476,7 +476,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/auth/authApp.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/auth/authApp.js"
     },
     "augments": [],
     "examples": [],
@@ -809,7 +809,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/auth/authApp.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/auth/authApp.js"
     },
     "augments": [],
     "examples": [],
@@ -1063,7 +1063,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/auth/authApp.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/auth/authApp.js"
     },
     "augments": [],
     "examples": [],
@@ -1340,7 +1340,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/auth/authApp.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/auth/authApp.js"
     },
     "augments": [],
     "examples": [],
@@ -1512,7 +1512,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/auth/authApp.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/auth/authApp.js"
     },
     "augments": [],
     "examples": [],
@@ -1749,7 +1749,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/auth/authApp.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/auth/authApp.js"
     },
     "augments": [],
     "examples": [],
@@ -2025,7 +2025,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/auth/authMessages.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/auth/authMessages.js"
     },
     "augments": [],
     "examples": [],
@@ -2716,7 +2716,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/auth/authApp.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/auth/authApp.js"
     },
     "augments": [],
     "examples": [],
@@ -2998,7 +2998,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/auth/authApp.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/auth/authApp.js"
     },
     "augments": [],
     "examples": [],
@@ -3101,325 +3101,6 @@
       }
     ],
     "namespace": "getAuthResponseToken"
-  },
-  {
-    "description": {
-      "type": "root",
-      "children": [
-        {
-          "type": "paragraph",
-          "children": [
-            {
-              "type": "text",
-              "value": "Verify the authentication response is valid",
-              "position": {
-                "start": {
-                  "line": 1,
-                  "column": 1,
-                  "offset": 0
-                },
-                "end": {
-                  "line": 1,
-                  "column": 44,
-                  "offset": 43
-                },
-                "indent": []
-              }
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 1,
-              "column": 1,
-              "offset": 0
-            },
-            "end": {
-              "line": 1,
-              "column": 44,
-              "offset": 43
-            },
-            "indent": []
-          }
-        }
-      ],
-      "position": {
-        "start": {
-          "line": 1,
-          "column": 1,
-          "offset": 0
-        },
-        "end": {
-          "line": 1,
-          "column": 44,
-          "offset": 43
-        }
-      }
-    },
-    "tags": [
-      {
-        "title": "param",
-        "description": "the authentication response token",
-        "lineNumber": 2,
-        "type": {
-          "type": "NameExpression",
-          "name": "String"
-        },
-        "name": "token"
-      },
-      {
-        "title": "param",
-        "description": "the url use to verify owner of a username",
-        "lineNumber": 3,
-        "type": {
-          "type": "NameExpression",
-          "name": "String"
-        },
-        "name": "nameLookupURL"
-      },
-      {
-        "title": "return",
-        "description": "that resolves to true if auth response\nis valid and false if it does not",
-        "lineNumber": 4,
-        "type": {
-          "type": "NameExpression",
-          "name": "Promise"
-        }
-      }
-    ],
-    "loc": {
-      "start": {
-        "line": 190,
-        "column": 0
-      },
-      "end": {
-        "line": 196,
-        "column": 3
-      }
-    },
-    "context": {
-      "loc": {
-        "start": {
-          "line": 197,
-          "column": 0
-        },
-        "end": {
-          "line": 213,
-          "column": 1
-        }
-      },
-      "file": "/Users/larry/git/blockstack.js/src/auth/authVerification.js"
-    },
-    "augments": [],
-    "examples": [],
-    "params": [
-      {
-        "title": "param",
-        "name": "token",
-        "lineNumber": 2,
-        "description": {
-          "type": "root",
-          "children": [
-            {
-              "type": "paragraph",
-              "children": [
-                {
-                  "type": "text",
-                  "value": "the authentication response token",
-                  "position": {
-                    "start": {
-                      "line": 1,
-                      "column": 1,
-                      "offset": 0
-                    },
-                    "end": {
-                      "line": 1,
-                      "column": 34,
-                      "offset": 33
-                    },
-                    "indent": []
-                  }
-                }
-              ],
-              "position": {
-                "start": {
-                  "line": 1,
-                  "column": 1,
-                  "offset": 0
-                },
-                "end": {
-                  "line": 1,
-                  "column": 34,
-                  "offset": 33
-                },
-                "indent": []
-              }
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 1,
-              "column": 1,
-              "offset": 0
-            },
-            "end": {
-              "line": 1,
-              "column": 34,
-              "offset": 33
-            }
-          }
-        },
-        "type": {
-          "type": "NameExpression",
-          "name": "String"
-        }
-      },
-      {
-        "title": "param",
-        "name": "nameLookupURL",
-        "lineNumber": 3,
-        "description": {
-          "type": "root",
-          "children": [
-            {
-              "type": "paragraph",
-              "children": [
-                {
-                  "type": "text",
-                  "value": "the url use to verify owner of a username",
-                  "position": {
-                    "start": {
-                      "line": 1,
-                      "column": 1,
-                      "offset": 0
-                    },
-                    "end": {
-                      "line": 1,
-                      "column": 42,
-                      "offset": 41
-                    },
-                    "indent": []
-                  }
-                }
-              ],
-              "position": {
-                "start": {
-                  "line": 1,
-                  "column": 1,
-                  "offset": 0
-                },
-                "end": {
-                  "line": 1,
-                  "column": 42,
-                  "offset": 41
-                },
-                "indent": []
-              }
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 1,
-              "column": 1,
-              "offset": 0
-            },
-            "end": {
-              "line": 1,
-              "column": 42,
-              "offset": 41
-            }
-          }
-        },
-        "type": {
-          "type": "NameExpression",
-          "name": "String"
-        }
-      }
-    ],
-    "properties": [],
-    "returns": [
-      {
-        "description": {
-          "type": "root",
-          "children": [
-            {
-              "type": "paragraph",
-              "children": [
-                {
-                  "type": "text",
-                  "value": "that resolves to true if auth response\nis valid and false if it does not",
-                  "position": {
-                    "start": {
-                      "line": 1,
-                      "column": 1,
-                      "offset": 0
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 34,
-                      "offset": 72
-                    },
-                    "indent": [
-                      1
-                    ]
-                  }
-                }
-              ],
-              "position": {
-                "start": {
-                  "line": 1,
-                  "column": 1,
-                  "offset": 0
-                },
-                "end": {
-                  "line": 2,
-                  "column": 34,
-                  "offset": 72
-                },
-                "indent": [
-                  1
-                ]
-              }
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 1,
-              "column": 1,
-              "offset": 0
-            },
-            "end": {
-              "line": 2,
-              "column": 34,
-              "offset": 72
-            }
-          }
-        },
-        "title": "returns",
-        "type": {
-          "type": "NameExpression",
-          "name": "Promise"
-        }
-      }
-    ],
-    "sees": [],
-    "throws": [],
-    "todos": [],
-    "name": "verifyAuthResponse",
-    "kind": "function",
-    "members": {
-      "global": [],
-      "inner": [],
-      "instance": [],
-      "events": [],
-      "static": []
-    },
-    "path": [
-      {
-        "name": "verifyAuthResponse",
-        "kind": "function"
-      }
-    ],
-    "namespace": "verifyAuthResponse"
   },
   {
     "name": "Profiles",
@@ -3698,7 +3379,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/profiles/profileTokens.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/profiles/profileTokens.js"
     },
     "augments": [],
     "examples": [],
@@ -4084,7 +3765,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/profiles/profileTokens.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/profiles/profileTokens.js"
     },
     "augments": [],
     "examples": [],
@@ -4439,7 +4120,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/profiles/profileTokens.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/profiles/profileTokens.js"
     },
     "augments": [],
     "examples": [],
@@ -5073,7 +4754,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/profiles/profileTokens.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/profiles/profileTokens.js"
     },
     "augments": [],
     "examples": [],
@@ -5469,7 +5150,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/profiles/profileProofs.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/profiles/profileProofs.js"
     },
     "augments": [],
     "examples": [],
@@ -5817,7 +5498,7 @@
           }
         },
         "name": "zoneFileLookupURL",
-        "default": "https://core.blockstack.org/v1/names/"
+        "default": "http://localhost:6270/v1/names/"
       },
       {
         "title": "returns",
@@ -5850,7 +5531,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/profiles/profileLookup.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/profiles/profileLookup.js"
     },
     "augments": [],
     "examples": [],
@@ -5980,7 +5661,7 @@
           "type": "NameExpression",
           "name": "string"
         },
-        "default": "https://core.blockstack.org/v1/names/"
+        "default": "http://localhost:6270/v1/names/"
       }
     ],
     "properties": [],
@@ -6320,254 +6001,6 @@
           "children": [
             {
               "type": "text",
-              "value": "Deletes the specified file from the app's data store.",
-              "position": {
-                "start": {
-                  "line": 1,
-                  "column": 1,
-                  "offset": 0
-                },
-                "end": {
-                  "line": 1,
-                  "column": 54,
-                  "offset": 53
-                },
-                "indent": []
-              }
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 1,
-              "column": 1,
-              "offset": 0
-            },
-            "end": {
-              "line": 1,
-              "column": 54,
-              "offset": 53
-            },
-            "indent": []
-          }
-        }
-      ],
-      "position": {
-        "start": {
-          "line": 1,
-          "column": 1,
-          "offset": 0
-        },
-        "end": {
-          "line": 1,
-          "column": 54,
-          "offset": 53
-        }
-      }
-    },
-    "tags": [
-      {
-        "title": "param",
-        "description": "the path to the file to delete",
-        "lineNumber": 2,
-        "type": {
-          "type": "NameExpression",
-          "name": "String"
-        },
-        "name": "path"
-      },
-      {
-        "title": "returns",
-        "description": "that resolves when the file has been removed\nor rejects with an error",
-        "lineNumber": 3,
-        "type": {
-          "type": "NameExpression",
-          "name": "Promise"
-        }
-      }
-    ],
-    "loc": {
-      "start": {
-        "line": 157,
-        "column": 0
-      },
-      "end": {
-        "line": 162,
-        "column": 3
-      }
-    },
-    "context": {
-      "loc": {
-        "start": {
-          "line": 163,
-          "column": 0
-        },
-        "end": {
-          "line": 165,
-          "column": 1
-        }
-      },
-      "file": "/Users/larry/git/blockstack.js/src/storage/index.js"
-    },
-    "augments": [],
-    "examples": [],
-    "params": [
-      {
-        "title": "param",
-        "name": "path",
-        "lineNumber": 2,
-        "description": {
-          "type": "root",
-          "children": [
-            {
-              "type": "paragraph",
-              "children": [
-                {
-                  "type": "text",
-                  "value": "the path to the file to delete",
-                  "position": {
-                    "start": {
-                      "line": 1,
-                      "column": 1,
-                      "offset": 0
-                    },
-                    "end": {
-                      "line": 1,
-                      "column": 31,
-                      "offset": 30
-                    },
-                    "indent": []
-                  }
-                }
-              ],
-              "position": {
-                "start": {
-                  "line": 1,
-                  "column": 1,
-                  "offset": 0
-                },
-                "end": {
-                  "line": 1,
-                  "column": 31,
-                  "offset": 30
-                },
-                "indent": []
-              }
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 1,
-              "column": 1,
-              "offset": 0
-            },
-            "end": {
-              "line": 1,
-              "column": 31,
-              "offset": 30
-            }
-          }
-        },
-        "type": {
-          "type": "NameExpression",
-          "name": "String"
-        }
-      }
-    ],
-    "properties": [],
-    "returns": [
-      {
-        "description": {
-          "type": "root",
-          "children": [
-            {
-              "type": "paragraph",
-              "children": [
-                {
-                  "type": "text",
-                  "value": "that resolves when the file has been removed\nor rejects with an error",
-                  "position": {
-                    "start": {
-                      "line": 1,
-                      "column": 1,
-                      "offset": 0
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 25,
-                      "offset": 69
-                    },
-                    "indent": [
-                      1
-                    ]
-                  }
-                }
-              ],
-              "position": {
-                "start": {
-                  "line": 1,
-                  "column": 1,
-                  "offset": 0
-                },
-                "end": {
-                  "line": 2,
-                  "column": 25,
-                  "offset": 69
-                },
-                "indent": [
-                  1
-                ]
-              }
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 1,
-              "column": 1,
-              "offset": 0
-            },
-            "end": {
-              "line": 2,
-              "column": 25,
-              "offset": 69
-            }
-          }
-        },
-        "title": "returns",
-        "type": {
-          "type": "NameExpression",
-          "name": "Promise"
-        }
-      }
-    ],
-    "sees": [],
-    "throws": [],
-    "todos": [],
-    "name": "deleteFile",
-    "kind": "function",
-    "members": {
-      "global": [],
-      "inner": [],
-      "instance": [],
-      "events": [],
-      "static": []
-    },
-    "path": [
-      {
-        "name": "deleteFile",
-        "kind": "function"
-      }
-    ],
-    "namespace": "deleteFile"
-  },
-  {
-    "description": {
-      "type": "root",
-      "children": [
-        {
-          "type": "paragraph",
-          "children": [
-            {
-              "type": "text",
               "value": "Retrieves the specified file from the app's data store.",
               "position": {
                 "start": {
@@ -6716,7 +6149,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/storage/index.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/storage/index.js"
     },
     "augments": [],
     "examples": [],
@@ -7329,7 +6762,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/storage/index.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/storage/index.js"
     },
     "augments": [],
     "examples": [],
@@ -7783,7 +7216,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/storage/index.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/storage/index.js"
     },
     "augments": [],
     "examples": [],
@@ -8126,7 +7559,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/storage/index.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/storage/index.js"
     },
     "augments": [],
     "examples": [],
@@ -8468,7 +7901,6 @@
     "namespace": "getUserAppFileUrl"
   },
   {
-    "name": "Blockchain",
     "description": {
       "type": "root",
       "children": [
@@ -8477,7 +7909,7 @@
           "children": [
             {
               "type": "text",
-              "value": "Generate and broadcast Blockstack blockchain transactions.",
+              "value": "Verify the authentication response is valid",
               "position": {
                 "start": {
                   "line": 1,
@@ -8486,8 +7918,8 @@
                 },
                 "end": {
                   "line": 1,
-                  "column": 59,
-                  "offset": 58
+                  "column": 44,
+                  "offset": 43
                 },
                 "indent": []
               }
@@ -8501,8 +7933,8 @@
             },
             "end": {
               "line": 1,
-              "column": 59,
-              "offset": 58
+              "column": 44,
+              "offset": 43
             },
             "indent": []
           }
@@ -8515,174 +7947,73 @@
           "offset": 0
         },
         "end": {
-          "line": 2,
-          "column": 1,
-          "offset": 59
-        }
-      }
-    },
-    "kind": "note",
-    "members": {
-      "global": [],
-      "inner": [],
-      "instance": [],
-      "events": [],
-      "static": []
-    },
-    "path": [
-      {
-        "name": "Blockchain",
-        "kind": "note"
-      }
-    ],
-    "namespace": "Blockchain"
-  },
-  {
-    "description": {
-      "type": "root",
-      "children": [
-        {
-          "type": "paragraph",
-          "children": [
-            {
-              "type": "text",
-              "value": "Broadcasts a signed bitcoin transaction to the network optionally waiting to broadcast the\ntransaction until a second transaction has a certain number of confirmations.",
-              "position": {
-                "start": {
-                  "line": 1,
-                  "column": 1,
-                  "offset": 0
-                },
-                "end": {
-                  "line": 2,
-                  "column": 78,
-                  "offset": 168
-                },
-                "indent": [
-                  1
-                ]
-              }
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 1,
-              "column": 1,
-              "offset": 0
-            },
-            "end": {
-              "line": 2,
-              "column": 78,
-              "offset": 168
-            },
-            "indent": [
-              1
-            ]
-          }
-        }
-      ],
-      "position": {
-        "start": {
           "line": 1,
-          "column": 1,
-          "offset": 0
-        },
-        "end": {
-          "line": 2,
-          "column": 78,
-          "offset": 168
+          "column": 44,
+          "offset": 43
         }
       }
     },
     "tags": [
       {
         "title": "param",
-        "description": "the hex-encoded transaction to broadcast",
-        "lineNumber": 4,
+        "description": "the authentication response token",
+        "lineNumber": 2,
         "type": {
           "type": "NameExpression",
-          "name": "string"
+          "name": "String"
         },
-        "name": "transaction"
+        "name": "token"
       },
       {
         "title": "param",
-        "description": "the hex transaction id of the transaction to watch for\nthe specified number of confirmations before broadcasting the `transaction`",
-        "lineNumber": 5,
+        "description": "the url use to verify owner of a username",
+        "lineNumber": 3,
         "type": {
           "type": "NameExpression",
-          "name": "string"
+          "name": "String"
         },
-        "name": "transactionToWatch"
-      },
-      {
-        "title": "param",
-        "description": "the number of confirmations `transactionToWatch` must have\nbefore broadcasting `transaction`.",
-        "lineNumber": 7,
-        "type": {
-          "type": "NameExpression",
-          "name": "number"
-        },
-        "name": "confirmations"
+        "name": "nameLookupURL"
       },
       {
         "title": "return",
-        "description": "Returns a Promise that resolves to an object with a\n`transaction_hash` key containing the transaction hash of the broadcasted transaction.\n\nIn the event of an error, it rejects with:\n* a `RemoteServiceError` if there is a problem\n  with the transaction broadcast service\n* `MissingParameterError` if you call the function without a required\n  parameter",
-        "lineNumber": 9,
+        "description": "that resolves to true if auth response\nis valid and false if it does not",
+        "lineNumber": 4,
         "type": {
-          "type": "TypeApplication",
-          "expression": {
-            "type": "NameExpression",
-            "name": "Promise"
-          },
-          "applications": [
-            {
-              "type": "UnionType",
-              "elements": [
-                {
-                  "type": "NameExpression",
-                  "name": "Object"
-                },
-                {
-                  "type": "NameExpression",
-                  "name": "Error"
-                }
-              ]
-            }
-          ]
+          "type": "NameExpression",
+          "name": "Promise"
         }
       }
     ],
     "loc": {
       "start": {
-        "line": 149,
-        "column": 2
+        "line": 190,
+        "column": 0
       },
       "end": {
-        "line": 166,
-        "column": 4
+        "line": 196,
+        "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 167,
-          "column": 2
+          "line": 197,
+          "column": 0
         },
         "end": {
-          "line": 222,
-          "column": 3
+          "line": 213,
+          "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/network.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/auth/authVerification.js"
     },
     "augments": [],
     "examples": [],
     "params": [
       {
         "title": "param",
-        "name": "transaction",
-        "lineNumber": 4,
+        "name": "token",
+        "lineNumber": 2,
         "description": {
           "type": "root",
           "children": [
@@ -8691,7 +8022,7 @@
               "children": [
                 {
                   "type": "text",
-                  "value": "the hex-encoded transaction to broadcast",
+                  "value": "the authentication response token",
                   "position": {
                     "start": {
                       "line": 1,
@@ -8700,8 +8031,8 @@
                     },
                     "end": {
                       "line": 1,
-                      "column": 41,
-                      "offset": 40
+                      "column": 34,
+                      "offset": 33
                     },
                     "indent": []
                   }
@@ -8715,8 +8046,8 @@
                 },
                 "end": {
                   "line": 1,
-                  "column": 41,
-                  "offset": 40
+                  "column": 34,
+                  "offset": 33
                 },
                 "indent": []
               }
@@ -8730,20 +8061,20 @@
             },
             "end": {
               "line": 1,
-              "column": 41,
-              "offset": 40
+              "column": 34,
+              "offset": 33
             }
           }
         },
         "type": {
           "type": "NameExpression",
-          "name": "string"
+          "name": "String"
         }
       },
       {
         "title": "param",
-        "name": "transactionToWatch",
-        "lineNumber": 5,
+        "name": "nameLookupURL",
+        "lineNumber": 3,
         "description": {
           "type": "root",
           "children": [
@@ -8752,7 +8083,7 @@
               "children": [
                 {
                   "type": "text",
-                  "value": "the hex transaction id of the transaction to watch for\nthe specified number of confirmations before broadcasting the ",
+                  "value": "the url use to verify owner of a username",
                   "position": {
                     "start": {
                       "line": 1,
@@ -8760,28 +8091,9 @@
                       "offset": 0
                     },
                     "end": {
-                      "line": 2,
-                      "column": 63,
-                      "offset": 117
-                    },
-                    "indent": [
-                      1
-                    ]
-                  }
-                },
-                {
-                  "type": "inlineCode",
-                  "value": "transaction",
-                  "position": {
-                    "start": {
-                      "line": 2,
-                      "column": 63,
-                      "offset": 117
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 76,
-                      "offset": 130
+                      "line": 1,
+                      "column": 42,
+                      "offset": 41
                     },
                     "indent": []
                   }
@@ -8794,147 +8106,11 @@
                   "offset": 0
                 },
                 "end": {
-                  "line": 2,
-                  "column": 76,
-                  "offset": 130
-                },
-                "indent": [
-                  1
-                ]
-              }
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 1,
-              "column": 1,
-              "offset": 0
-            },
-            "end": {
-              "line": 2,
-              "column": 76,
-              "offset": 130
-            }
-          }
-        },
-        "type": {
-          "type": "NameExpression",
-          "name": "string"
-        },
-        "default": "null"
-      },
-      {
-        "title": "param",
-        "name": "confirmations",
-        "lineNumber": 7,
-        "description": {
-          "type": "root",
-          "children": [
-            {
-              "type": "paragraph",
-              "children": [
-                {
-                  "type": "text",
-                  "value": "the number of confirmations ",
-                  "position": {
-                    "start": {
-                      "line": 1,
-                      "column": 1,
-                      "offset": 0
-                    },
-                    "end": {
-                      "line": 1,
-                      "column": 29,
-                      "offset": 28
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "inlineCode",
-                  "value": "transactionToWatch",
-                  "position": {
-                    "start": {
-                      "line": 1,
-                      "column": 29,
-                      "offset": 28
-                    },
-                    "end": {
-                      "line": 1,
-                      "column": 49,
-                      "offset": 48
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": " must have\nbefore broadcasting ",
-                  "position": {
-                    "start": {
-                      "line": 1,
-                      "column": 49,
-                      "offset": 48
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 21,
-                      "offset": 79
-                    },
-                    "indent": [
-                      1
-                    ]
-                  }
-                },
-                {
-                  "type": "inlineCode",
-                  "value": "transaction",
-                  "position": {
-                    "start": {
-                      "line": 2,
-                      "column": 21,
-                      "offset": 79
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 34,
-                      "offset": 92
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": ".",
-                  "position": {
-                    "start": {
-                      "line": 2,
-                      "column": 34,
-                      "offset": 92
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 35,
-                      "offset": 93
-                    },
-                    "indent": []
-                  }
-                }
-              ],
-              "position": {
-                "start": {
                   "line": 1,
-                  "column": 1,
-                  "offset": 0
+                  "column": 42,
+                  "offset": 41
                 },
-                "end": {
-                  "line": 2,
-                  "column": 35,
-                  "offset": 93
-                },
-                "indent": [
-                  1
-                ]
+                "indent": []
               }
             }
           ],
@@ -8945,17 +8121,16 @@
               "offset": 0
             },
             "end": {
-              "line": 2,
-              "column": 35,
-              "offset": 93
+              "line": 1,
+              "column": 42,
+              "offset": 41
             }
           }
         },
         "type": {
           "type": "NameExpression",
-          "name": "number"
-        },
-        "default": "6"
+          "name": "String"
+        }
       }
     ],
     "properties": [],
@@ -8969,1442 +8144,21 @@
               "children": [
                 {
                   "type": "text",
-                  "value": "Returns a Promise that resolves to an object with a\n",
+                  "value": "that resolves to true if auth response\nis valid and false if it does not",
                   "position": {
                     "start": {
                       "line": 1,
                       "column": 1,
                       "offset": 0
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 1,
-                      "offset": 52
-                    },
-                    "indent": [
-                      1
-                    ]
-                  }
-                },
-                {
-                  "type": "inlineCode",
-                  "value": "transaction_hash",
-                  "position": {
-                    "start": {
-                      "line": 2,
-                      "column": 1,
-                      "offset": 52
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 19,
-                      "offset": 70
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": " key containing the transaction hash of the broadcasted transaction.",
-                  "position": {
-                    "start": {
-                      "line": 2,
-                      "column": 19,
-                      "offset": 70
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 87,
-                      "offset": 138
-                    },
-                    "indent": []
-                  }
-                }
-              ],
-              "position": {
-                "start": {
-                  "line": 1,
-                  "column": 1,
-                  "offset": 0
-                },
-                "end": {
-                  "line": 2,
-                  "column": 87,
-                  "offset": 138
-                },
-                "indent": [
-                  1
-                ]
-              }
-            },
-            {
-              "type": "paragraph",
-              "children": [
-                {
-                  "type": "text",
-                  "value": "In the event of an error, it rejects with:",
-                  "position": {
-                    "start": {
-                      "line": 4,
-                      "column": 1,
-                      "offset": 140
-                    },
-                    "end": {
-                      "line": 4,
-                      "column": 43,
-                      "offset": 182
-                    },
-                    "indent": []
-                  }
-                }
-              ],
-              "position": {
-                "start": {
-                  "line": 4,
-                  "column": 1,
-                  "offset": 140
-                },
-                "end": {
-                  "line": 4,
-                  "column": 43,
-                  "offset": 182
-                },
-                "indent": []
-              }
-            },
-            {
-              "type": "list",
-              "ordered": false,
-              "start": null,
-              "loose": false,
-              "children": [
-                {
-                  "type": "listItem",
-                  "loose": false,
-                  "checked": null,
-                  "children": [
-                    {
-                      "type": "paragraph",
-                      "children": [
-                        {
-                          "type": "text",
-                          "value": "a ",
-                          "position": {
-                            "start": {
-                              "line": 5,
-                              "column": 3,
-                              "offset": 185
-                            },
-                            "end": {
-                              "line": 5,
-                              "column": 5,
-                              "offset": 187
-                            },
-                            "indent": []
-                          }
-                        },
-                        {
-                          "type": "inlineCode",
-                          "value": "RemoteServiceError",
-                          "position": {
-                            "start": {
-                              "line": 5,
-                              "column": 5,
-                              "offset": 187
-                            },
-                            "end": {
-                              "line": 5,
-                              "column": 25,
-                              "offset": 207
-                            },
-                            "indent": []
-                          }
-                        },
-                        {
-                          "type": "text",
-                          "value": " if there is a problem\nwith the transaction broadcast service",
-                          "position": {
-                            "start": {
-                              "line": 5,
-                              "column": 25,
-                              "offset": 207
-                            },
-                            "end": {
-                              "line": 6,
-                              "column": 41,
-                              "offset": 270
-                            },
-                            "indent": [
-                              3
-                            ]
-                          }
-                        }
-                      ],
-                      "position": {
-                        "start": {
-                          "line": 5,
-                          "column": 3,
-                          "offset": 185
-                        },
-                        "end": {
-                          "line": 6,
-                          "column": 41,
-                          "offset": 270
-                        },
-                        "indent": [
-                          3
-                        ]
-                      }
-                    }
-                  ],
-                  "position": {
-                    "start": {
-                      "line": 5,
-                      "column": 1,
-                      "offset": 183
-                    },
-                    "end": {
-                      "line": 6,
-                      "column": 41,
-                      "offset": 270
-                    },
-                    "indent": [
-                      1
-                    ]
-                  }
-                },
-                {
-                  "type": "listItem",
-                  "loose": false,
-                  "checked": null,
-                  "children": [
-                    {
-                      "type": "paragraph",
-                      "children": [
-                        {
-                          "type": "inlineCode",
-                          "value": "MissingParameterError",
-                          "position": {
-                            "start": {
-                              "line": 7,
-                              "column": 3,
-                              "offset": 273
-                            },
-                            "end": {
-                              "line": 7,
-                              "column": 26,
-                              "offset": 296
-                            },
-                            "indent": []
-                          }
-                        },
-                        {
-                          "type": "text",
-                          "value": " if you call the function without a required\nparameter",
-                          "position": {
-                            "start": {
-                              "line": 7,
-                              "column": 26,
-                              "offset": 296
-                            },
-                            "end": {
-                              "line": 8,
-                              "column": 12,
-                              "offset": 352
-                            },
-                            "indent": [
-                              3
-                            ]
-                          }
-                        }
-                      ],
-                      "position": {
-                        "start": {
-                          "line": 7,
-                          "column": 3,
-                          "offset": 273
-                        },
-                        "end": {
-                          "line": 8,
-                          "column": 12,
-                          "offset": 352
-                        },
-                        "indent": [
-                          3
-                        ]
-                      }
-                    }
-                  ],
-                  "position": {
-                    "start": {
-                      "line": 7,
-                      "column": 1,
-                      "offset": 271
-                    },
-                    "end": {
-                      "line": 8,
-                      "column": 12,
-                      "offset": 352
-                    },
-                    "indent": [
-                      1
-                    ]
-                  }
-                }
-              ],
-              "position": {
-                "start": {
-                  "line": 5,
-                  "column": 1,
-                  "offset": 183
-                },
-                "end": {
-                  "line": 8,
-                  "column": 12,
-                  "offset": 352
-                },
-                "indent": [
-                  1,
-                  1,
-                  1
-                ]
-              }
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 1,
-              "column": 1,
-              "offset": 0
-            },
-            "end": {
-              "line": 8,
-              "column": 12,
-              "offset": 352
-            }
-          }
-        },
-        "title": "returns",
-        "type": {
-          "type": "TypeApplication",
-          "expression": {
-            "type": "NameExpression",
-            "name": "Promise"
-          },
-          "applications": [
-            {
-              "type": "UnionType",
-              "elements": [
-                {
-                  "type": "NameExpression",
-                  "name": "Object"
-                },
-                {
-                  "type": "NameExpression",
-                  "name": "Error"
-                }
-              ]
-            }
-          ]
-        }
-      }
-    ],
-    "sees": [],
-    "throws": [],
-    "todos": [],
-    "name": "broadcastTransaction",
-    "kind": "function",
-    "memberof": "BlockstackNetwork",
-    "scope": "instance",
-    "members": {
-      "global": [],
-      "inner": [],
-      "instance": [],
-      "events": [],
-      "static": []
-    },
-    "path": [
-      {
-        "name": "broadcastTransaction",
-        "kind": "function",
-        "scope": "instance"
-      }
-    ],
-    "namespace": "#broadcastTransaction"
-  },
-  {
-    "description": {
-      "type": "root",
-      "children": [
-        {
-          "type": "paragraph",
-          "children": [
-            {
-              "type": "text",
-              "value": "Broadcasts a zone file to the Atlas network via the transaction broadcast service.",
-              "position": {
-                "start": {
-                  "line": 1,
-                  "column": 1,
-                  "offset": 0
-                },
-                "end": {
-                  "line": 1,
-                  "column": 83,
-                  "offset": 82
-                },
-                "indent": []
-              }
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 1,
-              "column": 1,
-              "offset": 0
-            },
-            "end": {
-              "line": 1,
-              "column": 83,
-              "offset": 82
-            },
-            "indent": []
-          }
-        }
-      ],
-      "position": {
-        "start": {
-          "line": 1,
-          "column": 1,
-          "offset": 0
-        },
-        "end": {
-          "line": 1,
-          "column": 83,
-          "offset": 82
-        }
-      }
-    },
-    "tags": [
-      {
-        "title": "param",
-        "description": "the zone file to be broadcast to the Atlas network",
-        "lineNumber": 3,
-        "type": {
-          "type": "NameExpression",
-          "name": "String"
-        },
-        "name": "zoneFile"
-      },
-      {
-        "title": "param",
-        "description": "the hex transaction id of the transaction\nto watch for confirmation before broadcasting the zone file to the Atlas network",
-        "lineNumber": 4,
-        "type": {
-          "type": "NameExpression",
-          "name": "String"
-        },
-        "name": "transactionToWatch"
-      },
-      {
-        "title": "return",
-        "description": "Returns a Promise that resolves to an object with a\n`transaction_hash` key containing the transaction hash of the broadcasted transaction.\n\nIn the event of an error, it rejects with:\n* a `RemoteServiceError` if there is a problem\n  with the transaction broadcast service\n* `MissingParameterError` if you call the function without a required\n  parameter",
-        "lineNumber": 6,
-        "type": {
-          "type": "TypeApplication",
-          "expression": {
-            "type": "NameExpression",
-            "name": "Promise"
-          },
-          "applications": [
-            {
-              "type": "UnionType",
-              "elements": [
-                {
-                  "type": "NameExpression",
-                  "name": "Object"
-                },
-                {
-                  "type": "NameExpression",
-                  "name": "Error"
-                }
-              ]
-            }
-          ]
-        }
-      }
-    ],
-    "loc": {
-      "start": {
-        "line": 224,
-        "column": 2
-      },
-      "end": {
-        "line": 238,
-        "column": 5
-      }
-    },
-    "context": {
-      "loc": {
-        "start": {
-          "line": 239,
-          "column": 2
-        },
-        "end": {
-          "line": 291,
-          "column": 3
-        }
-      },
-      "file": "/Users/larry/git/blockstack.js/src/network.js"
-    },
-    "augments": [],
-    "examples": [],
-    "params": [
-      {
-        "title": "param",
-        "name": "zoneFile",
-        "lineNumber": 3,
-        "description": {
-          "type": "root",
-          "children": [
-            {
-              "type": "paragraph",
-              "children": [
-                {
-                  "type": "text",
-                  "value": "the zone file to be broadcast to the Atlas network",
-                  "position": {
-                    "start": {
-                      "line": 1,
-                      "column": 1,
-                      "offset": 0
-                    },
-                    "end": {
-                      "line": 1,
-                      "column": 51,
-                      "offset": 50
-                    },
-                    "indent": []
-                  }
-                }
-              ],
-              "position": {
-                "start": {
-                  "line": 1,
-                  "column": 1,
-                  "offset": 0
-                },
-                "end": {
-                  "line": 1,
-                  "column": 51,
-                  "offset": 50
-                },
-                "indent": []
-              }
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 1,
-              "column": 1,
-              "offset": 0
-            },
-            "end": {
-              "line": 1,
-              "column": 51,
-              "offset": 50
-            }
-          }
-        },
-        "type": {
-          "type": "NameExpression",
-          "name": "String"
-        }
-      },
-      {
-        "title": "param",
-        "name": "transactionToWatch",
-        "lineNumber": 4,
-        "description": {
-          "type": "root",
-          "children": [
-            {
-              "type": "paragraph",
-              "children": [
-                {
-                  "type": "text",
-                  "value": "the hex transaction id of the transaction\nto watch for confirmation before broadcasting the zone file to the Atlas network",
-                  "position": {
-                    "start": {
-                      "line": 1,
-                      "column": 1,
-                      "offset": 0
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 81,
-                      "offset": 122
-                    },
-                    "indent": [
-                      1
-                    ]
-                  }
-                }
-              ],
-              "position": {
-                "start": {
-                  "line": 1,
-                  "column": 1,
-                  "offset": 0
-                },
-                "end": {
-                  "line": 2,
-                  "column": 81,
-                  "offset": 122
-                },
-                "indent": [
-                  1
-                ]
-              }
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 1,
-              "column": 1,
-              "offset": 0
-            },
-            "end": {
-              "line": 2,
-              "column": 81,
-              "offset": 122
-            }
-          }
-        },
-        "type": {
-          "type": "NameExpression",
-          "name": "String"
-        },
-        "default": "null"
-      }
-    ],
-    "properties": [],
-    "returns": [
-      {
-        "description": {
-          "type": "root",
-          "children": [
-            {
-              "type": "paragraph",
-              "children": [
-                {
-                  "type": "text",
-                  "value": "Returns a Promise that resolves to an object with a\n",
-                  "position": {
-                    "start": {
-                      "line": 1,
-                      "column": 1,
-                      "offset": 0
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 1,
-                      "offset": 52
-                    },
-                    "indent": [
-                      1
-                    ]
-                  }
-                },
-                {
-                  "type": "inlineCode",
-                  "value": "transaction_hash",
-                  "position": {
-                    "start": {
-                      "line": 2,
-                      "column": 1,
-                      "offset": 52
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 19,
-                      "offset": 70
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": " key containing the transaction hash of the broadcasted transaction.",
-                  "position": {
-                    "start": {
-                      "line": 2,
-                      "column": 19,
-                      "offset": 70
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 87,
-                      "offset": 138
-                    },
-                    "indent": []
-                  }
-                }
-              ],
-              "position": {
-                "start": {
-                  "line": 1,
-                  "column": 1,
-                  "offset": 0
-                },
-                "end": {
-                  "line": 2,
-                  "column": 87,
-                  "offset": 138
-                },
-                "indent": [
-                  1
-                ]
-              }
-            },
-            {
-              "type": "paragraph",
-              "children": [
-                {
-                  "type": "text",
-                  "value": "In the event of an error, it rejects with:",
-                  "position": {
-                    "start": {
-                      "line": 4,
-                      "column": 1,
-                      "offset": 140
-                    },
-                    "end": {
-                      "line": 4,
-                      "column": 43,
-                      "offset": 182
-                    },
-                    "indent": []
-                  }
-                }
-              ],
-              "position": {
-                "start": {
-                  "line": 4,
-                  "column": 1,
-                  "offset": 140
-                },
-                "end": {
-                  "line": 4,
-                  "column": 43,
-                  "offset": 182
-                },
-                "indent": []
-              }
-            },
-            {
-              "type": "list",
-              "ordered": false,
-              "start": null,
-              "loose": false,
-              "children": [
-                {
-                  "type": "listItem",
-                  "loose": false,
-                  "checked": null,
-                  "children": [
-                    {
-                      "type": "paragraph",
-                      "children": [
-                        {
-                          "type": "text",
-                          "value": "a ",
-                          "position": {
-                            "start": {
-                              "line": 5,
-                              "column": 3,
-                              "offset": 185
-                            },
-                            "end": {
-                              "line": 5,
-                              "column": 5,
-                              "offset": 187
-                            },
-                            "indent": []
-                          }
-                        },
-                        {
-                          "type": "inlineCode",
-                          "value": "RemoteServiceError",
-                          "position": {
-                            "start": {
-                              "line": 5,
-                              "column": 5,
-                              "offset": 187
-                            },
-                            "end": {
-                              "line": 5,
-                              "column": 25,
-                              "offset": 207
-                            },
-                            "indent": []
-                          }
-                        },
-                        {
-                          "type": "text",
-                          "value": " if there is a problem\nwith the transaction broadcast service",
-                          "position": {
-                            "start": {
-                              "line": 5,
-                              "column": 25,
-                              "offset": 207
-                            },
-                            "end": {
-                              "line": 6,
-                              "column": 41,
-                              "offset": 270
-                            },
-                            "indent": [
-                              3
-                            ]
-                          }
-                        }
-                      ],
-                      "position": {
-                        "start": {
-                          "line": 5,
-                          "column": 3,
-                          "offset": 185
-                        },
-                        "end": {
-                          "line": 6,
-                          "column": 41,
-                          "offset": 270
-                        },
-                        "indent": [
-                          3
-                        ]
-                      }
-                    }
-                  ],
-                  "position": {
-                    "start": {
-                      "line": 5,
-                      "column": 1,
-                      "offset": 183
-                    },
-                    "end": {
-                      "line": 6,
-                      "column": 41,
-                      "offset": 270
-                    },
-                    "indent": [
-                      1
-                    ]
-                  }
-                },
-                {
-                  "type": "listItem",
-                  "loose": false,
-                  "checked": null,
-                  "children": [
-                    {
-                      "type": "paragraph",
-                      "children": [
-                        {
-                          "type": "inlineCode",
-                          "value": "MissingParameterError",
-                          "position": {
-                            "start": {
-                              "line": 7,
-                              "column": 3,
-                              "offset": 273
-                            },
-                            "end": {
-                              "line": 7,
-                              "column": 26,
-                              "offset": 296
-                            },
-                            "indent": []
-                          }
-                        },
-                        {
-                          "type": "text",
-                          "value": " if you call the function without a required\nparameter",
-                          "position": {
-                            "start": {
-                              "line": 7,
-                              "column": 26,
-                              "offset": 296
-                            },
-                            "end": {
-                              "line": 8,
-                              "column": 12,
-                              "offset": 352
-                            },
-                            "indent": [
-                              3
-                            ]
-                          }
-                        }
-                      ],
-                      "position": {
-                        "start": {
-                          "line": 7,
-                          "column": 3,
-                          "offset": 273
-                        },
-                        "end": {
-                          "line": 8,
-                          "column": 12,
-                          "offset": 352
-                        },
-                        "indent": [
-                          3
-                        ]
-                      }
-                    }
-                  ],
-                  "position": {
-                    "start": {
-                      "line": 7,
-                      "column": 1,
-                      "offset": 271
-                    },
-                    "end": {
-                      "line": 8,
-                      "column": 12,
-                      "offset": 352
-                    },
-                    "indent": [
-                      1
-                    ]
-                  }
-                }
-              ],
-              "position": {
-                "start": {
-                  "line": 5,
-                  "column": 1,
-                  "offset": 183
-                },
-                "end": {
-                  "line": 8,
-                  "column": 12,
-                  "offset": 352
-                },
-                "indent": [
-                  1,
-                  1,
-                  1
-                ]
-              }
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 1,
-              "column": 1,
-              "offset": 0
-            },
-            "end": {
-              "line": 8,
-              "column": 12,
-              "offset": 352
-            }
-          }
-        },
-        "title": "returns",
-        "type": {
-          "type": "TypeApplication",
-          "expression": {
-            "type": "NameExpression",
-            "name": "Promise"
-          },
-          "applications": [
-            {
-              "type": "UnionType",
-              "elements": [
-                {
-                  "type": "NameExpression",
-                  "name": "Object"
-                },
-                {
-                  "type": "NameExpression",
-                  "name": "Error"
-                }
-              ]
-            }
-          ]
-        }
-      }
-    ],
-    "sees": [],
-    "throws": [],
-    "todos": [],
-    "name": "broadcastZoneFile",
-    "kind": "function",
-    "memberof": "BlockstackNetwork",
-    "scope": "instance",
-    "members": {
-      "global": [],
-      "inner": [],
-      "instance": [],
-      "events": [],
-      "static": []
-    },
-    "path": [
-      {
-        "name": "broadcastZoneFile",
-        "kind": "function",
-        "scope": "instance"
-      }
-    ],
-    "namespace": "#broadcastZoneFile"
-  },
-  {
-    "description": {
-      "type": "root",
-      "children": [
-        {
-          "type": "paragraph",
-          "children": [
-            {
-              "type": "text",
-              "value": "Sends the preorder and registration transactions and zone file\nfor a Blockstack name registration\nalong with the to the transaction broadcast service.",
-              "position": {
-                "start": {
-                  "line": 1,
-                  "column": 1,
-                  "offset": 0
-                },
-                "end": {
-                  "line": 3,
-                  "column": 53,
-                  "offset": 150
-                },
-                "indent": [
-                  1,
-                  1
-                ]
-              }
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 1,
-              "column": 1,
-              "offset": 0
-            },
-            "end": {
-              "line": 3,
-              "column": 53,
-              "offset": 150
-            },
-            "indent": [
-              1,
-              1
-            ]
-          }
-        },
-        {
-          "type": "paragraph",
-          "children": [
-            {
-              "type": "text",
-              "value": "The transaction broadcast:",
-              "position": {
-                "start": {
-                  "line": 5,
-                  "column": 1,
-                  "offset": 152
-                },
-                "end": {
-                  "line": 5,
-                  "column": 27,
-                  "offset": 178
-                },
-                "indent": []
-              }
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 5,
-              "column": 1,
-              "offset": 152
-            },
-            "end": {
-              "line": 5,
-              "column": 27,
-              "offset": 178
-            },
-            "indent": []
-          }
-        },
-        {
-          "type": "list",
-          "ordered": false,
-          "start": null,
-          "loose": false,
-          "children": [
-            {
-              "type": "listItem",
-              "loose": false,
-              "checked": null,
-              "children": [
-                {
-                  "type": "paragraph",
-                  "children": [
-                    {
-                      "type": "text",
-                      "value": "immediately broadcasts the preorder transaction",
-                      "position": {
-                        "start": {
-                          "line": 7,
-                          "column": 3,
-                          "offset": 182
-                        },
-                        "end": {
-                          "line": 7,
-                          "column": 50,
-                          "offset": 229
-                        },
-                        "indent": []
-                      }
-                    }
-                  ],
-                  "position": {
-                    "start": {
-                      "line": 7,
-                      "column": 3,
-                      "offset": 182
-                    },
-                    "end": {
-                      "line": 7,
-                      "column": 50,
-                      "offset": 229
-                    },
-                    "indent": []
-                  }
-                }
-              ],
-              "position": {
-                "start": {
-                  "line": 7,
-                  "column": 1,
-                  "offset": 180
-                },
-                "end": {
-                  "line": 7,
-                  "column": 50,
-                  "offset": 229
-                },
-                "indent": []
-              }
-            },
-            {
-              "type": "listItem",
-              "loose": false,
-              "checked": null,
-              "children": [
-                {
-                  "type": "paragraph",
-                  "children": [
-                    {
-                      "type": "text",
-                      "value": "broadcasts the register transactions after the preorder transaction\nhas an appropriate number of confirmations",
-                      "position": {
-                        "start": {
-                          "line": 8,
-                          "column": 3,
-                          "offset": 232
-                        },
-                        "end": {
-                          "line": 9,
-                          "column": 43,
-                          "offset": 342
-                        },
-                        "indent": [
-                          1
-                        ]
-                      }
-                    }
-                  ],
-                  "position": {
-                    "start": {
-                      "line": 8,
-                      "column": 3,
-                      "offset": 232
-                    },
-                    "end": {
-                      "line": 9,
-                      "column": 43,
-                      "offset": 342
-                    },
-                    "indent": [
-                      1
-                    ]
-                  }
-                }
-              ],
-              "position": {
-                "start": {
-                  "line": 8,
-                  "column": 1,
-                  "offset": 230
-                },
-                "end": {
-                  "line": 9,
-                  "column": 43,
-                  "offset": 342
-                },
-                "indent": [
-                  1
-                ]
-              }
-            },
-            {
-              "type": "listItem",
-              "loose": false,
-              "checked": null,
-              "children": [
-                {
-                  "type": "paragraph",
-                  "children": [
-                    {
-                      "type": "text",
-                      "value": "broadcasts the zone file to the Atlas network after the register transaction\nhas an appropriate number of confirmations",
-                      "position": {
-                        "start": {
-                          "line": 10,
-                          "column": 3,
-                          "offset": 345
-                        },
-                        "end": {
-                          "line": 11,
-                          "column": 43,
-                          "offset": 464
-                        },
-                        "indent": [
-                          1
-                        ]
-                      }
-                    }
-                  ],
-                  "position": {
-                    "start": {
-                      "line": 10,
-                      "column": 3,
-                      "offset": 345
-                    },
-                    "end": {
-                      "line": 11,
-                      "column": 43,
-                      "offset": 464
-                    },
-                    "indent": [
-                      1
-                    ]
-                  }
-                }
-              ],
-              "position": {
-                "start": {
-                  "line": 10,
-                  "column": 1,
-                  "offset": 343
-                },
-                "end": {
-                  "line": 11,
-                  "column": 43,
-                  "offset": 464
-                },
-                "indent": [
-                  1
-                ]
-              }
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 7,
-              "column": 1,
-              "offset": 180
-            },
-            "end": {
-              "line": 11,
-              "column": 43,
-              "offset": 464
-            },
-            "indent": [
-              1,
-              1,
-              1,
-              1
-            ]
-          }
-        }
-      ],
-      "position": {
-        "start": {
-          "line": 1,
-          "column": 1,
-          "offset": 0
-        },
-        "end": {
-          "line": 11,
-          "column": 43,
-          "offset": 464
-        }
-      }
-    },
-    "tags": [
-      {
-        "title": "param",
-        "description": "the hex-encoded, signed preorder transaction generated\nusing the `makePreorder` function",
-        "lineNumber": 13,
-        "type": {
-          "type": "NameExpression",
-          "name": "String"
-        },
-        "name": "preorderTransaction"
-      },
-      {
-        "title": "param",
-        "description": "the hex-encoded, signed register transaction generated\nusing the `makeRegister` function",
-        "lineNumber": 15,
-        "type": {
-          "type": "NameExpression",
-          "name": "String"
-        },
-        "name": "registerTransaction"
-      },
-      {
-        "title": "param",
-        "description": "the zone file to be broadcast to the Atlas network",
-        "lineNumber": 17,
-        "type": {
-          "type": "NameExpression",
-          "name": "String"
-        },
-        "name": "zoneFile"
-      },
-      {
-        "title": "return",
-        "description": "Returns a Promise that resolves to an object with a\n`transaction_hash` key containing the transaction hash of the broadcasted transaction.\n\nIn the event of an error, it rejects with:\n* a `RemoteServiceError` if there is a problem\n  with the transaction broadcast service\n* `MissingParameterError` if you call the function without a required\n  parameter",
-        "lineNumber": 18,
-        "type": {
-          "type": "TypeApplication",
-          "expression": {
-            "type": "NameExpression",
-            "name": "Promise"
-          },
-          "applications": [
-            {
-              "type": "UnionType",
-              "elements": [
-                {
-                  "type": "NameExpression",
-                  "name": "Object"
-                },
-                {
-                  "type": "NameExpression",
-                  "name": "Error"
-                }
-              ]
-            }
-          ]
-        }
-      }
-    ],
-    "loc": {
-      "start": {
-        "line": 293,
-        "column": 2
-      },
-      "end": {
-        "line": 319,
-        "column": 5
-      }
-    },
-    "context": {
-      "loc": {
-        "start": {
-          "line": 320,
-          "column": 2
-        },
-        "end": {
-          "line": 357,
-          "column": 3
-        }
-      },
-      "file": "/Users/larry/git/blockstack.js/src/network.js"
-    },
-    "augments": [],
-    "examples": [],
-    "params": [
-      {
-        "title": "param",
-        "name": "preorderTransaction",
-        "lineNumber": 13,
-        "description": {
-          "type": "root",
-          "children": [
-            {
-              "type": "paragraph",
-              "children": [
-                {
-                  "type": "text",
-                  "value": "the hex-encoded, signed preorder transaction generated\nusing the ",
-                  "position": {
-                    "start": {
-                      "line": 1,
-                      "column": 1,
-                      "offset": 0
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 11,
-                      "offset": 65
-                    },
-                    "indent": [
-                      1
-                    ]
-                  }
-                },
-                {
-                  "type": "inlineCode",
-                  "value": "makePreorder",
-                  "position": {
-                    "start": {
-                      "line": 2,
-                      "column": 11,
-                      "offset": 65
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 25,
-                      "offset": 79
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": " function",
-                  "position": {
-                    "start": {
-                      "line": 2,
-                      "column": 25,
-                      "offset": 79
                     },
                     "end": {
                       "line": 2,
                       "column": 34,
-                      "offset": 88
+                      "offset": 72
                     },
-                    "indent": []
+                    "indent": [
+                      1
+                    ]
                   }
                 }
               ],
@@ -10417,7 +8171,7 @@
                 "end": {
                   "line": 2,
                   "column": 34,
-                  "offset": 88
+                  "offset": 72
                 },
                 "indent": [
                   1
@@ -10434,142 +8188,47 @@
             "end": {
               "line": 2,
               "column": 34,
-              "offset": 88
+              "offset": 72
             }
           }
         },
+        "title": "returns",
         "type": {
           "type": "NameExpression",
-          "name": "String"
+          "name": "Promise"
         }
-      },
+      }
+    ],
+    "sees": [],
+    "throws": [],
+    "todos": [],
+    "name": "verifyAuthResponse",
+    "kind": "function",
+    "members": {
+      "global": [],
+      "inner": [],
+      "instance": [],
+      "events": [],
+      "static": []
+    },
+    "path": [
       {
-        "title": "param",
-        "name": "registerTransaction",
-        "lineNumber": 15,
-        "description": {
-          "type": "root",
+        "name": "verifyAuthResponse",
+        "kind": "function"
+      }
+    ],
+    "namespace": "verifyAuthResponse"
+  },
+  {
+    "description": {
+      "type": "root",
+      "children": [
+        {
+          "type": "paragraph",
           "children": [
             {
-              "type": "paragraph",
-              "children": [
-                {
-                  "type": "text",
-                  "value": "the hex-encoded, signed register transaction generated\nusing the ",
-                  "position": {
-                    "start": {
-                      "line": 1,
-                      "column": 1,
-                      "offset": 0
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 11,
-                      "offset": 65
-                    },
-                    "indent": [
-                      1
-                    ]
-                  }
-                },
-                {
-                  "type": "inlineCode",
-                  "value": "makeRegister",
-                  "position": {
-                    "start": {
-                      "line": 2,
-                      "column": 11,
-                      "offset": 65
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 25,
-                      "offset": 79
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": " function",
-                  "position": {
-                    "start": {
-                      "line": 2,
-                      "column": 25,
-                      "offset": 79
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 34,
-                      "offset": 88
-                    },
-                    "indent": []
-                  }
-                }
-              ],
-              "position": {
-                "start": {
-                  "line": 1,
-                  "column": 1,
-                  "offset": 0
-                },
-                "end": {
-                  "line": 2,
-                  "column": 34,
-                  "offset": 88
-                },
-                "indent": [
-                  1
-                ]
-              }
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 1,
-              "column": 1,
-              "offset": 0
-            },
-            "end": {
-              "line": 2,
-              "column": 34,
-              "offset": 88
-            }
-          }
-        },
-        "type": {
-          "type": "NameExpression",
-          "name": "String"
-        }
-      },
-      {
-        "title": "param",
-        "name": "zoneFile",
-        "lineNumber": 17,
-        "description": {
-          "type": "root",
-          "children": [
-            {
-              "type": "paragraph",
-              "children": [
-                {
-                  "type": "text",
-                  "value": "the zone file to be broadcast to the Atlas network",
-                  "position": {
-                    "start": {
-                      "line": 1,
-                      "column": 1,
-                      "offset": 0
-                    },
-                    "end": {
-                      "line": 1,
-                      "column": 51,
-                      "offset": 50
-                    },
-                    "indent": []
-                  }
-                }
-              ],
+              "type": "text",
+              "value": "Deletes the specified file from the app's data store.",
               "position": {
                 "start": {
                   "line": 1,
@@ -10578,8 +8237,8 @@
                 },
                 "end": {
                   "line": 1,
-                  "column": 51,
-                  "offset": 50
+                  "column": 54,
+                  "offset": 53
                 },
                 "indent": []
               }
@@ -10593,8 +8252,126 @@
             },
             "end": {
               "line": 1,
-              "column": 51,
-              "offset": 50
+              "column": 54,
+              "offset": 53
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 1,
+          "column": 1,
+          "offset": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 54,
+          "offset": 53
+        }
+      }
+    },
+    "tags": [
+      {
+        "title": "param",
+        "description": "the path to the file to delete",
+        "lineNumber": 2,
+        "type": {
+          "type": "NameExpression",
+          "name": "String"
+        },
+        "name": "path"
+      },
+      {
+        "title": "returns",
+        "description": "that resolves when the file has been removed\nor rejects with an error",
+        "lineNumber": 3,
+        "type": {
+          "type": "NameExpression",
+          "name": "Promise"
+        }
+      }
+    ],
+    "loc": {
+      "start": {
+        "line": 157,
+        "column": 0
+      },
+      "end": {
+        "line": 162,
+        "column": 3
+      }
+    },
+    "context": {
+      "loc": {
+        "start": {
+          "line": 163,
+          "column": 0
+        },
+        "end": {
+          "line": 165,
+          "column": 1
+        }
+      },
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/storage/index.js"
+    },
+    "augments": [],
+    "examples": [],
+    "params": [
+      {
+        "title": "param",
+        "name": "path",
+        "lineNumber": 2,
+        "description": {
+          "type": "root",
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "the path to the file to delete",
+                  "position": {
+                    "start": {
+                      "line": 1,
+                      "column": 1,
+                      "offset": 0
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 31,
+                      "offset": 30
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1,
+                  "offset": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 31,
+                  "offset": 30
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 31,
+              "offset": 30
             }
           }
         },
@@ -10615,7 +8392,7 @@
               "children": [
                 {
                   "type": "text",
-                  "value": "Returns a Promise that resolves to an object with a\n",
+                  "value": "that resolves when the file has been removed\nor rejects with an error",
                   "position": {
                     "start": {
                       "line": 1,
@@ -10624,46 +8401,12 @@
                     },
                     "end": {
                       "line": 2,
-                      "column": 1,
-                      "offset": 52
+                      "column": 25,
+                      "offset": 69
                     },
                     "indent": [
                       1
                     ]
-                  }
-                },
-                {
-                  "type": "inlineCode",
-                  "value": "transaction_hash",
-                  "position": {
-                    "start": {
-                      "line": 2,
-                      "column": 1,
-                      "offset": 52
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 19,
-                      "offset": 70
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": " key containing the transaction hash of the broadcasted transaction.",
-                  "position": {
-                    "start": {
-                      "line": 2,
-                      "column": 19,
-                      "offset": 70
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 87,
-                      "offset": 138
-                    },
-                    "indent": []
                   }
                 }
               ],
@@ -10675,243 +8418,10 @@
                 },
                 "end": {
                   "line": 2,
-                  "column": 87,
-                  "offset": 138
+                  "column": 25,
+                  "offset": 69
                 },
                 "indent": [
-                  1
-                ]
-              }
-            },
-            {
-              "type": "paragraph",
-              "children": [
-                {
-                  "type": "text",
-                  "value": "In the event of an error, it rejects with:",
-                  "position": {
-                    "start": {
-                      "line": 4,
-                      "column": 1,
-                      "offset": 140
-                    },
-                    "end": {
-                      "line": 4,
-                      "column": 43,
-                      "offset": 182
-                    },
-                    "indent": []
-                  }
-                }
-              ],
-              "position": {
-                "start": {
-                  "line": 4,
-                  "column": 1,
-                  "offset": 140
-                },
-                "end": {
-                  "line": 4,
-                  "column": 43,
-                  "offset": 182
-                },
-                "indent": []
-              }
-            },
-            {
-              "type": "list",
-              "ordered": false,
-              "start": null,
-              "loose": false,
-              "children": [
-                {
-                  "type": "listItem",
-                  "loose": false,
-                  "checked": null,
-                  "children": [
-                    {
-                      "type": "paragraph",
-                      "children": [
-                        {
-                          "type": "text",
-                          "value": "a ",
-                          "position": {
-                            "start": {
-                              "line": 5,
-                              "column": 3,
-                              "offset": 185
-                            },
-                            "end": {
-                              "line": 5,
-                              "column": 5,
-                              "offset": 187
-                            },
-                            "indent": []
-                          }
-                        },
-                        {
-                          "type": "inlineCode",
-                          "value": "RemoteServiceError",
-                          "position": {
-                            "start": {
-                              "line": 5,
-                              "column": 5,
-                              "offset": 187
-                            },
-                            "end": {
-                              "line": 5,
-                              "column": 25,
-                              "offset": 207
-                            },
-                            "indent": []
-                          }
-                        },
-                        {
-                          "type": "text",
-                          "value": " if there is a problem\nwith the transaction broadcast service",
-                          "position": {
-                            "start": {
-                              "line": 5,
-                              "column": 25,
-                              "offset": 207
-                            },
-                            "end": {
-                              "line": 6,
-                              "column": 41,
-                              "offset": 270
-                            },
-                            "indent": [
-                              3
-                            ]
-                          }
-                        }
-                      ],
-                      "position": {
-                        "start": {
-                          "line": 5,
-                          "column": 3,
-                          "offset": 185
-                        },
-                        "end": {
-                          "line": 6,
-                          "column": 41,
-                          "offset": 270
-                        },
-                        "indent": [
-                          3
-                        ]
-                      }
-                    }
-                  ],
-                  "position": {
-                    "start": {
-                      "line": 5,
-                      "column": 1,
-                      "offset": 183
-                    },
-                    "end": {
-                      "line": 6,
-                      "column": 41,
-                      "offset": 270
-                    },
-                    "indent": [
-                      1
-                    ]
-                  }
-                },
-                {
-                  "type": "listItem",
-                  "loose": false,
-                  "checked": null,
-                  "children": [
-                    {
-                      "type": "paragraph",
-                      "children": [
-                        {
-                          "type": "inlineCode",
-                          "value": "MissingParameterError",
-                          "position": {
-                            "start": {
-                              "line": 7,
-                              "column": 3,
-                              "offset": 273
-                            },
-                            "end": {
-                              "line": 7,
-                              "column": 26,
-                              "offset": 296
-                            },
-                            "indent": []
-                          }
-                        },
-                        {
-                          "type": "text",
-                          "value": " if you call the function without a required\nparameter",
-                          "position": {
-                            "start": {
-                              "line": 7,
-                              "column": 26,
-                              "offset": 296
-                            },
-                            "end": {
-                              "line": 8,
-                              "column": 12,
-                              "offset": 352
-                            },
-                            "indent": [
-                              3
-                            ]
-                          }
-                        }
-                      ],
-                      "position": {
-                        "start": {
-                          "line": 7,
-                          "column": 3,
-                          "offset": 273
-                        },
-                        "end": {
-                          "line": 8,
-                          "column": 12,
-                          "offset": 352
-                        },
-                        "indent": [
-                          3
-                        ]
-                      }
-                    }
-                  ],
-                  "position": {
-                    "start": {
-                      "line": 7,
-                      "column": 1,
-                      "offset": 271
-                    },
-                    "end": {
-                      "line": 8,
-                      "column": 12,
-                      "offset": 352
-                    },
-                    "indent": [
-                      1
-                    ]
-                  }
-                }
-              ],
-              "position": {
-                "start": {
-                  "line": 5,
-                  "column": 1,
-                  "offset": 183
-                },
-                "end": {
-                  "line": 8,
-                  "column": 12,
-                  "offset": 352
-                },
-                "indent": [
-                  1,
-                  1,
                   1
                 ]
               }
@@ -10924,44 +8434,24 @@
               "offset": 0
             },
             "end": {
-              "line": 8,
-              "column": 12,
-              "offset": 352
+              "line": 2,
+              "column": 25,
+              "offset": 69
             }
           }
         },
         "title": "returns",
         "type": {
-          "type": "TypeApplication",
-          "expression": {
-            "type": "NameExpression",
-            "name": "Promise"
-          },
-          "applications": [
-            {
-              "type": "UnionType",
-              "elements": [
-                {
-                  "type": "NameExpression",
-                  "name": "Object"
-                },
-                {
-                  "type": "NameExpression",
-                  "name": "Error"
-                }
-              ]
-            }
-          ]
+          "type": "NameExpression",
+          "name": "Promise"
         }
       }
     ],
     "sees": [],
     "throws": [],
     "todos": [],
-    "name": "broadcastNameRegistration",
+    "name": "deleteFile",
     "kind": "function",
-    "memberof": "BlockstackNetwork",
-    "scope": "instance",
     "members": {
       "global": [],
       "inner": [],
@@ -10971,11 +8461,325 @@
     },
     "path": [
       {
-        "name": "broadcastNameRegistration",
-        "kind": "function",
-        "scope": "instance"
+        "name": "deleteFile",
+        "kind": "function"
       }
     ],
-    "namespace": "#broadcastNameRegistration"
+    "namespace": "deleteFile"
+  },
+  {
+    "description": {
+      "type": "root",
+      "children": [
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "Versioning",
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1,
+                  "offset": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 11,
+                  "offset": 10
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 11,
+              "offset": 10
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 1,
+          "column": 1,
+          "offset": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 11,
+          "offset": 10
+        }
+      }
+    },
+    "tags": [
+      {
+        "title": "param",
+        "description": "the left half of the version inequality",
+        "lineNumber": 2,
+        "type": {
+          "type": "NameExpression",
+          "name": "string"
+        },
+        "name": "v1"
+      },
+      {
+        "title": "param",
+        "description": "right half of the version inequality",
+        "lineNumber": 3,
+        "type": {
+          "type": "NameExpression",
+          "name": "string"
+        },
+        "name": "v2"
+      },
+      {
+        "title": "returns",
+        "description": "iff v1 >= v2",
+        "lineNumber": 4,
+        "type": {
+          "type": "NameExpression",
+          "name": "bool"
+        }
+      }
+    ],
+    "loc": {
+      "start": {
+        "line": 52,
+        "column": 0
+      },
+      "end": {
+        "line": 57,
+        "column": 3
+      }
+    },
+    "context": {
+      "loc": {
+        "start": {
+          "line": 58,
+          "column": 0
+        },
+        "end": {
+          "line": 71,
+          "column": 1
+        }
+      },
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/utils.js"
+    },
+    "augments": [],
+    "examples": [],
+    "params": [
+      {
+        "title": "param",
+        "name": "v1",
+        "lineNumber": 2,
+        "description": {
+          "type": "root",
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "the left half of the version inequality",
+                  "position": {
+                    "start": {
+                      "line": 1,
+                      "column": 1,
+                      "offset": 0
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 40,
+                      "offset": 39
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1,
+                  "offset": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 40,
+                  "offset": 39
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 40,
+              "offset": 39
+            }
+          }
+        },
+        "type": {
+          "type": "NameExpression",
+          "name": "string"
+        }
+      },
+      {
+        "title": "param",
+        "name": "v2",
+        "lineNumber": 3,
+        "description": {
+          "type": "root",
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "right half of the version inequality",
+                  "position": {
+                    "start": {
+                      "line": 1,
+                      "column": 1,
+                      "offset": 0
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 37,
+                      "offset": 36
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1,
+                  "offset": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 37,
+                  "offset": 36
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 37,
+              "offset": 36
+            }
+          }
+        },
+        "type": {
+          "type": "NameExpression",
+          "name": "string"
+        }
+      }
+    ],
+    "properties": [],
+    "returns": [
+      {
+        "description": {
+          "type": "root",
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "iff v1 >= v2",
+                  "position": {
+                    "start": {
+                      "line": 1,
+                      "column": 1,
+                      "offset": 0
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 13,
+                      "offset": 12
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1,
+                  "offset": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 13,
+                  "offset": 12
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 13,
+              "offset": 12
+            }
+          }
+        },
+        "title": "returns",
+        "type": {
+          "type": "NameExpression",
+          "name": "bool"
+        }
+      }
+    ],
+    "sees": [],
+    "throws": [],
+    "todos": [],
+    "name": "isLaterVersion",
+    "kind": "function",
+    "members": {
+      "global": [],
+      "inner": [],
+      "instance": [],
+      "events": [],
+      "static": []
+    },
+    "path": [
+      {
+        "name": "isLaterVersion",
+        "kind": "function"
+      }
+    ],
+    "namespace": "isLaterVersion"
   }
 ]

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset='utf-8' />
-  <title>blockstack 0.15.0 | Documentation</title>
+  <title>blockstack 0.15.1 | Documentation</title>
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <link href='assets/bass.css' type='text/css' rel='stylesheet' />
   <link href='assets/style.css' type='text/css' rel='stylesheet' />
@@ -14,7 +14,7 @@
       <div class='fixed xs-hide fix-3 overflow-auto max-height-100'>
         <div class='py1 px2'>
           <h3 class='mb0 no-anchor'>blockstack</h3>
-          <div class='mb1'><code>0.15.0</code></div>
+          <div class='mb1'><code>0.15.1</code></div>
           <input
             placeholder='Filter'
             id='filter-input'
@@ -125,6 +125,16 @@
               
                 
                 <li><a
+                  href='#verifyauthresponse'
+                  class="">
+                  verifyAuthResponse
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
                   href='#profiles'
                   class="h5 bold black caps">
                   Profiles
@@ -225,6 +235,16 @@
               
                 
                 <li><a
+                  href='#deletefile'
+                  class="">
+                  deleteFile
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
                   href='#getappbucketurl'
                   class="">
                   getAppBucketUrl
@@ -245,9 +265,9 @@
               
                 
                 <li><a
-                  href='#verifyauthresponse'
-                  class="">
-                  verifyAuthResponse
+                  href='#blockchain'
+                  class="h5 bold black caps">
+                  Blockchain
                   
                 </a>
                 
@@ -255,9 +275,9 @@
               
                 
                 <li><a
-                  href='#deletefile'
+                  href='#broadcasttransaction'
                   class="">
-                  deleteFile
+                  broadcastTransaction
                   
                 </a>
                 
@@ -265,9 +285,19 @@
               
                 
                 <li><a
-                  href='#islaterversion'
+                  href='#broadcastzonefile'
                   class="">
-                  isLaterVersion
+                  broadcastZoneFile
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#broadcastnameregistration'
+                  class="">
+                  broadcastNameRegistration
                   
                 </a>
                 
@@ -977,6 +1007,85 @@ protocol handler is not detected
           
         
           
+            <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='verifyauthresponse'>
+      verifyAuthResponse
+    </h3>
+    
+    
+  </div>
+  
+
+  <p>Verify the authentication response is valid</p>
+
+
+  <div class='pre p1 fill-light mt0'>verifyAuthResponse(token: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>, nameLookupURL: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>token</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)</code>
+	    the authentication response token
+
+          </div>
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>nameLookupURL</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)</code>
+	    the url use to verify owner of a username
+
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
+        that resolves to true if auth response
+is valid and false if it does not
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
             <div class='keyline-top-not py2'><section class='py2 clearfix'>
 
   <h2 id='profiles' class='mt0'>
@@ -1502,7 +1611,7 @@ Facebook, Twitter, GitHub, Instagram, LinkedIn and HackerNews accounts.</p>
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>zoneFileLookupURL</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
-            = <code>http://localhost:6270/v1/names/</code>)</code>
+            = <code>https://core.blockstack.org/v1/names/</code>)</code>
 	    The URL
 to use for zonefile lookup
 
@@ -1809,6 +1918,76 @@ if it failed
   
   <div class='clearfix'>
     
+    <h3 class='fl m0' id='deletefile'>
+      deleteFile
+    </h3>
+    
+    
+  </div>
+  
+
+  <p>Deletes the specified file from the app's data store.</p>
+
+
+  <div class='pre p1 fill-light mt0'>deleteFile(path: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>path</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)</code>
+	    the path to the file to delete
+
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
+        that resolves when the file has been removed
+or rejects with an error
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+            <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
     <h3 class='fl m0' id='getappbucketurl'>
       getAppBucketUrl
     </h3>
@@ -1982,23 +2161,39 @@ or rejects with an error
           
         
           
+            <div class='keyline-top-not py2'><section class='py2 clearfix'>
+
+  <h2 id='blockchain' class='mt0'>
+    Blockchain
+  </h2>
+
+  
+    <p>Generate and broadcast Blockstack blockchain transactions.</p>
+
+  
+</section>
+</div>
+          
+        
+          
             <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
     
-    <h3 class='fl m0' id='verifyauthresponse'>
-      verifyAuthResponse
+    <h3 class='fl m0' id='broadcasttransaction'>
+      broadcastTransaction
     </h3>
     
     
   </div>
   
 
-  <p>Verify the authentication response is valid</p>
+  <p>Broadcasts a signed bitcoin transaction to the network optionally waiting to broadcast the
+transaction until a second transaction has a certain number of confirmations.</p>
 
 
-  <div class='pre p1 fill-light mt0'>verifyAuthResponse(token: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>, nameLookupURL: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
+  <div class='pre p1 fill-light mt0'>broadcastTransaction(transaction: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, transactionToWatch: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, confirmations: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error">Error</a>)></div>
   
   
 
@@ -2015,8 +2210,8 @@ or rejects with an error
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>token</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)</code>
-	    the authentication response token
+            <span class='code bold'>transaction</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+	    the hex-encoded transaction to broadcast
 
           </div>
           
@@ -2024,8 +2219,26 @@ or rejects with an error
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>nameLookupURL</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)</code>
-	    the url use to verify owner of a username
+            <span class='code bold'>transactionToWatch</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
+            = <code>null</code>)</code>
+	    the hex transaction id of the transaction to watch for
+the specified number of confirmations before broadcasting the 
+<code>transaction</code>
+
+          </div>
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>confirmations</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>
+            = <code>6</code>)</code>
+	    the number of confirmations 
+<code>transactionToWatch</code>
+ must have
+before broadcasting 
+<code>transaction</code>
+.
 
           </div>
           
@@ -2039,9 +2252,18 @@ or rejects with an error
   
     
       <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
-        that resolves to true if auth response
-is valid and false if it does not
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error">Error</a>)></code>:
+        Returns a Promise that resolves to an object with a
+
+<code>transaction_hash</code>
+ key containing the transaction hash of the broadcasted transaction.
+<p>In the event of an error, it rejects with:</p>
+<ul>
+<li>a <code>RemoteServiceError</code> if there is a problem
+with the transaction broadcast service</li>
+<li><code>MissingParameterError</code> if you call the function without a required
+parameter</li>
+</ul>
 
       
     
@@ -2066,18 +2288,18 @@ is valid and false if it does not
   
   <div class='clearfix'>
     
-    <h3 class='fl m0' id='deletefile'>
-      deleteFile
+    <h3 class='fl m0' id='broadcastzonefile'>
+      broadcastZoneFile
     </h3>
     
     
   </div>
   
 
-  <p>Deletes the specified file from the app's data store.</p>
+  <p>Broadcasts a zone file to the Atlas network via the transaction broadcast service.</p>
 
 
-  <div class='pre p1 fill-light mt0'>deleteFile(path: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
+  <div class='pre p1 fill-light mt0'>broadcastZoneFile(zoneFile: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>, transactionToWatch: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error">Error</a>)></div>
   
   
 
@@ -2094,8 +2316,19 @@ is valid and false if it does not
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>path</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)</code>
-	    the path to the file to delete
+            <span class='code bold'>zoneFile</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)</code>
+	    the zone file to be broadcast to the Atlas network
+
+          </div>
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>transactionToWatch</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>
+            = <code>null</code>)</code>
+	    the hex transaction id of the transaction
+to watch for confirmation before broadcasting the zone file to the Atlas network
 
           </div>
           
@@ -2109,9 +2342,18 @@ is valid and false if it does not
   
     
       <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
-        that resolves when the file has been removed
-or rejects with an error
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error">Error</a>)></code>:
+        Returns a Promise that resolves to an object with a
+
+<code>transaction_hash</code>
+ key containing the transaction hash of the broadcasted transaction.
+<p>In the event of an error, it rejects with:</p>
+<ul>
+<li>a <code>RemoteServiceError</code> if there is a problem
+with the transaction broadcast service</li>
+<li><code>MissingParameterError</code> if you call the function without a required
+parameter</li>
+</ul>
 
       
     
@@ -2136,18 +2378,28 @@ or rejects with an error
   
   <div class='clearfix'>
     
-    <h3 class='fl m0' id='islaterversion'>
-      isLaterVersion
+    <h3 class='fl m0' id='broadcastnameregistration'>
+      broadcastNameRegistration
     </h3>
     
     
   </div>
   
 
-  <p>Versioning</p>
+  <p>Sends the preorder and registration transactions and zone file
+for a Blockstack name registration
+along with the to the transaction broadcast service.</p>
+<p>The transaction broadcast:</p>
+<ul>
+<li>immediately broadcasts the preorder transaction</li>
+<li>broadcasts the register transactions after the preorder transaction
+has an appropriate number of confirmations</li>
+<li>broadcasts the zone file to the Atlas network after the register transaction
+has an appropriate number of confirmations</li>
+</ul>
 
 
-  <div class='pre p1 fill-light mt0'>isLaterVersion(v1: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, v2: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): bool</div>
+  <div class='pre p1 fill-light mt0'>broadcastNameRegistration(preorderTransaction: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>, registerTransaction: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>, zoneFile: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error">Error</a>)></div>
   
   
 
@@ -2164,8 +2416,11 @@ or rejects with an error
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>v1</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-	    the left half of the version inequality
+            <span class='code bold'>preorderTransaction</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)</code>
+	    the hex-encoded, signed preorder transaction generated
+using the 
+<code>makePreorder</code>
+ function
 
           </div>
           
@@ -2173,8 +2428,20 @@ or rejects with an error
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>v2</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-	    right half of the version inequality
+            <span class='code bold'>registerTransaction</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)</code>
+	    the hex-encoded, signed register transaction generated
+using the 
+<code>makeRegister</code>
+ function
+
+          </div>
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>zoneFile</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)</code>
+	    the zone file to be broadcast to the Atlas network
 
           </div>
           
@@ -2188,8 +2455,18 @@ or rejects with an error
   
     
       <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code>bool</code>:
-        iff v1 >= v2
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error">Error</a>)></code>:
+        Returns a Promise that resolves to an object with a
+
+<code>transaction_hash</code>
+ key containing the transaction hash of the broadcasted transaction.
+<p>In the event of an error, it rejects with:</p>
+<ul>
+<li>a <code>RemoteServiceError</code> if there is a problem
+with the transaction broadcast service</li>
+<li><code>MissingParameterError</code> if you call the function without a required
+parameter</li>
+</ul>
 
       
     

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset='utf-8' />
-  <title>blockstack 0.15.1 | Documentation</title>
+  <title>blockstack 0.15.0 | Documentation</title>
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <link href='assets/bass.css' type='text/css' rel='stylesheet' />
   <link href='assets/style.css' type='text/css' rel='stylesheet' />
@@ -14,7 +14,7 @@
       <div class='fixed xs-hide fix-3 overflow-auto max-height-100'>
         <div class='py1 px2'>
           <h3 class='mb0 no-anchor'>blockstack</h3>
-          <div class='mb1'><code>0.15.1</code></div>
+          <div class='mb1'><code>0.15.0</code></div>
           <input
             placeholder='Filter'
             id='filter-input'
@@ -125,16 +125,6 @@
               
                 
                 <li><a
-                  href='#verifyauthresponse'
-                  class="">
-                  verifyAuthResponse
-                  
-                </a>
-                
-                </li>
-              
-                
-                <li><a
                   href='#profiles'
                   class="h5 bold black caps">
                   Profiles
@@ -215,16 +205,6 @@
               
                 
                 <li><a
-                  href='#deletefile'
-                  class="">
-                  deleteFile
-                  
-                </a>
-                
-                </li>
-              
-                
-                <li><a
                   href='#getfile'
                   class="">
                   getFile
@@ -265,9 +245,9 @@
               
                 
                 <li><a
-                  href='#blockchain'
-                  class="h5 bold black caps">
-                  Blockchain
+                  href='#verifyauthresponse'
+                  class="">
+                  verifyAuthResponse
                   
                 </a>
                 
@@ -275,9 +255,9 @@
               
                 
                 <li><a
-                  href='#broadcasttransaction'
+                  href='#deletefile'
                   class="">
-                  broadcastTransaction
+                  deleteFile
                   
                 </a>
                 
@@ -285,19 +265,9 @@
               
                 
                 <li><a
-                  href='#broadcastzonefile'
+                  href='#islaterversion'
                   class="">
-                  broadcastZoneFile
-                  
-                </a>
-                
-                </li>
-              
-                
-                <li><a
-                  href='#broadcastnameregistration'
-                  class="">
-                  broadcastNameRegistration
+                  isLaterVersion
                   
                 </a>
                 
@@ -1007,85 +977,6 @@ protocol handler is not detected
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    <h3 class='fl m0' id='verifyauthresponse'>
-      verifyAuthResponse
-    </h3>
-    
-    
-  </div>
-  
-
-  <p>Verify the authentication response is valid</p>
-
-
-  <div class='pre p1 fill-light mt0'>verifyAuthResponse(token: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>, nameLookupURL: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Parameters</div>
-    <div class='prose'>
-      
-        <div class='space-bottom0'>
-          <div>
-            <span class='code bold'>token</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)</code>
-	    the authentication response token
-
-          </div>
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <div>
-            <span class='code bold'>nameLookupURL</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)</code>
-	    the url use to verify owner of a username
-
-          </div>
-          
-        </div>
-      
-    </div>
-  
-
-  
-
-  
-    
-      <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
-        that resolves to true if auth response
-is valid and false if it does not
-
-      
-    
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-          
-        
-          
             <div class='keyline-top-not py2'><section class='py2 clearfix'>
 
   <h2 id='profiles' class='mt0'>
@@ -1611,7 +1502,7 @@ Facebook, Twitter, GitHub, Instagram, LinkedIn and HackerNews accounts.</p>
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>zoneFileLookupURL</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
-            = <code>https://core.blockstack.org/v1/names/</code>)</code>
+            = <code>http://localhost:6270/v1/names/</code>)</code>
 	    The URL
 to use for zonefile lookup
 
@@ -1666,76 +1557,6 @@ version. These features will be rolled out in future updates.</em></p>
   
 </section>
 </div>
-          
-        
-          
-            <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    <h3 class='fl m0' id='deletefile'>
-      deleteFile
-    </h3>
-    
-    
-  </div>
-  
-
-  <p>Deletes the specified file from the app's data store.</p>
-
-
-  <div class='pre p1 fill-light mt0'>deleteFile(path: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Parameters</div>
-    <div class='prose'>
-      
-        <div class='space-bottom0'>
-          <div>
-            <span class='code bold'>path</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)</code>
-	    the path to the file to delete
-
-          </div>
-          
-        </div>
-      
-    </div>
-  
-
-  
-
-  
-    
-      <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
-        that resolves when the file has been removed
-or rejects with an error
-
-      
-    
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
           
         
           
@@ -2161,39 +1982,23 @@ or rejects with an error
           
         
           
-            <div class='keyline-top-not py2'><section class='py2 clearfix'>
-
-  <h2 id='blockchain' class='mt0'>
-    Blockchain
-  </h2>
-
-  
-    <p>Generate and broadcast Blockstack blockchain transactions.</p>
-
-  
-</section>
-</div>
-          
-        
-          
             <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
     
-    <h3 class='fl m0' id='broadcasttransaction'>
-      broadcastTransaction
+    <h3 class='fl m0' id='verifyauthresponse'>
+      verifyAuthResponse
     </h3>
     
     
   </div>
   
 
-  <p>Broadcasts a signed bitcoin transaction to the network optionally waiting to broadcast the
-transaction until a second transaction has a certain number of confirmations.</p>
+  <p>Verify the authentication response is valid</p>
 
 
-  <div class='pre p1 fill-light mt0'>broadcastTransaction(transaction: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, transactionToWatch: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, confirmations: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error">Error</a>)></div>
+  <div class='pre p1 fill-light mt0'>verifyAuthResponse(token: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>, nameLookupURL: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
   
   
 
@@ -2210,8 +2015,8 @@ transaction until a second transaction has a certain number of confirmations.</p
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>transaction</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-	    the hex-encoded transaction to broadcast
+            <span class='code bold'>token</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)</code>
+	    the authentication response token
 
           </div>
           
@@ -2219,26 +2024,8 @@ transaction until a second transaction has a certain number of confirmations.</p
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>transactionToWatch</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
-            = <code>null</code>)</code>
-	    the hex transaction id of the transaction to watch for
-the specified number of confirmations before broadcasting the 
-<code>transaction</code>
-
-          </div>
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <div>
-            <span class='code bold'>confirmations</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>
-            = <code>6</code>)</code>
-	    the number of confirmations 
-<code>transactionToWatch</code>
- must have
-before broadcasting 
-<code>transaction</code>
-.
+            <span class='code bold'>nameLookupURL</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)</code>
+	    the url use to verify owner of a username
 
           </div>
           
@@ -2252,18 +2039,9 @@ before broadcasting
   
     
       <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error">Error</a>)></code>:
-        Returns a Promise that resolves to an object with a
-
-<code>transaction_hash</code>
- key containing the transaction hash of the broadcasted transaction.
-<p>In the event of an error, it rejects with:</p>
-<ul>
-<li>a <code>RemoteServiceError</code> if there is a problem
-with the transaction broadcast service</li>
-<li><code>MissingParameterError</code> if you call the function without a required
-parameter</li>
-</ul>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
+        that resolves to true if auth response
+is valid and false if it does not
 
       
     
@@ -2288,18 +2066,18 @@ parameter</li>
   
   <div class='clearfix'>
     
-    <h3 class='fl m0' id='broadcastzonefile'>
-      broadcastZoneFile
+    <h3 class='fl m0' id='deletefile'>
+      deleteFile
     </h3>
     
     
   </div>
   
 
-  <p>Broadcasts a zone file to the Atlas network via the transaction broadcast service.</p>
+  <p>Deletes the specified file from the app's data store.</p>
 
 
-  <div class='pre p1 fill-light mt0'>broadcastZoneFile(zoneFile: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>, transactionToWatch: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error">Error</a>)></div>
+  <div class='pre p1 fill-light mt0'>deleteFile(path: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
   
   
 
@@ -2316,19 +2094,8 @@ parameter</li>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>zoneFile</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)</code>
-	    the zone file to be broadcast to the Atlas network
-
-          </div>
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <div>
-            <span class='code bold'>transactionToWatch</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>
-            = <code>null</code>)</code>
-	    the hex transaction id of the transaction
-to watch for confirmation before broadcasting the zone file to the Atlas network
+            <span class='code bold'>path</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)</code>
+	    the path to the file to delete
 
           </div>
           
@@ -2342,18 +2109,9 @@ to watch for confirmation before broadcasting the zone file to the Atlas network
   
     
       <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error">Error</a>)></code>:
-        Returns a Promise that resolves to an object with a
-
-<code>transaction_hash</code>
- key containing the transaction hash of the broadcasted transaction.
-<p>In the event of an error, it rejects with:</p>
-<ul>
-<li>a <code>RemoteServiceError</code> if there is a problem
-with the transaction broadcast service</li>
-<li><code>MissingParameterError</code> if you call the function without a required
-parameter</li>
-</ul>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
+        that resolves when the file has been removed
+or rejects with an error
 
       
     
@@ -2378,28 +2136,18 @@ parameter</li>
   
   <div class='clearfix'>
     
-    <h3 class='fl m0' id='broadcastnameregistration'>
-      broadcastNameRegistration
+    <h3 class='fl m0' id='islaterversion'>
+      isLaterVersion
     </h3>
     
     
   </div>
   
 
-  <p>Sends the preorder and registration transactions and zone file
-for a Blockstack name registration
-along with the to the transaction broadcast service.</p>
-<p>The transaction broadcast:</p>
-<ul>
-<li>immediately broadcasts the preorder transaction</li>
-<li>broadcasts the register transactions after the preorder transaction
-has an appropriate number of confirmations</li>
-<li>broadcasts the zone file to the Atlas network after the register transaction
-has an appropriate number of confirmations</li>
-</ul>
+  <p>Versioning</p>
 
 
-  <div class='pre p1 fill-light mt0'>broadcastNameRegistration(preorderTransaction: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>, registerTransaction: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>, zoneFile: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error">Error</a>)></div>
+  <div class='pre p1 fill-light mt0'>isLaterVersion(v1: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, v2: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): bool</div>
   
   
 
@@ -2416,11 +2164,8 @@ has an appropriate number of confirmations</li>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>preorderTransaction</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)</code>
-	    the hex-encoded, signed preorder transaction generated
-using the 
-<code>makePreorder</code>
- function
+            <span class='code bold'>v1</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+	    the left half of the version inequality
 
           </div>
           
@@ -2428,20 +2173,8 @@ using the
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>registerTransaction</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)</code>
-	    the hex-encoded, signed register transaction generated
-using the 
-<code>makeRegister</code>
- function
-
-          </div>
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <div>
-            <span class='code bold'>zoneFile</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)</code>
-	    the zone file to be broadcast to the Atlas network
+            <span class='code bold'>v2</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+	    right half of the version inequality
 
           </div>
           
@@ -2455,18 +2188,8 @@ using the
   
     
       <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error">Error</a>)></code>:
-        Returns a Promise that resolves to an object with a
-
-<code>transaction_hash</code>
- key containing the transaction hash of the broadcasted transaction.
-<p>In the event of an error, it rejects with:</p>
-<ul>
-<li>a <code>RemoteServiceError</code> if there is a problem
-with the transaction broadcast service</li>
-<li><code>MissingParameterError</code> if you call the function without a required
-parameter</li>
-</ul>
+      <code>bool</code>:
+        iff v1 >= v2
 
       
     

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,9 @@
 {
   "name": "blockstack",
-  "version": "0.15.1",
+  "version": "0.15.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "JSONStream": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
-      "dev": true,
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
-    },
     "accepts": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
@@ -60,7 +50,7 @@
     "anymatch": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+      "integrity": "sha1-VT3Lj5HjyImEXf26NMd3IbkLnXo=",
       "dev": true,
       "requires": {
         "micromatch": "2.3.11",
@@ -119,7 +109,7 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
       "dev": true
     },
     "arr-union": {
@@ -160,12 +150,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-    },
-    "assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true
     },
     "async-each": {
       "version": "1.0.1",
@@ -1355,6 +1339,15 @@
                     }
                   }
                 },
+                "string_decoder": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+                  "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+                  "dev": true,
+                  "requires": {
+                    "safe-buffer": "5.0.1"
+                  }
+                },
                 "string-width": {
                   "version": "1.0.2",
                   "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -1364,15 +1357,6 @@
                     "code-point-at": "1.1.0",
                     "is-fullwidth-code-point": "1.0.0",
                     "strip-ansi": "3.0.1"
-                  }
-                },
-                "string_decoder": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-                  "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
-                  "dev": true,
-                  "requires": {
-                    "safe-buffer": "5.0.1"
                   }
                 },
                 "stringstream": {
@@ -1635,7 +1619,7 @@
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -1894,7 +1878,7 @@
         "minimatch": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
           "dev": true,
           "requires": {
             "brace-expansion": "1.1.8"
@@ -2547,30 +2531,6 @@
         "esutils": "2.0.2"
       }
     },
-    "babel-helper-call-delegate": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
-      "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
-      "dev": true,
-      "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-helper-define-map": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
-      "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
-      "dev": true,
-      "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.4"
-      }
-    },
     "babel-helper-explode-assignable-expression": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
@@ -2617,37 +2577,6 @@
         "babel-types": "6.26.0"
       }
     },
-    "babel-helper-hoist-variables": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
-      "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-helper-optimise-call-expression": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
-      "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-helper-regex": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
-      "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.4"
-      }
-    },
     "babel-helper-remap-async-to-generator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
@@ -2655,20 +2584,6 @@
       "dev": true,
       "requires": {
         "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-helper-replace-supers": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
-      "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
-      "dev": true,
-      "requires": {
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-messages": "6.23.0",
         "babel-runtime": "6.26.0",
         "babel-template": "6.26.0",
         "babel-traverse": "6.26.0",
@@ -2689,15 +2604,6 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-check-es2015-constants": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
-      "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
       "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
@@ -2875,240 +2781,6 @@
         "babel-runtime": "6.26.0"
       }
     },
-    "babel-plugin-transform-es2015-arrow-functions": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
-      "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-block-scoped-functions": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
-      "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-block-scoping": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
-      "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.4"
-      }
-    },
-    "babel-plugin-transform-es2015-classes": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
-      "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
-      "dev": true,
-      "requires": {
-        "babel-helper-define-map": "6.26.0",
-        "babel-helper-function-name": "6.24.1",
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-computed-properties": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
-      "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-destructuring": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
-      "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-duplicate-keys": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
-      "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-for-of": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
-      "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-function-name": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
-      "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
-      "dev": true,
-      "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-literals": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
-      "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-modules-amd": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
-      "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-modules-commonjs": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
-      "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-transform-strict-mode": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-modules-systemjs": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
-      "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
-      "dev": true,
-      "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-modules-umd": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
-      "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-object-super": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
-      "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
-      "dev": true,
-      "requires": {
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-parameters": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
-      "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-      "dev": true,
-      "requires": {
-        "babel-helper-call-delegate": "6.24.1",
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-shorthand-properties": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
-      "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-spread": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
-      "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-sticky-regex": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
-      "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-      "dev": true,
-      "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-template-literals": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
-      "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-typeof-symbol": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
-      "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-unicode-regex": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
-      "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-      "dev": true,
-      "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "regexpu-core": "2.0.0"
-      }
-    },
     "babel-plugin-transform-exponentiation-operator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
@@ -3200,25 +2872,6 @@
         "babel-runtime": "6.26.0"
       }
     },
-    "babel-plugin-transform-regenerator": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
-      "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
-      "dev": true,
-      "requires": {
-        "regenerator-transform": "0.10.1"
-      }
-    },
-    "babel-plugin-transform-strict-mode": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
-      "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
     "babel-polyfill": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
@@ -3260,44 +2913,6 @@
           "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
           "dev": true
         }
-      }
-    },
-    "babel-preset-env": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
-      "integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
-      "dev": true,
-      "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-        "babel-plugin-transform-async-to-generator": "6.24.1",
-        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-        "babel-plugin-transform-es2015-classes": "6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-        "babel-plugin-transform-es2015-for-of": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-literals": "6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-        "babel-plugin-transform-es2015-object-super": "6.24.1",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-        "babel-plugin-transform-exponentiation-operator": "6.24.1",
-        "babel-plugin-transform-regenerator": "6.26.0",
-        "browserslist": "2.11.3",
-        "invariant": "2.2.2",
-        "semver": "5.4.1"
       }
     },
     "babel-preset-es2015": {
@@ -4101,7 +3716,7 @@
     "babylon": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+      "integrity": "sha1-ry87iPpvXB5MY00aD46sT1WzleM=",
       "dev": true
     },
     "bail": {
@@ -4418,7 +4033,6 @@
       "integrity": "sha1-tanJAgJD8McORnW+yCI7xifkFc4=",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.1",
         "assert": "1.4.1",
         "browser-pack": "6.0.2",
         "browser-resolve": "1.11.2",
@@ -4440,6 +4054,7 @@
         "https-browserify": "0.0.1",
         "inherits": "2.0.3",
         "insert-module-globals": "7.0.1",
+        "JSONStream": "1.3.1",
         "labeled-stream-splicer": "2.0.0",
         "module-deps": "4.1.1",
         "os-browserify": "0.1.2",
@@ -4467,16 +4082,6 @@
         "xtend": "4.0.1"
       },
       "dependencies": {
-        "JSONStream": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-          "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
-          "dev": true,
-          "requires": {
-            "jsonparse": "1.3.1",
-            "through": "2.3.8"
-          }
-        },
         "acorn": {
           "version": "4.0.13",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
@@ -4570,9 +4175,9 @@
           "integrity": "sha1-+GzWzvT1MAyOY+B6TVEvZfv/RTE=",
           "dev": true,
           "requires": {
-            "JSONStream": "1.3.1",
             "combine-source-map": "0.7.2",
             "defined": "1.0.0",
+            "JSONStream": "1.3.1",
             "through2": "2.0.3",
             "umd": "3.0.1"
           }
@@ -4930,7 +4535,7 @@
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -5005,10 +4610,10 @@
           "integrity": "sha1-wDv04BywhtW15azorQr+eInWOMM=",
           "dev": true,
           "requires": {
-            "JSONStream": "1.3.1",
             "combine-source-map": "0.7.2",
             "concat-stream": "1.5.2",
             "is-buffer": "1.1.5",
+            "JSONStream": "1.3.1",
             "lexical-scope": "1.2.0",
             "process": "0.11.10",
             "through2": "2.0.3",
@@ -5047,6 +4652,16 @@
           "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
           "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
           "dev": true
+        },
+        "JSONStream": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+          "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+          "dev": true,
+          "requires": {
+            "jsonparse": "1.3.1",
+            "through": "2.3.8"
+          }
         },
         "labeled-stream-splicer": {
           "version": "2.0.0",
@@ -5101,7 +4716,7 @@
         "minimatch": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
           "dev": true,
           "requires": {
             "brace-expansion": "1.1.8"
@@ -5119,7 +4734,6 @@
           "integrity": "sha1-IyFYM/HaE/1gbMuAh7RIUty4If0=",
           "dev": true,
           "requires": {
-            "JSONStream": "1.3.1",
             "browser-resolve": "1.11.2",
             "cached-path-relative": "1.0.1",
             "concat-stream": "1.5.2",
@@ -5127,6 +4741,7 @@
             "detective": "4.5.0",
             "duplexer2": "0.1.4",
             "inherits": "2.0.3",
+            "JSONStream": "1.3.1",
             "parents": "1.0.1",
             "readable-stream": "2.3.3",
             "resolve": "1.4.0",
@@ -5534,16 +5149,6 @@
         }
       }
     },
-    "browserslist": {
-      "version": "2.11.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
-      "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
-      "dev": true,
-      "requires": {
-        "caniuse-lite": "1.0.30000792",
-        "electron-to-chromium": "1.3.32"
-      }
-    },
     "buffer-shims": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
@@ -5593,12 +5198,6 @@
       "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
       "dev": true
     },
-    "caniuse-lite": {
-      "version": "1.0.30000792",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000792.tgz",
-      "integrity": "sha1-0M6pgfgRjzlhRxr7tDyaHlu/AzI=",
-      "dev": true
-    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -5609,25 +5208,6 @@
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.2.tgz",
       "integrity": "sha1-U7ai+BW7d7nChx97mnLDol8djok=",
       "dev": true
-    },
-    "chai": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
-      "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
-      "dev": true,
-      "requires": {
-        "assertion-error": "1.1.0",
-        "deep-eql": "0.1.3",
-        "type-detect": "1.0.0"
-      },
-      "dependencies": {
-        "type-detect": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
-          "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
-          "dev": true
-        }
-      }
     },
     "chalk": {
       "version": "2.3.0",
@@ -5873,7 +5453,7 @@
     "commander": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "integrity": "sha1-FXFS/R56bI2YpbcVzzdt+SgARWM=",
       "dev": true
     },
     "component-emitter": {
@@ -5995,7 +5575,7 @@
     "custom-protocol-detection-blockstack": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/custom-protocol-detection-blockstack/-/custom-protocol-detection-blockstack-1.1.3.tgz",
-      "integrity": "sha512-iGwXqKU60VAzfjLF/amcJKQYMLeMlXAlzkZttakOQA7IjZw2WFSYAmn9a13d0LOBTzdVpbHnF+zZArNC9csiZw=="
+      "integrity": "sha1-6oR/0Kgbd5XXn3JJUCoa1p25Nlg="
     },
     "dashdash": {
       "version": "1.14.1",
@@ -6025,23 +5605,6 @@
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
-    },
-    "deep-eql": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
-      "dev": true,
-      "requires": {
-        "type-detect": "0.1.1"
-      },
-      "dependencies": {
-        "type-detect": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-          "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
-          "dev": true
-        }
-      }
     },
     "deep-equal": {
       "version": "0.2.2",
@@ -6083,7 +5646,7 @@
     "detab": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/detab/-/detab-2.0.1.tgz",
-      "integrity": "sha512-/hhdqdQc5thGrqzjyO/pz76lDZ5GSuAs6goxOaKTsvPk7HNnzAyFN5lyHgqpX4/s1i66K8qMGj+VhA9504x7DQ==",
+      "integrity": "sha1-Ux9eMmYg4v1PAyZKkF+zvMivTfQ=",
       "dev": true,
       "requires": {
         "repeat-string": "1.6.1"
@@ -6197,13 +5760,13 @@
           "integrity": "sha1-ElGkuixEqS32mJvQKdoSGk8hCbA=",
           "dev": true,
           "requires": {
-            "JSONStream": "1.3.1",
             "browser-resolve": "1.11.2",
             "concat-stream": "1.5.2",
             "defined": "1.0.0",
             "detective": "4.5.0",
             "duplexer2": "0.1.4",
             "inherits": "2.0.3",
+            "JSONStream": "1.3.1",
             "parents": "1.0.1",
             "readable-stream": "2.3.3",
             "resolve": "1.5.0",
@@ -6306,7 +5869,7 @@
     "duplexify": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.1.tgz",
-      "integrity": "sha512-j5goxHTwVED1Fpe5hh3q9R93Kip0Bg2KVAt4f8CEYM3UEwYcPSvWbXaUQOzdX/HtiNomipv+gU7ASQPDbV7pGQ==",
+      "integrity": "sha1-ThUWvmiDi8kKSZlPCzmm5ZYL780=",
       "dev": true,
       "requires": {
         "end-of-stream": "1.4.0",
@@ -6337,12 +5900,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
-      "dev": true
-    },
-    "electron-to-chromium": {
-      "version": "1.3.32",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.32.tgz",
-      "integrity": "sha1-EdBoTAhA4APEvoko+KxfNdvCtOY=",
       "dev": true
     },
     "elliptic": {
@@ -6932,7 +6489,7 @@
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -7143,7 +6700,7 @@
         "minimatch": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
           "dev": true,
           "requires": {
             "brace-expansion": "1.1.8"
@@ -7374,6 +6931,15 @@
           "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
           "dev": true
         },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -7383,15 +6949,6 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
           }
         },
         "strip-ansi": {
@@ -7785,7 +7342,7 @@
         "minimatch": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
           "dev": true,
           "requires": {
             "brace-expansion": "1.1.8"
@@ -7930,7 +7487,7 @@
     "esprima": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+      "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ=",
       "dev": true
     },
     "esutils": {
@@ -9081,6 +8638,15 @@
             }
           }
         },
+        "string_decoder": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -9090,15 +8656,6 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -9467,7 +9024,7 @@
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo=",
       "dev": true
     },
     "globals-docs": {
@@ -10391,6 +9948,16 @@
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
     },
+    "JSONStream": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+      "dev": true,
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
+    },
     "jsontokens": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-0.7.6.tgz",
@@ -10669,9 +10236,9 @@
       "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0="
     },
     "lolex": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.2.tgz",
-      "integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.1.tgz",
+      "integrity": "sha512-mQuW55GhduF3ppo+ZRUTz1PRjEh1hS5BbqU7d8D0ez2OKxHDod7StPPeAVKisZR5aLkHZjdGWSL42LSONUJsZw==",
       "dev": true
     },
     "longest-streak": {
@@ -11144,9 +10711,9 @@
       "dev": true
     },
     "nise": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.2.2.tgz",
-      "integrity": "sha512-rvxf+PSZeCKtP0DgmwMmNf1G3I6X1r4WHiP2H88PlIkOkt7mGqufdokjS8caoHBgZzVx0ee/5ytGcGHbZaUw8w==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.2.0.tgz",
+      "integrity": "sha512-q9jXh3UNsMV28KeqI43ILz5+c3l+RiNW8mhurEwCKckuHQbL+hTJIKKTiUlCPKlgQ/OukFvSnKB/Jk3+sFbkGA==",
       "dev": true,
       "requires": {
         "formatio": "1.2.0",
@@ -11176,31 +10743,6 @@
           "requires": {
             "isarray": "0.0.1"
           }
-        }
-      }
-    },
-    "nock": {
-      "version": "9.1.6",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-9.1.6.tgz",
-      "integrity": "sha512-DuKF+1W/FnMO6MXIGgCIWcM95bETjBbmFdR4v7dAj1zH9a9XhOjAa//PuWh98XIXxcZt7wdiv0JlO0AA0e2kqQ==",
-      "dev": true,
-      "requires": {
-        "chai": "3.5.0",
-        "debug": "2.6.9",
-        "deep-equal": "1.0.1",
-        "json-stringify-safe": "5.0.1",
-        "lodash": "4.17.4",
-        "mkdirp": "0.5.1",
-        "propagate": "0.4.0",
-        "qs": "6.5.1",
-        "semver": "5.4.1"
-      },
-      "dependencies": {
-        "deep-equal": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-          "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
-          "dev": true
         }
       }
     },
@@ -11277,1807 +10819,6 @@
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
-    },
-    "nyc": {
-      "version": "11.4.1",
-      "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.4.1.tgz",
-      "integrity": "sha512-5eCZpvaksFVjP2rt1r60cfXmt3MUtsQDw8bAzNqNEr4WLvUMLgiVENMf/B9bE9YAX0mGVvaGA3v9IS9ekNqB1Q==",
-      "dev": true,
-      "requires": {
-        "archy": "1.0.0",
-        "arrify": "1.0.1",
-        "caching-transform": "1.0.1",
-        "convert-source-map": "1.5.1",
-        "debug-log": "1.0.1",
-        "default-require-extensions": "1.0.0",
-        "find-cache-dir": "0.1.1",
-        "find-up": "2.1.0",
-        "foreground-child": "1.5.6",
-        "glob": "7.1.2",
-        "istanbul-lib-coverage": "1.1.1",
-        "istanbul-lib-hook": "1.1.0",
-        "istanbul-lib-instrument": "1.9.1",
-        "istanbul-lib-report": "1.1.2",
-        "istanbul-lib-source-maps": "1.2.2",
-        "istanbul-reports": "1.1.3",
-        "md5-hex": "1.3.0",
-        "merge-source-map": "1.0.4",
-        "micromatch": "2.3.11",
-        "mkdirp": "0.5.1",
-        "resolve-from": "2.0.0",
-        "rimraf": "2.6.2",
-        "signal-exit": "3.0.2",
-        "spawn-wrap": "1.4.2",
-        "test-exclude": "4.1.1",
-        "yargs": "10.0.3",
-        "yargs-parser": "8.0.0"
-      },
-      "dependencies": {
-        "align-text": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-          "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2",
-            "longest": "1.0.1",
-            "repeat-string": "1.6.1"
-          }
-        },
-        "amdefine": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-          "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-          "dev": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "append-transform": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
-          "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
-          "dev": true,
-          "requires": {
-            "default-require-extensions": "1.0.0"
-          }
-        },
-        "archy": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
-          "dev": true
-        },
-        "arr-diff": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "1.1.0"
-          }
-        },
-        "arr-flatten": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-          "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-          "dev": true
-        },
-        "array-unique": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-          "dev": true
-        },
-        "arrify": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-          "dev": true
-        },
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true
-        },
-        "babel-code-frame": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-          "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-          "dev": true,
-          "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
-          }
-        },
-        "babel-generator": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
-          "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
-          "dev": true,
-          "requires": {
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "detect-indent": "4.0.0",
-            "jsesc": "1.3.0",
-            "lodash": "4.17.4",
-            "source-map": "0.5.7",
-            "trim-right": "1.0.1"
-          }
-        },
-        "babel-messages": {
-          "version": "6.23.0",
-          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-          "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-          "dev": true,
-          "requires": {
-            "babel-runtime": "6.26.0"
-          }
-        },
-        "babel-runtime": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-          "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-          "dev": true,
-          "requires": {
-            "core-js": "2.5.3",
-            "regenerator-runtime": "0.11.1"
-          }
-        },
-        "babel-template": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-          "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-          "dev": true,
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "lodash": "4.17.4"
-          }
-        },
-        "babel-traverse": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-          "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-          "dev": true,
-          "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "debug": "2.6.9",
-            "globals": "9.18.0",
-            "invariant": "2.2.2",
-            "lodash": "4.17.4"
-          }
-        },
-        "babel-types": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-          "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-          "dev": true,
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "esutils": "2.0.2",
-            "lodash": "4.17.4",
-            "to-fast-properties": "1.0.3"
-          }
-        },
-        "babylon": {
-          "version": "6.18.0",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-          "dev": true
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
-        },
-        "brace-expansion": {
-          "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-          "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-          "dev": true,
-          "requires": {
-            "balanced-match": "1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "braces": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-          "dev": true,
-          "requires": {
-            "expand-range": "1.8.2",
-            "preserve": "0.2.0",
-            "repeat-element": "1.1.2"
-          }
-        },
-        "builtin-modules": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-          "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-          "dev": true
-        },
-        "caching-transform": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
-          "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
-          "dev": true,
-          "requires": {
-            "md5-hex": "1.3.0",
-            "mkdirp": "0.5.1",
-            "write-file-atomic": "1.3.4"
-          }
-        },
-        "camelcase": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-          "dev": true,
-          "optional": true
-        },
-        "center-align": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-          "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "align-text": "0.1.4",
-            "lazy-cache": "1.0.4"
-          }
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "cliui": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "center-align": "0.1.3",
-            "right-align": "0.1.3",
-            "wordwrap": "0.0.2"
-          },
-          "dependencies": {
-            "wordwrap": {
-              "version": "0.0.2",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-              "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
-        },
-        "commondir": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-          "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
-          "dev": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
-        },
-        "convert-source-map": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-          "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
-          "dev": true
-        },
-        "core-js": {
-          "version": "2.5.3",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
-          "dev": true
-        },
-        "cross-spawn": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "4.1.1",
-            "which": "1.3.0"
-          }
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "debug-log": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
-          "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
-          "dev": true
-        },
-        "decamelize": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-          "dev": true
-        },
-        "default-require-extensions": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
-          "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
-          "dev": true,
-          "requires": {
-            "strip-bom": "2.0.0"
-          }
-        },
-        "detect-indent": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-          "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-          "dev": true,
-          "requires": {
-            "repeating": "2.0.1"
-          }
-        },
-        "error-ex": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-          "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-          "dev": true,
-          "requires": {
-            "is-arrayish": "0.2.1"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
-        },
-        "esutils": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-          "dev": true
-        },
-        "execa": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "5.1.0",
-            "get-stream": "3.0.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
-          },
-          "dependencies": {
-            "cross-spawn": {
-              "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-              "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-              "dev": true,
-              "requires": {
-                "lru-cache": "4.1.1",
-                "shebang-command": "1.2.0",
-                "which": "1.3.0"
-              }
-            }
-          }
-        },
-        "expand-brackets": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-          "dev": true,
-          "requires": {
-            "is-posix-bracket": "0.1.1"
-          }
-        },
-        "expand-range": {
-          "version": "1.8.2",
-          "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-          "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-          "dev": true,
-          "requires": {
-            "fill-range": "2.2.3"
-          }
-        },
-        "extglob": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "1.0.0"
-          }
-        },
-        "filename-regex": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-          "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-          "dev": true
-        },
-        "fill-range": {
-          "version": "2.2.3",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-          "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-          "dev": true,
-          "requires": {
-            "is-number": "2.1.0",
-            "isobject": "2.1.0",
-            "randomatic": "1.1.7",
-            "repeat-element": "1.1.2",
-            "repeat-string": "1.6.1"
-          }
-        },
-        "find-cache-dir": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
-          "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
-          "dev": true,
-          "requires": {
-            "commondir": "1.0.1",
-            "mkdirp": "0.5.1",
-            "pkg-dir": "1.0.0"
-          }
-        },
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true,
-          "requires": {
-            "locate-path": "2.0.0"
-          }
-        },
-        "for-in": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-          "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-          "dev": true
-        },
-        "for-own": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-          "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-          "dev": true,
-          "requires": {
-            "for-in": "1.0.2"
-          }
-        },
-        "foreground-child": {
-          "version": "1.5.6",
-          "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
-          "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "4.0.2",
-            "signal-exit": "3.0.2"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-          "dev": true
-        },
-        "get-caller-file": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-          "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
-          "dev": true
-        },
-        "get-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-          "dev": true
-        },
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "glob-base": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-          "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-          "dev": true,
-          "requires": {
-            "glob-parent": "2.0.0",
-            "is-glob": "2.0.1"
-          }
-        },
-        "glob-parent": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-          "dev": true,
-          "requires": {
-            "is-glob": "2.0.1"
-          }
-        },
-        "globals": {
-          "version": "9.18.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-          "dev": true
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
-        },
-        "handlebars": {
-          "version": "4.0.11",
-          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
-          "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
-          "dev": true,
-          "requires": {
-            "async": "1.5.2",
-            "optimist": "0.6.1",
-            "source-map": "0.4.4",
-            "uglify-js": "2.8.29"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.4.4",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-              "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-              "dev": true,
-              "requires": {
-                "amdefine": "1.0.1"
-              }
-            }
-          }
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
-        "hosted-git-info": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-          "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
-          "dev": true
-        },
-        "imurmurhash": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-          "dev": true
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-          "dev": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
-        },
-        "invariant": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-          "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
-          "dev": true,
-          "requires": {
-            "loose-envify": "1.3.1"
-          }
-        },
-        "invert-kv": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-          "dev": true
-        },
-        "is-arrayish": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-          "dev": true
-        },
-        "is-buffer": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-          "dev": true
-        },
-        "is-builtin-module": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-          "dev": true,
-          "requires": {
-            "builtin-modules": "1.1.1"
-          }
-        },
-        "is-dotfile": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-          "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-          "dev": true
-        },
-        "is-equal-shallow": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-          "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-          "dev": true,
-          "requires": {
-            "is-primitive": "2.0.0"
-          }
-        },
-        "is-extendable": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-          "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-          "dev": true
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "is-finite": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-          "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "1.0.0"
-          }
-        },
-        "is-number": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-          "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          }
-        },
-        "is-posix-bracket": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-          "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-          "dev": true
-        },
-        "is-primitive": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-          "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-          "dev": true
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-          "dev": true
-        },
-        "is-utf8": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-          "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-          "dev": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "isexe": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-          "dev": true
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "dev": true,
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        },
-        "istanbul-lib-coverage": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
-          "integrity": "sha512-0+1vDkmzxqJIn5rcoEqapSB4DmPxE31EtI2dF2aCkV5esN9EWHxZ0dwgDClivMXJqE7zaYQxq30hj5L0nlTN5Q==",
-          "dev": true
-        },
-        "istanbul-lib-hook": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.1.0.tgz",
-          "integrity": "sha512-U3qEgwVDUerZ0bt8cfl3dSP3S6opBoOtk3ROO5f2EfBr/SRiD9FQqzwaZBqFORu8W7O0EXpai+k7kxHK13beRg==",
-          "dev": true,
-          "requires": {
-            "append-transform": "0.4.0"
-          }
-        },
-        "istanbul-lib-instrument": {
-          "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.9.1.tgz",
-          "integrity": "sha512-RQmXeQ7sphar7k7O1wTNzVczF9igKpaeGQAG9qR2L+BS4DCJNTI9nytRmIVYevwO0bbq+2CXvJmYDuz0gMrywA==",
-          "dev": true,
-          "requires": {
-            "babel-generator": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "istanbul-lib-coverage": "1.1.1",
-            "semver": "5.4.1"
-          }
-        },
-        "istanbul-lib-report": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.2.tgz",
-          "integrity": "sha512-UTv4VGx+HZivJQwAo1wnRwe1KTvFpfi/NYwN7DcsrdzMXwpRT/Yb6r4SBPoHWj4VuQPakR32g4PUUeyKkdDkBA==",
-          "dev": true,
-          "requires": {
-            "istanbul-lib-coverage": "1.1.1",
-            "mkdirp": "0.5.1",
-            "path-parse": "1.0.5",
-            "supports-color": "3.2.3"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "3.2.3",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-              "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-              "dev": true,
-              "requires": {
-                "has-flag": "1.0.0"
-              }
-            }
-          }
-        },
-        "istanbul-lib-source-maps": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.2.tgz",
-          "integrity": "sha512-8BfdqSfEdtip7/wo1RnrvLpHVEd8zMZEDmOFEnpC6dg0vXflHt9nvoAyQUzig2uMSXfF2OBEYBV3CVjIL9JvaQ==",
-          "dev": true,
-          "requires": {
-            "debug": "3.1.0",
-            "istanbul-lib-coverage": "1.1.1",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.2",
-            "source-map": "0.5.7"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-              "dev": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            }
-          }
-        },
-        "istanbul-reports": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.3.tgz",
-          "integrity": "sha512-ZEelkHh8hrZNI5xDaKwPMFwDsUf5wIEI2bXAFGp1e6deR2mnEKBPhLJEgr4ZBt8Gi6Mj38E/C8kcy9XLggVO2Q==",
-          "dev": true,
-          "requires": {
-            "handlebars": "4.0.11"
-          }
-        },
-        "js-tokens": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-          "dev": true
-        },
-        "jsesc": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
-          "dev": true
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "1.1.6"
-          }
-        },
-        "lazy-cache": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-          "dev": true,
-          "optional": true
-        },
-        "lcid": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-          "dev": true,
-          "requires": {
-            "invert-kv": "1.0.0"
-          }
-        },
-        "load-json-file": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-          "dev": true,
-          "requires": {
-            "p-locate": "2.0.0",
-            "path-exists": "3.0.0"
-          },
-          "dependencies": {
-            "path-exists": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-              "dev": true
-            }
-          }
-        },
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-          "dev": true
-        },
-        "longest": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-          "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-          "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-          "dev": true,
-          "requires": {
-            "js-tokens": "3.0.2"
-          }
-        },
-        "lru-cache": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-          "dev": true,
-          "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
-          }
-        },
-        "md5-hex": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
-          "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
-          "dev": true,
-          "requires": {
-            "md5-o-matic": "0.1.1"
-          }
-        },
-        "md5-o-matic": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
-          "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
-          "dev": true
-        },
-        "mem": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-          "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-          "dev": true,
-          "requires": {
-            "mimic-fn": "1.1.0"
-          }
-        },
-        "merge-source-map": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz",
-          "integrity": "sha1-pd5GU42uhNQRTMXqArR3KmNGcB8=",
-          "dev": true,
-          "requires": {
-            "source-map": "0.5.7"
-          }
-        },
-        "micromatch": {
-          "version": "2.3.11",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-          "dev": true,
-          "requires": {
-            "arr-diff": "2.0.0",
-            "array-unique": "0.2.1",
-            "braces": "1.8.5",
-            "expand-brackets": "0.1.5",
-            "extglob": "0.3.2",
-            "filename-regex": "2.0.1",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1",
-            "kind-of": "3.2.2",
-            "normalize-path": "2.1.1",
-            "object.omit": "2.0.1",
-            "parse-glob": "3.0.4",
-            "regex-cache": "0.4.4"
-          }
-        },
-        "mimic-fn": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-          "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        },
-        "normalize-package-data": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-          "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-          "dev": true,
-          "requires": {
-            "hosted-git-info": "2.5.0",
-            "is-builtin-module": "1.0.0",
-            "semver": "5.4.1",
-            "validate-npm-package-license": "3.0.1"
-          }
-        },
-        "normalize-path": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-          "dev": true,
-          "requires": {
-            "remove-trailing-separator": "1.1.0"
-          }
-        },
-        "npm-run-path": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-          "dev": true,
-          "requires": {
-            "path-key": "2.0.1"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        },
-        "object.omit": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-          "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-          "dev": true,
-          "requires": {
-            "for-own": "0.1.5",
-            "is-extendable": "0.1.1"
-          }
-        },
-        "once": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "dev": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "optimist": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-          "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8",
-            "wordwrap": "0.0.3"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-          "dev": true
-        },
-        "os-locale": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-          "dev": true,
-          "requires": {
-            "execa": "0.7.0",
-            "lcid": "1.0.0",
-            "mem": "1.1.0"
-          }
-        },
-        "p-finally": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-          "dev": true
-        },
-        "p-limit": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-          "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
-          "dev": true
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-          "dev": true,
-          "requires": {
-            "p-limit": "1.1.0"
-          }
-        },
-        "parse-glob": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-          "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-          "dev": true,
-          "requires": {
-            "glob-base": "0.3.0",
-            "is-dotfile": "1.0.3",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1"
-          }
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "1.3.1"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-          "dev": true
-        },
-        "path-key": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-          "dev": true
-        },
-        "path-parse": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-          "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
-          "dev": true
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        },
-        "pinkie": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-          "dev": true
-        },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-          "dev": true,
-          "requires": {
-            "pinkie": "2.0.4"
-          }
-        },
-        "pkg-dir": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
-          "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
-          "dev": true,
-          "requires": {
-            "find-up": "1.1.2"
-          },
-          "dependencies": {
-            "find-up": {
-              "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-              "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-              "dev": true,
-              "requires": {
-                "path-exists": "2.1.0",
-                "pinkie-promise": "2.0.1"
-              }
-            }
-          }
-        },
-        "preserve": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-          "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-          "dev": true
-        },
-        "pseudomap": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-          "dev": true
-        },
-        "randomatic": {
-          "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-          "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
-          "dev": true,
-          "requires": {
-            "is-number": "3.0.0",
-            "kind-of": "4.0.0"
-          },
-          "dependencies": {
-            "is-number": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-              "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-              "dev": true,
-              "requires": {
-                "kind-of": "3.2.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "1.1.6"
-                  }
-                }
-              }
-            },
-            "kind-of": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-              "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-          "dev": true,
-          "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
-          },
-          "dependencies": {
-            "find-up": {
-              "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-              "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-              "dev": true,
-              "requires": {
-                "path-exists": "2.1.0",
-                "pinkie-promise": "2.0.1"
-              }
-            }
-          }
-        },
-        "regenerator-runtime": {
-          "version": "0.11.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-          "dev": true
-        },
-        "regex-cache": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-          "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-          "dev": true,
-          "requires": {
-            "is-equal-shallow": "0.1.3"
-          }
-        },
-        "remove-trailing-separator": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-          "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-          "dev": true
-        },
-        "repeat-element": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-          "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
-          "dev": true
-        },
-        "repeat-string": {
-          "version": "1.6.1",
-          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-          "dev": true
-        },
-        "repeating": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-          "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-          "dev": true,
-          "requires": {
-            "is-finite": "1.0.2"
-          }
-        },
-        "require-directory": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-          "dev": true
-        },
-        "require-main-filename": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-          "dev": true
-        },
-        "resolve-from": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
-          "dev": true
-        },
-        "right-align": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-          "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "align-text": "0.1.4"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-          "dev": true,
-          "requires": {
-            "glob": "7.1.2"
-          }
-        },
-        "semver": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-          "dev": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-          "dev": true
-        },
-        "shebang-command": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-          "dev": true,
-          "requires": {
-            "shebang-regex": "1.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-          "dev": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-          "dev": true
-        },
-        "slide": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-          "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        },
-        "spawn-wrap": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.4.2.tgz",
-          "integrity": "sha512-vMwR3OmmDhnxCVxM8M+xO/FtIp6Ju/mNaDfCMMW7FDcLRTPFWUswec4LXJHTJE2hwTI9O0YBfygu4DalFl7Ylg==",
-          "dev": true,
-          "requires": {
-            "foreground-child": "1.5.6",
-            "mkdirp": "0.5.1",
-            "os-homedir": "1.0.2",
-            "rimraf": "2.6.2",
-            "signal-exit": "3.0.2",
-            "which": "1.3.0"
-          }
-        },
-        "spdx-correct": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-          "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-          "dev": true,
-          "requires": {
-            "spdx-license-ids": "1.2.2"
-          }
-        },
-        "spdx-expression-parse": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-          "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
-          "dev": true
-        },
-        "spdx-license-ids": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-          "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-              "dev": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-              "dev": true
-            },
-            "strip-ansi": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "3.0.0"
-              }
-            }
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
-        },
-        "strip-eof": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        },
-        "test-exclude": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
-          "integrity": "sha512-35+Asrsk3XHJDBgf/VRFexPgh3UyETv8IAn/LRTiZjVy6rjPVqdEk8dJcJYBzl1w0XCJM48lvTy8SfEsCWS4nA==",
-          "dev": true,
-          "requires": {
-            "arrify": "1.0.1",
-            "micromatch": "2.3.11",
-            "object-assign": "4.1.1",
-            "read-pkg-up": "1.0.1",
-            "require-main-filename": "1.0.1"
-          }
-        },
-        "to-fast-properties": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
-          "dev": true
-        },
-        "trim-right": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-          "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-          "dev": true
-        },
-        "uglify-js": {
-          "version": "2.8.29",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "source-map": "0.5.7",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.10.0"
-          },
-          "dependencies": {
-            "yargs": {
-              "version": "3.10.0",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-              "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "camelcase": "1.2.1",
-                "cliui": "2.1.0",
-                "decamelize": "1.2.0",
-                "window-size": "0.1.0"
-              }
-            }
-          }
-        },
-        "uglify-to-browserify": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-          "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-          "dev": true,
-          "optional": true
-        },
-        "validate-npm-package-license": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-          "dev": true,
-          "requires": {
-            "spdx-correct": "1.0.2",
-            "spdx-expression-parse": "1.0.4"
-          }
-        },
-        "which": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-          "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
-          "dev": true,
-          "requires": {
-            "isexe": "2.0.0"
-          }
-        },
-        "which-module": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-          "dev": true
-        },
-        "window-size": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-          "dev": true,
-          "optional": true
-        },
-        "wordwrap": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-          "dev": true
-        },
-        "wrap-ansi": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-          "dev": true,
-          "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1"
-          },
-          "dependencies": {
-            "string-width": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-              "dev": true,
-              "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
-              }
-            }
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
-        },
-        "write-file-atomic": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-          "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "imurmurhash": "0.1.4",
-            "slide": "1.1.6"
-          }
-        },
-        "y18n": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-          "dev": true
-        },
-        "yallist": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-          "dev": true
-        },
-        "yargs": {
-          "version": "10.0.3",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.0.3.tgz",
-          "integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
-          "dev": true,
-          "requires": {
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "find-up": "2.1.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "8.0.0"
-          },
-          "dependencies": {
-            "cliui": {
-              "version": "3.2.0",
-              "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-              "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-              "dev": true,
-              "requires": {
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "wrap-ansi": "2.1.0"
-              },
-              "dependencies": {
-                "string-width": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                  "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                  "dev": true,
-                  "requires": {
-                    "code-point-at": "1.1.0",
-                    "is-fullwidth-code-point": "1.0.0",
-                    "strip-ansi": "3.0.1"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "yargs-parser": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.0.0.tgz",
-          "integrity": "sha1-IdR2Mw5agieaS4gTRb8GYQLiGcY=",
-          "dev": true,
-          "requires": {
-            "camelcase": "4.1.0"
-          },
-          "dependencies": {
-            "camelcase": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-              "dev": true
-            }
-          }
-        }
-      }
     },
     "oauth-sign": {
       "version": "0.8.2",
@@ -13530,16 +11271,10 @@
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
       "requires": {
         "asap": "2.0.6"
       }
-    },
-    "propagate": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/propagate/-/propagate-0.4.0.tgz",
-      "integrity": "sha1-8/zKCm/gZzanulcpZgaWF8EwtIE=",
-      "dev": true
     },
     "property-information": {
       "version": "3.2.0",
@@ -13617,7 +11352,7 @@
     "randomatic": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+      "integrity": "sha1-x6vpzIuHwLqodrGf3oP9RkeX44w=",
       "dev": true,
       "requires": {
         "is-number": "3.0.0",
@@ -13703,7 +11438,7 @@
     "readable-stream": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
       "dev": true,
       "requires": {
         "core-util-is": "1.0.2",
@@ -13736,28 +11471,11 @@
         "resolve": "1.5.0"
       }
     },
-    "regenerate": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
-      "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
-      "dev": true
-    },
     "regenerator-runtime": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-      "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+      "integrity": "sha1-flT+W1zNXWYk6mJVw0c74JC4AuE=",
       "dev": true
-    },
-    "regenerator-transform": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
-      "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "private": "0.1.8"
-      }
     },
     "regex-cache": {
       "version": "0.4.4",
@@ -13777,44 +11495,10 @@
         "extend-shallow": "2.0.1"
       }
     },
-    "regexpu-core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
-      "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-      "dev": true,
-      "requires": {
-        "regenerate": "1.3.3",
-        "regjsgen": "0.2.0",
-        "regjsparser": "0.1.5"
-      }
-    },
-    "regjsgen": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
-      "dev": true
-    },
-    "regjsparser": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-      "dev": true,
-      "requires": {
-        "jsesc": "0.5.0"
-      },
-      "dependencies": {
-        "jsesc": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-          "dev": true
-        }
-      }
-    },
     "remark": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/remark/-/remark-8.0.0.tgz",
-      "integrity": "sha512-K0PTsaZvJlXTl9DN6qYlvjTkqSZBFELhROZMrblm2rB+085flN84nz4g/BscKRMqDvhzlK1oQ/xnWQumdeNZYw==",
+      "integrity": "sha1-KHtt8v4RkOJjwdFeSG0/qDVZTW0=",
       "dev": true,
       "requires": {
         "remark-parse": "4.0.0",
@@ -13837,7 +11521,7 @@
     "remark-parse": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-4.0.0.tgz",
-      "integrity": "sha512-XZgICP2gJ1MHU7+vQaRM+VA9HEL3X253uwUM/BGgx3iv6TH2B3bF3B8q00DKcyP9YrJV+/7WOWEWBFF/u8cIsw==",
+      "integrity": "sha1-mfHwSa+sgDgjZuLg0L1VQp3UXYs=",
       "dev": true,
       "requires": {
         "collapse-white-space": "1.0.3",
@@ -13871,7 +11555,7 @@
     "remark-stringify": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-4.0.0.tgz",
-      "integrity": "sha512-xLuyKTnuQer3ke9hkU38SUYLiTmS078QOnoFavztmbt/pAJtNSkNtFgR0U//uCcmG0qnyxao+PDuatQav46F1w==",
+      "integrity": "sha1-RDGITAQY8RLaRJkbTjVs/jf6zYc=",
       "dev": true,
       "requires": {
         "ccount": "1.0.2",
@@ -14037,7 +11721,7 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
     },
     "safe-json-parse": {
       "version": "1.0.1",
@@ -14069,7 +11753,7 @@
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+      "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4=",
       "dev": true
     },
     "send": {
@@ -14161,18 +11845,18 @@
       "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
     },
     "sinon": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.2.2.tgz",
-      "integrity": "sha512-BEa593xl+IkIc94nKo0O0LauQC/gQy8Gyv4DkzPwF/9DweC5phr1y+42zibCpn9abfkdHxt9r8AhD0R6u9DE/Q==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.2.1.tgz",
+      "integrity": "sha512-lx9ZCoScNhvs6+n3ku78CqIpQNIiY9gLfvuIdhZjnKOkcVL6FfWfA1jkOrcO+n3mX4BIg2XwQnyCS/Ive21QMw==",
       "dev": true,
       "requires": {
         "diff": "3.4.0",
         "formatio": "1.2.0",
         "lodash.get": "4.4.2",
-        "lolex": "2.3.2",
-        "nise": "1.2.2",
+        "lolex": "2.3.1",
+        "nise": "1.2.0",
         "supports-color": "5.1.0",
-        "type-detect": "4.0.8"
+        "type-detect": "4.0.7"
       },
       "dependencies": {
         "diff": {
@@ -14489,6 +12173,15 @@
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "dev": true
     },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "string-template": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
@@ -14504,15 +12197,6 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
       }
     },
     "stringify-entities": {
@@ -14600,7 +12284,7 @@
     "tape": {
       "version": "4.8.0",
       "resolved": "https://registry.npmjs.org/tape/-/tape-4.8.0.tgz",
-      "integrity": "sha512-TWILfEnvO7I8mFe35d98F6T5fbLaEtbFTG/lxWvid8qDfFTxt19EBijWmB4j3+Hoh5TfHE2faWs73ua+EphuBA==",
+      "integrity": "sha1-9qn+xBzFCh3lD6M2A6tYCZH2Bo4=",
       "dev": true,
       "requires": {
         "deep-equal": "1.0.1",
@@ -14716,7 +12400,7 @@
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -14788,7 +12472,7 @@
         "minimatch": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
           "dev": true,
           "requires": {
             "brace-expansion": "1.1.8"
@@ -14803,7 +12487,7 @@
         "object-inspect": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.3.0.tgz",
-          "integrity": "sha512-OHHnLgLNXpM++GnJRyyhbr2bwl3pPVm4YvaraHrRvDt/N3r+s/gDVHciA7EJBTkijKXj61ssgSAikq1fb0IBRg==",
+          "integrity": "sha1-Wx645nQuLugzQqY3A02ESSi6L20=",
           "dev": true
         },
         "object-keys": {
@@ -15093,9 +12777,9 @@
       "optional": true
     },
     "type-detect": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.7.tgz",
+      "integrity": "sha512-4Rh17pAMVdMWzktddFhISRnUnFIStObtUMNGzDwlA6w/77bmGv3aBbRdCmQR6IjzfkTo9otnW+2K/cDRhKSxDA==",
       "dev": true
     },
     "type-is": {
@@ -15400,7 +13084,7 @@
     "validator": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/validator/-/validator-7.2.0.tgz",
-      "integrity": "sha512-c8NGTUYeBEcUIGeMppmNVKHE7wwfm3mYbNZxV+c5mlv9fDHI7Ad3p07qfNrn/CvpdkK2k61fOLRO2sTEhgQXmg=="
+      "integrity": "sha1-pj3Lq6UdQ1C/jfIJiODVpU1xF5E="
     },
     "vary": {
       "version": "1.1.2",

--- a/src/network.js
+++ b/src/network.js
@@ -483,12 +483,13 @@ class BlockstackNetwork {
 
 class LocalRegtest extends BlockstackNetwork {
   bitcoindUrl: string
+  bitcoindCredentials: Object
 
   constructor(apiUrl: string, bitcoindUrl: string, broadcastServiceUrl: string,
     bitcoindCredentials: ?Object = null) {
     super(apiUrl, '', broadcastServiceUrl, bitcoinjs.networks.testnet)
     this.bitcoindUrl = bitcoindUrl
-    this.bitcoindCredentials = bitcoindCredentials
+    this.bitcoindCredentials = Object.assign({}, bitcoindCredentials)
   }
 
   getFeeRate() : Promise<number> {
@@ -579,7 +580,7 @@ class LocalRegtest extends BlockstackNetwork {
 
 const LOCAL_REGTEST = new LocalRegtest(
   'http://localhost:16268',
-  'http://blockstack:blockstacksystem@127.0.0.1:18332/',
+  'http://localhost:18332/',
   'http://localhost:16269',
   { username: 'blockstack', password: 'blockstacksystem' })
 


### PR DESCRIPTION
Send bitcoind credentials in request header for local regtest environment so that we can use the CORS proxy.

In order to use the bitcoind node in the regtest docker container, we need to pass the requests through the CORS proxy. The credentials needed to be passed in an authorization header instead of in the URL.