### PR TITLE
Add empty version string for legacy auth responses

### DIFF
--- a/src/auth/authMessages.js
+++ b/src/auth/authMessages.js
@@ -173,7 +173,7 @@ export function makeAuthResponse(privateKey: string,
   } else {
     Logger.info('blockstack.js: generating legacy auth response')
     additionalProperties = {
-      version: ""
+      version: ''
     }
   }
 

--- a/src/auth/authMessages.js
+++ b/src/auth/authMessages.js
@@ -172,6 +172,9 @@ export function makeAuthResponse(privateKey: string,
     }
   } else {
     Logger.info('blockstack.js: generating legacy auth response')
+    additionalProperties = {
+      version: ""
+    }
   }
 
   /* Create the payload */


### PR DESCRIPTION
This PR 
* adds an empty version string to legacy auth responses
* fixes #514 

