### PR TITLE
Remove uri-js so create-react-app will build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -992,8 +992,7 @@
                   "version": "0.1.1",
                   "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
                   "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-                  "dev": true,
-                  "optional": true
+                  "dev": true
                 },
                 "json-schema": {
                   "version": "0.2.3",
@@ -13250,11 +13249,6 @@
         }
       }
     },
-    "punycode": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-      "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
-    },
     "pushdata-bitcoin": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pushdata-bitcoin/-/pushdata-bitcoin-1.0.1.tgz",
@@ -14966,14 +14960,6 @@
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "dev": true
         }
-      }
-    },
-    "uri-js": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-3.0.2.tgz",
-      "integrity": "sha1-+QuFhQf4HepNz7s8TD2/orVX+qo=",
-      "requires": {
-        "punycode": "2.1.0"
       }
     },
     "urix": {

--- a/package.json
+++ b/package.json
@@ -119,7 +119,6 @@
     "ripemd160": "^2.0.1",
     "schema-inspector": "^1.6.4",
     "sprintf-js": "^1.0.3",
-    "uri-js": "^3.0.2",
     "uuid": "^3.2.1",
     "validator": "^7.0.0",
     "zone-file": "^0.2.2"

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,8 +1,9 @@
 /* @flow */
-import { parse as uriParse } from 'uri-js'
+import url from 'url'
 import { ECPair } from 'bitcoinjs-lib'
 import { config } from './config'
 import BigInteger from 'bigi'
+
 
 export const BLOCKSTACK_HANDLER = 'blockstack'
 /**
@@ -123,17 +124,18 @@ export function makeUUID4() {
  * @private
  */
 export function isSameOriginAbsoluteUrl(uri1: string, uri2: string) {
-  const parsedUri1 = uriParse(uri1)
-  const parsedUri2 = uriParse(uri2)
+  const parsedUri1 = url.parse(uri1)
+  const parsedUri2 = url.parse(uri2)
 
-  const port1 = parsedUri1.port | 0 || (parsedUri1.scheme === 'https' ? 443 : 80)
-  const port2 = parsedUri2.port | 0 || (parsedUri2.scheme === 'https' ? 443 : 80)
+  const port1 = parseInt(parsedUri1.port, 10) | 0 || (parsedUri1.protocol === 'https' ? 443 : 80)
+  const port2 = parseInt(parsedUri2.port, 10) | 0 || (parsedUri2.protocol === 'https' ? 443 : 80)
 
   const match = {
-    scheme: parsedUri1.scheme === parsedUri2.scheme,
+    scheme: parsedUri1.protocol === parsedUri2.protocol,
     hostname: parsedUri1.hostname === parsedUri2.hostname,
     port: port1 === port2,
-    absolute: (parsedUri1.reference === 'absolute') && (parsedUri2.reference === 'absolute')
+    absolute: (uri1.includes('http://') || uri1.includes('https')) 
+    && (uri2.includes('http://') || uri2.includes('https'))
   }
 
   return match.scheme && match.hostname && match.port && match.absolute

--- a/src/utils.js
+++ b/src/utils.js
@@ -127,15 +127,15 @@ export function isSameOriginAbsoluteUrl(uri1: string, uri2: string) {
   const parsedUri1 = url.parse(uri1)
   const parsedUri2 = url.parse(uri2)
 
-  const port1 = parseInt(parsedUri1.port, 10) | 0 || (parsedUri1.protocol === 'https' ? 443 : 80)
-  const port2 = parseInt(parsedUri2.port, 10) | 0 || (parsedUri2.protocol === 'https' ? 443 : 80)
+  const port1 = parseInt(parsedUri1.port, 10) | 0 || (parsedUri1.protocol === 'https:' ? 443 : 80)
+  const port2 = parseInt(parsedUri2.port, 10) | 0 || (parsedUri2.protocol === 'https:' ? 443 : 80)
 
   const match = {
     scheme: parsedUri1.protocol === parsedUri2.protocol,
     hostname: parsedUri1.hostname === parsedUri2.hostname,
     port: port1 === port2,
-    absolute: (uri1.includes('http://') || uri1.includes('https')) 
-    && (uri2.includes('http://') || uri2.includes('https'))
+    absolute: (uri1.includes('http://') || uri1.includes('https://')) 
+    && (uri2.includes('http://') || uri2.includes('https://'))
   }
 
   return match.scheme && match.hostname && match.port && match.absolute


### PR DESCRIPTION
Removes `url-js` in favor of only using `url` from the node api.

fixes #472