### PR TITLE
Fix a padding issue in ecPairToHexString

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ encrypt content for other users.
   responses should now behave correctly.
 - `handlePendingSignIn` now takes a second parameter which is the
    signed authentication response token. Thanks to @muneebm for this!
+-  Fixed an issue in `ecPairToHexString` that may result in generation of
+   an incorrectly hex string encoding of the private key.
 
 ## [17.2.0]
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -91,7 +91,7 @@ export function hexStringToECPair(skHex: string) {
 }
 
 export function ecPairToHexString(secretKey: ECPair) {
-  const ecPointHex = secretKey.d.toHex()
+  const ecPointHex = secretKey.d.toBuffer(32).toString('hex')
   if (secretKey.compressed) {
     return `${ecPointHex}01`
   } else {

--- a/tests/unitTests/src/unitTestsUtils.js
+++ b/tests/unitTests/src/unitTestsUtils.js
@@ -1,7 +1,8 @@
 import test from 'tape-promise/tape'
 import { SECP256K1Client } from 'jsontokens'
 import {
-  getEntropy, makeECPrivateKey, publicKeyToAddress, isSameOriginAbsoluteUrl
+  getEntropy, makeECPrivateKey, publicKeyToAddress, isSameOriginAbsoluteUrl,
+  ecPairToHexString, hexStringToECPair
 } from '../../../lib'
 
 export function runUtilsTests() {
@@ -20,6 +21,18 @@ export function runUtilsTests() {
     const address = publicKeyToAddress(publicKey)
     t.ok(address, 'Address should have been created')
     t.equal(typeof address, 'string', 'Address should be a string')
+  })
+
+  test('ecPairToHexString', (t) => {
+    t.plan(2)
+
+    const privateKey = '00cdce6b5f87d38f2a830cae0da82162e1b487f07c5affa8130f01fe1a2a25fb01'
+    const expectedAddress = '1WykMawQRnLh7SWmmoRL4qTDNCgAsVRF1'
+
+    const computedECPair = hexStringToECPair(privateKey)
+    t.equal(privateKey, ecPairToHexString(computedECPair), 'Should return same hex string')
+
+    t.equal(expectedAddress, computedECPair.getAddress(), 'Should parse to correct address')
   })
 
   test('isSameOriginAbsoluteUrl', (t) => {


### PR DESCRIPTION
This fixes an issue in `ecPairToHexString` which will result in generating an _incorrect_ hex string encoding of the private key. This will lead to outputting an address which won't correspond to the original ECPair. I don't believe this function is used elsewhere in our codebase, so this shouldn't have created any issues so far, but this should be patched.

Included a test which uses a private key which previously would have been incorrectly encoded to ensure that the behavior is corrected.