### PR TITLE
Improvements for multi-sig support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   code. First, coerce address now correctly coerces P2SH
   addresses. Second, bitcoinjs-lib recently switched to defaulting to
   version 2 transactions, which breaks our interoperability with a handful
-  of other libraries. Finally, with comes a little bit of refactoring, to
-  reduce the repeated code in the transaction libraries.
+  of other libraries. Finally, with this comes a little bit of refactoring,
+  to reduce the repeated code in the transaction libraries.
 
 ## [18.0.4] - 2018-08-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ecosystem.
 - A `listFiles` function allows an application to list files in its
   Gaia storage bucket.
+- In the transaction generation library, the makeTX functions now
+  take an optional 'buildIncomplete' argument, allowing you to get
+  a serialized transaction which hasn't been fully signed yet.
 
 ### Changed
 - Fixed a bug in version checking during the authentication process
   that manifested itself when signing in with apps using very old versions
   of blockstack.js.
+- Fixed a couple bugs in the transaction generation, networking
+  code. First, coerce address now correctly coerces P2SH
+  addresses. Second, bitcoinjs-lib recently switched to defaulting to
+  version 2 transactions, which breaks our interoperability with a handful
+  of other libraries. Finally, with comes a little bit of refactoring, to
+  reduce the repeated code in the transaction libraries.
 
 ## [18.0.4] - 2018-08-06
 

--- a/src/network.js
+++ b/src/network.js
@@ -61,8 +61,16 @@ export class BlockstackNetwork {
   }
 
   coerceAddress(address: string) {
-    const addressHash = bitcoinjs.address.fromBase58Check(address).hash
-    return bitcoinjs.address.toBase58Check(addressHash, this.layer1.pubKeyHash)
+    const { hash, version } = bitcoinjs.address.fromBase58Check(address)
+    const scriptHashes = [bitcoinjs.networks.bitcoin.scriptHash,
+                          bitcoinjs.networks.testnet.scriptHash]
+    let coercedVersion
+    if (scriptHashes.indexOf(version) >= 0) {
+      coercedVersion = this.layer1.scriptHash
+    } else {
+      coercedVersion = this.layer1.pubKeyHash
+    }
+    return bitcoinjs.address.toBase58Check(hash, coercedVersion)
   }
 
   getDefaultBurnAddress() {

--- a/src/operations/skeletons.js
+++ b/src/operations/skeletons.js
@@ -233,7 +233,6 @@ export function makeRegisterSkeleton(
   */
 
   let payload
-  const network = config.network
   if (!!valueHash) {
     if (valueHash.length !== 40) {
       throw new Error('Value hash length incorrect. Expecting 20-bytes, hex-encoded')
@@ -314,7 +313,6 @@ export function makeTransferSkeleton(
     magic op keep  hash128(name.ns_id) consensus hash
              data?
   */
-  const network = config.network
   const opRet = Buffer.alloc(36)
   let keepChar = '~'
   if (keepZonefile) {
@@ -356,7 +354,6 @@ export function makeUpdateSkeleton(
     magic op  hash128(name.ns_id,consensus hash) hash160(data)
   */
 
-  const network = config.network
   const opRet = Buffer.alloc(39)
 
   const nameBuff = Buffer.from(fullyQualifiedName, 'ascii')
@@ -395,7 +392,6 @@ export function makeRevokeSkeleton(fullyQualifiedName: string) {
    magic op   name.ns_id (37 bytes)
   */
 
-  const network = config.network
   const opRet = Buffer.alloc(3)
 
   const nameBuff = Buffer.from(fullyQualifiedName, 'ascii')
@@ -475,7 +471,6 @@ export function makeNamespaceRevealSkeleton(
                                                   bucket exponents        no-vowel
                                                                           discounts
   */
-  const network = config.network
   const hexPayload = namespace.toHexPayload()
 
   const opReturnBuffer = Buffer.alloc(3 + hexPayload.length / 2)
@@ -503,7 +498,6 @@ export function makeNamespaceReadySkeleton(
    magic op  .  ns_id
 
    */
-  const network = config.network
   const opReturnBuffer = Buffer.alloc(3 + namespaceID.length + 1)
   opReturnBuffer.write('id!', 0, 3, 'ascii')
   opReturnBuffer.write(`.${namespaceID}`, 3, namespaceID.length + 1, 'ascii')
@@ -565,7 +559,6 @@ export function makeAnnounceSkeleton(messageHash: string) {
     throw new Error('Invalid message hash: must be 20 bytes hex-encoded')
   }
 
-  const network = config.network
   const opReturnBuffer = Buffer.alloc(3 + messageHash.length / 2)
   opReturnBuffer.write('id#', 0, 3, 'ascii')
   opReturnBuffer.write(messageHash, 3, messageHash.length, 'hex')

--- a/src/operations/skeletons.js
+++ b/src/operations/skeletons.js
@@ -143,6 +143,12 @@ function asAmountV2(amount: AmountType): AmountTypeV2 {
   }
 }
 
+function makeTXbuilder() {
+  const txb = new bitcoin.TransactionBuilder(config.network.layer1)
+  txb.setVersion(1)
+  return txb
+}
+
 export function makePreorderSkeleton(
   fullyQualifiedName: string, consensusHash : string, preorderAddress: string,
   burnAddress : string, burn: AmountType,
@@ -183,7 +189,7 @@ export function makePreorderSkeleton(
   const nullOutput = bitcoin.payments.embed({ data: [opReturnBuffer] }).output
 
 
-  const tx = new bitcoin.TransactionBuilder(network.layer1)
+  const tx = makeTXbuilder()
 
   tx.addOutput(nullOutput, 0)
   tx.addOutput(preorderAddress, DUST_MINIMUM)
@@ -245,7 +251,7 @@ export function makeRegisterSkeleton(
   const nullOutput = bitcoin.payments.embed({ data: [opReturnBuffer] }).output
 
 
-  const tx = new bitcoin.TransactionBuilder(network.layer1)
+  const tx = makeTXbuilder()
 
   tx.addOutput(nullOutput, 0)
   tx.addOutput(ownerAddress, DUST_MINIMUM)
@@ -324,7 +330,7 @@ export function makeTransferSkeleton(
 
   const opRetPayload = bitcoin.payments.embed({ data: [opRet] }).output
 
-  const tx = new bitcoin.TransactionBuilder(network.layer1)
+  const tx = makeTXbuilder()
 
   tx.addOutput(opRetPayload, 0)
   tx.addOutput(newOwner, DUST_MINIMUM)
@@ -366,7 +372,7 @@ export function makeUpdateSkeleton(
 
   const opRetPayload = bitcoin.payments.embed({ data: [opRet] }).output
 
-  const tx = new bitcoin.TransactionBuilder(network.layer1)
+  const tx = makeTXbuilder()
 
   tx.addOutput(opRetPayload, 0)
 
@@ -400,7 +406,7 @@ export function makeRevokeSkeleton(fullyQualifiedName: string) {
   const nullOutput = bitcoin.payments.embed({ data: [opReturnBuffer] }).output
 
 
-  const tx = new bitcoin.TransactionBuilder(network.layer1)
+  const tx = makeTXbuilder()
 
   tx.addOutput(nullOutput, 0)
 
@@ -447,7 +453,7 @@ export function makeNamespacePreorderSkeleton(
 
   const nullOutput = bitcoin.payments.embed({ data: [opReturnBuffer] }).output
 
-  const tx = new bitcoin.TransactionBuilder(network.layer1)
+  const tx = makeTXbuilder()
 
   tx.addOutput(nullOutput, 0)
   tx.addOutput(preorderAddress, DUST_MINIMUM)
@@ -477,7 +483,7 @@ export function makeNamespaceRevealSkeleton(
   opReturnBuffer.write(hexPayload, 3, hexPayload.length / 2, 'hex')
 
   const nullOutput = bitcoin.payments.embed({ data: [opReturnBuffer] }).output
-  const tx = new bitcoin.TransactionBuilder(network.layer1)
+  const tx = makeTXbuilder()
 
   tx.addOutput(nullOutput, 0)
   tx.addOutput(revealAddress, DUST_MINIMUM)
@@ -503,7 +509,7 @@ export function makeNamespaceReadySkeleton(
   opReturnBuffer.write(`.${namespaceID}`, 3, namespaceID.length + 1, 'ascii')
 
   const nullOutput = bitcoin.payments.embed({ data: [opReturnBuffer] }).output
-  const tx = new bitcoin.TransactionBuilder(network.layer1)
+  const tx = makeTXbuilder()
 
   tx.addOutput(nullOutput, 0)
 
@@ -534,7 +540,7 @@ export function makeNameImportSkeleton(name: string, recipientAddr: string, zone
 
   const nullOutput = bitcoin.payments.embed({ data: [opReturnBuffer] }).output
 
-  const tx = new bitcoin.TransactionBuilder(network.layer1)
+  const tx = makeTXbuilder()
   const zonefileHashB58 = bitcoin.address.toBase58Check(
     new Buffer(zonefileHash, 'hex'), network.layer1.pubKeyHash
   )
@@ -566,7 +572,7 @@ export function makeAnnounceSkeleton(messageHash: string) {
 
   const nullOutput = bitcoin.payments.embed({ data: [opReturnBuffer] }).output
 
-  const tx = new bitcoin.TransactionBuilder(network.layer1)
+  const tx = makeTXbuilder()
 
   tx.addOutput(nullOutput, 0)
   return tx.buildIncomplete()

--- a/src/operations/txbuild.js
+++ b/src/operations/txbuild.js
@@ -57,9 +57,9 @@ function fundTransaction(txB: bitcoinjs.TransactionBuilder, paymentAddress: stri
 function returnTransactionHex(txB: bitcoinjs.TransactionBuilder,
                               buildIncomplete?: boolean = false) {
   if (buildIncomplete) {
-    return txB.build().toHex()
-  } else {
     return txB.buildIncomplete().toHex()
+  } else {
+    return txB.build().toHex()
   }
 }
 

--- a/tests/unitTests/src/unitTestsOperations.js
+++ b/tests/unitTests/src/unitTestsOperations.js
@@ -399,6 +399,56 @@ function transactionTests() {
     }, 0)
   }
 
+  test('address coercion', (t) => {
+    t.plan(8)
+    const stashed = config.network.layer1
+    try {
+      const singleSigAddressMain = '1EJh2y3xKUwFjJ8v29a2NRruPJ71neozEE'
+      const singleSigAddressTest = 'mtpeL28w8WNWWQcXjiYQCM5EFHhijXMF62'
+      const multiSigAddressTest  = '2N6GHvciC9M4ze5QXpW2jZxjf5trnPFsyqZ'
+      const multiSigAddressMain  = '3Ei5rsnAXtZeSHmz9NQrx1kPsYecbfdKiy'
+      config.network.layer1 = btc.networks.testnet
+      t.equal(config.network.coerceAddress(singleSigAddressMain), singleSigAddressTest)
+      t.equal(config.network.coerceAddress(singleSigAddressTest), singleSigAddressTest)
+      t.equal(config.network.coerceAddress(multiSigAddressMain), multiSigAddressTest)
+      t.equal(config.network.coerceAddress(multiSigAddressTest), multiSigAddressTest)
+      config.network.layer1 = btc.networks.bitcoin
+      t.equal(config.network.coerceAddress(singleSigAddressMain), singleSigAddressMain)
+      t.equal(config.network.coerceAddress(singleSigAddressTest), singleSigAddressMain)
+      t.equal(config.network.coerceAddress(multiSigAddressMain), multiSigAddressMain)
+      t.equal(config.network.coerceAddress(multiSigAddressTest), multiSigAddressMain)
+    } finally {
+      config.network.layer1 = stashed
+    }
+  })
+
+  test('build incomplete', (t) => {
+    setupMocks()
+    t.plan(2)
+    const getAddress = () => Promise.resolve(testAddresses[2].address)
+    const signTransaction = () => Promise.resolve()
+    const nullSigner = { getAddress, signTransaction }
+    return transactions.makeNamespacePreorder('hello',
+                                              testAddresses[3].address,
+                                              nullSigner)
+      .then(() => {
+        t.fail('Should have failed to build unsigned TX.')
+      })
+      .catch(() => {
+        t.pass('Should have failed to build unsigned TX.')
+      })
+      .then(() => transactions.makeNamespacePreorder('hello',
+                                                     testAddresses[3].address,
+                                                     nullSigner,
+                                                     true))
+      .then((txhex) => {
+        t.ok(txhex, 'Should have built incomplete TX when buildIncomplete = true')
+      })
+      .catch((err) => {
+        t.fail(`Should have built incomplete TX when buildIncomplete = true: Error: ${err}`)
+      })
+  })
+
   test('build and fund namespace preorder', (t) => {
     t.plan(6)
     setupMocks()


### PR DESCRIPTION
This includes improvements to the transaction generation library for use with multi-sig.

1. `coerceAddress` now works correctly for script-hash addresses that it can identity the version of (currently can identify mainnet and testnet bitcoin)
2. The `transaction.makeFoo` functions now have an optional argument `buildIncomplete`, which, if passed, will allow the transaction building library to construct an unsigned transaction hex. This is helpful for passing around unfinished transactions between co-signers.
3. Default transaction version to version 1. The upgrade to bitcoinjs-lib changed the default behavior of the `TransactionBuilder` object to use version 2 transactions. This passes the version 1 explicitly, as version 1 transactions generally have wider support with other libraries we may interact with (in particular, both `trezor.js` and `ledgerjs` are much harder to use with version 2 transactions).

This also includes some code refactoring which eliminated a bunch of duplication in `txbuild.js`.

Tests are added for (1) and (2), and the refactors have full coverage with the existing unit tests.