### PR TITLE
Missing charset in content-type default for putFile([string type])

### DIFF
--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -381,7 +381,7 @@ export function putFile(path: string, content: string | Buffer, options?: {
 
   let { contentType } = opt
   if (!contentType) {
-    contentType = (typeof (content) === 'string') ? 'text/plain' : 'application/octet-stream'
+    contentType = (typeof (content) === 'string') ? 'text/plain; charset=utf-8' : 'application/octet-stream'
   }
 
   // First, let's figure out if we need to get public/private keys,


### PR DESCRIPTION
Fix for https://github.com/blockstack/blockstack.js/issues/574

(Ignore the previous PRs, had the wrong forks/branches)