### PR TITLE
Redirect iOS Auth Requests to HTTPS Browser

### DIFF
--- a/src/auth/authApp.js
+++ b/src/auth/authApp.js
@@ -83,9 +83,17 @@ export function redirectToSignInWithAuthRequest(authRequest: string = makeAuthRe
     window.location = httpsURI
   }
 
-  function unsupportedBrowserCallback() { // Safari is unsupported by protocolCheck
-    Logger.warn('can not detect custom protocols on this browser')
-    window.location = protocolURI
+  function unsupportedBrowserCallback() {
+    if (/iPad|iPhone|iPod/.test(navigator.platform)) {
+      // iOS doesn’t do protocols (yet)
+      Logger.warn('platform does not support custom protocols, sending to https')
+      window.location = httpsURI
+    }
+    else {
+      // Safari is unsupported by protocolCheck
+      Logger.warn('can not detect custom protocols on this browser')
+      window.location = protocolURI
+    }
   }
 
   protocolCheck(protocolURI, failCallback, successCallback, unsupportedBrowserCallback)

--- a/src/auth/authApp.js
+++ b/src/auth/authApp.js
@@ -88,8 +88,7 @@ export function redirectToSignInWithAuthRequest(authRequest: string = makeAuthRe
       // iOS doesn’t do protocols (yet)
       Logger.warn('platform does not support custom protocols, sending to https')
       window.location = httpsURI
-    }
-    else {
+    } else {
       // Safari is unsupported by protocolCheck
       Logger.warn('can not detect custom protocols on this browser')
       window.location = protocolURI


### PR DESCRIPTION
Closes #481. Redirects iOS devices to `https://browser.blockstack.org/...` instead of `blockstack://...`. Tested on iOS simulator to make sure it works, and macOS Safari to make sure it didn't change that behavior.