### PR TITLE
Add `email` field to the user data object

### DIFF
--- a/src/auth/authApp.js
+++ b/src/auth/authApp.js
@@ -495,6 +495,7 @@ export function handlePendingSignInImpl(caller: UserSession,
       const userData = {
         username: tokenPayload.username,
         profile: tokenPayload.profile,
+        email: tokenPayload.email,
         decentralizedID: tokenPayload.iss,
         identityAddress: getAddressFromDID(tokenPayload.iss),
         appPrivateKey,


### PR DESCRIPTION
Add `email` field to the user data object (the one stored and returned by `loadUserData()`) for apps to access. 

Part of the email scope issue
https://github.com/blockstack/blockstack-browser/issues/1780
https://github.com/blockstack/blockstack-browser/issues/1853