### PR TITLE
Do not use `browser` field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "19.0.0",
   "description": "The Blockstack Javascript library for authentication, identity, and storage.",
   "main": "lib/index",
-  "browser": "dist/blockstack.js",
+  "unpkg": "dist/blockstack.js",
   "scripts": {
     "browserify": "rm -rf ./dist/blockstack.js && browserify src/index.js --standalone blockstack -o ./dist/blockstack.js",
     "browserify-tests": "browserify src/index.js --debug --standalone blockstack -o ./tests/browserTests/bundle.js",


### PR DESCRIPTION
Webpack will actually use the package.json `browser` field by default. This is not ideal because the dist file has all dependencies bundled in, so webpack can't perform any module tree-shaking or de-duplication on the bundle. 

There are several webpack issues about this since its not really what it should be doing, but it is legacy behavior that will not change: https://github.com/webpack/webpack/issues/7646 https://github.com/webpack/webpack/issues/4674

Switched the field to `unpkg` which is more appropriate in the ecosystem for this type of bundle.