### PR TITLE
Update host url to point to webapp

### DIFF
--- a/src/auth/authConstants.js
+++ b/src/auth/authConstants.js
@@ -1,6 +1,6 @@
 export const BLOCKSTACK_HANDLER = 'blockstack'
 export const BLOCKSTACK_STORAGE_LABEL = 'blockstack'
-export const DEFAULT_BLOCKSTACK_HOST = 'https://blockstack.org/auth'
+export const DEFAULT_BLOCKSTACK_HOST = 'https://browser.blockstack.org/auth'
 export const DEFAULT_SCOPE = ['store_write']
 export const BLOCKSTACK_APP_PRIVATE_KEY_LABEL = 'blockstack-transit-private-key'
 export const BLOCKSTACK_DEFAULT_GAIA_HUB_URL = 'https://hub.blockstack.org'


### PR DESCRIPTION
This PR changes the default host constant to point to `browser.blockstack.org` versus the website. This should remove the need for this page -> blockstack.org/auth

cc @larrysalibra 