### PR TITLE
Resolving Instagram Proofs Update #417

### DIFF
--- a/src/profiles/services/instagram.js
+++ b/src/profiles/services/instagram.js
@@ -39,7 +39,7 @@ class Instagram extends Service {
     const $ = cheerio.load(searchText)
     const username = $('meta[property="og:description"]').attr('content')
     if (username !== undefined && username.split(':').length > 1) {
-      return username.split(':')[0].match(/\(([^)]+)\)/)[1].substr(1)
+      return username.split(':')[0].match(/(@\w+)/)[0].substr(1)
     } else {
       return ''
     }

--- a/tests/testData/profiles/ken.verification.instagram.html
+++ b/tests/testData/profiles/ken.verification.instagram.html
@@ -50,11 +50,11 @@ Instagram
     
     
     <link rel="canonical" href="https://www.instagram.com/p/BYj6UDwgaX7/" />
-    <meta content="0 Likes, 1 Comments - blckstck (@blckstcktest) on Instagram: “Verifying my Blockstack ID is secured with the address 1AtFqXxcckuoEN4iMNNe7n83c5nugxpzb5”" name="description" />
+    <meta content="0 Likes, 1 Comments - @blckstcktest on Instagram: “Verifying my Blockstack ID is secured with the address 1AtFqXxcckuoEN4iMNNe7n83c5nugxpzb5”" name="description" />
     <meta property="og:site_name" content="Instagram" />
     <meta property="og:title" content="Instagram post by blckstck • Sep 3, 2017 at 1:52am UTC" />
     <meta property="og:image" content="https://instagram.fybz1-1.fna.fbcdn.net/t51.2885-15/e35/21294992_902201159928919_7676736614004948992_n.jpg" />
-    <meta property="og:description" content="0 Likes, 1 Comments - blckstck (@blckstcktest) on Instagram: “Verifying my Blockstack ID is secured with the address 1AtFqXxcckuoEN4iMNNe7n83c5nugxpzb5”" />
+    <meta property="og:description" content="0 Likes, 1 Comments - @blckstcktest on Instagram: “Verifying my Blockstack ID is secured with the address 1AtFqXxcckuoEN4iMNNe7n83c5nugxpzb5”" />
     <meta property="fb:app_id" content="124024574287414" />
     <meta property="og:url" content="https://www.instagram.com/p/BYj6UDwgaX7/" />
     <meta property="instapp:owner_user_id" content="5962630902" />


### PR DESCRIPTION
This fix updates Instagram social proof checking #417 since the format of the meta tag has been changed.

Fixes include:
- Changing regular expression to quickly find "username" in meta tag content.
- Updating test cases.