### PR TITLE
Two transaction related fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of other libraries. Finally, with this comes a little bit of refactoring,
   to reduce the repeated code in the transaction libraries.
 - Increments the authentication process version to 1.3.
+- When using the bitcoind client in development networks,
+  track which addresses we've already called `importaddress` with
+  and do not retry.
 
 ## [18.0.4] - 2018-08-06
 

--- a/src/network.js
+++ b/src/network.js
@@ -573,10 +573,13 @@ export class BitcoindAPI extends BitcoinNetwork {
 
   bitcoindCredentials: Object
 
+  importedBefore: Object
+
   constructor(bitcoindUrl: string, bitcoindCredentials: {username: string, password: string}) {
     super()
     this.bitcoindUrl = bitcoindUrl
     this.bitcoindCredentials = bitcoindCredentials
+    this.importedBefore = {}
   }
 
   broadcastTransaction(transaction: string) {
@@ -659,15 +662,20 @@ export class BitcoindAPI extends BitcoinNetwork {
       method: 'listunspent',
       params: [0, 9999999, [address]]
     }
-    const authString =      Buffer.from(`${this.bitcoindCredentials.username}:${this.bitcoindCredentials.password}`)
+    const authString = Buffer.from(`${this.bitcoindCredentials.username}:${this.bitcoindCredentials.password}`)
       .toString('base64')
     const headers = { Authorization: `Basic ${authString}` }
 
-    return fetch(this.bitcoindUrl, {
-      method: 'POST',
-      body: JSON.stringify(jsonRPCImport),
-      headers
-    })
+    const importPromise = (this.importedBefore[address])
+      ? Promise.resolve()
+      : fetch(this.bitcoindUrl, {
+        method: 'POST',
+        body: JSON.stringify(jsonRPCImport),
+        headers
+      })
+        .then(() => { this.importedBefore[address] = true })
+
+    return importPromise
       .then(() => fetch(this.bitcoindUrl, {
         method: 'POST',
         body: JSON.stringify(jsonRPCUnspent),

--- a/src/operations/txbuild.js
+++ b/src/operations/txbuild.js
@@ -1009,6 +1009,7 @@ function makeBitcoinSpend(destinationAddress: string,
     paymentAddress => Promise.all([network.getUTXOs(paymentAddress), network.getFeeRate()])
       .then(([utxos, feeRate]) => {
         const txB = new bitcoinjs.TransactionBuilder(network.layer1)
+        txb.setVersion(1)
         const destinationIndex = txB.addOutput(destinationAddress, 0)
 
         // will add utxos up to _amount_ and return the amount of leftover _change_

--- a/src/operations/txbuild.js
+++ b/src/operations/txbuild.js
@@ -1009,7 +1009,7 @@ function makeBitcoinSpend(destinationAddress: string,
     paymentAddress => Promise.all([network.getUTXOs(paymentAddress), network.getFeeRate()])
       .then(([utxos, feeRate]) => {
         const txB = new bitcoinjs.TransactionBuilder(network.layer1)
-        txb.setVersion(1)
+        txB.setVersion(1)
         const destinationIndex = txB.addOutput(destinationAddress, 0)
 
         // will add utxos up to _amount_ and return the amount of leftover _change_

--- a/tests/unitTests/src/unitTestsOperations.js
+++ b/tests/unitTests/src/unitTestsOperations.js
@@ -2,7 +2,7 @@ import test from 'tape'
 import FetchMock from 'fetch-mock'
 import btc from 'bitcoinjs-lib'
 
-import { network, InsightClient } from '../../../lib/network'
+import { network, InsightClient, BitcoindAPI } from '../../../lib/network'
 import {
   estimateTXBytes, addUTXOsToFund, sumOutputValues,
   hash160, hash128, decodeB40
@@ -89,6 +89,51 @@ function networkTests() {
         t.deepEqual(utxos, [{
           value: 1e8, confirmations: 2, tx_hash: 'bar', tx_output_n: 10
         }])
+      })
+  })
+  test('bitcoind-client', (t) => {
+    t.plan(2)
+    const mynet = new BitcoindAPI('https://utxo.tester.com', { username: 'foo', password: 'bar' })
+
+    FetchMock.restore()
+
+    FetchMock.postOnce({
+      name: 'Broadcast',
+      matcher: (url, opts) => (url === 'https://utxo.tester.com'
+          && opts
+          && opts.body.indexOf('importaddress') > 0),
+      response: {
+        body: {},
+        status: 200
+      }
+    })
+
+    FetchMock.post({
+      name: 'Broadcast',
+      matcher: (url, opts) => (url === 'https://utxo.tester.com'
+          && opts
+          && opts.body.indexOf('listunspent') > 0),
+      response: {
+        body: JSON.stringify({ result: [] }),
+        status: 200
+      }
+    })
+
+    mynet.getNetworkedUTXOs(testAddresses[0].address)
+      .then((utxos) => {
+        t.deepEqual(utxos, [])
+      })
+      .catch((err) => {
+        console.log(err)
+        t.fail()
+      })
+      .then(() => mynet.getNetworkedUTXOs(testAddresses[0].address))
+      .then((utxos) => {
+        t.deepEqual(utxos, [])
+      })
+      .catch((err) => {
+        console.log(err)
+        t.fail()
       })
   })
 }


### PR DESCRIPTION
1. Per #538, we try to set the transaction version to version 1. This was _missed_ in bitcoin spends. This PR fixes that.
2. For the bitcoind network interface (used in dev environments, mostly), we call `importaddress` on every UTXO fetch (this is because bitcoind only tracks imported address' UTXOs). However, we can be a bit more intelligent (and get better behavior out of the endpoint) by only doing this on the first such request. This PR implements that behavior.

A unit test was added for the above bitcoind behavior.