### PR TITLE
make estimateTokenTransfer private

### DIFF
--- a/src/operations/txbuild.js
+++ b/src/operations/txbuild.js
@@ -441,6 +441,7 @@ function estimateAnnounce(messageHash: string,
  *  just the recipient output (default = 1, if the token owner is also the bitcoin funder)
  * @returns {Promise} - a promise which resolves to the satoshi cost to
  *  fund this token-transfer transaction
+ * @private
  */
 function estimateTokenTransfer(recipientAddress: string,
                                tokenType: string,


### PR DESCRIPTION
estimateTokenTransfer currently appears in the js docs.

This PR add `@private` in the js docs for estimateTokenTransfer