### PR TITLE
Send browsers that can't protocol check to HTTPS

### DIFF
--- a/src/auth/authApp.js
+++ b/src/auth/authApp.js
@@ -92,9 +92,9 @@ export function redirectToSignInWithAuthRequest(authRequest: string = makeAuthRe
   }
 
   function unsupportedBrowserCallback() {
-    // Safari is unsupported by protocolCheck
-    Logger.warn('can not detect custom protocols on this browser')
-    window.location = protocolURI
+    // Safari, Opera & others are unsupported by protocolCheck
+    Logger.warn('can not detect custom protocols on this browser, sending to https')
+    window.location = httpsURI
   }
 
   protocolCheck(protocolURI, failCallback, successCallback, unsupportedBrowserCallback)


### PR DESCRIPTION
This is a small PR that changes the behavior of where users are redirected if their browser doesn't support checking if they can handle the `blockstack://` protocol URL. Currently, users of those browsers (namely Safari and Opera) get the following when trying to auth, if they don't have the desktop app installed:

<img align="center" width="250" alt="screen shot 2018-08-06 at 11 19 46 am" src="https://user-images.githubusercontent.com/649992/43725825-9498ac46-996b-11e8-9c3a-67ed242b3156.png">
<img align="center" width="250" alt="screen shot 2018-08-06 at 11 20 10 am" src="https://user-images.githubusercontent.com/649992/43725829-96edbaf4-996b-11e8-909c-0d8b219ce7e3.png">

<sup>Opera on the left, Safari on the right.</sup>

This PR changes it to default to redirecting browsers that can't do detection to `browser.blockstack.org` instead of `blockstack://` (Much like #522.) This makes the new user experience much better, but effectively makes the native app unusable in these browsers, since the user will never be directed to `blockstack://` and subsequently `localhost:8888`.

### Open Questions

* Do we have a large existing Opera / Safari userbase that this will affect?
* Can we communicate this change to users in a way that won't make them think they've had their app data erased?
* Is this tradeoff worthwhile? Does our community of developers agree?
* Should we provide a way for them to use the native app once they hit `browser.blockstack.org`?