### PR TITLE
Allow for subdomain proofs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ encrypt content for other users.
   responses should now behave correctly.
 - `handlePendingSignIn` now takes a second parameter which is the
    signed authentication response token. Thanks to @muneebm for this!
+- Proofs now support subdomains.
 
 ## [17.2.0]
 

--- a/src/profiles/services/serviceUtils.js
+++ b/src/profiles/services/serviceUtils.js
@@ -6,7 +6,7 @@ export function containsValidProofStatement(searchText: string, name: ?string = 
 
   searchText = searchText.toLowerCase()
 
-  if (name.split('.').length !== 2) {
+  if (name.split('.').length < 2) {
     throw new Error('Please provide the fully qualified Blockstack name.')
   }
 

--- a/tests/unitTests/src/unitTestsProofs.js
+++ b/tests/unitTests/src/unitTestsProofs.js
@@ -188,7 +188,7 @@ export function runInBodyIdentityVerificationTests() {
 
 export function runProofUtilsUnitTests() {
   test('containsValidProofStatement', (t) => {
-    t.plan(8)
+    t.plan(9)
 
     const naval = sampleVerifications.naval
 
@@ -209,6 +209,12 @@ export function runProofUtilsUnitTests() {
       false, 'Github gist post body should not contain valid proof statement for larry.id')
     t.equal(containsValidProofStatement(larry.facebook.body, 'larry.id'),
       true, 'Facebook post body should contain valid proof statement for larry.id')
+
+    const subdomainId = 'subdomainiac.id.blockstack'
+    t.equal(containsValidProofStatement(
+      `verifying that ${subdomainId} is my blockstack id`,
+      subdomainId
+    ), true, 'Subdomain IDs work as proofs')
 
     t.throws(() => {
       containsValidProofStatement(larry.facebook.body, 'larry')


### PR DESCRIPTION
Closes #446. Loosens the check against blockstack names to allow for subdomains. Adds a unit test to make sure this continues to work.