### PR TITLE
Add intended hubUrl to the Gaia authentication JWT

### DIFF
--- a/src/storage/hub.js
+++ b/src/storage/hub.js
@@ -62,7 +62,7 @@ function makeLegacyAuthToken(challengeText: string, signerKeyHex: string): strin
   }
 }
 
-function makeV1GaiaAuthToken(hubInfo: Object, signerKeyHex: string): string {
+function makeV1GaiaAuthToken(hubInfo: Object, signerKeyHex: string, hubUrl: string): string {
   const challengeText = hubInfo.challenge_text
   const handlesV1Auth = (hubInfo.latest_auth_version &&
                          parseInt(hubInfo.latest_auth_version.slice(1), 10) >= 1)
@@ -74,7 +74,7 @@ function makeV1GaiaAuthToken(hubInfo: Object, signerKeyHex: string): string {
 
   const salt = crypto.randomBytes(16).toString('hex')
   const payload = { gaiaChallenge: challengeText,
-                    iss, salt }
+                    hubUrl, iss, salt }
   const token = new TokenSigner('ES256K', signerKeyHex).sign(payload)
   return `v1:${token}`
 }
@@ -87,7 +87,7 @@ export function connectToGaiaHub(gaiaHubUrl: string,
     .then((response) => response.json())
     .then((hubInfo) => {
       const readURL = hubInfo.read_url_prefix
-      const token = makeV1GaiaAuthToken(hubInfo, challengeSignerHex)
+      const token = makeV1GaiaAuthToken(hubInfo, challengeSignerHex, gaiaHubUrl)
       const address = hexStringToECPair(challengeSignerHex +
                                         (challengeSignerHex.length === 64 ? '01' : ''))
             .getAddress()

--- a/tests/unitTests/src/unitTestsStorage.js
+++ b/tests/unitTests/src/unitTestsStorage.js
@@ -8,7 +8,7 @@ import { uploadToGaiaHub, getFullReadUrl,
 import { getFile, encryptContent, decryptContent } from '../../../lib/storage'
 import { BLOCKSTACK_STORAGE_LABEL } from '../../../lib/auth/authConstants'
 import { getPublicKeyFromPrivate } from '../../../lib/keys'
-import { TokenVerifier } from 'jsontokens'
+import { TokenVerifier, decodeToken } from 'jsontokens'
 
 class LocalStorage {
   constructor() {
@@ -693,7 +693,7 @@ export function runStorageTests() {
   })
 
   test('connectToGaiaHub', (t) => {
-    t.plan(5)
+    t.plan(6)
 
     const hubServer = 'hub.testblockstack.org'
 
@@ -716,10 +716,12 @@ export function runStorageTests() {
         t.equal(hubInfo.read_url_prefix, config.url_prefix)
         t.equal(address, config.address)
         t.equal(hubServer, config.server)
+        const jsonTokenPart = config.token.slice('v1:'.length)
 
         const verified = new TokenVerifier('ES256K', publicKey)
-              .verify(config.token.slice('v1:'.length))
+              .verify(jsonTokenPart)
         t.ok(verified, 'Verified token')
+        t.equal(hubServer, decodeToken(jsonTokenPart).payload.hubUrl, 'Intended hubUrl')
       })
   })
 


### PR DESCRIPTION
This adds a `.hubUrl` field to the Gaia authentication JWT.

This will allow (future) versions of Gaia hubs to require that authentication tokens contain the correct `.hubUrl` field, which will prevent a malicious hub from replaying authentication tokens on another hub.
