### PR TITLE
No need to specify parameter in InvalidDIDError

### DIFF
--- a/dist/blockstack.js
+++ b/dist/blockstack.js
@@ -1544,7 +1544,7 @@ var InvalidDIDError = exports.InvalidDIDError = function (_BlockstackError4) {
 
     _classCallCheck(this, InvalidDIDError);
 
-    var _this5 = _possibleConstructorReturn(this, (InvalidDIDError.__proto__ || Object.getPrototypeOf(InvalidDIDError)).call(this, { code: 'invalid_did_error', message: message, param: '' }));
+    var _this5 = _possibleConstructorReturn(this, (InvalidDIDError.__proto__ || Object.getPrototypeOf(InvalidDIDError)).call(this, { code: 'invalid_did_error', message: message }));
 
     _this5.name = 'InvalidDIDError';
     _this5.message = message;
@@ -11019,7 +11019,7 @@ module.exports={
   "_args": [
     [
       "bigi@1.4.2",
-      "/home/aaron/devel/blockstack.js"
+      "/Users/larry/git/blockstack.js"
     ]
   ],
   "_from": "bigi@1.4.2",
@@ -11045,7 +11045,7 @@ module.exports={
   ],
   "_resolved": "https://registry.npmjs.org/bigi/-/bigi-1.4.2.tgz",
   "_spec": "1.4.2",
-  "_where": "/home/aaron/devel/blockstack.js",
+  "_where": "/Users/larry/git/blockstack.js",
   "bugs": {
     "url": "https://github.com/cryptocoinjs/bigi/issues"
   },
@@ -33852,7 +33852,7 @@ module.exports={
   "_args": [
     [
       "cheerio@0.22.0",
-      "/home/aaron/devel/blockstack.js"
+      "/Users/larry/git/blockstack.js"
     ]
   ],
   "_from": "cheerio@0.22.0",
@@ -33876,7 +33876,7 @@ module.exports={
   ],
   "_resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
   "_spec": "0.22.0",
-  "_where": "/home/aaron/devel/blockstack.js",
+  "_where": "/Users/larry/git/blockstack.js",
   "author": {
     "name": "Matt Mueller",
     "email": "mattmuelle@gmail.com",
@@ -42121,7 +42121,7 @@ module.exports={
   "_args": [
     [
       "elliptic@6.4.0",
-      "/home/aaron/devel/blockstack.js"
+      "/Users/larry/git/blockstack.js"
     ]
   ],
   "_from": "elliptic@6.4.0",
@@ -42148,7 +42148,7 @@ module.exports={
   ],
   "_resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
   "_spec": "6.4.0",
-  "_where": "/home/aaron/devel/blockstack.js",
+  "_where": "/Users/larry/git/blockstack.js",
   "author": {
     "name": "Fedor Indutny",
     "email": "fedor@indutny.com"
@@ -54609,7 +54609,7 @@ module.exports={
   "_args": [
     [
       "elliptic@5.2.1",
-      "/home/aaron/devel/blockstack.js"
+      "/Users/larry/git/blockstack.js"
     ]
   ],
   "_from": "elliptic@5.2.1",
@@ -54633,7 +54633,7 @@ module.exports={
   ],
   "_resolved": "https://registry.npmjs.org/elliptic/-/elliptic-5.2.1.tgz",
   "_spec": "5.2.1",
-  "_where": "/home/aaron/devel/blockstack.js",
+  "_where": "/Users/larry/git/blockstack.js",
   "author": {
     "name": "Fedor Indutny",
     "email": "fedor@indutny.com"

--- a/dist/blockstack.js
+++ b/dist/blockstack.js
@@ -1547,7 +1547,6 @@ var InvalidDIDError = exports.InvalidDIDError = function (_BlockstackError4) {
     var _this5 = _possibleConstructorReturn(this, (InvalidDIDError.__proto__ || Object.getPrototypeOf(InvalidDIDError)).call(this, { code: 'invalid_did_error', message: message }));
 
     _this5.name = 'InvalidDIDError';
-    _this5.message = message;
     return _this5;
   }
 

--- a/src/errors.js
+++ b/src/errors.js
@@ -56,7 +56,6 @@ export class InvalidDIDError extends BlockstackError {
   constructor(message: string = '') {
     super({ code: 'invalid_did_error', message })
     this.name = 'InvalidDIDError'
-    this.message = message
   }
 }
 

--- a/src/errors.js
+++ b/src/errors.js
@@ -54,7 +54,7 @@ export class RemoteServiceError extends BlockstackError {
 
 export class InvalidDIDError extends BlockstackError {
   constructor(message: string = '') {
-    super({ code: 'invalid_did_error', message, param: '' })
+    super({ code: 'invalid_did_error', message })
     this.name = 'InvalidDIDError'
     this.message = message
   }

--- a/tests/unitTests/src/index.js
+++ b/tests/unitTests/src/index.js
@@ -4,7 +4,8 @@ import { runProofsUnitTests }   from './unitTestsProofs'
 import { runUtilsTests }        from './unitTestsUtils'
 import { runEncryptionTests }   from './unitTestsEncryption'
 import { runStorageTests }      from './unitTestsStorage'
-import { runOperationsTests }      from './unitTestsOperations'
+import { runOperationsTests }   from './unitTestsOperations'
+import { runErrorsTests }       from './unitTestsErrors'
 
 // Utils tests
 runUtilsTests()
@@ -26,3 +27,6 @@ runStorageTests()
 
 // Operations Tests
 runOperationsTests()
+
+// Errors Tests
+runErrorsTests()

--- a/tests/unitTests/src/unitTestsErrors.js
+++ b/tests/unitTests/src/unitTestsErrors.js
@@ -1,0 +1,14 @@
+import test from 'tape-promise/tape'
+
+import { InvalidDIDError } from '../../../lib/errors'
+
+export function runErrorsTests() {
+  test('InvalidDIDError', (t) => {
+    t.plan(3)
+    const error = new InvalidDIDError('the message')
+
+    t.equal(error.message, 'the message')
+    t.equal(error.parameter, null)
+    t.equal(error.param, undefined)
+  })
+}


### PR DESCRIPTION
We incorrectly specified "param" in the object passed to the call to super when we don't need to specify any parameter at all.

Addresses #468 raised by @michaelfedora and @vsund.

If either of you have a second, let me know if this addresses the issue.

I'm planning on merging this into develop since I don't think we need to actually ship a hotfix release for this change. Will include it in the next release.