### PR TITLE
Hotfix/safety expire block

### DIFF
--- a/src/operations/safety.js
+++ b/src/operations/safety.js
@@ -109,7 +109,7 @@ function isInGracePeriod(fullyQualifiedName: string) {
                       network.getBlockHeight(),
                       network.getGracePeriod(fullyQualifiedName)])
     .then(([nameInfo, blockHeight, gracePeriod]) => {
-      const expiresAt = nameInfo.expires_block
+      const expiresAt = nameInfo.expire_block
       return (blockHeight >= expiresAt) && (blockHeight < (gracePeriod + expiresAt))
     })
     .catch((e) => {

--- a/tests/unitTests/src/unitTestsOperations.js
+++ b/tests/unitTests/src/unitTestsOperations.js
@@ -1156,7 +1156,7 @@ function safetyTests() {
     FetchMock.get('https://core.blockstack.org/v1/names/bar.test',
                   { body: 'Name available', status: 404 })
     FetchMock.get('https://core.blockstack.org/v1/names/foo.test',
-                  { expires_block: 50 })
+                  { expire_block: 50 })
     FetchMock.getOnce('https://blockchain.info/latestblock?cors=true',
                       { height: 49 })
     safety.isInGracePeriod('foo.test')


### PR DESCRIPTION
Core returns `expire_block`, not `expires_block` on `GET /v1/names/{name}`.