### PR TITLE
Generate dist script file usage with a cdn and the subresource integrity hash

### DIFF
--- a/mdincludes/script-dist-file.md
+++ b/mdincludes/script-dist-file.md
@@ -1,0 +1,3 @@
+```html
+<script src="https://unpkg.com/blockstack@19.1.0/dist/blockstack.js" integrity="sha384-iyP2Q91bL61TbHoDcBUQy5tXDFEhbswcT7syEyDLz9rlIa9hBJnd4YCt0vXFCbmK" crossorigin="anonymous"></script>
+```

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "typedoc": "^0.14.2",
     "typescript": "^3.3.3333",
     "webpack": "^4.29.6",
+    "webpack-assets-manifest": "^3.1.1",
     "webpack-bundle-analyzer": "^3.1.0",
     "webpack-cli": "^3.2.3"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,24 @@
 const path = require('path');
+const fs = require('fs');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
+const WebpackAssetsManifest = require('webpack-assets-manifest');
+
+/**
+ * Generates markdown example for using the blockstack.js dist file with a CDN 
+ * and Subresource Integrity. Uses the lib version specified in the package.json. 
+ * Writes the output to `mdincludes/script-dist-file.md`.
+ * @see https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity
+ * @param {string} sriHash The hash string used for the script `integrity` attribute.
+ */
+function writeDistFileDoc(sriHash) {
+  const { version } = require(path.resolve(__dirname, 'package.json'));
+  const cdnUrl = `https://unpkg.com/blockstack@${version}/dist/blockstack.js`;
+  const scriptTag = `<script src="${cdnUrl}" integrity="${sriHash}" crossorigin="anonymous"></script>`;
+  const docOutput = "```html\n" + scriptTag + "\n```";
+  const outputDir = path.resolve(__dirname, 'mdincludes');
+  fs.mkdirSync(outputDir, { recursive: true });
+  fs.writeFileSync(path.join(outputDir, 'script-dist-file.md'), docOutput)
+}
 
 module.exports = (env, argv) => {
 
@@ -8,6 +27,7 @@ module.exports = (env, argv) => {
   const isEnvAnalyze = process.env.ANALYZE || env.ANALYZE;
   const isEnvDev = [process.env, env.NODE_ENV, argv.mode].includes('development') || env.development;
   const isEnvTest = [process.env, env.NODE_ENV, argv.mode].includes('test') || env.test;
+  const isEnvProd = [process.env, env.NODE_ENV, argv.mode].includes('production') || env.production;
 
   if (isEnvAnalyze) {
     console.log(`Webpack with 'ANALYZE' environment enabled`);
@@ -18,8 +38,8 @@ module.exports = (env, argv) => {
   if (isEnvTest) {
     console.timeLog(`Webpack with 'TEST' environment enabled`);
   }
-  
-  return {
+
+  const opts = {
     entry: './src/index.ts',
     devtool: "source-map",
     module: {
@@ -58,6 +78,25 @@ module.exports = (env, argv) => {
       libraryTarget: 'umd',
       globalObject: 'this'
     },
-    plugins: [].concat(isEnvAnalyze ? new BundleAnalyzerPlugin() : [])
+    plugins: []
   }
+
+  if (isEnvAnalyze) {
+    opts.plugins.push(new BundleAnalyzerPlugin())
+  }
+
+  if (isEnvProd) {
+    opts.plugins.push(new WebpackAssetsManifest({
+      integrity: true, 
+      integrityHashes: ['sha384'], 
+      customize(entry, original, manifest, asset) {
+        if (entry.value === 'blockstack.js') {
+          writeDistFileDoc(asset.integrity);
+          return { key: entry.value, value: asset.integrity };
+        }
+      }
+    }))
+  }
+
+  return opts;
 };


### PR DESCRIPTION
Related to https://github.com/blockstack/blockstack.js/issues/584 and https://github.com/blockstack/blockstack.js/issues/560

Adds example of secure usage of the blockstack.js dist bundle from a cdn using the latest lib version and [Subresource Integrity hash](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity).

Example:
```html
<script src="https://unpkg.com/blockstack@19.1.0/dist/blockstack.js"
 integrity="sha384-iyP2Q91bL61TbHoDcBUQy5tXDFEhbswcT7syEyDLz9rlIa9hBJnd4YCt0vXFCbmK"
 crossorigin="anonymous"></script>
```

This example is generated on dist file build so that we don't have to add an extra manual step to our process (generating hash, setting version number, updating docs). 

@moxiegirl is going to take care of the doc work (something like linking to the example from the readme.md and generated typedoc, etc..)
EDIT: PR for that here: https://github.com/blockstack/blockstack.js/pull/657/files