### PR TITLE
fix return type for BlockstackNetwork.getAccountTokens

### DIFF
--- a/src/network.ts
+++ b/src/network.ts
@@ -517,7 +517,7 @@ export class BlockstackNetwork {
    * @return {Promise} a promise that resolves to an Array of Strings, where each item encodes the 
    *   type of token this account holds (excluding the underlying blockchain's tokens)
    */
-  getAccountTokens(address: string): Promise<string[]> {
+  getAccountTokens(address: string): Promise<{tokens: string[]}> {
     return fetch(`${this.blockstackAPIUrl}/v1/accounts/${address}/tokens`)
       .then((resp) => {
         if (resp.status === 404) {


### PR DESCRIPTION
The endpoint `/v1/accounts/${address}/tokens` returns `{ tokens: ["STACKS"] }` or similar, which is what the Core node returns.