### PR TITLE
Improved error handling in authentication

### DIFF
--- a/src/auth/authApp.js
+++ b/src/auth/authApp.js
@@ -3,8 +3,9 @@ import queryString from 'query-string'
 import { decodeToken } from 'jsontokens'
 import { makeAuthRequest, verifyAuthResponse } from './index'
 import protocolCheck from 'custom-protocol-detection-blockstack'
-import { BLOCKSTACK_HANDLER, isLaterVersion } from '../utils'
+import { BLOCKSTACK_HANDLER, isLaterVersion, hexStringToECPair } from '../utils'
 import { makeECPrivateKey } from '../index'
+import { LoginFailedError } from '../errors'
 import { decryptPrivateKey } from './authMessages'
 import { BLOCKSTACK_APP_PRIVATE_KEY_LABEL,
          BLOCKSTACK_STORAGE_LABEL,
@@ -146,81 +147,87 @@ export function isSignInPending() {
 export function handlePendingSignIn(nameLookupURL: string = 'https://core.blockstack.org/v1/names/') {
   const authResponseToken = getAuthResponseToken()
 
-  return new Promise((resolve, reject) => {
-    verifyAuthResponse(authResponseToken, nameLookupURL)
+  return verifyAuthResponse(authResponseToken, nameLookupURL)
     .then(isValid => {
-      if (isValid) {
-        const tokenPayload = decodeToken(authResponseToken).payload
-        // TODO: real version handling
-        let appPrivateKey = tokenPayload.private_key
-        let coreSessionToken = tokenPayload.core_token
-        if (isLaterVersion(tokenPayload.version, '1.1.0')) {
-          const transitKey = getTransitKey()
-          if (transitKey !== undefined && transitKey != null) {
-            if (appPrivateKey !== undefined && appPrivateKey !== null) {
+      if (!isValid) {
+        throw new LoginFailedError('Invalid authentication response.')
+      }
+      const tokenPayload = decodeToken(authResponseToken).payload
+      // TODO: real version handling
+      let appPrivateKey = tokenPayload.private_key
+      let coreSessionToken = tokenPayload.core_token
+      if (isLaterVersion(tokenPayload.version, '1.1.0')) {
+        const transitKey = getTransitKey()
+        if (transitKey !== undefined && transitKey != null) {
+          if (tokenPayload.private_key !== undefined && tokenPayload.private_key !== null) {
+            try {
+              appPrivateKey = decryptPrivateKey(transitKey, tokenPayload.private_key)
+            } catch (e) {
+              console.log('Failed decryption of appPrivateKey, will try to use as given')
               try {
-                appPrivateKey = decryptPrivateKey(transitKey, appPrivateKey)
-              } catch (e) {
-                console.log('Failed decryption of appPrivateKey, will try to use as given')
-              }
-            }
-            if (coreSessionToken !== undefined && coreSessionToken !== null) {
-              try {
-                coreSessionToken = decryptPrivateKey(transitKey, coreSessionToken)
-              } catch (e) {
-                console.log('Failed decryption of coreSessionToken, will try to use as given')
+                hexStringToECPair(tokenPayload.private_key)
+              } catch (ecPairError) {
+                throw new LoginFailedError('Failed decrypting appPrivateKey. Usually means' +
+                                           ' that the transit key has changed during login.')
               }
             }
           }
+          if (coreSessionToken !== undefined && coreSessionToken !== null) {
+            try {
+              coreSessionToken = decryptPrivateKey(transitKey, coreSessionToken)
+            } catch (e) {
+              console.log('Failed decryption of coreSessionToken, will try to use as given')
+            }
+          }
+        } else {
+          throw new LoginFailedError('Authenticating with protocol > 1.1.0 requires transit' +
+                                     ' key, and none found.')
         }
-        let hubUrl = BLOCKSTACK_DEFAULT_GAIA_HUB_URL
-        if (isLaterVersion(tokenPayload.version, '1.2.0') &&
-            tokenPayload.hubUrl !== null && tokenPayload.hubUrl !== undefined) {
-          hubUrl = tokenPayload.hubUrl
-        }
+      }
+      let hubUrl = BLOCKSTACK_DEFAULT_GAIA_HUB_URL
+      if (isLaterVersion(tokenPayload.version, '1.2.0') &&
+          tokenPayload.hubUrl !== null && tokenPayload.hubUrl !== undefined) {
+        hubUrl = tokenPayload.hubUrl
+      }
 
-        const userData = {
-          username: tokenPayload.username,
-          profile: tokenPayload.profile,
-          appPrivateKey,
-          coreSessionToken,
-          authResponseToken,
-          hubUrl
-        }
-        const profileURL = tokenPayload.profile_url
-        if ((userData.profile === null ||
-             userData.profile === undefined) &&
-            profileURL !== undefined && profileURL !== null) {
-          fetch(profileURL)
-            .then(response => {
-              if (!response.ok) { // return blank profile if we fail to fetch
-                userData.profile = Object.assign({}, DEFAULT_PROFILE)
-                window.localStorage.setItem(
-                  BLOCKSTACK_STORAGE_LABEL, JSON.stringify(userData))
-                resolve(userData)
-              } else {
-                response.text()
+      const userData = {
+        username: tokenPayload.username,
+        profile: tokenPayload.profile,
+        appPrivateKey,
+        coreSessionToken,
+        authResponseToken,
+        hubUrl
+      }
+      const profileURL = tokenPayload.profile_url
+      if ((userData.profile === null ||
+           userData.profile === undefined) &&
+          profileURL !== undefined && profileURL !== null) {
+        return fetch(profileURL)
+          .then(response => {
+            if (!response.ok) { // return blank profile if we fail to fetch
+              userData.profile = Object.assign({}, DEFAULT_PROFILE)
+              window.localStorage.setItem(
+                BLOCKSTACK_STORAGE_LABEL, JSON.stringify(userData))
+              return userData
+            } else {
+              return response.text()
                 .then(responseText => JSON.parse(responseText))
                 .then(wrappedProfile => extractProfile(wrappedProfile[0].token))
                 .then(profile => {
                   userData.profile = profile
                   window.localStorage.setItem(
                     BLOCKSTACK_STORAGE_LABEL, JSON.stringify(userData))
-                  resolve(userData)
+                  return userData
                 })
-              }
-            })
-        } else {
-          userData.profile = tokenPayload.profile
-          window.localStorage.setItem(
-            BLOCKSTACK_STORAGE_LABEL, JSON.stringify(userData))
-          resolve(userData)
-        }
+            }
+          })
       } else {
-        reject()
+        userData.profile = tokenPayload.profile
+        window.localStorage.setItem(
+          BLOCKSTACK_STORAGE_LABEL, JSON.stringify(userData))
+        return userData
       }
     })
-  })
 }
 
 /**

--- a/src/errors.js
+++ b/src/errors.js
@@ -84,3 +84,12 @@ export class InvalidAmountError extends BlockstackError {
     this.message = message
   }
 }
+
+export class LoginFailedError extends BlockstackError {
+  constructor(reason: string) {
+    const message = `Failed to login: ${reason}`
+    super({ code: 'login_failed', message })
+    this.message = message
+    this.name = 'LoginFailedError'
+  }
+}


### PR DESCRIPTION
This improves error handling in `blockstack.js` authentication.

If the given auth response object is invalid, it rejects with: 

```javascript
LoginFailedError('Invalid authentication response.')
```

If the given auth response object has version > `1.1.0` (when the transit key began to be used), and the decryption of the appPrivateKey _fails_, then the function rejects with:

```javascript
LoginFailedError('Failed decrypting appPrivateKey. Usually means that the' +
                            ' transit key has changed during login.')
```

I also added code coverage for `handlePendingSignin` with both a bad transit key, and a good transit key.

You can test this by linking the modified `blockstack.js` and trying to sign in with a bad transit key (start the login in, in say, private browsing mode) and a good one.
