### PR TITLE
Add bitcoin spending support 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "blockstack",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/errors.js
+++ b/src/errors.js
@@ -70,3 +70,17 @@ export class NotEnoughFundsError extends BlockstackError {
     this.message = message
   }
 }
+
+export class InvalidAmountError extends BlockstackError {
+  fees: number
+  specifiedAmount: number
+  constructor(fees: number, specifiedAmount: number) {
+    const message = `Not enough coin to fund fees transaction fees. Fees would be ${fees},` +
+          ` specified spend is  ${specifiedAmount}`
+    super({ code: 'invalid_amount_error', message })
+    this.specifiedAmount = specifiedAmount
+    this.fees = fees
+    this.name = 'InvalidAmountError'
+    this.message = message
+  }
+}

--- a/src/errors.js
+++ b/src/errors.js
@@ -59,3 +59,14 @@ export class InvalidDIDError extends BlockstackError {
     this.message = message
   }
 }
+
+export class NotEnoughFundsError extends BlockstackError {
+  leftToFund: number
+  constructor(leftToFund: number) {
+    const message = `Not enough UTXOs to fund. Left to fund: ${leftToFund}`
+    super({ code: 'not_enough_error', message })
+    this.leftToFund = leftToFund
+    this.name = 'NotEnoughFundsError'
+    this.message = message
+  }
+}

--- a/src/operations/txbuild.js
+++ b/src/operations/txbuild.js
@@ -523,10 +523,8 @@ function makeBitcoinSpend(destinationAddress: string,
         const changeIndex = txB.addOutput(paymentAddress, DUST_MINIMUM)
         tryFund = bestEffortFund(txB, amount + baseFees + feeForChange)
         txB.tx.outs[changeIndex].value = tryFund.change
-        console.log(`Amount: ${amount} Change: ${tryFund.change} LeftToFund: ${tryFund.leftToFund}`)
         outAmount = amount - tryFund.leftToFund
       } else {
-        console.log(`Amount: ${amount} Fee: ${baseFees} LeftToFund: ${tryFund.leftToFund}`)
         outAmount = amount - tryFund.leftToFund
       }
       txB.tx.outs[destinationIndex].value = outAmount

--- a/tests/unitTests/src/unitTestsOperations.js
+++ b/tests/unitTests/src/unitTestsOperations.js
@@ -462,7 +462,7 @@ function transactionTests() {
   })
 
   test('fund bitcoin spends', (t) => {
-    t.plan(9)
+    t.plan(13)
     setupMocks()
     transactions.makeBitcoinSpend(testAddresses[2].address,
                                   testAddresses[1].skHex,
@@ -497,6 +497,20 @@ function transactionTests() {
              'Fee should be correct (within an output fee): ' +
              `Actual fee: ${fee}, expected: ${1000 * txLen}`)
         t.equal(outputVals, 80000, 'Should fund correct amount')
+      })
+      .then(() => transactions.makeBitcoinSpend(testAddresses[2].address,
+                                                testAddresses[1].skHex,
+                                                288000 + 287825 + 287825))
+      .then(hexTX => {
+        const tx = btc.Transaction.fromHex(hexTX)
+        const txLen = hexTX.length / 2
+        const outputVals = sumOutputValues(tx)
+        const inputVals = getInputVals(tx)
+        const fee = inputVals - outputVals
+        t.equal(tx.ins.length, 3, 'Should use 3 inputs')
+        t.equal(tx.outs.length, 1, 'Should not have a change output')
+        t.equal(fee - 2000, 1000 * txLen, 'Fee should be correct.')
+        t.equal(outputVals + fee, 288000 + 287825 + 287825, 'Should fund correct amount')
       })
   })
 


### PR DESCRIPTION
This implements support for generating a bitcoin _spend_ via a new function `transactions.makeBitcoinSpend`

```javascript
/**
 * Generates a bitcoin spend to a specified address. This will fund up to `amount`
 *   of satoshis from the payer's UTXOs. It will generate a change output if and only
 *   if the amount of leftover change is *greater* than the additional fees associated
 *   with the extra output. If the requested amount is not enough to fund the transaction's
 *   associated fees, then this will reject with a InvalidAmountError
 *
 * UTXOs are selected largest to smallest, and UTXOs which cannot fund the fees associated
 *   with their own input will not be included.
 *
 * If you specify an amount > the total balance of the payer address, then this will
 *   generate a maximum spend transaction
 *
 * @param {String} destinationAddress - the address to receive the bitcoin payment
 * @param {String} paymentKeyHex - a hex string of the private key used to
 *    fund the bitcoin spend
 * @param {number} amount - the amount in satoshis for the payment address to
 *    spend in this transaction
 * @returns {Promise} - a promise which resolves to the hex-encoded transaction.
 * @private
 */
function makeBitcoinSpend(destinationAddress: string,
                          paymentKeyHex: string,
                          amount: number)
```

The above JSDoc should explain the behavior of the function pretty well.

There's included unit tests [here](https://github.com/blockstack/blockstack.js/blob/feature/bitcoin-transaction/tests/unitTests/src/unitTestsOperations.js#L464), and I added a spend transaction to the [operations integration test](https://github.com/blockstack/blockstack.js/blob/feature/bitcoin-transaction/tests/operationsTests/src/operationsTests.js#L136).

### Regtest Testing

To test this in regtest, I would run the docker integration test environment

```bash
$ docker run --name test-bsk-core -dt -p 16268:16268 -p 18332:18332 -e BLOCKSTACK_TEST_CLIENT_RPC_PORT=16268 -e BLOCKSTACK_TEST_CLIENT_BIND=0.0.0.0 -e BLOCKSTACK_TEST_BITCOIND_ALLOWIP=172.17.0.0/16 quay.io/blockstack/integrationtests:develop blockstack-test-scenario --interactive 2 blockstack_integration_tests.scenarios.portal_test_env
$ docker logs -f test-bsk-core | grep -q 'Test finished'
$ npm run test
```

Then, in node:

```javascript
const bsk = require('.')
const payer = 'bb68eda988e768132bc6c7ca73a87fb9b0918e9a38d3618b74099be25f7cab7d01'
const dest = 'mtpeL28w8WNWWQcXjiYQCM5EFHhijXMF62'
bsk.config.network = bsk.network.defaults.LOCAL_REGTEST
bsk.config.network.getUTXOs(dest).then(console.log)
// should output `[]`
let transactionHex
bsk.transactions.makeBitcoinSpend(dest, payer, 500000).then( x => transactionHex = x).then(() => console.log('generated'))
// when that outputs generated, you can broadcast the tx
bsk.config.network.broadcastTransaction(transactionHex).then(console.log)
// wait a second or two for your bitcoind to process the transaction
bsk.config.network.getUTXOs(dest).then(console.log)
// should output a new UTXO.
```

### Mainnet Testing

This is pretty similar to the regtest testing, except you don't need to start a regtest environment, but you do need to use actual coins.

```javascript
const bsk = require('.')
// usually you need to import from a WIF
const btc = require('bitcoinjs-lib')
const payer = btc.ECPair.fromWIF(myWIF).d.toHex() + '01'

const dest = 'your destination address'
let transactionHex
// I used a large number of satoshis so that it generated a max-spend transaction
bsk.transactions.makeBitcoinSpend(dest, payer, 1e9).then(x => transactionHex = x).then(() => console.log('generated'))
// you can inspect `transactionHex` in your favorite bitcoin transaction deserializer.
//    then broadcast it!
bsk.config.network.broadcastTransaction(transactionHex).then(console.log)
// your internet money is sent.
```

Anyways, let me know if this works for you, and if the interface is one that makes sense.