### PR TITLE
Updating auth README example

### DIFF
--- a/src/auth/README.md
+++ b/src/auth/README.md
@@ -62,7 +62,8 @@ if (blockstack.isUserSignedIn()) {
   const userData = blockstack.loadUserData()
   showProfile(userData.profile)
 } else if (blockstack.isSignInPending()) {
-  blockstack.handlePendingSignIn(function(userData) {
+  blockstack.handlePendingSignIn()
+  .then(userData => {
     showProfile(userData.profile)
   })
 }


### PR DESCRIPTION
Spotted this small issue with an example in the `auth/README.md` while working on an app. `handlePendingSignIn` doesn't take a callback anymore and instead returns a promise.