### PR TITLE
Enable Custom Gaia Hubs

### DIFF
--- a/src/auth/authMessages.js
+++ b/src/auth/authMessages.js
@@ -17,7 +17,7 @@ import {
 
 import { encryptECIES, decryptECIES } from '../encryption'
 
-const VERSION = '1.1.0'
+const VERSION = '1.2.0'
 
 type AuthMetadata = {
   email: ?string,


### PR DESCRIPTION
This PR enables reading a Gaia hub from the `authResponse` token.

I tested this by:

- [x] linking the change into blockstack-todos, logging in with current browser
- [x] linking the change into browser, unlinking change in todos, logging in
- [x] linking the change in both, logging in

The reason we had left this version unbumped is kind of a blockstack source code history lesson. Version numbers were added to the auth protocol using a hacky equality check on " === 1.1.0". This meant that a "1.2.0" request would break the protocol. So we decided to fix the version check, wait a version or two, and then bump the protocol version. Then we forgot about it.

 