### PR TITLE
Fix for #374

### DIFF
--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -75,16 +75,18 @@ export function getFile(path: string, options?: {decrypt?: boolean, username?: s
         return getFullReadUrl(path, gaiaHubConfig)
       }
     })
-    .then((readUrl) => new Promise((resolve, reject) => {
+    .then((readUrl) => {
       if (!readUrl) {
-        console.log(`User does not have apps key, returning null`)
         return null
       } else {
-        resolve(readUrl)
+        fetch(readUrl)
       }
-    }))
-    .then((readUrl) => fetch(readUrl))
+    })
     .then((response) => {
+      if(response == null){
+        console.log(`User does not have apps key, returning null`)
+        return null
+      }
       if (response.status !== 200) {
         if (response.status === 404) {
           console.log(`getFile ${path} returned 404, returning null`)

--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -77,7 +77,8 @@ export function getFile(path: string, options?: {decrypt?: boolean, username?: s
     })
     .then((readUrl) => new Promise((resolve, reject) => {
       if (!readUrl) {
-        reject(null)
+        console.log(`User does not have apps key, returning null`)
+        return null
       } else {
         resolve(readUrl)
       }


### PR DESCRIPTION
Return null from blockstack.getFile for a user with no apps key, instead of reject()ing. This was tested using blockstack.js prior to the update to arrow notation, and has been adapted; it has not been tested with the arrow notation code.