### PR TITLE
force UTXO values to be integers

### DIFF
--- a/src/network.js
+++ b/src/network.js
@@ -617,7 +617,7 @@ export class BitcoindAPI extends BitcoinNetwork {
       .then(resp => resp.json())
       .then(x => x.result)
       .then(utxos => utxos.map(
-        x => Object({ value: x.amount * SATOSHIS_PER_BTC,
+        x => Object({ value: parseInt(Math.round(x.amount * SATOSHIS_PER_BTC)),
                       confirmations: x.confirmations,
                       tx_hash: x.txid,
                       tx_output_n: x.vout })))

--- a/src/network.js
+++ b/src/network.js
@@ -617,7 +617,7 @@ export class BitcoindAPI extends BitcoinNetwork {
       .then(resp => resp.json())
       .then(x => x.result)
       .then(utxos => utxos.map(
-        x => Object({ value: parseInt(Math.round(x.amount * SATOSHIS_PER_BTC)),
+        x => Object({ value: Math.round(x.amount * SATOSHIS_PER_BTC),
                       confirmations: x.confirmations,
                       tx_hash: x.txid,
                       tx_output_n: x.vout })))


### PR DESCRIPTION
This forces the values of UTXOs to be integers.  It's very hard to test this--I discovered it by accident in the integration test framework when I noticed a test failing because one of the values was `999251499.9999999`.