### PR TITLE
Hotfix/safety name count fix

### DIFF
--- a/src/operations/safety.js
+++ b/src/operations/safety.js
@@ -123,7 +123,8 @@ function isInGracePeriod(fullyQualifiedName: string) {
 
 function addressCanReceiveName(address: string) {
   return config.network.getNamesOwned(address)
-    .then((names) => (names.length < 25))
+    .then((names) => (Promise.all(names.map((name) => isNameValid(name)))
+      .then((validNames) => validNames.filter((nameValid) => nameValid).length < 25)))
 }
 
 export const safety = {

--- a/tests/unitTests/src/unitTestsOperations.js
+++ b/tests/unitTests/src/unitTestsOperations.js
@@ -1074,7 +1074,7 @@ function transactionTests() {
 
 function safetyTests() {
   test('addCanReceiveName', (t) => {
-    t.plan(2)
+    t.plan(3)
     FetchMock.restore()
     FetchMock.get(`https://core.blockstack.org/v1/addresses/bitcoin/${testAddresses[1].address}`,
                   { names: ['dummy.id', 'dummy.id', 'dummy.id'] })
@@ -1083,11 +1083,19 @@ function safetyTests() {
     FetchMock.get(`https://core.blockstack.org/v1/addresses/bitcoin/${testAddresses[0].address}`,
                   { names: namesTooMany })
 
+    const namesWithSubdomains = new Array(25)
+    namesWithSubdomains.fill('dummy.id')
+    namesWithSubdomains[24] = 'dummy.dummy.id'
+    FetchMock.get(`https://core.blockstack.org/v1/addresses/bitcoin/${testAddresses[2].address}`,
+                  { names: namesWithSubdomains })
+
     Promise.all([safety.addressCanReceiveName(testAddresses[0].address),
-                 safety.addressCanReceiveName(testAddresses[1].address)])
-      .then(([t0, t1]) => {
-        t.ok(t1, 'Test address ${testAddresses[1].address} should not have too many names.')
-        t.ok(!t0, 'Test address ${testAddresses[0].address} should have too many names.')
+                 safety.addressCanReceiveName(testAddresses[1].address),
+                 safety.addressCanReceiveName(testAddresses[2].address)])
+      .then(([t0, t1, t2]) => {
+        t.ok(t1, `Test address ${testAddresses[1].address} should not have too many names.`)
+        t.ok(!t0, `Test address ${testAddresses[0].address} should have too many names.`)
+        t.ok(t2, `Test address ${testAddresses[2].address} should not have too many names.`)
       })
   })
 


### PR DESCRIPTION
This fixes a bug in `safety.js` where sponsored names are also counted towards the number of names an address owns.  The consensus core does not count sponsored names towards an address's name quota, so this safety check should only count on-chain names as well.