### PR TITLE
Return correct file count

### DIFF
--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -529,7 +529,7 @@ function listFilesLoop(hubConfig: GaiaHubConfig,
         )
       } else {
         // no more entries -- end of data
-        return Promise.resolve(fileCount)
+        return Promise.resolve(fileCount + entries.length)
       }
     })
 }


### PR DESCRIPTION
This PR
* fixes a wrong file count in listFiles

Call listFiles for an account with a small number of files (e.g. 4). Then currently 0 is returned.