### PR TITLE
retry `putFile` with fresh Gaia config if the first write fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to the project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [18.2.1] - 2018-01-08
+
+### Added
+
+- Added automatic retry logic to `putFile` in the case of a failed storage call. This might be
+the case if there have been any token revokations. This new logic will catch the first failed write,
+construct (and cache) a new Gaia token, and then attempt the write again. This allows tokens
+to be revoked without any hiccups from a user experience standpoint.
+
 ## [18.2.0] - 2018-12-20
 
 ### Added

--- a/dist/blockstack.js
+++ b/dist/blockstack.js
@@ -8118,6 +8118,7 @@ function uploadToGaiaHub(filename, contents, hubConfig) {
   var contentType = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : 'application/octet-stream';
 
   _logger.Logger.debug('uploadToGaiaHub: uploading ' + filename + ' to ' + hubConfig.server);
+  console.log(hubConfig.token);
   return fetch(hubConfig.server + '/store/' + hubConfig.address + '/' + filename, {
     method: 'POST',
     headers: {
@@ -8128,7 +8129,7 @@ function uploadToGaiaHub(filename, contents, hubConfig) {
   }).then(function (response) {
     return response.text();
   }).then(function (responseText) {
-    return JSON.parse(responseText);
+    console.log(responseText);return JSON.parse(responseText);
   }).then(function (responseJSON) {
     return responseJSON.publicURL;
   });

--- a/dist/blockstack.js
+++ b/dist/blockstack.js
@@ -8118,7 +8118,6 @@ function uploadToGaiaHub(filename, contents, hubConfig) {
   var contentType = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : 'application/octet-stream';
 
   _logger.Logger.debug('uploadToGaiaHub: uploading ' + filename + ' to ' + hubConfig.server);
-  console.log(hubConfig.token);
   return fetch(hubConfig.server + '/store/' + hubConfig.address + '/' + filename, {
     method: 'POST',
     headers: {
@@ -8127,9 +8126,13 @@ function uploadToGaiaHub(filename, contents, hubConfig) {
     },
     body: contents
   }).then(function (response) {
-    return response.text();
+    if (response.ok) {
+      return response.text();
+    } else {
+      throw new Error('Error when uploading to Gaia hub');
+    }
   }).then(function (responseText) {
-    console.log(responseText);return JSON.parse(responseText);
+    return JSON.parse(responseText);
   }).then(function (responseJSON) {
     return responseJSON.publicURL;
   });
@@ -8687,8 +8690,9 @@ function putFile(path, content, options) {
   }
   return (0, _hub.getOrSetLocalGaiaHubConnection)().then(function (gaiaHubConfig) {
     return new Promise(function (resolve, reject) {
-      (0, _hub.uploadToGaiaHub)(path, content, gaiaHubConfig, contentType).then(resolve).catch(function () {
-        (0, _hub.setLocalGaiaHubConnection)().then(function (freshHubConfig) {
+      (0, _hub.uploadToGaiaHub)(path, content, gaiaHubConfig, contentType).then(resolve).catch(function (error) {
+        console.log(error);
+        return (0, _hub.setLocalGaiaHubConnection)().then(function (freshHubConfig) {
           return (0, _hub.uploadToGaiaHub)(path, content, freshHubConfig, contentType).then(resolve).catch(reject);
         });
       });

--- a/dist/blockstack.js
+++ b/dist/blockstack.js
@@ -2328,6 +2328,7 @@ var BlockstackNetwork = exports.BlockstackNetwork = function () {
     this.DUST_MINIMUM = 5500;
     this.includeUtxoMap = {};
     this.excludeUtxoSet = [];
+    this.MAGIC_BYTES = 'id';
   }
 
   _createClass(BlockstackNetwork, [{
@@ -4059,6 +4060,15 @@ function makeTXbuilder() {
   return txb;
 }
 
+function opEncode(opcode) {
+  // NOTE: must *always* a 3-character string
+  var res = '' + _config.config.network.MAGIC_BYTES + opcode;
+  if (res.length !== 3) {
+    throw new Error('Runtime error: invalid MAGIC_BYTES');
+  }
+  return res;
+}
+
 function makePreorderSkeleton(fullyQualifiedName, consensusHash, preorderAddress, burnAddress, burn) {
   var registerAddress = arguments.length > 5 && arguments[5] !== undefined ? arguments[5] : null;
 
@@ -4095,7 +4105,7 @@ function makePreorderSkeleton(fullyQualifiedName, consensusHash, preorderAddress
 
   var opReturnBufferLen = burnAmount.units === 'BTC' ? 39 : 66;
   var opReturnBuffer = Buffer.alloc(opReturnBufferLen);
-  opReturnBuffer.write('id?', 0, 3, 'ascii');
+  opReturnBuffer.write(opEncode('?'), 0, 3, 'ascii');
   hashed.copy(opReturnBuffer, 3);
   opReturnBuffer.write(consensusHash, 23, 16, 'hex');
 
@@ -4183,7 +4193,7 @@ function makeRegisterSkeleton(fullyQualifiedName, ownerAddress) {
     payload = Buffer.from(fullyQualifiedName, 'ascii');
   }
 
-  var opReturnBuffer = Buffer.concat([Buffer.from('id:', 'ascii'), payload]);
+  var opReturnBuffer = Buffer.concat([Buffer.from(opEncode(':'), 'ascii'), payload]);
   var nullOutput = _bitcoinjsLib2.default.payments.embed({ data: [opReturnBuffer] }).output;
   var tx = makeTXbuilder();
 
@@ -4264,7 +4274,7 @@ function makeTransferSkeleton(fullyQualifiedName, consensusHash, newOwner) {
     keepChar = '>';
   }
 
-  opRet.write('id>', 0, 3, 'ascii');
+  opRet.write(opEncode('>'), 0, 3, 'ascii');
   opRet.write(keepChar, 3, 1, 'ascii');
 
   var hashed = (0, _utils.hash128)(Buffer.from(fullyQualifiedName, 'ascii'));
@@ -4305,7 +4315,7 @@ function makeUpdateSkeleton(fullyQualifiedName, consensusHash, valueHash) {
 
   var hashedName = (0, _utils.hash128)(Buffer.concat([nameBuff, consensusBuff]));
 
-  opRet.write('id+', 0, 3, 'ascii');
+  opRet.write(opEncode('+'), 0, 3, 'ascii');
   hashedName.copy(opRet, 3);
   opRet.write(valueHash, 19, 20, 'hex');
 
@@ -4337,7 +4347,7 @@ function makeRevokeSkeleton(fullyQualifiedName) {
 
   var nameBuff = Buffer.from(fullyQualifiedName, 'ascii');
 
-  opRet.write('id~', 0, 3, 'ascii');
+  opRet.write(opEncode('~'), 0, 3, 'ascii');
 
   var opReturnBuffer = Buffer.concat([opRet, nameBuff]);
   var nullOutput = _bitcoinjsLib2.default.payments.embed({ data: [opReturnBuffer] }).output;
@@ -4391,7 +4401,7 @@ function makeNamespacePreorderSkeleton(namespaceID, consensusHash, preorderAddre
   }
 
   var opReturnBuffer = Buffer.alloc(opReturnBufferLen);
-  opReturnBuffer.write('id*', 0, 3, 'ascii');
+  opReturnBuffer.write(opEncode('*'), 0, 3, 'ascii');
   hashed.copy(opReturnBuffer, 3);
   opReturnBuffer.write(consensusHash, 23, 16, 'hex');
 
@@ -4426,7 +4436,7 @@ function makeNamespaceRevealSkeleton(namespace, revealAddress) {
   var hexPayload = namespace.toHexPayload();
 
   var opReturnBuffer = Buffer.alloc(3 + hexPayload.length / 2);
-  opReturnBuffer.write('id&', 0, 3, 'ascii');
+  opReturnBuffer.write(opEncode('&'), 0, 3, 'ascii');
   opReturnBuffer.write(hexPayload, 3, hexPayload.length / 2, 'hex');
 
   var nullOutput = _bitcoinjsLib2.default.payments.embed({ data: [opReturnBuffer] }).output;
@@ -4447,7 +4457,7 @@ function makeNamespaceReadySkeleton(namespaceID) {
     output 0: namespace ready code
    */
   var opReturnBuffer = Buffer.alloc(3 + namespaceID.length + 1);
-  opReturnBuffer.write('id!', 0, 3, 'ascii');
+  opReturnBuffer.write(opEncode('!'), 0, 3, 'ascii');
   opReturnBuffer.write('.' + namespaceID, 3, namespaceID.length + 1, 'ascii');
 
   var nullOutput = _bitcoinjsLib2.default.payments.embed({ data: [opReturnBuffer] }).output;
@@ -4474,7 +4484,7 @@ function makeNameImportSkeleton(name, recipientAddr, zonefileHash) {
 
   var network = _config.config.network;
   var opReturnBuffer = Buffer.alloc(3 + name.length);
-  opReturnBuffer.write('id;', 0, 3, 'ascii');
+  opReturnBuffer.write(opEncode(';'), 0, 3, 'ascii');
   opReturnBuffer.write(name, 3, name.length, 'ascii');
 
   var nullOutput = _bitcoinjsLib2.default.payments.embed({ data: [opReturnBuffer] }).output;
@@ -4502,7 +4512,7 @@ function makeAnnounceSkeleton(messageHash) {
   }
 
   var opReturnBuffer = Buffer.alloc(3 + messageHash.length / 2);
-  opReturnBuffer.write('id#', 0, 3, 'ascii');
+  opReturnBuffer.write(opEncode('#'), 0, 3, 'ascii');
   opReturnBuffer.write(messageHash, 3, messageHash.length / 2, 'hex');
 
   var nullOutput = _bitcoinjsLib2.default.payments.embed({ data: [opReturnBuffer] }).output;
@@ -4540,7 +4550,7 @@ function makeTokenTransferSkeleton(recipientAddress, consensusHash, tokenType, t
 
   var tokenValueHexPadded = ('0000000000000000' + tokenValueHex).slice(-16);
 
-  opReturnBuffer.write('id$', 0, 3, 'ascii');
+  opReturnBuffer.write(opEncode('$'), 0, 3, 'ascii');
   opReturnBuffer.write(consensusHash, 3, consensusHash.length / 2, 'hex');
   opReturnBuffer.write(tokenTypeHexPadded, 19, tokenTypeHexPadded.length / 2, 'hex');
   opReturnBuffer.write(tokenValueHexPadded, 38, tokenValueHexPadded.length / 2, 'hex');
@@ -8647,7 +8657,13 @@ function putFile(path, content, options) {
     var signatureObject = (0, _encryption.signECDSA)(privateKey, content);
     var signatureContent = JSON.stringify(signatureObject);
     return (0, _hub.getOrSetLocalGaiaHubConnection)().then(function (gaiaHubConfig) {
-      return Promise.all([(0, _hub.uploadToGaiaHub)(path, content, gaiaHubConfig, contentType), (0, _hub.uploadToGaiaHub)('' + path + SIGNATURE_FILE_SUFFIX, signatureContent, gaiaHubConfig, 'application/json')]);
+      return new Promise(function (resolve, reject) {
+        return Promise.all([(0, _hub.uploadToGaiaHub)(path, content, gaiaHubConfig, contentType), (0, _hub.uploadToGaiaHub)('' + path + SIGNATURE_FILE_SUFFIX, signatureContent, gaiaHubConfig, 'application/json')]).then(resolve).catch(function () {
+          (0, _hub.setLocalGaiaHubConnection)().then(function (freshHubConfig) {
+            return Promise.all([(0, _hub.uploadToGaiaHub)(path, content, freshHubConfig, contentType), (0, _hub.uploadToGaiaHub)('' + path + SIGNATURE_FILE_SUFFIX, signatureContent, freshHubConfig, 'application/json')]).then(resolve).catch(reject);
+          });
+        });
+      });
     }).then(function (fileUrls) {
       return fileUrls[0];
     });
@@ -8669,7 +8685,13 @@ function putFile(path, content, options) {
     contentType = 'application/json';
   }
   return (0, _hub.getOrSetLocalGaiaHubConnection)().then(function (gaiaHubConfig) {
-    return (0, _hub.uploadToGaiaHub)(path, content, gaiaHubConfig, contentType);
+    return new Promise(function (resolve, reject) {
+      (0, _hub.uploadToGaiaHub)(path, content, gaiaHubConfig, contentType).then(resolve).catch(function () {
+        (0, _hub.setLocalGaiaHubConnection)().then(function (freshHubConfig) {
+          return (0, _hub.uploadToGaiaHub)(path, content, freshHubConfig, contentType).then(resolve).catch(reject);
+        });
+      });
+    });
   });
 }
 
@@ -8755,7 +8777,7 @@ function listFilesLoop(hubConfig, page, callCount, fileCount, callback) {
       return listFilesLoop(hubConfig, nextPage, callCount + 1, fileCount + entries.length, callback);
     } else {
       // no more entries -- end of data
-      return Promise.resolve(fileCount);
+      return Promise.resolve(fileCount + entries.length);
     }
   });
 }
@@ -13031,7 +13053,7 @@ module.exports={
   "_args": [
     [
       "bigi@1.4.2",
-      "/Users/Yukan/Desktop/work/blockstack/blockstack.js"
+      "/Users/hank/blockstack/js"
     ]
   ],
   "_from": "bigi@1.4.2",
@@ -13056,7 +13078,7 @@ module.exports={
   ],
   "_resolved": "https://registry.npmjs.org/bigi/-/bigi-1.4.2.tgz",
   "_spec": "1.4.2",
-  "_where": "/Users/Yukan/Desktop/work/blockstack/blockstack.js",
+  "_where": "/Users/hank/blockstack/js",
   "bugs": {
     "url": "https://github.com/cryptocoinjs/bigi/issues"
   },
@@ -54287,7 +54309,7 @@ module.exports={
   "_args": [
     [
       "cheerio@0.22.0",
-      "/Users/Yukan/Desktop/work/blockstack/blockstack.js"
+      "/Users/hank/blockstack/js"
     ]
   ],
   "_from": "cheerio@0.22.0",
@@ -54311,7 +54333,7 @@ module.exports={
   ],
   "_resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
   "_spec": "0.22.0",
-  "_where": "/Users/Yukan/Desktop/work/blockstack/blockstack.js",
+  "_where": "/Users/hank/blockstack/js",
   "author": {
     "name": "Matt Mueller",
     "email": "mattmuelle@gmail.com",
@@ -62629,7 +62651,7 @@ module.exports={
   "_args": [
     [
       "elliptic@6.4.0",
-      "/Users/Yukan/Desktop/work/blockstack/blockstack.js"
+      "/Users/hank/blockstack/js"
     ]
   ],
   "_from": "elliptic@6.4.0",
@@ -62657,7 +62679,7 @@ module.exports={
   ],
   "_resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
   "_spec": "6.4.0",
-  "_where": "/Users/Yukan/Desktop/work/blockstack/blockstack.js",
+  "_where": "/Users/hank/blockstack/js",
   "author": {
     "name": "Fedor Indutny",
     "email": "fedor@indutny.com"
@@ -75743,7 +75765,7 @@ module.exports={
   "_args": [
     [
       "elliptic@5.2.1",
-      "/Users/Yukan/Desktop/work/blockstack/blockstack.js"
+      "/Users/hank/blockstack/js"
     ]
   ],
   "_from": "elliptic@5.2.1",
@@ -75767,7 +75789,7 @@ module.exports={
   ],
   "_resolved": "https://registry.npmjs.org/elliptic/-/elliptic-5.2.1.tgz",
   "_spec": "5.2.1",
-  "_where": "/Users/Yukan/Desktop/work/blockstack/blockstack.js",
+  "_where": "/Users/hank/blockstack/js",
   "author": {
     "name": "Fedor Indutny",
     "email": "fedor@indutny.com"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blockstack",
-  "version": "18.2.0",
+  "version": "18.2.1",
   "description": "The Blockstack Javascript library for authentication, identity, and storage.",
   "main": "lib/index",
   "scripts": {

--- a/src/storage/hub.js
+++ b/src/storage/hub.js
@@ -31,7 +31,13 @@ export function uploadToGaiaHub(filename: string, contents: any,
                  },
                  body: contents
                })
-    .then(response => response.text())
+    .then((response) => {
+      if (response.ok) {
+        return response.text()
+      } else {
+        throw new Error('Error when uploading to Gaia hub')
+      }
+    })
     .then(responseText => JSON.parse(responseText))
     .then(responseJSON => responseJSON.publicURL)
 }

--- a/tests/unitTests/src/unitTestsStorage.js
+++ b/tests/unitTests/src/unitTestsStorage.js
@@ -704,6 +704,48 @@ export function runStorageTests() {
       .catch(() => t.ok(true, 'Should have rejected promise'))
   })
 
+  test('putFile gets a new gaia config and tries again', (t) => {
+    t.plan(3)
+    const path = 'file.json'
+    const fullWriteUrl = 'https://hub.testblockstack.org/store/1NZNxhoxobqwsNvTb16pdeiqvFvce3Yabc/file.json'
+    const invalidHubConfig = {
+      address: '1NZNxhoxobqwsNvTb16pdeiqvFvce3Yabc',
+      server: 'https://hub.testblockstack.org',
+      token: '',
+      url_prefix: 'gaia.testblockstack.org/hub/'
+    }
+
+    const validHubConfig = Object.assign({}, invalidHubConfig, {
+      token: 'valid'
+    })
+
+    const getOrSetLocalGaiaHubConnection = sinon.stub().resolves(invalidHubConfig)
+    const setLocalGaiaHubConnection = sinon.stub().resolves(validHubConfig)
+    const { putFile } = proxyquire('../../../lib/storage', {
+      './hub': {
+        getOrSetLocalGaiaHubConnection,
+        setLocalGaiaHubConnection
+      }
+    })
+
+    FetchMock.post(fullWriteUrl, (url, { headers }) => {
+      console.log(url, headers)
+      if (headers.Authorization === 'bearer ') {
+        t.ok(true, 'tries with invalid token')
+        return 421
+      } else if (headers.Authorization === 'bearer valid') {
+        t.ok(true, 'Tries with valid hub config')
+        return {
+          status: 200,
+          body: JSON.stringify({ publicURL: 'readURL' })
+        }
+      }
+      return 421
+    })
+    putFile(path, 'hello world', { encrypt: false })
+      .then(() => t.ok(true, 'Request should pass'))
+  })
+
   test('fetch404null', (t) => {
     t.plan(2)
     const config = {

--- a/tests/unitTests/src/unitTestsStorage.js
+++ b/tests/unitTests/src/unitTestsStorage.js
@@ -681,9 +681,14 @@ export function runStorageTests() {
       token: '',
       url_prefix: 'gaia.testblockstack.org/hub/'
     }
+
     const getOrSetLocalGaiaHubConnection = sinon.stub().resolves(gaiaHubConfig)
+    const setLocalGaiaHubConnection = sinon.stub().resolves(gaiaHubConfig)
     const { putFile } = proxyquire('../../../lib/storage', {
-      './hub': { getOrSetLocalGaiaHubConnection }
+      './hub': { 
+        getOrSetLocalGaiaHubConnection, 
+        setLocalGaiaHubConnection
+      }
     })
 
     FetchMock.post(`${fullReadUrl}`, { status: 404, body: 'Not found.' })

--- a/tests/unitTests/src/unitTestsStorage.js
+++ b/tests/unitTests/src/unitTestsStorage.js
@@ -732,7 +732,7 @@ export function runStorageTests() {
       console.log(url, headers)
       if (headers.Authorization === 'bearer ') {
         t.ok(true, 'tries with invalid token')
-        return 421
+        return 401
       } else if (headers.Authorization === 'bearer valid') {
         t.ok(true, 'Tries with valid hub config')
         return {
@@ -740,7 +740,7 @@ export function runStorageTests() {
           body: JSON.stringify({ publicURL: 'readURL' })
         }
       }
-      return 421
+      return 401
     })
     putFile(path, 'hello world', { encrypt: false })
       .then(() => t.ok(true, 'Request should pass'))


### PR DESCRIPTION
This PR adds some retry logic to `putFile`. In the case of Gaia tokens being revoked, app users will have invalid Gaia configuration cached in `localStorage`. All writes will fail until this Gaia config is updated manually.

This PR adds retry logic to `putFile`, so that if the first write fails, it'll make a new Gaia token, and then try writes again.

This should support any and all token revoke events, and make the experience for users much smoother.

TODO:

- [x] create a demo app that uses and demonstrates this. It'll start with bad Gaia config in `localStorage`, and then try an upload. It should work
- [x] add unit tests.