### PR TITLE
Remove dependency on hasprop

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,6 @@
     "ecurve": "^1.0.6",
     "elliptic": "^6.4.0",
     "es6-promise": "^4.2.4",
-    "hasprop": "0.0.4",
     "isomorphic-fetch": "^2.2.1",
     "jsontokens": "^0.7.7",
     "promise": "^7.1.1",

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ export {
   getEntropy, makeECPrivateKey, publicKeyToAddress, getPublicKeyFromPrivate
 } from './keys'
 export {
-  nextYear, nextMonth, nextHour, makeUUID4, hasprop, updateQueryStringParameter,
+  nextYear, nextMonth, nextHour, makeUUID4, updateQueryStringParameter,
   isLaterVersion, isSameOriginAbsoluteUrl, hexStringToECPair, ecPairToHexString
 } from './utils'
 

--- a/src/profiles/profileSchemas/personLegacy.js
+++ b/src/profiles/profileSchemas/personLegacy.js
@@ -1,8 +1,6 @@
-import hasprop from 'hasprop'
-
 function formatAccount(serviceName, data) {
   let proofUrl
-  if (hasprop(data, 'proof.url')) {
+  if (data.proof && data.proof.url) {
     proofUrl = data.proof.url
   }
   return {
@@ -19,89 +17,91 @@ export function getPersonFromLegacyFormat(profile) {
     '@type': 'Person'
   }
 
-  if (hasprop(profile, 'name.formatted')) {
-    profileData.name = profile.name.formatted
-  }
-
-  if (hasprop(profile, 'bio')) {
-    profileData.description = profile.bio
-  }
-
-  if (hasprop(profile, 'location.formatted')) {
-    profileData.address = {
-      '@type': 'PostalAddress',
-      addressLocality: profile.location.formatted
+  if (profile) {
+    if (profile.name && profile.name.formatted) {
+      profileData.name = profile.name.formatted
     }
-  }
 
-  const images = []
-  if (hasprop(profile, 'avatar.url')) {
-    images.push({
-      '@type': 'ImageObject',
-      name: 'avatar',
-      contentUrl: profile.avatar.url
-    })
-  }
-  if (hasprop(profile, 'cover.url')) {
-    images.push({
-      '@type': 'ImageObject',
-      name: 'cover',
-      contentUrl: profile.cover.url
-    })
-  }
-  if (images.length) {
-    profileData.image = images
-  }
+    if (profile.bio) {
+      profileData.description = profile.bio
+    }
 
-  if (hasprop(profile, 'website')) {
-    profileData.website = [{
-      '@type': 'WebSite',
-      url: profile.website
-    }]
-  }
-
-  const accounts = []
-  if (hasprop(profile, 'bitcoin.address')) {
-    accounts.push({
-      '@type': 'Account',
-      role: 'payment',
-      service: 'bitcoin',
-      identifier: profile.bitcoin.address
-    })
-  }
-  if (hasprop(profile, 'twitter.username')) {
-    accounts.push(formatAccount('twitter', profile.twitter))
-  }
-  if (hasprop(profile, 'facebook.username')) {
-    accounts.push(formatAccount('facebook', profile.facebook))
-  }
-  if (hasprop(profile, 'github.username')) {
-    accounts.push(formatAccount('github', profile.github))
-  }
-
-  if (hasprop(profile, 'auth')) {
-    if (profile.auth.length > 0) {
-      if (hasprop(profile.auth[0], 'publicKeychain')) {
-        accounts.push({
-          '@type': 'Account',
-          role: 'key',
-          service: 'bip32',
-          identifier: profile.auth[0].publicKeychain
-        })
+    if (profile.location && profile.location.formatted) {
+      profileData.address = {
+        '@type': 'PostalAddress',
+        addressLocality: profile.location.formatted
       }
     }
-  }
-  if (hasprop(profile, 'pgp.url')) {
-    accounts.push({
-      '@type': 'Account',
-      role: 'key',
-      service: 'pgp',
-      identifier: profile.pgp.fingerprint,
-      contentUrl: profile.pgp.url
-    })
-  }
 
-  profileData.account = accounts
+    const images = []
+    if (profile.avatar && profile.avatar.url) {
+      images.push({
+        '@type': 'ImageObject',
+        name: 'avatar',
+        contentUrl: profile.avatar.url
+      })
+    }
+    if (profile.cover && profile.cover.url) {
+      images.push({
+        '@type': 'ImageObject',
+        name: 'cover',
+        contentUrl: profile.cover.url
+      })
+    }
+    if (images.length) {
+      profileData.image = images
+    }
+
+    if (profile.website) {
+      profileData.website = [{
+        '@type': 'WebSite',
+        url: profile.website
+      }]
+    }
+
+    const accounts = []
+    if (profile.bitcoin && profile.bitcoin.address) {
+      accounts.push({
+        '@type': 'Account',
+        role: 'payment',
+        service: 'bitcoin',
+        identifier: profile.bitcoin.address
+      })
+    }
+    if (profile.twitter && profile.twitter.username) {
+      accounts.push(formatAccount('twitter', profile.twitter))
+    }
+    if (profile.facebook && profile.facebook.username) {
+      accounts.push(formatAccount('facebook', profile.facebook))
+    }
+    if (profile.github && profile.github.username) {
+      accounts.push(formatAccount('github', profile.github))
+    }
+
+    if (profile.auth) {
+      if (profile.auth.length > 0) {
+        if (profile.auth[0] && profile.auth[0].publicKeychain) {
+          accounts.push({
+            '@type': 'Account',
+            role: 'key',
+            service: 'bip32',
+            identifier: profile.auth[0].publicKeychain
+          })
+        }
+      }
+    }
+    if (profile.pgp && profile.pgp.url) {
+      accounts.push({
+        '@type': 'Account',
+        role: 'key',
+        service: 'pgp',
+        identifier: profile.pgp.fingerprint,
+        contentUrl: profile.pgp.url
+      })
+    }
+
+    profileData.account = accounts
+  }
 
   return profileData
 }

--- a/tests/testData/profiles/naval-legacy-convert.json
+++ b/tests/testData/profiles/naval-legacy-convert.json
@@ -1,0 +1,76 @@
+{
+  "profile": {
+    "@type": "Person",
+    "@context": "http://schema.org/",
+    "name": "Naval Ravikant",
+    "description": "Co-founder AngelList • Founder Epinions, Vast • Author Startupboy, Venture Hacks • Investor Twitter, Uber, Yammer, Postmates",
+    "address": {
+      "@type": "PostalAddress",
+      "addressLocality": "San Francisco, CA"
+    },
+    "image": [
+      {
+        "@type": "ImageObject",
+        "name": "avatar",
+        "contentUrl": "https://pbs.twimg.com/profile_images/3696617328/667874c5936764d93d56ccc76a2bcc13.jpeg"
+      },
+      {
+        "@type": "ImageObject",
+        "name": "cover",
+        "contentUrl": "https://pbs.twimg.com/profile_banners/745273/1355705777/web_retina"
+      }
+    ],
+    "website": [
+      {
+        "@type": "WebSite",
+        "url": "https://angel.co/naval"
+      }
+    ],
+    "account": [
+      {
+        "@type": "Account",
+        "role": "payment",
+        "service": "bitcoin",
+        "identifier": "1919UrhYyhs471ps8CFcJ3DRpWSda8qtSk"
+      },
+      {
+        "@type": "Account",
+        "service": "twitter",
+        "identifier": "naval",
+        "proofType": "http",
+        "proofUrl": "https://twitter.com/naval/status/486609266212499456"
+      },
+      {
+        "@type": "Account",
+        "service": "facebook",
+        "identifier": "navalr",
+        "proofType": "http",
+        "proofUrl": "https://facebook.com/navalr/posts/10152190734077261"
+      },
+      {
+        "@type": "Account",
+        "service": "github",
+        "identifier": "navalr",
+        "proofType": "http",
+        "proofUrl": "https://gist.github.com/navalr/f31a74054f859ec0ac6a"
+      },
+      {
+        "@type": "Account",
+        "role": "key",
+        "service": "pgp",
+        "identifier": "07354EDF5C6CF2572847840D8FA3F960B62B7C41",
+        "contentUrl": "https://s3.amazonaws.com/pk9/naval"
+      }
+    ]
+  },
+  "name": "Naval Ravikant",
+  "givenName": "Naval",
+  "familyName": "Ravikant",
+  "description": "Co-founder AngelList • Founder Epinions, Vast • Author Startupboy, Venture Hacks • Investor Twitter, Uber, Yammer, Postmates",
+  "avatarUrl": "https://pbs.twimg.com/profile_images/3696617328/667874c5936764d93d56ccc76a2bcc13.jpeg",
+  "verifiedAccounts": [],
+  "address": "San Francisco, CA",
+  "birthDate": null,
+  "connections": [],
+  "organizations": []
+}

--- a/tests/unitTests/src/sampleData.js
+++ b/tests/unitTests/src/sampleData.js
@@ -30,7 +30,9 @@ export const sampleProfiles = {
   ryan: JSON.parse(fs.readFileSync(`${TEST_DATA_DIR}/profiles/ryan.json`)),
   larry: JSON.parse(fs.readFileSync(`${TEST_DATA_DIR}/profiles/larry.json`)),
   google: JSON.parse(fs.readFileSync(`${TEST_DATA_DIR}/profiles/google.json`)),
-  navalLegacy: JSON.parse(fs.readFileSync(`${TEST_DATA_DIR}/profiles/naval-legacy.json`))
+  navalLegacy: JSON.parse(fs.readFileSync(`${TEST_DATA_DIR}/profiles/naval-legacy.json`)),
+  navalLegacyConvert: JSON.parse(
+    fs.readFileSync(`${TEST_DATA_DIR}/profiles/naval-legacy-convert.json`))
 }
 
 export const sampleTokenFiles = {

--- a/tests/unitTests/src/unitTestsProfiles.js
+++ b/tests/unitTests/src/unitTestsProfiles.js
@@ -184,13 +184,17 @@ function testSchemas() {
   })
 
   test('legacyFormat', (t) => {
-    t.plan(2)
+    t.plan(3)
 
     const profileObject = Person.fromLegacyFormat(sampleProfiles.navalLegacy)
     t.ok(profileObject, 'Profile object should have been created from legacy formatted profile')
 
     const validationResults = Person.validateSchema(profileObject.toJSON(), true)
     t.ok(validationResults, 'Profile should be in a valid format')
+
+    t.deepEqual(profileObject.toJSON(),
+                sampleProfiles.navalLegacyConvert,
+                'Parsed Legacy profile should match expectations.')
   })
 
   test('resolveZoneFileToPerson', (t) => {


### PR DESCRIPTION
This removes our dependency on `hasprop` which is a stale package, with dependencies that emit npm warnings. I also removed the `hasprop` export from utils, which was previously `undefined`.

I added a regression test for the naval-legacy profile parsing, that ensures that the response from `getPersonFromLegacyFormat` is still the same.
