### PR TITLE
Add option to pass Content-Type to putFile API

### DIFF
--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -362,23 +362,26 @@ export function getFile(path: string, options?: {
  *                                                  or the provided public key
  * @param {Boolean} [options.sign=false] - sign the data using ECDSA on SHA256 hashes with
  *                                         the app private key
+ * @param {String} [options.contentType=''] - set a Content-Type header for unencrypted data
  * @return {Promise} that resolves if the operation succeed and rejects
  * if it failed
  */
 export function putFile(path: string, content: string | Buffer, options?: {
   encrypt?: boolean | string,
-  sign?: boolean
+  sign?: boolean,
+  contentType?: string
   }) {
   const defaults = {
     encrypt: true,
-    sign: false
+    sign: false,
+    contentType: ''
   }
 
   const opt = Object.assign({}, defaults, options)
 
-  let contentType = 'text/plain'
-  if (typeof (content) !== 'string') {
-    contentType = 'application/octet-stream'
+  let contentType = opt.contentType
+  if (!contentType) {
+    contentType = (typeof (content) === 'string') ? 'text/plain' : 'application/octet-stream'
   }
 
   // First, let's figure out if we need to get public/private keys,

--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -379,7 +379,7 @@ export function putFile(path: string, content: string | Buffer, options?: {
 
   const opt = Object.assign({}, defaults, options)
 
-  let contentType = opt.contentType
+  let { contentType } = opt
   if (!contentType) {
     contentType = (typeof (content) === 'string') ? 'text/plain' : 'application/octet-stream'
   }

--- a/tests/unitTests/src/unitTestsStorage.js
+++ b/tests/unitTests/src/unitTestsStorage.js
@@ -283,7 +283,7 @@ export function runStorageTests() {
   })
   
   test('putFile & getFile unencrypted, not signed, with contentType', (t) => {
-    t.plan(2)
+    t.plan(3)
     const path = 'file.html'
     const gaiaHubConfig = {
       address: '1NZNxhoxobqwsNvTb16pdeiqvFvce3Yg8U',
@@ -322,6 +322,7 @@ export function runStorageTests() {
         const decryptOptions = { decrypt: false }
         getFile(path, decryptOptions).then((readContent) => {
           t.equal(readContent, fileContent)
+          t.ok(typeof (readContent) === 'string')
         })
       })
   })


### PR DESCRIPTION
Changes to resolve #551 
putFile API: added a third option `contentType` in `options` parameter.
Added unit test: 'putFile & getFile unencrypted, not signed, with contentType'.