### PR TITLE
[Storage] encrypt and decrypt strings

### DIFF
--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -45,6 +45,30 @@ export function getUserAppFileUrl(path: string, username: string, appOrigin: str
 }
 
 /**
+ * Encrypts the data provided with the transit public key.
+ * @param {String|Buffer} content - data to encrypt
+ * @return {String} Stringified ciphertext object
+ */
+export function encryptContent(content: string | Buffer) {
+  const privateKey = loadUserData().appPrivateKey
+  const publicKey = getPublicKeyFromPrivate(privateKey)
+  const cipherObject = encryptECIES(publicKey, content)
+  return JSON.stringify(cipherObject)
+}
+
+/**
+ * Decrypts data encrypted with `encryptContent` with the
+ * transit private key.
+ * @param {String|Buffer} content - encrypted content.
+ * @return {String|Buffer} decrypted content.
+ */
+export function decryptContent(content: string) {
+  const privateKey = loadUserData().appPrivateKey
+  const cipherObject = JSON.parse(content)
+  return decryptECIES(privateKey, cipherObject)
+}
+
+/**
  * Retrieves the specified file from the app's data store.
  * @param {String} path - the path to the file to read
  * @param {Object} [options=null] - options object
@@ -105,9 +129,7 @@ export function getFile(path: string, options?: {decrypt?: boolean, username?: s
     })
     .then((storedContents) => {
       if (opt.decrypt && storedContents !== null) {
-        const privateKey = loadUserData().appPrivateKey
-        const cipherObject = JSON.parse(storedContents)
-        return decryptECIES(privateKey, cipherObject)
+        return decryptContent(storedContents)
       } else {
         return storedContents
       }
@@ -135,10 +157,7 @@ export function putFile(path: string, content: string | Buffer, options?: {encry
     contentType = 'application/octet-stream'
   }
   if (opt.encrypt) {
-    const privateKey = loadUserData().appPrivateKey
-    const publicKey = getPublicKeyFromPrivate(privateKey)
-    const cipherObject = encryptECIES(publicKey, content)
-    content = JSON.stringify(cipherObject)
+    content = encryptContent(content)
     contentType = 'application/json'
   }
   return getOrSetLocalGaiaHubConnection()

--- a/tests/unitTests/src/unitTestsStorage.js
+++ b/tests/unitTests/src/unitTestsStorage.js
@@ -6,7 +6,8 @@ import bitcoin from 'bitcoinjs-lib'
 import { uploadToGaiaHub, getFullReadUrl,
          connectToGaiaHub, BLOCKSTACK_GAIA_HUB_LABEL,
          getBucketUrl } from '../../../lib/storage/hub'
-import { getFile } from '../../../lib/storage'
+import { getFile, encryptContent, decryptContent } from '../../../lib/storage'
+import { BLOCKSTACK_STORAGE_LABEL } from '../../../lib/auth/authConstants'
 
 class LocalStorage {
   constructor() {
@@ -212,6 +213,23 @@ export function runStorageTests() {
         t.ok(file, 'Returns file content')
         t.same(JSON.parse(file), JSON.parse(fileContents))
       })
+  })
+
+  test('encrypt & decrypt content', (t) => {
+    t.plan(2)
+    const privateKey = 'a5c61c6ca7b3e7e55edee68566aeab22e4da26baa285c7bd10e8d2218aa3b229'
+    const userData = JSON.stringify({ appPrivateKey: privateKey })
+    // save any previous content
+    const oldContent = window.localStorage.getItem(BLOCKSTACK_STORAGE_LABEL)
+    // simulate fake user signed in
+    window.localStorage.setItem(BLOCKSTACK_STORAGE_LABEL, userData)
+    const content = 'yellowsubmarine'
+    const ciphertext = encryptContent(content)
+    t.ok(ciphertext)
+    const deciphered = decryptContent(ciphertext)
+    t.equal(content, deciphered)
+    // put back whatever was inside before
+    window.localStorage.setItem(BLOCKSTACK_STORAGE_LABEL, oldContent)
   })
 
   test('putFile unencrypted', (t) => {


### PR DESCRIPTION
This PR fixes #269 by allowing to encrypt and decrypt strings directly. It's a take over from the work in https://github.com/blockstack/blockstack.js/pull/274 from https://github.com/nivas8292 .

During my code exploration I've noted that the `getFile` and `putFile` never gets tested with encryption turned on. As a further step, I think it might be good to add that test coverage. What do you think ? 
I could open an issue and work on this later on if you think that makes sense.