### PR TITLE
Ability to pass `extraParams` to a Gaia token payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [18.3.0] - 2019-06-07
+
+### Added
+
+- Added an extra parameter to `connectToGaiaHub` called `extraParams`. This wildcard object
+adds all keys and values included in this argument to be included in the `payload` of the
+generated token that is passed to a Gaia hub.
+
 ## [18.2.0] - 2018-12-20
 
 ### Added

--- a/dist/blockstack.js
+++ b/dist/blockstack.js
@@ -2328,6 +2328,7 @@ var BlockstackNetwork = exports.BlockstackNetwork = function () {
     this.DUST_MINIMUM = 5500;
     this.includeUtxoMap = {};
     this.excludeUtxoSet = [];
+    this.MAGIC_BYTES = 'id';
   }
 
   _createClass(BlockstackNetwork, [{
@@ -4059,6 +4060,15 @@ function makeTXbuilder() {
   return txb;
 }
 
+function opEncode(opcode) {
+  // NOTE: must *always* a 3-character string
+  var res = '' + _config.config.network.MAGIC_BYTES + opcode;
+  if (res.length !== 3) {
+    throw new Error('Runtime error: invalid MAGIC_BYTES');
+  }
+  return res;
+}
+
 function makePreorderSkeleton(fullyQualifiedName, consensusHash, preorderAddress, burnAddress, burn) {
   var registerAddress = arguments.length > 5 && arguments[5] !== undefined ? arguments[5] : null;
 
@@ -4095,7 +4105,7 @@ function makePreorderSkeleton(fullyQualifiedName, consensusHash, preorderAddress
 
   var opReturnBufferLen = burnAmount.units === 'BTC' ? 39 : 66;
   var opReturnBuffer = Buffer.alloc(opReturnBufferLen);
-  opReturnBuffer.write('id?', 0, 3, 'ascii');
+  opReturnBuffer.write(opEncode('?'), 0, 3, 'ascii');
   hashed.copy(opReturnBuffer, 3);
   opReturnBuffer.write(consensusHash, 23, 16, 'hex');
 
@@ -4183,7 +4193,7 @@ function makeRegisterSkeleton(fullyQualifiedName, ownerAddress) {
     payload = Buffer.from(fullyQualifiedName, 'ascii');
   }
 
-  var opReturnBuffer = Buffer.concat([Buffer.from('id:', 'ascii'), payload]);
+  var opReturnBuffer = Buffer.concat([Buffer.from(opEncode(':'), 'ascii'), payload]);
   var nullOutput = _bitcoinjsLib2.default.payments.embed({ data: [opReturnBuffer] }).output;
   var tx = makeTXbuilder();
 
@@ -4264,7 +4274,7 @@ function makeTransferSkeleton(fullyQualifiedName, consensusHash, newOwner) {
     keepChar = '>';
   }
 
-  opRet.write('id>', 0, 3, 'ascii');
+  opRet.write(opEncode('>'), 0, 3, 'ascii');
   opRet.write(keepChar, 3, 1, 'ascii');
 
   var hashed = (0, _utils.hash128)(Buffer.from(fullyQualifiedName, 'ascii'));
@@ -4305,7 +4315,7 @@ function makeUpdateSkeleton(fullyQualifiedName, consensusHash, valueHash) {
 
   var hashedName = (0, _utils.hash128)(Buffer.concat([nameBuff, consensusBuff]));
 
-  opRet.write('id+', 0, 3, 'ascii');
+  opRet.write(opEncode('+'), 0, 3, 'ascii');
   hashedName.copy(opRet, 3);
   opRet.write(valueHash, 19, 20, 'hex');
 
@@ -4337,7 +4347,7 @@ function makeRevokeSkeleton(fullyQualifiedName) {
 
   var nameBuff = Buffer.from(fullyQualifiedName, 'ascii');
 
-  opRet.write('id~', 0, 3, 'ascii');
+  opRet.write(opEncode('~'), 0, 3, 'ascii');
 
   var opReturnBuffer = Buffer.concat([opRet, nameBuff]);
   var nullOutput = _bitcoinjsLib2.default.payments.embed({ data: [opReturnBuffer] }).output;
@@ -4391,7 +4401,7 @@ function makeNamespacePreorderSkeleton(namespaceID, consensusHash, preorderAddre
   }
 
   var opReturnBuffer = Buffer.alloc(opReturnBufferLen);
-  opReturnBuffer.write('id*', 0, 3, 'ascii');
+  opReturnBuffer.write(opEncode('*'), 0, 3, 'ascii');
   hashed.copy(opReturnBuffer, 3);
   opReturnBuffer.write(consensusHash, 23, 16, 'hex');
 
@@ -4426,7 +4436,7 @@ function makeNamespaceRevealSkeleton(namespace, revealAddress) {
   var hexPayload = namespace.toHexPayload();
 
   var opReturnBuffer = Buffer.alloc(3 + hexPayload.length / 2);
-  opReturnBuffer.write('id&', 0, 3, 'ascii');
+  opReturnBuffer.write(opEncode('&'), 0, 3, 'ascii');
   opReturnBuffer.write(hexPayload, 3, hexPayload.length / 2, 'hex');
 
   var nullOutput = _bitcoinjsLib2.default.payments.embed({ data: [opReturnBuffer] }).output;
@@ -4447,7 +4457,7 @@ function makeNamespaceReadySkeleton(namespaceID) {
     output 0: namespace ready code
    */
   var opReturnBuffer = Buffer.alloc(3 + namespaceID.length + 1);
-  opReturnBuffer.write('id!', 0, 3, 'ascii');
+  opReturnBuffer.write(opEncode('!'), 0, 3, 'ascii');
   opReturnBuffer.write('.' + namespaceID, 3, namespaceID.length + 1, 'ascii');
 
   var nullOutput = _bitcoinjsLib2.default.payments.embed({ data: [opReturnBuffer] }).output;
@@ -4474,7 +4484,7 @@ function makeNameImportSkeleton(name, recipientAddr, zonefileHash) {
 
   var network = _config.config.network;
   var opReturnBuffer = Buffer.alloc(3 + name.length);
-  opReturnBuffer.write('id;', 0, 3, 'ascii');
+  opReturnBuffer.write(opEncode(';'), 0, 3, 'ascii');
   opReturnBuffer.write(name, 3, name.length, 'ascii');
 
   var nullOutput = _bitcoinjsLib2.default.payments.embed({ data: [opReturnBuffer] }).output;
@@ -4502,7 +4512,7 @@ function makeAnnounceSkeleton(messageHash) {
   }
 
   var opReturnBuffer = Buffer.alloc(3 + messageHash.length / 2);
-  opReturnBuffer.write('id#', 0, 3, 'ascii');
+  opReturnBuffer.write(opEncode('#'), 0, 3, 'ascii');
   opReturnBuffer.write(messageHash, 3, messageHash.length / 2, 'hex');
 
   var nullOutput = _bitcoinjsLib2.default.payments.embed({ data: [opReturnBuffer] }).output;
@@ -4540,7 +4550,7 @@ function makeTokenTransferSkeleton(recipientAddress, consensusHash, tokenType, t
 
   var tokenValueHexPadded = ('0000000000000000' + tokenValueHex).slice(-16);
 
-  opReturnBuffer.write('id$', 0, 3, 'ascii');
+  opReturnBuffer.write(opEncode('$'), 0, 3, 'ascii');
   opReturnBuffer.write(consensusHash, 3, consensusHash.length / 2, 'hex');
   opReturnBuffer.write(tokenTypeHexPadded, 19, tokenTypeHexPadded.length / 2, 'hex');
   opReturnBuffer.write(tokenValueHexPadded, 38, tokenValueHexPadded.length / 2, 'hex');
@@ -8149,6 +8159,8 @@ function makeLegacyAuthToken(challengeText, signerKeyHex) {
 }
 
 function makeV1GaiaAuthToken(hubInfo, signerKeyHex, hubUrl, associationToken) {
+  var extraParams = arguments.length > 4 && arguments[4] !== undefined ? arguments[4] : {};
+
   var challengeText = hubInfo.challenge_text;
   var handlesV1Auth = hubInfo.latest_auth_version && parseInt(hubInfo.latest_auth_version.slice(1), 10) >= 1;
   var iss = (0, _index.getPublicKeyFromPrivate)(signerKeyHex);
@@ -8158,18 +8170,20 @@ function makeV1GaiaAuthToken(hubInfo, signerKeyHex, hubUrl, associationToken) {
   }
 
   var salt = _crypto2.default.randomBytes(16).toString('hex');
-  var payload = {
+  var payload = Object.assign({}, extraParams, {
     gaiaChallenge: challengeText,
     hubUrl: hubUrl,
     iss: iss,
     salt: salt,
     associationToken: associationToken
-  };
+  });
   var token = new _jsontokens.TokenSigner('ES256K', signerKeyHex).sign(payload);
   return 'v1:' + token;
 }
 
 function connectToGaiaHub(gaiaHubUrl, challengeSignerHex, associationToken) {
+  var extraParams = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : {};
+
   if (!associationToken) {
     // maybe given in local storage?
     try {
@@ -8188,7 +8202,7 @@ function connectToGaiaHub(gaiaHubUrl, challengeSignerHex, associationToken) {
     return response.json();
   }).then(function (hubInfo) {
     var readURL = hubInfo.read_url_prefix;
-    var token = makeV1GaiaAuthToken(hubInfo, challengeSignerHex, gaiaHubUrl, associationToken);
+    var token = makeV1GaiaAuthToken(hubInfo, challengeSignerHex, gaiaHubUrl, associationToken, extraParams);
     var address = (0, _utils.ecPairToAddress)((0, _index.hexStringToECPair)(challengeSignerHex + (challengeSignerHex.length === 64 ? '01' : '')));
     return {
       url_prefix: readURL,
@@ -8755,7 +8769,7 @@ function listFilesLoop(hubConfig, page, callCount, fileCount, callback) {
       return listFilesLoop(hubConfig, nextPage, callCount + 1, fileCount + entries.length, callback);
     } else {
       // no more entries -- end of data
-      return Promise.resolve(fileCount);
+      return Promise.resolve(fileCount + entries.length);
     }
   });
 }
@@ -13031,7 +13045,7 @@ module.exports={
   "_args": [
     [
       "bigi@1.4.2",
-      "/Users/Yukan/Desktop/work/blockstack/blockstack.js"
+      "/Users/hank/blockstack/js"
     ]
   ],
   "_from": "bigi@1.4.2",
@@ -13056,7 +13070,7 @@ module.exports={
   ],
   "_resolved": "https://registry.npmjs.org/bigi/-/bigi-1.4.2.tgz",
   "_spec": "1.4.2",
-  "_where": "/Users/Yukan/Desktop/work/blockstack/blockstack.js",
+  "_where": "/Users/hank/blockstack/js",
   "bugs": {
     "url": "https://github.com/cryptocoinjs/bigi/issues"
   },
@@ -54287,7 +54301,7 @@ module.exports={
   "_args": [
     [
       "cheerio@0.22.0",
-      "/Users/Yukan/Desktop/work/blockstack/blockstack.js"
+      "/Users/hank/blockstack/js"
     ]
   ],
   "_from": "cheerio@0.22.0",
@@ -54311,7 +54325,7 @@ module.exports={
   ],
   "_resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
   "_spec": "0.22.0",
-  "_where": "/Users/Yukan/Desktop/work/blockstack/blockstack.js",
+  "_where": "/Users/hank/blockstack/js",
   "author": {
     "name": "Matt Mueller",
     "email": "mattmuelle@gmail.com",
@@ -62629,7 +62643,7 @@ module.exports={
   "_args": [
     [
       "elliptic@6.4.0",
-      "/Users/Yukan/Desktop/work/blockstack/blockstack.js"
+      "/Users/hank/blockstack/js"
     ]
   ],
   "_from": "elliptic@6.4.0",
@@ -62657,7 +62671,7 @@ module.exports={
   ],
   "_resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
   "_spec": "6.4.0",
-  "_where": "/Users/Yukan/Desktop/work/blockstack/blockstack.js",
+  "_where": "/Users/hank/blockstack/js",
   "author": {
     "name": "Fedor Indutny",
     "email": "fedor@indutny.com"
@@ -75743,7 +75757,7 @@ module.exports={
   "_args": [
     [
       "elliptic@5.2.1",
-      "/Users/Yukan/Desktop/work/blockstack/blockstack.js"
+      "/Users/hank/blockstack/js"
     ]
   ],
   "_from": "elliptic@5.2.1",
@@ -75767,7 +75781,7 @@ module.exports={
   ],
   "_resolved": "https://registry.npmjs.org/elliptic/-/elliptic-5.2.1.tgz",
   "_spec": "5.2.1",
-  "_where": "/Users/Yukan/Desktop/work/blockstack/blockstack.js",
+  "_where": "/Users/hank/blockstack/js",
   "author": {
     "name": "Fedor Indutny",
     "email": "fedor@indutny.com"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blockstack",
-  "version": "18.2.0",
+  "version": "18.3.0",
   "description": "The Blockstack Javascript library for authentication, identity, and storage.",
   "main": "lib/index",
   "scripts": {

--- a/src/storage/hub.js
+++ b/src/storage/hub.js
@@ -68,7 +68,8 @@ function makeLegacyAuthToken(challengeText: string, signerKeyHex: string): strin
 function makeV1GaiaAuthToken(hubInfo: Object,
                              signerKeyHex: string,
                              hubUrl: string, 
-                             associationToken?: string): string {
+                             associationToken?: string,
+                             extraParams: Object = {}): string {
   const challengeText = hubInfo.challenge_text
   const handlesV1Auth = (hubInfo.latest_auth_version
                          && parseInt(hubInfo.latest_auth_version.slice(1), 10) >= 1)
@@ -79,20 +80,21 @@ function makeV1GaiaAuthToken(hubInfo: Object,
   }
 
   const salt = crypto.randomBytes(16).toString('hex')
-  const payload = {
+  const payload = Object.assign({}, extraParams, {
     gaiaChallenge: challengeText,
     hubUrl,
     iss,
     salt,
     associationToken
-  }
+  })
   const token = new TokenSigner('ES256K', signerKeyHex).sign(payload)
   return `v1:${token}`
 }
 
 export function connectToGaiaHub(gaiaHubUrl: string,
                                  challengeSignerHex: string,
-                                 associationToken?: string): Promise<GaiaHubConfig> {
+                                 associationToken?: string,
+                                 extraParams: Object = {}): Promise<GaiaHubConfig> {
   if (!associationToken) {
     // maybe given in local storage?
     try {
@@ -111,7 +113,11 @@ export function connectToGaiaHub(gaiaHubUrl: string,
     .then(response => response.json())
     .then((hubInfo) => {
       const readURL = hubInfo.read_url_prefix
-      const token = makeV1GaiaAuthToken(hubInfo, challengeSignerHex, gaiaHubUrl, associationToken)
+      const token = makeV1GaiaAuthToken(hubInfo, 
+                                        challengeSignerHex, 
+                                        gaiaHubUrl, 
+                                        associationToken, 
+                                        extraParams)
       const address = ecPairToAddress(hexStringToECPair(challengeSignerHex
                                         + (challengeSignerHex.length === 64 ? '01' : '')))
       return {


### PR DESCRIPTION
Similar to the change we just made to the `authRequest`, this adds an `extraParams` parameter to `connectToGaiaHub`.

All keys and values in `extraParams` are added to the payload in the token that is generated for writes to Gaia hubs.