### PR TITLE
Hotfix/namespace burn address

### DIFF
--- a/src/network.js
+++ b/src/network.js
@@ -90,23 +90,28 @@ export class BlockstackNetwork {
   }
 
   getNamespaceBurnAddress(namespace: string) {
-    return fetch(`${this.blockstackAPIUrl}/v1/namespaces/${namespace}`)
-      .then(resp => {
-        if (resp.status === 404) {
-          throw new Error(`No such namespace '${namespace}'`)
-        } else {
-          return resp.json()
-        }
-      })
-      .then(namespaceInfo => {
-        let address = '1111111111111111111114oLvT2' // default burn address
-        if (namespaceInfo.version === 2) {
-          // pay-to-namespace-creator
+    return Promise.all([
+      fetch(`${this.blockstackAPIUrl}/v1/namespaces/${namespace}`),
+      this.getBlockHeight()
+    ])
+    .then(([resp, blockHeight]) => {
+      if (resp.status === 404) {
+        throw new Error(`No such namespace '${namespace}'`)
+      } else {
+        return Promise.all([resp.json(), blockHeight])
+      }
+    })
+    .then(([namespaceInfo, blockHeight]) => {
+      let address = '1111111111111111111114oLvT2' // default burn address
+      if (namespaceInfo.version === 2) {
+        // pay-to-namespace-creator if this namespace is less than 1 year old
+        if (namespaceInfo.reveal_block + 52595 >= blockHeight) {
           address = namespaceInfo.address
         }
-        return address
-      })
-      .then(address => this.coerceAddress(address))
+      }
+      return address
+    })
+    .then(address => this.coerceAddress(address))
   }
 
   getNameInfo(fullyQualifiedName: string) {

--- a/src/network.js
+++ b/src/network.js
@@ -100,14 +100,10 @@ export class BlockstackNetwork {
       })
       .then(namespaceInfo => {
         let address = '1111111111111111111114oLvT2' // default burn address
-        const blockHeights = Object.keys(namespaceInfo.history)
-        blockHeights.sort((x, y) => (parseInt(x, 10) - parseInt(y, 10)))
-        blockHeights.forEach(blockHeight => {
-          const infoAtBlock = namespaceInfo.history[blockHeight][0]
-          if (infoAtBlock.hasOwnProperty('burn_address')) {
-            address = infoAtBlock.burn_address
-          }
-        })
+        if (namespaceInfo.version === 2) {
+          // pay-to-namespace-creator
+          address = namespaceInfo.address
+        }
         return address
       })
       .then(address => this.coerceAddress(address))

--- a/tests/unitTests/src/unitTestsOperations.js
+++ b/tests/unitTests/src/unitTestsOperations.js
@@ -327,7 +327,7 @@ function transactionTests() {
     FetchMock.get('https://core.blockstack.org/v1/prices/namespaces/hello',
                   NAMESPACE_PRICE)
     FetchMock.get('https://core.blockstack.org/v1/namespaces/test',
-                  { history: { 10: [{ burn_address: BURN_ADDR }] } })
+                  { version: 2, address: BURN_ADDR })
     FetchMock.get('https://core.blockstack.org/v1/blockchains/bitcoin/consensus',
                   { consensus_hash: 'dfe87cfd31ffa2a3b8101e3e93096f2b' })
   }


### PR DESCRIPTION
The burn address for a namespace is chosen by its `version` field.  `version === 1` means "burn to the default burn address", and `version === 2` means "burn to the namespace's `address` value".  This PR fixes this behavior in `network.js` and fixes the operations unit test to test for this behavior.