### PR TITLE
Include babel-runtime

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,11 @@
 {
-  "presets": ["env", "flow"]
+  "presets": ["env", "flow"],
+  "plugins": [
+    ["transform-runtime", {
+      "helpers": false,
+      "polyfill": false,
+      "regenerator": true,
+      "moduleName": "babel-runtime"
+    }]
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-eslint": "^8.2.5",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.7.0",
     "babel-preset-flow": "^6.23.0",
@@ -106,6 +107,7 @@
   },
   "dependencies": {
     "ajv": "^4.11.5",
+    "babel-runtime": "^6.26.0",
     "bigi": "^1.4.2",
     "bip32": "^1.0.2",
     "bip39": "^2.5.0",


### PR DESCRIPTION
This PR adds babel-runtime and the transform to include it in the `.babelrc`, which allows for the current develop branch to work.

Previously, we didn't need to include a regenerator for node includes, because we weren't using async/await. But recently, this became necessary. You can see the bad behavior in the current `develop` branch by running:

```
$ nvm current
v8.11.2
$ npm -v
6.3.0
$ npm i && npm run build
$ node -e 'var bsk = require(".")'
/home/aaron/devel/blockstack.js/lib/wallet.js:282
      var _ref = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee(mnemonic, password) {
                                                 ^

ReferenceError: regeneratorRuntime is not defined
    at /home/aaron/devel/blockstack.js/lib/wallet.js:282:50
    at /home/aaron/devel/blockstack.js/lib/wallet.js:308:6
    at Object.<anonymous> (/home/aaron/devel/blockstack.js/lib/wallet.js:416:2)
    at Module._compile (module.js:652:30)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
    at Module.require (module.js:596:17)
    at require (internal/module.js:11:18)
```

`master` doesn't use any async/await calls, so this isn't an issue there yet, though if `develop` releases, it will be broken.