### PR TITLE
Add types for auth scopes

### DIFF
--- a/src/auth/appConfig.ts
+++ b/src/auth/appConfig.ts
@@ -1,5 +1,5 @@
 
-import { DEFAULT_CORE_NODE, DEFAULT_SCOPE, DEFAULT_BLOCKSTACK_HOST } from './authConstants'
+import { DEFAULT_CORE_NODE, DEFAULT_SCOPE, DEFAULT_BLOCKSTACK_HOST, AuthScope } from './authConstants'
 
 
 /**
@@ -23,7 +23,7 @@ export class AppConfig {
    * An array of string representing permissions requested by the app.
    *
    */
-  scopes: Array<string>
+  scopes: Array<AuthScope | string>
 
 
   /**
@@ -67,7 +67,7 @@ export class AppConfig {
    * @param {string} authenticatorURL - the web-based fall back authenticator 
    * ([[DEFAULT_BLOCKSTACK_HOST]])
    */
-  constructor(scopes: Array<string> = DEFAULT_SCOPE.slice(),
+  constructor(scopes: Array<AuthScope | string> = DEFAULT_SCOPE.slice(),
               appDomain: string = window.location.origin,
               redirectPath: string = '',
               manifestPath: string = '/manifest.json',

--- a/src/auth/authApp.ts
+++ b/src/auth/authApp.ts
@@ -10,7 +10,8 @@ import { decryptPrivateKey, makeAuthRequest } from './authMessages'
 import {
   BLOCKSTACK_DEFAULT_GAIA_HUB_URL,
   DEFAULT_BLOCKSTACK_HOST,
-  NAME_LOOKUP_PATH
+  NAME_LOOKUP_PATH,
+  AuthScope
 } from './authConstants'
 import { extractProfile } from '../profiles/profileTokens'
 import { UserSession } from './userSession'
@@ -109,7 +110,7 @@ export function isUserSignedIn() {
  */
 export function redirectToSignIn(redirectURI?: string, 
                                  manifestURI?: string, 
-                                 scopes?: string[]) { 
+                                 scopes?: Array<AuthScope | string>) { 
   console.warn('DEPRECATION WARNING: The static redirectToSignIn() function will be deprecated in the '
     + 'next major release of blockstack.js. Create an instance of UserSession and call the '
     + 'instance method redirectToSignIn().')

--- a/src/auth/authConstants.ts
+++ b/src/auth/authConstants.ts
@@ -23,8 +23,8 @@ export const enum AuthScope {
   store_write = 'store_write',
   /**
    * Publish data so that other users of the app can discover and interact with the user.
-   * The user's files stored on Gaia are made visible to others via the apps property in the 
-   * user’s profile.json file. 
+   * The user's files stored on Gaia hub are made visible to others via the `apps` property in the 
+   * user’s `profile.json` file. 
    */
   publish_data = 'publish_data',
   /**

--- a/src/auth/authConstants.ts
+++ b/src/auth/authConstants.ts
@@ -11,10 +11,34 @@ export const BLOCKSTACK_STORAGE_LABEL = 'blockstack'
 * This constant is used in the [[redirectToSignInWithAuthRequest]]
 */
 export const DEFAULT_BLOCKSTACK_HOST = 'https://browser.blockstack.org/auth'
+
+/**
+ * Non-exhaustive list of common permission scopes. 
+ */
+export const enum AuthScope {
+  /**
+   * Read and write data to the user's Gaia hub in an app-specific storage bucket.
+   * This is the default scope.
+   */
+  store_write = 'store_write',
+  /**
+   * Publish data so that other users of the app can discover and interact with the user.
+   * The user's files stored on Gaia are made visible to others via the apps property in the 
+   * user’s profile.json file. 
+   */
+  publish_data = 'publish_data',
+  /**
+   * Request the user's email if available.
+   */
+  email = 'email'
+}
+
+
 /**
 * @ignore
 */
-export const DEFAULT_SCOPE = ['store_write']
+export const DEFAULT_SCOPE = [AuthScope.store_write]
+
 /**
 * @ignore
 */

--- a/src/auth/authMessages.ts
+++ b/src/auth/authMessages.ts
@@ -8,7 +8,7 @@ import { makeUUID4, nextMonth } from '../utils'
 import { makeDIDFromAddress } from '../dids'
 import { encryptECIES, decryptECIES } from '../encryption/ec'
 import { Logger } from '../logger'
-import { DEFAULT_SCOPE } from './authConstants'
+import { DEFAULT_SCOPE, AuthScope } from './authConstants'
 import { UserSession } from './userSession'
 
 
@@ -58,7 +58,7 @@ export function makeAuthRequest(
   transitPrivateKey?: string,
   redirectURI?: string, 
   manifestURI?: string, 
-  scopes: string[] = DEFAULT_SCOPE,
+  scopes: Array<AuthScope | string> = DEFAULT_SCOPE.slice(),
   appDomain?: string,
   expiresAt: number = nextMonth().getTime(),
   extraParams: any = {}

--- a/src/auth/userSession.ts
+++ b/src/auth/userSession.ts
@@ -19,7 +19,7 @@ import {
 } from '../errors'
 import { Logger } from '../logger'
 import { GaiaHubConfig, connectToGaiaHub } from '../storage/hub'
-import { BLOCKSTACK_DEFAULT_GAIA_HUB_URL } from './authConstants'
+import { BLOCKSTACK_DEFAULT_GAIA_HUB_URL, AuthScope } from './authConstants'
 
 
 /**
@@ -104,7 +104,7 @@ export class UserSession {
   redirectToSignIn(
     redirectURI?: string,
     manifestURI?: string,
-    scopes?: string[]
+    scopes?: Array<AuthScope | string>
   ) {
     const transitKey = this.generateAndStoreTransitKey()
     const authRequest = this.makeAuthRequest(transitKey, redirectURI, manifestURI, scopes)
@@ -159,7 +159,7 @@ export class UserSession {
     transitKey?: string,
     redirectURI?: string,
     manifestURI?: string,
-    scopes?: string[],
+    scopes?: Array<AuthScope | string>,
     appDomain?: string,
     expiresAt: number = nextHour().getTime(),
     extraParams: any = {}


### PR DESCRIPTION
These are only typing & comment changes, should not result in any logic changes. 
Intention is to help devs see the available/common auth scopes in their editor intellisense / hinting.
It also adds more info to the generated docs aside from just `string` for the scope input. 