### PR TITLE
Support for passing a wildcard of extra params in an `authRequest`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to the project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [18.2.0] - 2018-12-20
+
+### Added
+
+- Added an extra parameter to `makeAuthRequest`, called `extraParams`. This is a wildcard object, 
+and all keys and values included in this argument will be included in the `payload` of
+an `authRequest`.
+- `authRequest` version bumped to `1.3.1` from `1.3.0`.
+
 ## [18.1.0] - 2018-10-24
 
 ### Added

--- a/dist/blockstack.js
+++ b/dist/blockstack.js
@@ -344,7 +344,7 @@ var _encryption = require('../encryption');
 
 var _logger = require('../logger');
 
-var VERSION = '1.3.0';
+var VERSION = '1.3.1';
 
 /**
  * Generates an authentication request that can be sent to the Blockstack
@@ -363,6 +363,9 @@ var VERSION = '1.3.0';
  * @param {Array<String>} scopes - the permissions this app is requesting
  * @param {String} appDomain - the origin of this app
  * @param {Number} expiresAt - the time at which this request is no longer valid
+ * @param {Object} extraParams - Any extra parameters you'd like to pass to the authenticator.
+ * Use this to pass options that aren't part of the Blockstack auth spec, but might be supported
+ * by special authenticators.
  * @return {String} the authentication request
  */
 function makeAuthRequest() {
@@ -372,9 +375,10 @@ function makeAuthRequest() {
   var scopes = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : _authConstants.DEFAULT_SCOPE;
   var appDomain = arguments.length > 4 && arguments[4] !== undefined ? arguments[4] : window.location.origin;
   var expiresAt = arguments.length > 5 && arguments[5] !== undefined ? arguments[5] : (0, _index.nextHour)().getTime();
+  var extraParams = arguments.length > 6 && arguments[6] !== undefined ? arguments[6] : {};
 
   /* Create the payload */
-  var payload = {
+  var payload = Object.assign({}, extraParams, {
     jti: (0, _index.makeUUID4)(),
     iat: Math.floor(new Date().getTime() / 1000), // JWT times are in seconds
     exp: Math.floor(expiresAt / 1000), // JWT times are in seconds
@@ -387,7 +391,7 @@ function makeAuthRequest() {
     do_not_include_profile: true,
     supports_hub_url: true,
     scopes: scopes
-  };
+  });
 
   _logger.Logger.info('blockstack.js: generating v' + VERSION + ' auth request');
 
@@ -13027,7 +13031,7 @@ module.exports={
   "_args": [
     [
       "bigi@1.4.2",
-      "/Users/larry/git/blockstack.js"
+      "/Users/hank/blockstack/js"
     ]
   ],
   "_from": "bigi@1.4.2",
@@ -13052,7 +13056,7 @@ module.exports={
   ],
   "_resolved": "https://registry.npmjs.org/bigi/-/bigi-1.4.2.tgz",
   "_spec": "1.4.2",
-  "_where": "/Users/larry/git/blockstack.js",
+  "_where": "/Users/hank/blockstack/js",
   "bugs": {
     "url": "https://github.com/cryptocoinjs/bigi/issues"
   },
@@ -54283,7 +54287,7 @@ module.exports={
   "_args": [
     [
       "cheerio@0.22.0",
-      "/Users/larry/git/blockstack.js"
+      "/Users/hank/blockstack/js"
     ]
   ],
   "_from": "cheerio@0.22.0",
@@ -54307,7 +54311,7 @@ module.exports={
   ],
   "_resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
   "_spec": "0.22.0",
-  "_where": "/Users/larry/git/blockstack.js",
+  "_where": "/Users/hank/blockstack/js",
   "author": {
     "name": "Matt Mueller",
     "email": "mattmuelle@gmail.com",
@@ -62625,7 +62629,7 @@ module.exports={
   "_args": [
     [
       "elliptic@6.4.0",
-      "/Users/larry/git/blockstack.js"
+      "/Users/hank/blockstack/js"
     ]
   ],
   "_from": "elliptic@6.4.0",
@@ -62653,7 +62657,7 @@ module.exports={
   ],
   "_resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
   "_spec": "6.4.0",
-  "_where": "/Users/larry/git/blockstack.js",
+  "_where": "/Users/hank/blockstack/js",
   "author": {
     "name": "Fedor Indutny",
     "email": "fedor@indutny.com"
@@ -75739,7 +75743,7 @@ module.exports={
   "_args": [
     [
       "elliptic@5.2.1",
-      "/Users/larry/git/blockstack.js"
+      "/Users/hank/blockstack/js"
     ]
   ],
   "_from": "elliptic@5.2.1",
@@ -75763,7 +75767,7 @@ module.exports={
   ],
   "_resolved": "https://registry.npmjs.org/elliptic/-/elliptic-5.2.1.tgz",
   "_spec": "5.2.1",
-  "_where": "/Users/larry/git/blockstack.js",
+  "_where": "/Users/hank/blockstack/js",
   "author": {
     "name": "Fedor Indutny",
     "email": "fedor@indutny.com"

--- a/src/auth/authMessages.js
+++ b/src/auth/authMessages.js
@@ -43,6 +43,9 @@ type AuthMetadata = {
  * @param {Array<String>} scopes - the permissions this app is requesting
  * @param {String} appDomain - the origin of this app
  * @param {Number} expiresAt - the time at which this request is no longer valid
+ * @param {Object} extraParams - Any extra parameters you'd like to pass to the authenticator.
+ * Use this to pass options that aren't part of the Blockstack auth spec, but might be supported
+ * by special authenticators.
  * @return {String} the authentication request
  */
 export function makeAuthRequest(transitPrivateKey: string = generateAndStoreTransitKey(),
@@ -50,9 +53,10 @@ export function makeAuthRequest(transitPrivateKey: string = generateAndStoreTran
                                 manifestURI: string = `${window.location.origin}/manifest.json`,
                                 scopes: Array<String> = DEFAULT_SCOPE,
                                 appDomain: string = window.location.origin,
-                                expiresAt: number = nextHour().getTime()): string {
+                                expiresAt: number = nextHour().getTime(),
+                                extraParams: Object = {}): string {
   /* Create the payload */
-  const payload = {
+  const payload = Object.assign({}, extraParams, {
     jti: makeUUID4(),
     iat: Math.floor(new Date().getTime() / 1000), // JWT times are in seconds
     exp: Math.floor(expiresAt / 1000), // JWT times are in seconds
@@ -65,7 +69,7 @@ export function makeAuthRequest(transitPrivateKey: string = generateAndStoreTran
     do_not_include_profile: true,
     supports_hub_url: true,
     scopes
-  }
+  })
 
   Logger.info(`blockstack.js: generating v${VERSION} auth request`)
 

--- a/src/auth/authMessages.js
+++ b/src/auth/authMessages.js
@@ -19,7 +19,7 @@ import { encryptECIES, decryptECIES } from '../encryption'
 
 import { Logger } from '../logger'
 
-const VERSION = '1.3.0'
+const VERSION = '1.3.1'
 
 type AuthMetadata = {
   email: ?string,

--- a/tests/unitTests/src/unitTestsAuth.js
+++ b/tests/unitTests/src/unitTestsAuth.js
@@ -103,6 +103,31 @@ export function runAuthTests() {
       })
   })
 
+  test('make and verify auth request with extraParams', (t) => {
+    t.plan(4)
+    global.window.location = {
+      origin: 'http://localhost:3000',
+      hostname: 'localhost',
+      host: 'localhost:3000',
+      href: 'http://localhost:3000/signin'
+    }
+
+    const authRequest = makeAuthRequest(
+      privateKey, undefined, undefined, undefined, undefined, undefined, { myCustomParam: 'asdf' }
+    )
+    t.ok(authRequest, 'auth request should have been created')
+
+    const decodedToken = decodeToken(authRequest)
+    t.ok(decodedToken, 'auth request token should have been decoded')
+
+    t.equal(decodedToken.payload.myCustomParam, 'asdf', 'custom param from extraParams is included in payload')
+
+    verifyAuthRequest(authRequest)
+      .then((verified) => {
+        t.true(verified, 'auth request should be verified')
+      })
+  })
+
   test('invalid auth request - signature not verified', (t) => {
     t.plan(3)
 


### PR DESCRIPTION
This PR adds one new parameter to `makeAuthRequest` called `extraParams`.

This parameter is essentially a "wildcard" to allow passing extra parameters in the auth request. This allows apps to pass in parameters that might not be part of the standard Blockstack auth protocol, but may be supported by various authenticators.

The immediate need for this is to support #568 , which requires a developer to be able to pass a few new 'beta' parameters to the Browser, which will trigger a modified onboarding flow that prompts the user to specify their Gaia hub.

I opted for this wildcard approach instead of hard-coded parameters, because this supports a future with multiple authenticators, each that might allow for a more customized onboarding flow.

Hypothetically, you might imagine one authenticator allowing parameters that change the styling and display of the onboarding flow to match the style of an app.