### PR TITLE
Feature/tx magic variable

### DIFF
--- a/src/network.js
+++ b/src/network.js
@@ -49,6 +49,8 @@ export class BlockstackNetwork {
 
   btc: BitcoinNetwork
 
+  MAGIC_BYTES: string
+
   constructor(apiUrl: string, broadcastServiceUrl: string,
               bitcoinAPI: BitcoinNetwork,
               network: Object = bitcoinjs.networks.bitcoin) {
@@ -60,6 +62,7 @@ export class BlockstackNetwork {
     this.DUST_MINIMUM = 5500
     this.includeUtxoMap = {}
     this.excludeUtxoSet = []
+    this.MAGIC_BYTES = 'id'
   }
 
   coerceAddress(address: string) {
@@ -81,6 +84,17 @@ export class BlockstackNetwork {
 
   getDefaultBurnAddress() {
     return this.coerceAddress('1111111111111111111114oLvT2')
+  }
+
+  getMagicBytes(): string {
+    return this.MAGIC_BYTES
+  }
+
+  setMagicBytes(newMagic: string) {
+    if (newMagic.length !== 2) {
+      throw new Error('Invalid magic bytes')
+    }
+    this.MAGIC_BYTES = newMagic
   }
 
   /**

--- a/src/network.js
+++ b/src/network.js
@@ -86,17 +86,6 @@ export class BlockstackNetwork {
     return this.coerceAddress('1111111111111111111114oLvT2')
   }
 
-  getMagicBytes(): string {
-    return this.MAGIC_BYTES
-  }
-
-  setMagicBytes(newMagic: string) {
-    if (newMagic.length !== 2) {
-      throw new Error('Invalid magic bytes')
-    }
-    this.MAGIC_BYTES = newMagic
-  }
-
   /**
    * Get the price of a name via the legacy /v1/prices API endpoint.
    * @param {String} fullyQualifiedName the name to query

--- a/src/operations/skeletons.js
+++ b/src/operations/skeletons.js
@@ -152,7 +152,7 @@ function makeTXbuilder() {
 
 function opEncode(opcode: string): string {
   // NOTE: must *always* a 3-character string
-  const res = `${config.network.getMagicBytes()}${opcode}`
+  const res = `${config.network.MAGIC_BYTES}${opcode}`
   if (res.length !== 3) {
     throw new Error('Runtime error: invalid MAGIC_BYTES')
   }

--- a/src/operations/skeletons.js
+++ b/src/operations/skeletons.js
@@ -150,6 +150,15 @@ function makeTXbuilder() {
   return txb
 }
 
+function opEncode(opcode: string): string {
+  // NOTE: must *always* a 3-character string
+  const res = `${config.network.getMagicBytes()}${opcode}`
+  if (res.length !== 3) {
+    throw new Error('Runtime error: invalid MAGIC_BYTES')
+  }
+  return res
+}
+
 export function makePreorderSkeleton(
   fullyQualifiedName: string, consensusHash : string, preorderAddress: string,
   burnAddress : string, burn: AmountType,
@@ -188,7 +197,7 @@ export function makePreorderSkeleton(
 
   const opReturnBufferLen = burnAmount.units === 'BTC' ? 39 : 66
   const opReturnBuffer = Buffer.alloc(opReturnBufferLen)
-  opReturnBuffer.write('id?', 0, 3, 'ascii')
+  opReturnBuffer.write(opEncode('?'), 0, 3, 'ascii')
   hashed.copy(opReturnBuffer, 3)
   opReturnBuffer.write(consensusHash, 23, 16, 'hex')
 
@@ -282,7 +291,7 @@ export function makeRegisterSkeleton(
     payload = Buffer.from(fullyQualifiedName, 'ascii')
   }
 
-  const opReturnBuffer = Buffer.concat([Buffer.from('id:', 'ascii'), payload])
+  const opReturnBuffer = Buffer.concat([Buffer.from(opEncode(':'), 'ascii'), payload])
   const nullOutput = bitcoin.payments.embed({ data: [opReturnBuffer] }).output
   const tx = makeTXbuilder()
 
@@ -381,7 +390,7 @@ export function makeTransferSkeleton(
     keepChar = '>'
   }
 
-  opRet.write('id>', 0, 3, 'ascii')
+  opRet.write(opEncode('>'), 0, 3, 'ascii')
   opRet.write(keepChar, 3, 1, 'ascii')
 
   const hashed = hash128(Buffer.from(fullyQualifiedName, 'ascii'))
@@ -429,7 +438,7 @@ export function makeUpdateSkeleton(
     [nameBuff, consensusBuff]
   ))
 
-  opRet.write('id+', 0, 3, 'ascii')
+  opRet.write(opEncode('+'), 0, 3, 'ascii')
   hashedName.copy(opRet, 3)
   opRet.write(valueHash, 19, 20, 'hex')
 
@@ -464,7 +473,7 @@ export function makeRevokeSkeleton(fullyQualifiedName: string) {
 
   const nameBuff = Buffer.from(fullyQualifiedName, 'ascii')
 
-  opRet.write('id~', 0, 3, 'ascii')
+  opRet.write(opEncode('~'), 0, 3, 'ascii')
 
   const opReturnBuffer = Buffer.concat([opRet, nameBuff])
   const nullOutput = bitcoin.payments.embed({ data: [opReturnBuffer] }).output
@@ -527,7 +536,7 @@ export function makeNamespacePreorderSkeleton(
   }
 
   const opReturnBuffer = Buffer.alloc(opReturnBufferLen)
-  opReturnBuffer.write('id*', 0, 3, 'ascii')
+  opReturnBuffer.write(opEncode('*'), 0, 3, 'ascii')
   hashed.copy(opReturnBuffer, 3)
   opReturnBuffer.write(consensusHash, 23, 16, 'hex')
 
@@ -566,7 +575,7 @@ export function makeNamespaceRevealSkeleton(
   const hexPayload = namespace.toHexPayload()
 
   const opReturnBuffer = Buffer.alloc(3 + hexPayload.length / 2)
-  opReturnBuffer.write('id&', 0, 3, 'ascii')
+  opReturnBuffer.write(opEncode('&'), 0, 3, 'ascii')
   opReturnBuffer.write(hexPayload, 3, hexPayload.length / 2, 'hex')
 
   const nullOutput = bitcoin.payments.embed({ data: [opReturnBuffer] }).output
@@ -590,7 +599,7 @@ export function makeNamespaceReadySkeleton(namespaceID: string) {
    output 0: namespace ready code
    */
   const opReturnBuffer = Buffer.alloc(3 + namespaceID.length + 1)
-  opReturnBuffer.write('id!', 0, 3, 'ascii')
+  opReturnBuffer.write(opEncode('!'), 0, 3, 'ascii')
   opReturnBuffer.write(`.${namespaceID}`, 3, namespaceID.length + 1, 'ascii')
 
   const nullOutput = bitcoin.payments.embed({ data: [opReturnBuffer] }).output
@@ -620,7 +629,7 @@ export function makeNameImportSkeleton(name: string, recipientAddr: string, zone
 
   const network = config.network
   const opReturnBuffer = Buffer.alloc(3 + name.length)
-  opReturnBuffer.write('id;', 0, 3, 'ascii')
+  opReturnBuffer.write(opEncode(';'), 0, 3, 'ascii')
   opReturnBuffer.write(name, 3, name.length, 'ascii')
 
   const nullOutput = bitcoin.payments.embed({ data: [opReturnBuffer] }).output
@@ -653,7 +662,7 @@ export function makeAnnounceSkeleton(messageHash: string) {
   }
 
   const opReturnBuffer = Buffer.alloc(3 + messageHash.length / 2)
-  opReturnBuffer.write('id#', 0, 3, 'ascii')
+  opReturnBuffer.write(opEncode('#'), 0, 3, 'ascii')
   opReturnBuffer.write(messageHash, 3, messageHash.length / 2, 'hex')
 
   const nullOutput = bitcoin.payments.embed({ data: [opReturnBuffer] }).output
@@ -696,7 +705,7 @@ export function makeTokenTransferSkeleton(recipientAddress: string, consensusHas
 
   const tokenValueHexPadded = `0000000000000000${tokenValueHex}`.slice(-16)
 
-  opReturnBuffer.write('id$', 0, 3, 'ascii')
+  opReturnBuffer.write(opEncode('$'), 0, 3, 'ascii')
   opReturnBuffer.write(consensusHash, 3, consensusHash.length / 2, 'hex')
   opReturnBuffer.write(tokenTypeHexPadded, 19, tokenTypeHexPadded.length / 2, 'hex')
   opReturnBuffer.write(tokenValueHexPadded, 38, tokenValueHexPadded.length / 2, 'hex')

--- a/tests/unitTests/src/unitTestsOperations.js
+++ b/tests/unitTests/src/unitTestsOperations.js
@@ -1153,7 +1153,7 @@ function transactionTests() {
   })
 
   test('use alternative magic bytes', (t) => {
-    t.plan(12)
+    t.plan(24)
     setupMocks()
 
     const ns = new transactions.BlockstackNamespace('hello')
@@ -1215,8 +1215,8 @@ function transactionTests() {
         for (let i = 0; i < txs.length; i++) {
           const tx = btc.Transaction.fromHex(txs[i])
           const nullOut = tx.outs[0].script
-          t.equal(Buffer.from(nullOut).toString().substring(2, 4),
-                  network.defaults.MAINNET_DEFAULT.getMagicBytes())
+          t.equal(network.defaults.MAINNET_DEFAULT.getMagicBytes(), 'di')
+          t.equal(Buffer.from(nullOut).toString().substring(2, 4), 'di')
         }
       })
       .then(() => network.defaults.MAINNET_DEFAULT.setMagicBytes('id'))

--- a/tests/unitTests/src/unitTestsOperations.js
+++ b/tests/unitTests/src/unitTestsOperations.js
@@ -1152,6 +1152,76 @@ function transactionTests() {
       .catch((err) => { console.log(err.stack); throw err })
   })
 
+  test('use alternative magic bytes', (t) => {
+    t.plan(12)
+    setupMocks()
+
+    const ns = new transactions.BlockstackNamespace('hello')
+    ns.setVersion(3)
+    ns.setLifetime(52595)
+    ns.setCoeff(4)
+    ns.setBase(4)
+    ns.setBuckets([6, 5, 4, 3, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
+    ns.setNonalphaDiscount(10)
+    ns.setNoVowelDiscount(10)
+
+    Promise.resolve().then(() => network.defaults.MAINNET_DEFAULT.setMagicBytes('di'))
+      .then(() => Promise.all([
+        transactions.makeNamespacePreorder('hello',
+                                           testAddresses[3].address,
+                                           testAddresses[2].skHex),
+        transactions.makeNamespaceReveal(ns,
+                                         testAddresses[3].address,
+                                         testAddresses[2].skHex),
+        transactions.makeNameImport(
+          'import.hello', '151nahdGD9Dxd7xpwPeBECn5iEi4Thb7Rv',
+          'cabdbc18ece9ffb6a7378faa4ac4ce58dcaaf575', testAddresses[3].skHex
+        ),
+        transactions.makeNamespaceReady('hello',
+                                        testAddresses[3].skHex),
+        transactions.makePreorder('foo.test',
+                                  testAddresses[0].address,
+                                  testAddresses[1].skHex),
+        transactions.makeRegister('foo.test',
+                                  testAddresses[0].address,
+                                  testAddresses[1].skHex, 'hello world'),
+        transactions.makeUpdate('foo.test',
+                                testAddresses[0].skHex,
+                                testAddresses[1].skHex,
+                                'hello world'),
+        transactions.makeTransfer('foo.test',
+                                  testAddresses[2].address,
+                                  testAddresses[0].skHex,
+                                  testAddresses[1].skHex),
+        transactions.makeRenewal('foo.test',
+                                 testAddresses[2].address,
+                                 testAddresses[0].skHex,
+                                 testAddresses[1].skHex,
+                                 'hello world'),
+        transactions.makeRevoke('foo.test',
+                                testAddresses[0].skHex,
+                                testAddresses[1].skHex),
+        transactions.makeAnnounce(
+          '53bb740c47435a51b07ecf0b9e086a2ad3c12c1d', testAddresses[3].skHex
+        ),
+        transactions.makeTokenTransfer(testAddresses[1].address,
+                                       'STACKS',
+                                       bigi.fromByteArrayUnsigned('123'),
+                                       'hello world!',
+                                       testAddresses[4].skHex)
+      ])
+      )
+      .then((txs) => {
+        for (let i = 0; i < txs.length; i++) {
+          const tx = btc.Transaction.fromHex(txs[i])
+          const nullOut = tx.outs[0].script
+          t.equal(Buffer.from(nullOut).toString().substring(2, 4),
+                  network.defaults.MAINNET_DEFAULT.getMagicBytes())
+        }
+      })
+      .then(() => network.defaults.MAINNET_DEFAULT.setMagicBytes('id'))
+  })
+        
   test(`broadcastTransaction:
     send via broadcast service with transaction to watch with default confs`, (t) => {
     t.plan(1)

--- a/tests/unitTests/src/unitTestsOperations.js
+++ b/tests/unitTests/src/unitTestsOperations.js
@@ -1165,8 +1165,9 @@ function transactionTests() {
     ns.setNonalphaDiscount(10)
     ns.setNoVowelDiscount(10)
 
-    Promise.resolve().then(() => network.defaults.MAINNET_DEFAULT.setMagicBytes('di'))
-      .then(() => Promise.all([
+    Promise.resolve().then(() => {
+      network.defaults.MAINNET_DEFAULT.MAGIC_BYTES = 'di'
+      return Promise.all([
         transactions.makeNamespacePreorder('hello',
                                            testAddresses[3].address,
                                            testAddresses[2].skHex),
@@ -1210,16 +1211,16 @@ function transactionTests() {
                                        'hello world!',
                                        testAddresses[4].skHex)
       ])
-      )
+    })
       .then((txs) => {
         for (let i = 0; i < txs.length; i++) {
           const tx = btc.Transaction.fromHex(txs[i])
           const nullOut = tx.outs[0].script
-          t.equal(network.defaults.MAINNET_DEFAULT.getMagicBytes(), 'di')
+          t.equal(network.defaults.MAINNET_DEFAULT.MAGIC_BYTES, 'di')
           t.equal(Buffer.from(nullOut).toString().substring(2, 4), 'di')
         }
       })
-      .then(() => network.defaults.MAINNET_DEFAULT.setMagicBytes('id'))
+      .then(() => { network.defaults.MAINNET_DEFAULT.MAGIC_BYTES = 'id' })
   })
         
   test(`broadcastTransaction:


### PR DESCRIPTION
This PR adds `network.getMagicBytes()` and `network.setMagicBytes()`, which lets the user override the magic bytes used to identify Blockstack transactions.  The purpose of this pull request is to enable the user to interact with one or more Blockstack testnets, realized as alternative virtualchains on top of Bitcoin mainnet.  This lets us test other pieces of Blockstack software against Bitcoin mainnet without having to either deal with either interacting with the (highly-prone-to-reorg) Bitcoin testnet or having to run a Bitcoin regtest node.  In particular, when used in conjunction with Blockstack Core and the CLI, this lets us instantiate an alternative Blockstack network so we can test hardware wallets with fake Stacks (but real Bitcoin).