### PR TITLE
Remove console.log in resolveZoneFileToProfile

### DIFF
--- a/src/profiles/profileZoneFiles.js
+++ b/src/profiles/profileZoneFiles.js
@@ -97,11 +97,9 @@ export function resolveZoneFileToProfile(zoneFile, publicKeyOrAddress) {
           return
         })
         .catch((error) => {
-          console.log(`resolveZoneFileToProfile: error fetching token file ${tokenFileUrl}`, error)
           reject(error)
         })
     } else {
-      console.log('Token file url not found. Resolving to blank profile.')
       resolve({})
       return
     }


### PR DESCRIPTION
I find these console.log'd errors pretty annoying, and printing things with console.log as a library is generally frowned upon.

Opening a PR to see if others agree with me :grinning: 