### PR TITLE
Add option to pass auth response token to handlePendingSignIn

### DIFF
--- a/src/auth/authApp.js
+++ b/src/auth/authApp.js
@@ -122,9 +122,9 @@ export function redirectToSignIn(redirectURI: string = `${window.location.origin
  * Retrieve the authentication token from the URL query
  * @return {String} the authentication token if it exists otherwise `null`
  */
-export function getAuthResponseToken() {
+export function getAuthResponseToken(): string {
   const queryDict = queryString.parse(location.search)
-  return queryDict.authResponse ? queryDict.authResponse : null
+  return queryDict.authResponse ? queryDict.authResponse : ''
 }
 
 /**
@@ -142,13 +142,12 @@ export function isSignInPending() {
  *
  * @param {String} nameLookupURL - the endpoint against which to verify public
  * keys match claimed username
- *
+ * @param  {String} authResponseToken - the auth response token
  * @return {Promise} that resolves to the user data object if successful and rejects
  * if handling the sign in request fails or there was no pending sign in request.
  */
-export function handlePendingSignIn(nameLookupURL: string = 'https://core.blockstack.org/v1/names/') {
-  const authResponseToken = getAuthResponseToken()
-
+export function handlePendingSignIn(nameLookupURL: string = 'https://core.blockstack.org/v1/names/', 
+                                    authResponseToken: string = getAuthResponseToken()) {
   return verifyAuthResponse(authResponseToken, nameLookupURL)
     .then(isValid => {
       if (!isValid) {

--- a/tests/unitTests/src/unitTestsAuth.js
+++ b/tests/unitTests/src/unitTestsAuth.js
@@ -290,4 +290,31 @@ export function runAuthTests() {
     signUserOut()
     t.equal(startURL, window.location, 'User should not be redirected')
   })
+
+  test('handlePendingSignIn with authResponseToken', (t) => {
+    t.plan(1)
+
+    const url = `${nameLookupURL}ryan.id`
+
+    FetchMock.get(url, sampleNameRecords.ryan)
+
+    const appPrivateKey = makeECPrivateKey()
+    const transitPrivateKey = makeECPrivateKey()
+    const transitPublicKey = getPublicKeyFromPrivate(transitPrivateKey)
+    const metadata = {}
+
+    const authResponse = makeAuthResponse(privateKey, sampleProfiles.ryan, 'ryan.id',
+                                          metadata, undefined, appPrivateKey, undefined,
+                                          transitPublicKey)
+    global.window.localStorage.setItem(BLOCKSTACK_APP_PRIVATE_KEY_LABEL,
+                                       transitPrivateKey)
+    handlePendingSignIn(nameLookupURL, authResponse)
+      .then(() => {
+        t.pass('Should correctly sign in with auth response')
+      })
+      .catch((err) => {
+        console.log(err.stack)
+        t.fail('Should not error')
+      })
+  })
 }


### PR DESCRIPTION
Changes to resolve #464.
Added a second parameter `authResponseToken` with default value `getAuthResponseToken()` to `handlePendingSignIn` .
New syntax:
`export function handlePendingSignIn(nameLookupURL: string = 'https://core.blockstack.org/v1/names/', authResponseToken: string = getAuthResponseToken())`
Added  unit test 'handlePendingSignIn with authResponseToken' in `unitTestsAuth.js` to validate the changes.
