### PR TITLE
Modularized the bitcoin operations in network.js

### DIFF
--- a/dist/blockstack.js
+++ b/dist/blockstack.js
@@ -2353,7 +2353,7 @@ var InsightClient = exports.InsightClient = function (_BitcoinNetwork2) {
         return resp.json();
       }).then(function (utxos) {
         return utxos.map(function (x) {
-          return { value: x.value,
+          return { value: x.satoshis,
             confirmations: x.confirmations,
             tx_hash: x.outpoint.txid,
             tx_output_n: x.outpoint.vout };
@@ -2453,6 +2453,7 @@ var LOCAL_REGTEST = new LocalRegtest('http://localhost:16268', 'http://localhost
 var MAINNET_DEFAULT = new BlockstackNetwork('https://core.blockstack.org', 'https://broadcast.blockstack.org', new BlockchainInfoApi());
 
 var network = exports.network = { BlockstackNetwork: BlockstackNetwork, LocalRegtest: LocalRegtest,
+  BlockchainInfoApi: BlockchainInfoApi, BitcoindAPI: BitcoindAPI, InsightClient: InsightClient,
   defaults: { LOCAL_REGTEST: LOCAL_REGTEST, MAINNET_DEFAULT: MAINNET_DEFAULT } };
 }).call(this,require("buffer").Buffer)
 },{"./errors":11,"bitcoinjs-lib":86,"buffer":142,"form-data":300}],15:[function(require,module,exports){

--- a/dist/blockstack.js
+++ b/dist/blockstack.js
@@ -1639,7 +1639,7 @@ function getPublicKeyFromPrivate(privateKey) {
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.network = exports.BlockchainInfoApi = exports.InsightClient = exports.BitcoindAPI = exports.BitcoinNetwork = undefined;
+exports.network = exports.BlockchainInfoApi = exports.InsightClient = exports.BitcoindAPI = exports.BitcoinNetwork = exports.LocalRegtest = exports.BlockstackNetwork = undefined;
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
@@ -1666,7 +1666,7 @@ var TX_BROADCAST_SERVICE_ZONE_FILE_ENDPOINT = 'zone-file';
 var TX_BROADCAST_SERVICE_REGISTRATION_ENDPOINT = 'registration';
 var TX_BROADCAST_SERVICE_TX_ENDPOINT = 'transaction';
 
-var BlockstackNetwork = function () {
+var BlockstackNetwork = exports.BlockstackNetwork = function () {
   function BlockstackNetwork(apiUrl, broadcastServiceUrl, bitcoinAPI) {
     var network = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : _bitcoinjsLib2.default.networks.bitcoin;
 
@@ -2130,7 +2130,7 @@ var BlockstackNetwork = function () {
   return BlockstackNetwork;
 }();
 
-var LocalRegtest = function (_BlockstackNetwork) {
+var LocalRegtest = exports.LocalRegtest = function (_BlockstackNetwork) {
   _inherits(LocalRegtest, _BlockstackNetwork);
 
   function LocalRegtest(apiUrl, broadcastServiceUrl, bitcoinAPI) {

--- a/src/network.js
+++ b/src/network.js
@@ -16,19 +16,20 @@ const TX_BROADCAST_SERVICE_TX_ENDPOINT = 'transaction'
 
 class BlockstackNetwork {
   blockstackAPIUrl: string
-  utxoProviderUrl: string
   broadcastServiceUrl: string
   layer1: Object
   DUST_MINIMUM: number
   includeUtxoMap: Object
   excludeUtxoSet: Array<UTXO>
+  btc: BitcoinNetwork
 
-  constructor(apiUrl: string, utxoProviderUrl: string, broadcastServiceUrl: string,
+  constructor(apiUrl: string, broadcastServiceUrl: string,
+              bitcoinAPI: BitcoinNetwork,
               network: Object = bitcoinjs.networks.bitcoin) {
     this.blockstackAPIUrl = apiUrl
-    this.utxoProviderUrl = utxoProviderUrl
     this.broadcastServiceUrl = broadcastServiceUrl
     this.layer1 = network
+    this.btc = bitcoinAPI
 
     this.DUST_MINIMUM = 5500
     this.includeUtxoMap = {}
@@ -55,12 +56,6 @@ class BlockstackNetwork {
           throw new Error('Failed to parse price of name')
         }
       })
-  }
-
-  getBlockHeight() {
-    return fetch(`${this.utxoProviderUrl}/latestblock`)
-      .then(resp => resp.json())
-      .then(blockObj => blockObj.height)
   }
 
   getGracePeriod() {
@@ -188,27 +183,7 @@ class BlockstackNetwork {
     }
 
     if (transactionToWatch === null) {
-      const form = new FormData()
-      form.append('tx', transaction)
-      return fetch(`${this.utxoProviderUrl}/pushtx?cors=true`,
-                   { method: 'POST',
-                     body: form })
-        .then(resp => {
-          const text = resp.text()
-          return text
-          .then(respText => {
-            if (respText.toLowerCase().indexOf('transaction submitted') >= 0) {
-              const txHash = bitcoinjs.Transaction.fromHex(transaction)
-                    .getHash()
-                    .reverse()
-                    .toString('hex') // big_endian
-              return txHash
-            } else {
-              throw new RemoteServiceError(resp,
-                `Broadcast transaction failed with message: ${respText}`)
-            }
-          })
-        })
+      return this.btc.broadcastTransaction(transaction)
     } else {
       /*
        * POST /v1/broadcast/transaction
@@ -366,19 +341,6 @@ class BlockstackNetwork {
     return this.broadcastServiceFetchHelper(endpoint, requestBody)
   }
 
-
-  getTransactionInfo(txHash: string) : Promise<{block_height: Number}> {
-    return fetch(`${this.utxoProviderUrl}/rawtx/${txHash}`)
-      .then(resp => {
-        if (resp.status === 200) {
-          return resp.json()
-        } else {
-          throw new Error(`Could not lookup transaction info for '${txHash}'. Server error.`)
-        }
-      })
-      .then(respObj => ({ block_height: respObj.block_height }))
-  }
-
   getFeeRate() : Promise<number> {
     return fetch('https://bitcoinfees.earn.com/api/v1/fees/recommended')
       .then(resp => resp.json())
@@ -387,29 +349,6 @@ class BlockstackNetwork {
 
   countDustOutputs() {
     throw new Error('Not implemented.')
-  }
-
-  getNetworkedUTXOs(address: string) : Promise<Array<UTXO>> {
-    return fetch(`${this.utxoProviderUrl}/unspent?format=json&active=${address}`)
-      .then(resp => {
-        if (resp.status === 500) {
-          console.log('DEBUG: UTXO provider 500 usually means no UTXOs: returning []')
-          return {
-            unspent_outputs: []
-          }
-        } else {
-          return resp.json()
-        }
-      })
-      .then(utxoJSON => utxoJSON.unspent_outputs)
-      .then(utxoList => utxoList.map(
-        utxo => {
-          const utxoOut = { value: utxo.value,
-                            tx_output_n: utxo.tx_output_n,
-                            confirmations: utxo.confirmations,
-                            tx_hash: utxo.tx_hash_big_endian }
-          return utxoOut
-        }))
   }
 
   getUTXOs(address: string) : Promise<Array<UTXO>> {
@@ -489,21 +428,55 @@ class BlockstackNetwork {
       .then(resp => resp.json())
       .then(x => x.consensus_hash)
   }
+
+  getTransactionInfo(txHash: string) : Promise<{block_height: Number}> {
+    return this.btc.getTransactionInfo(txHash)
+  }
+
+  getBlockHeight() {
+    return this.btc.getBlockHeight()
+  }
+
+  getNetworkedUTXOs(address: string) : Promise<Array<UTXO>> {
+    return this.btc.getNetworkedUTXOs(address)
+  }
 }
 
 class LocalRegtest extends BlockstackNetwork {
-  bitcoindUrl: string
-  bitcoindCredentials: Object
-
-  constructor(apiUrl: string, bitcoindUrl: string, broadcastServiceUrl: string,
-    bitcoindCredentials: ?Object = null) {
-    super(apiUrl, '', broadcastServiceUrl, bitcoinjs.networks.testnet)
-    this.bitcoindUrl = bitcoindUrl
-    this.bitcoindCredentials = Object.assign({}, bitcoindCredentials)
+  constructor(apiUrl: string, broadcastServiceUrl: string,
+              bitcoinAPI: BitcoinNetwork) {
+    super(apiUrl, broadcastServiceUrl, bitcoinAPI, bitcoinjs.networks.testnet)
   }
 
   getFeeRate() : Promise<number> {
     return Promise.resolve(Math.floor(0.00001000 * SATOSHIS_PER_BTC))
+  }
+
+}
+
+export class BitcoinNetwork {
+  broadcastTransaction(transaction: string) : Promise<Object> {
+    return Promise.reject(new Error(`Not implemented, broadcastTransaction(${transaction})`))
+  }
+  getBlockHeight() : Promise<Number> {
+    return Promise.reject(new Error('Not implemented, getBlockHeight()'))
+  }
+  getTransactionInfo(txid: string) : Promise<{block_height: Number}> {
+    return Promise.reject(new Error(`Not implemented, getTransactionInfo(${txid})`))
+  }
+  getNetworkedUTXOs(address: string) : Promise<Array<UTXO>> {
+    return Promise.reject(new Error(`Not implemented, getNetworkedUTXOs(${address})`))
+  }
+}
+
+export class BitcoindAPI extends BitcoinNetwork {
+  bitcoindUrl: string
+  bitcoindCredentials: Object
+
+  constructor(bitcoindUrl: string, bitcoindCredentials: {username: string, password: string}) {
+    super()
+    this.bitcoindUrl = bitcoindUrl
+    this.bitcoindCredentials = bitcoindCredentials
   }
 
   broadcastTransaction(transaction: string) {
@@ -589,19 +562,140 @@ class LocalRegtest extends BlockstackNetwork {
                       tx_output_n: x.vout })))
   }
 
+}
 
+export class InsightClient extends BitcoinNetwork {
+  apiUrl: string
+
+  constructor(insightUrl: string = 'https://utxo.technofractal.com/') {
+    super()
+    this.apiUrl = insightUrl
+  }
+
+  broadcastTransaction(transaction: string) {
+    const jsonData = { tx: transaction }
+    return fetch(`${this.apiUrl}/tx/send`,
+                 { method: 'POST',
+                   headers: new Headers({ 'Content-Type': 'application/json' }),
+                   body: JSON.stringify(jsonData) })
+      .then(resp => resp.json())
+  }
+
+  getBlockHeight() {
+    return fetch(`${this.apiUrl}/status`)
+      .then(resp => resp.json())
+      .then(status => status.blocks)
+  }
+
+  getTransactionInfo(txHash: string) : Promise<{block_height: Number}> {
+    return fetch(`${this.apiUrl}/tx/${txHash}`)
+      .then(resp => resp.json())
+      .then(transactionInfo => {
+        if (transactionInfo.error) {
+          throw new Error(`Error finding transaction: ${transactionInfo.error}`)
+        }
+        return fetch(`${this.apiUrl}/block/${transactionInfo.blockHash}`)
+      })
+      .then(resp => resp.json())
+      .then(blockInfo => ({ block_height: blockInfo.height }))
+  }
+
+  getNetworkedUTXOs(address: string) : Promise<Array<UTXO>> {
+    return fetch(`${this.apiUrl}/addr/${address}/utxo`)
+      .then(resp => resp.json())
+      .then(utxos => utxos.map(
+        x => ({ value: x.value,
+                confirmations: x.confirmations,
+                tx_hash: x.outpoint.txid,
+                tx_output_n: x.outpoint.vout })))
+  }
+
+}
+
+export class BlockchainInfoApi extends BitcoinNetwork {
+  utxoProviderUrl: string
+
+  constructor(blockchainInfoUrl: string = 'https://blockchain.info') {
+    super()
+    this.utxoProviderUrl = blockchainInfoUrl
+  }
+
+  getBlockHeight() {
+    return fetch(`${this.utxoProviderUrl}/latestblock`)
+      .then(resp => resp.json())
+      .then(blockObj => blockObj.height)
+  }
+
+  getNetworkedUTXOs(address: string) : Promise<Array<UTXO>> {
+    return fetch(`${this.utxoProviderUrl}/unspent?format=json&active=${address}`)
+      .then(resp => {
+        if (resp.status === 500) {
+          console.log('DEBUG: UTXO provider 500 usually means no UTXOs: returning []')
+          return {
+            unspent_outputs: []
+          }
+        } else {
+          return resp.json()
+        }
+      })
+      .then(utxoJSON => utxoJSON.unspent_outputs)
+      .then(utxoList => utxoList.map(
+        utxo => {
+          const utxoOut = { value: utxo.value,
+                            tx_output_n: utxo.tx_output_n,
+                            confirmations: utxo.confirmations,
+                            tx_hash: utxo.tx_hash_big_endian }
+          return utxoOut
+        }))
+  }
+
+  getTransactionInfo(txHash: string) : Promise<{block_height: Number}> {
+    return fetch(`${this.utxoProviderUrl}/rawtx/${txHash}`)
+      .then(resp => {
+        if (resp.status === 200) {
+          return resp.json()
+        } else {
+          throw new Error(`Could not lookup transaction info for '${txHash}'. Server error.`)
+        }
+      })
+      .then(respObj => ({ block_height: respObj.block_height }))
+  }
+
+  broadcastTransaction(transaction: string) {
+    const form = new FormData()
+    form.append('tx', transaction)
+    return fetch(`${this.utxoProviderUrl}/pushtx?cors=true`,
+                 { method: 'POST',
+                   body: form })
+      .then(resp => {
+        const text = resp.text()
+        return text
+          .then(respText => {
+            if (respText.toLowerCase().indexOf('transaction submitted') >= 0) {
+              const txHash = bitcoinjs.Transaction.fromHex(transaction)
+                    .getHash()
+                    .reverse()
+                    .toString('hex') // big_endian
+              return txHash
+            } else {
+              throw new RemoteServiceError(resp,
+                                           `Broadcast transaction failed with message: ${respText}`)
+            }
+          })
+      })
+  }
 }
 
 const LOCAL_REGTEST = new LocalRegtest(
   'http://localhost:16268',
-  'http://localhost:18332/',
   'http://localhost:16269',
-  { username: 'blockstack', password: 'blockstacksystem' })
+  new BitcoindAPI('http://localhost:18332/',
+                  { username: 'blockstack', password: 'blockstacksystem' }))
 
 const MAINNET_DEFAULT = new BlockstackNetwork(
   'https://core.blockstack.org',
-  'https://blockchain.info',
-  'https://broadcast.blockstack.org')
+  'https://broadcast.blockstack.org',
+  new BlockchainInfoApi())
 
 export const network = { BlockstackNetwork, LocalRegtest,
                          defaults: { LOCAL_REGTEST, MAINNET_DEFAULT } }

--- a/src/network.js
+++ b/src/network.js
@@ -605,7 +605,7 @@ export class InsightClient extends BitcoinNetwork {
     return fetch(`${this.apiUrl}/addr/${address}/utxo`)
       .then(resp => resp.json())
       .then(utxos => utxos.map(
-        x => ({ value: x.value,
+        x => ({ value: x.satoshis,
                 confirmations: x.confirmations,
                 tx_hash: x.outpoint.txid,
                 tx_output_n: x.outpoint.vout })))
@@ -699,4 +699,5 @@ const MAINNET_DEFAULT = new BlockstackNetwork(
   new BlockchainInfoApi())
 
 export const network = { BlockstackNetwork, LocalRegtest,
+                         BlockchainInfoApi, BitcoindAPI, InsightClient,
                          defaults: { LOCAL_REGTEST, MAINNET_DEFAULT } }

--- a/src/network.js
+++ b/src/network.js
@@ -14,7 +14,7 @@ const TX_BROADCAST_SERVICE_ZONE_FILE_ENDPOINT = 'zone-file'
 const TX_BROADCAST_SERVICE_REGISTRATION_ENDPOINT = 'registration'
 const TX_BROADCAST_SERVICE_TX_ENDPOINT = 'transaction'
 
-class BlockstackNetwork {
+export class BlockstackNetwork {
   blockstackAPIUrl: string
   broadcastServiceUrl: string
   layer1: Object
@@ -442,7 +442,7 @@ class BlockstackNetwork {
   }
 }
 
-class LocalRegtest extends BlockstackNetwork {
+export class LocalRegtest extends BlockstackNetwork {
   constructor(apiUrl: string, broadcastServiceUrl: string,
               bitcoinAPI: BitcoinNetwork) {
     super(apiUrl, broadcastServiceUrl, bitcoinAPI, bitcoinjs.networks.testnet)

--- a/tests/operationsTests/src/operationsTests.js
+++ b/tests/operationsTests/src/operationsTests.js
@@ -36,6 +36,10 @@ function initializeBlockstackCore() {
       console.log('Started regtest container, waiting until initialized')
       return pExec('docker logs -f test-bsk-core | grep -q inished')
     })
+    .then(() => {
+      console.log('Initialized, waiting an additional 30 seconds')
+      return new Promise((resolve) => setTimeout(resolve, 30000))
+    })
 }
 
 function shutdownBlockstackCore() {

--- a/tests/unitTests/src/unitTestsOperations.js
+++ b/tests/unitTests/src/unitTestsOperations.js
@@ -41,7 +41,8 @@ function networkTests() {
     FetchMock.get(`https://utxo.tester.com/block/${blockHash}`,
                   { height: 300 })
     FetchMock.get(`https://utxo.tester.com/addr/${testAddresses[0].address}/utxo`,
-                  [{ value: 1, confirmations: 2, outpoint: { txid: 'bar', vout: 10 } }])
+                  [{ value: 1, satoshis: 1e8, confirmations: 2,
+                     outpoint: { txid: 'bar', vout: 10 } }])
 
     FetchMock.get('https://utxo.tester.com/status',
                   { blocks: 500 })
@@ -64,7 +65,7 @@ function networkTests() {
 
     mynet.getNetworkedUTXOs(testAddresses[0].address)
       .then((utxos) => {
-        t.deepEqual(utxos, [{ value: 1, confirmations: 2, tx_hash: 'bar', tx_output_n: 10 }])
+        t.deepEqual(utxos, [{ value: 1e8, confirmations: 2, tx_hash: 'bar', tx_output_n: 10 }])
       })
   })
 }


### PR DESCRIPTION
The plan for supporting bitcoin lookups for client transaction generation is: 

1. In mainnet, that bitcoin requests will go to an insight-api mimicking service being built by @jackzampolin 
2. In regtest, we interact with bitcoind directly
3. Until (1) is implemented, bitcoin interactions query blockchain.info (as is currently the case in `feature/blockstack-operations`)

I _know_ we didn't want to pursue a driver model, but in order to support the above arrangement, we need three different ways of querying the bitcoin network. In working on writing the API for (1), modularizing and separating these parts out into different "BitcoinNetwork" objects was easier than the alternative.

Will add test cases for the InsightClient -- all of the other code changes are covered by the existing unit tests -- after that, I'll request review.