### PR TITLE
Prevent 'fetch' from leaking app urls in referrer header

### DIFF
--- a/src/auth/authApp.ts
+++ b/src/auth/authApp.ts
@@ -4,6 +4,7 @@ import queryString from 'query-string'
 import { decodeToken } from 'jsontokens'
 import { verifyAuthResponse } from './authVerification'
 import { isLaterVersion, hexStringToECPair, checkWindowAPI } from '../utils'
+import { fetchPrivate } from '../fetchUtil'
 import { getAddressFromDID } from '../dids'
 import { LoginFailedError } from '../errors'
 import { decryptPrivateKey, makeAuthRequest } from './authMessages'
@@ -357,7 +358,7 @@ export async function handlePendingSignIn(
   }
   const profileURL = tokenPayload.profile_url
   if (!userData.profile && profileURL) {
-    const response = await fetch(profileURL)
+    const response = await fetchPrivate(profileURL)
     if (!response.ok) { // return blank profile if we fail to fetch
       userData.profile = Object.assign({}, DEFAULT_PROFILE)
     } else {

--- a/src/auth/authProvider.ts
+++ b/src/auth/authProvider.ts
@@ -2,6 +2,7 @@ import queryString from 'query-string'
 // @ts-ignore: Could not find a declaration file for module
 import { decodeToken } from 'jsontokens'
 import { BLOCKSTACK_HANDLER, checkWindowAPI, updateQueryStringParameter } from '../utils'
+import { fetchPrivate } from '../fetchUtil'
 
 import { Logger } from '../logger'
 
@@ -41,7 +42,7 @@ export function fetchAppManifest(authRequest: string): Promise<any> {
       const manifestURI = payload.manifest_uri
       try {
         Logger.debug(`Fetching manifest from ${manifestURI}`)
-        fetch(manifestURI)
+        fetchPrivate(manifestURI)
           .then(response => response.text())
           .then(responseText => JSON.parse(responseText))
           .then((responseJSON) => {

--- a/src/auth/authSession.ts
+++ b/src/auth/authSession.ts
@@ -1,6 +1,7 @@
 // @ts-ignore: Could not find a declaration file for module
 import { TokenSigner, decodeToken, SECP256K1Client } from 'jsontokens'
 import 'cross-fetch/polyfill'
+import { fetchPrivate } from '../fetchUtil'
 
 /**
  * Create an authentication token to be sent to the Core API server
@@ -81,7 +82,7 @@ export function sendCoreSessionRequest(coreHost: string,
         }
       }
       const url = `http://${coreHost}:${corePort}/v1/auth?authRequest=${coreAuthRequest}`
-      return fetch(url, options)
+      return fetchPrivate(url, options)
     })
     .then((response) => {
       if (!response.ok) {

--- a/src/auth/authVerification.ts
+++ b/src/auth/authVerification.ts
@@ -3,6 +3,7 @@ import { decodeToken, TokenVerifier } from 'jsontokens'
 import { getAddressFromDID } from '../dids'
 import { publicKeyToAddress } from '../keys'
 import { isSameOriginAbsoluteUrl } from '../utils'
+import { fetchPrivate } from '../fetchUtil'
 import { fetchAppManifest } from './authProvider'
 
 /**
@@ -97,7 +98,7 @@ export function doPublicKeysMatchUsername(token: string,
 
     const username = payload.username
     const url = `${nameLookupURL.replace(/\/$/, '')}/${username}`
-    return fetch(url)
+    return fetchPrivate(url)
       .then(response => response.text())
       .then((responseText) => {
         const responseJSON = JSON.parse(responseText)

--- a/src/fetchUtil.ts
+++ b/src/fetchUtil.ts
@@ -1,0 +1,10 @@
+
+/** @ignore */
+export function fetchPrivate(input: RequestInfo, init?: RequestInit): Promise<Response> {
+  if (!init) {
+    init = { referrerPolicy: 'no-referrer' }
+  } else {
+    init.referrerPolicy = 'no-referrer'
+  }
+  return fetch(input, init)
+}

--- a/src/fetchUtil.ts
+++ b/src/fetchUtil.ts
@@ -1,10 +1,7 @@
 
 /** @ignore */
 export function fetchPrivate(input: RequestInfo, init?: RequestInit): Promise<Response> {
-  if (!init) {
-    init = { referrerPolicy: 'no-referrer' }
-  } else {
-    init.referrerPolicy = 'no-referrer'
-  }
+  init = init || { }
+  init.referrerPolicy = 'no-referrer'
   return fetch(input, init)
 }

--- a/src/network.ts
+++ b/src/network.ts
@@ -6,6 +6,7 @@ import RIPEMD160 from 'ripemd160'
 import { MissingParameterError, RemoteServiceError } from './errors'
 import { Logger } from './logger'
 import { config } from './config'
+import { fetchPrivate } from './fetchUtil'
 
 /**
  * @ignore
@@ -111,7 +112,7 @@ export class BlockstackNetwork {
    */
   getNamePriceV1(fullyQualifiedName: string): Promise<{units: string, amount: BN}> {
     // legacy code path
-    return fetch(`${this.blockstackAPIUrl}/v1/prices/names/${fullyQualifiedName}`)
+    return fetchPrivate(`${this.blockstackAPIUrl}/v1/prices/names/${fullyQualifiedName}`)
       .then((resp) => {
         if (!resp.ok) {
           throw new Error(`Failed to query name price for ${fullyQualifiedName}`)
@@ -145,7 +146,7 @@ export class BlockstackNetwork {
    */
   getNamespacePriceV1(namespaceID: string): Promise<{units: string, amount: BN}> {
     // legacy code path
-    return fetch(`${this.blockstackAPIUrl}/v1/prices/namespaces/${namespaceID}`)
+    return fetchPrivate(`${this.blockstackAPIUrl}/v1/prices/namespaces/${namespaceID}`)
       .then((resp) => {
         if (!resp.ok) {
           throw new Error(`Failed to query name price for ${namespaceID}`)
@@ -175,7 +176,7 @@ export class BlockstackNetwork {
    * @private
    */
   getNamePriceV2(fullyQualifiedName: string): Promise<{units: string, amount: BN}> {
-    return fetch(`${this.blockstackAPIUrl}/v2/prices/names/${fullyQualifiedName}`)
+    return fetchPrivate(`${this.blockstackAPIUrl}/v2/prices/names/${fullyQualifiedName}`)
       .then((resp) => {
         if (resp.status !== 200) {
           // old core node 
@@ -213,7 +214,7 @@ export class BlockstackNetwork {
    * @private
    */
   getNamespacePriceV2(namespaceID: string): Promise<{units: string, amount: BN}> {
-    return fetch(`${this.blockstackAPIUrl}/v2/prices/namespaces/${namespaceID}`)
+    return fetchPrivate(`${this.blockstackAPIUrl}/v2/prices/namespaces/${namespaceID}`)
       .then((resp) => {
         if (resp.status !== 200) {
           // old core node 
@@ -288,7 +289,7 @@ export class BlockstackNetwork {
    */
   getNamesOwned(address: string): Promise<string[]> {
     const networkAddress = this.coerceAddress(address)
-    return fetch(`${this.blockstackAPIUrl}/v1/addresses/bitcoin/${networkAddress}`)
+    return fetchPrivate(`${this.blockstackAPIUrl}/v1/addresses/bitcoin/${networkAddress}`)
       .then(resp => resp.json())
       .then(obj => obj.names)
   }
@@ -301,7 +302,7 @@ export class BlockstackNetwork {
    */
   getNamespaceBurnAddress(namespace: string) {
     return Promise.all([
-      fetch(`${this.blockstackAPIUrl}/v1/namespaces/${namespace}`),
+      fetchPrivate(`${this.blockstackAPIUrl}/v1/namespaces/${namespace}`),
       this.getBlockHeight()
     ])
       .then(([resp, blockHeight]) => {
@@ -333,7 +334,7 @@ export class BlockstackNetwork {
   getNameInfo(fullyQualifiedName: string) {
     Logger.debug(this.blockstackAPIUrl)
     const nameLookupURL = `${this.blockstackAPIUrl}/v1/names/${fullyQualifiedName}`
-    return fetch(nameLookupURL)
+    return fetchPrivate(nameLookupURL)
       .then((resp) => {
         if (resp.status === 404) {
           throw new Error('Name not found')
@@ -362,7 +363,7 @@ export class BlockstackNetwork {
    * @return {Promise} a promise that resolves to the namespace information.
    */
   getNamespaceInfo(namespaceID: string) {
-    return fetch(`${this.blockstackAPIUrl}/v1/namespaces/${namespaceID}`)
+    return fetchPrivate(`${this.blockstackAPIUrl}/v1/namespaces/${namespaceID}`)
       .then((resp) => {
         if (resp.status === 404) {
           throw new Error('Namespace not found')
@@ -394,7 +395,7 @@ export class BlockstackNetwork {
    * @return {Promise} a promise that resolves to the zone file's text
    */
   getZonefile(zonefileHash: string) {
-    return fetch(`${this.blockstackAPIUrl}/v1/zonefiles/${zonefileHash}`)
+    return fetchPrivate(`${this.blockstackAPIUrl}/v1/zonefiles/${zonefileHash}`)
       .then((resp) => {
         if (resp.status === 200) {
           return resp.text()
@@ -421,7 +422,7 @@ export class BlockstackNetwork {
    *   for this token
    */
   getAccountStatus(address: string, tokenType: string) {
-    return fetch(`${this.blockstackAPIUrl}/v1/accounts/${address}/${tokenType}/status`)
+    return fetchPrivate(`${this.blockstackAPIUrl}/v1/accounts/${address}/${tokenType}/status`)
       .then((resp) => {
         if (resp.status === 404) {
           throw new Error('Account not found')
@@ -452,7 +453,7 @@ export class BlockstackNetwork {
   getAccountHistoryPage(address: string,
                         page: number): Promise<any[]> {
     const url = `${this.blockstackAPIUrl}/v1/accounts/${address}/history?page=${page}`
-    return fetch(url)
+    return fetchPrivate(url)
       .then((resp) => {
         if (resp.status === 404) {
           throw new Error('Account not found')
@@ -487,7 +488,7 @@ export class BlockstackNetwork {
    */
   getAccountAt(address: string, blockHeight: number): Promise<any[]> {
     const url = `${this.blockstackAPIUrl}/v1/accounts/${address}/history/${blockHeight}`
-    return fetch(url)
+    return fetchPrivate(url)
       .then((resp) => {
         if (resp.status === 404) {
           throw new Error('Account not found')
@@ -518,7 +519,7 @@ export class BlockstackNetwork {
    *   type of token this account holds (excluding the underlying blockchain's tokens)
    */
   getAccountTokens(address: string): Promise<string[]> {
-    return fetch(`${this.blockstackAPIUrl}/v1/accounts/${address}/tokens`)
+    return fetchPrivate(`${this.blockstackAPIUrl}/v1/accounts/${address}/tokens`)
       .then((resp) => {
         if (resp.status === 404) {
           throw new Error('Account not found')
@@ -545,7 +546,7 @@ export class BlockstackNetwork {
    *   held by this account.
    */
   getAccountBalance(address: string, tokenType: string): Promise<BN> {
-    return fetch(`${this.blockstackAPIUrl}/v1/accounts/${address}/${tokenType}/balance`)
+    return fetchPrivate(`${this.blockstackAPIUrl}/v1/accounts/${address}/${tokenType}/balance`)
       .then((resp) => {
         if (resp.status === 404) {
           // talking to an older blockstack core node without the accounts API
@@ -595,7 +596,7 @@ export class BlockstackNetwork {
     }
 
     const url = `${this.broadcastServiceUrl}/v1/broadcast/${endpoint}`
-    return fetch(url, options)
+    return fetchPrivate(url, options)
       .then((response) => {
         if (response.ok) {
           return response.json()
@@ -715,14 +716,14 @@ export class BlockstackNetwork {
       // zone file is two words but core's api treats it as one word 'zonefile'
       const requestBody = { zonefile: zoneFile }
 
-      return fetch(`${this.blockstackAPIUrl}/v1/zonefile/`,
-                   {
-                     method: 'POST',
-                     body: JSON.stringify(requestBody),
-                     headers: {
-                       'Content-Type': 'application/json'
-                     }
-                   })
+      return fetchPrivate(`${this.blockstackAPIUrl}/v1/zonefile/`,
+                          {
+                            method: 'POST',
+                            body: JSON.stringify(requestBody),
+                            headers: {
+                              'Content-Type': 'application/json'
+                            }
+                          })
         .then((resp) => {
           const json = resp.json()
           return json
@@ -809,7 +810,7 @@ export class BlockstackNetwork {
    * @ignore
    */
   getFeeRate(): Promise<number> {
-    return fetch('https://bitcoinfees.earn.com/api/v1/fees/recommended')
+    return fetchPrivate('https://bitcoinfees.earn.com/api/v1/fees/recommended')
       .then(resp => resp.json())
       .then(rates => Math.floor(rates.fastestFee))
   }
@@ -915,7 +916,7 @@ export class BlockstackNetwork {
   * @ignore
   */
   getConsensusHash() {
-    return fetch(`${this.blockstackAPIUrl}/v1/blockchains/bitcoin/consensus`)
+    return fetchPrivate(`${this.blockstackAPIUrl}/v1/blockchains/bitcoin/consensus`)
       .then(resp => resp.json())
       .then(x => x.consensus_hash)
   }
@@ -976,7 +977,7 @@ export class BitcoindAPI extends BitcoinNetwork {
     const authString =      Buffer.from(`${this.bitcoindCredentials.username}:${this.bitcoindCredentials.password}`)
       .toString('base64')
     const headers = { Authorization: `Basic ${authString}` }
-    return fetch(this.bitcoindUrl, {
+    return fetchPrivate(this.bitcoindUrl, {
       method: 'POST',
       body: JSON.stringify(jsonRPC),
       headers
@@ -993,7 +994,7 @@ export class BitcoindAPI extends BitcoinNetwork {
     const authString =      Buffer.from(`${this.bitcoindCredentials.username}:${this.bitcoindCredentials.password}`)
       .toString('base64')
     const headers = { Authorization: `Basic ${authString}` }
-    return fetch(this.bitcoindUrl, {
+    return fetchPrivate(this.bitcoindUrl, {
       method: 'POST',
       body: JSON.stringify(jsonRPC),
       headers
@@ -1011,7 +1012,7 @@ export class BitcoindAPI extends BitcoinNetwork {
     const authString =      Buffer.from(`${this.bitcoindCredentials.username}:${this.bitcoindCredentials.password}`)
       .toString('base64')
     const headers = { Authorization: `Basic ${authString}` }
-    return fetch(this.bitcoindUrl, {
+    return fetchPrivate(this.bitcoindUrl, {
       method: 'POST',
       body: JSON.stringify(jsonRPC),
       headers
@@ -1026,7 +1027,7 @@ export class BitcoindAPI extends BitcoinNetwork {
           params: [blockhash]
         }
         headers.Authorization = `Basic ${authString}`
-        return fetch(this.bitcoindUrl, {
+        return fetchPrivate(this.bitcoindUrl, {
           method: 'POST',
           body: JSON.stringify(jsonRPCBlock),
           headers
@@ -1060,7 +1061,7 @@ export class BitcoindAPI extends BitcoinNetwork {
 
     const importPromise = (this.importedBefore[address])
       ? Promise.resolve()
-      : fetch(this.bitcoindUrl, {
+      : fetchPrivate(this.bitcoindUrl, {
         method: 'POST',
         body: JSON.stringify(jsonRPCImport),
         headers
@@ -1068,7 +1069,7 @@ export class BitcoindAPI extends BitcoinNetwork {
         .then(() => { this.importedBefore[address] = true })
 
     return importPromise
-      .then(() => fetch(this.bitcoindUrl, {
+      .then(() => fetchPrivate(this.bitcoindUrl, {
         method: 'POST',
         body: JSON.stringify(jsonRPCUnspent),
         headers
@@ -1099,36 +1100,36 @@ export class InsightClient extends BitcoinNetwork {
 
   broadcastTransaction(transaction: string) {
     const jsonData = { rawtx: transaction }
-    return fetch(`${this.apiUrl}/tx/send`,
-                 {
-                   method: 'POST',
-                   headers: { 'Content-Type': 'application/json' },
-                   body: JSON.stringify(jsonData)
-                 })
+    return fetchPrivate(`${this.apiUrl}/tx/send`,
+                        {
+                          method: 'POST',
+                          headers: { 'Content-Type': 'application/json' },
+                          body: JSON.stringify(jsonData)
+                        })
       .then(resp => resp.json())
   }
 
   getBlockHeight() {
-    return fetch(`${this.apiUrl}/status`)
+    return fetchPrivate(`${this.apiUrl}/status`)
       .then(resp => resp.json())
       .then(status => status.blocks)
   }
 
   getTransactionInfo(txHash: string): Promise<{block_height: number}> {
-    return fetch(`${this.apiUrl}/tx/${txHash}`)
+    return fetchPrivate(`${this.apiUrl}/tx/${txHash}`)
       .then(resp => resp.json())
       .then((transactionInfo) => {
         if (transactionInfo.error) {
           throw new Error(`Error finding transaction: ${transactionInfo.error}`)
         }
-        return fetch(`${this.apiUrl}/block/${transactionInfo.blockHash}`)
+        return fetchPrivate(`${this.apiUrl}/block/${transactionInfo.blockHash}`)
       })
       .then(resp => resp.json())
       .then(blockInfo => ({ block_height: blockInfo.height }))
   }
 
   getNetworkedUTXOs(address: string): Promise<Array<UTXO>> {
-    return fetch(`${this.apiUrl}/addr/${address}/utxo`)
+    return fetchPrivate(`${this.apiUrl}/addr/${address}/utxo`)
       .then(resp => resp.json())
       .then(utxos => utxos.map(
         (x: any) => ({
@@ -1154,13 +1155,13 @@ export class BlockchainInfoApi extends BitcoinNetwork {
   }
 
   getBlockHeight() {
-    return fetch(`${this.utxoProviderUrl}/latestblock?cors=true`)
+    return fetchPrivate(`${this.utxoProviderUrl}/latestblock?cors=true`)
       .then(resp => resp.json())
       .then(blockObj => blockObj.height)
   }
 
   getNetworkedUTXOs(address: string): Promise<Array<UTXO>> {
-    return fetch(`${this.utxoProviderUrl}/unspent?format=json&active=${address}&cors=true`)
+    return fetchPrivate(`${this.utxoProviderUrl}/unspent?format=json&active=${address}&cors=true`)
       .then((resp) => {
         if (resp.status === 500) {
           Logger.debug('UTXO provider 500 usually means no UTXOs: returning []')
@@ -1186,7 +1187,7 @@ export class BlockchainInfoApi extends BitcoinNetwork {
   }
 
   getTransactionInfo(txHash: string): Promise<{block_height: number}> {
-    return fetch(`${this.utxoProviderUrl}/rawtx/${txHash}?cors=true`)
+    return fetchPrivate(`${this.utxoProviderUrl}/rawtx/${txHash}?cors=true`)
       .then((resp) => {
         if (resp.status === 200) {
           return resp.json()
@@ -1200,11 +1201,11 @@ export class BlockchainInfoApi extends BitcoinNetwork {
   broadcastTransaction(transaction: string) {
     const form = new FormData()
     form.append('tx', transaction)
-    return fetch(`${this.utxoProviderUrl}/pushtx?cors=true`,
-                 {
-                   method: 'POST',
-                   body: <any>form
-                 })
+    return fetchPrivate(`${this.utxoProviderUrl}/pushtx?cors=true`,
+                        {
+                          method: 'POST',
+                          body: <any>form
+                        })
       .then((resp) => {
         const text = resp.text()
         return text

--- a/src/profiles/profileLookup.ts
+++ b/src/profiles/profileLookup.ts
@@ -1,6 +1,7 @@
 
 import { resolveZoneFileToProfile } from './profileZoneFiles'
 import { config } from '../config'
+import { fetchPrivate } from '../fetchUtil'
 
 /**
  * Look up a user profile by blockstack ID
@@ -18,7 +19,7 @@ export function lookupProfile(username: string, zoneFileLookupURL?: string): Pro
   let lookupPromise
   if (zoneFileLookupURL) {
     const url = `${zoneFileLookupURL.replace(/\/$/, '')}/${username}`
-    lookupPromise = fetch(url)
+    lookupPromise = fetchPrivate(url)
       .then(response => response.json())
   } else {
     lookupPromise = config.network.getNameInfo(username)

--- a/src/profiles/profileSchemas/personZoneFiles.ts
+++ b/src/profiles/profileSchemas/personZoneFiles.ts
@@ -4,6 +4,7 @@ import { parseZoneFile } from 'zone-file'
 import { Person } from './person'
 import { getTokenFileUrl } from '../profileZoneFiles'
 import { extractProfile } from '../profileTokens'
+import { fetchPrivate } from '../../fetchUtil'
 
 /**
  * 
@@ -45,7 +46,7 @@ export function resolveZoneFileToPerson(
   }
 
   if (tokenFileUrl) {
-    fetch(tokenFileUrl)
+    fetchPrivate(tokenFileUrl)
       .then(response => response.text())
       .then(responseText => JSON.parse(responseText))
       .then((responseJson) => {

--- a/src/profiles/profileZoneFiles.ts
+++ b/src/profiles/profileZoneFiles.ts
@@ -3,6 +3,7 @@ import { makeZoneFile, parseZoneFile } from 'zone-file'
 import { extractProfile } from './profileTokens'
 import { Person } from './profileSchemas/person'
 import { Logger } from '../logger'
+import { fetchPrivate } from '../fetchUtil'
 
 /**
  * 
@@ -109,7 +110,7 @@ export function resolveZoneFileToProfile(zoneFile: any, publicKeyOrAddress: stri
     }
 
     if (tokenFileUrl) {
-      fetch(tokenFileUrl)
+      fetchPrivate(tokenFileUrl)
         .then(response => response.text())
         .then(responseText => JSON.parse(responseText))
         .then((responseJson) => {

--- a/src/profiles/services/service.ts
+++ b/src/profiles/services/service.ts
@@ -1,6 +1,7 @@
 
 import 'cross-fetch/polyfill'
 import { containsValidProofStatement, containsValidAddressProofStatement } from './serviceUtils'
+import { fetchPrivate } from '../../fetchUtil'
 
 /**
  * @ignore
@@ -13,7 +14,7 @@ export class Service {
     return Promise.resolve()
       .then(() => {
         proofUrl = this.getProofUrl(proof)
-        return fetch(proofUrl)
+        return fetchPrivate(proofUrl)
       })
       .then((res) => {
         if (res.status !== 200) {

--- a/src/storage/hub.ts
+++ b/src/storage/hub.ts
@@ -5,6 +5,7 @@ import crypto from 'crypto'
 // @ts-ignore: Could not find a declaration file for module
 import { TokenSigner } from 'jsontokens'
 import { ecPairToAddress, hexStringToECPair } from '../utils'
+import { fetchPrivate } from '../fetchUtil'
 import { getPublicKeyFromPrivate } from '../keys'
 import { Logger } from '../logger'
 
@@ -38,7 +39,7 @@ export async function uploadToGaiaHub(
   contentType: string = 'application/octet-stream'
 ): Promise<string> {
   Logger.debug(`uploadToGaiaHub: uploading ${filename} to ${hubConfig.server}`)
-  const response = await fetch(
+  const response = await fetchPrivate(
     `${hubConfig.server}/store/${hubConfig.address}/${filename}`, {
       method: 'POST',
       headers: {
@@ -152,7 +153,7 @@ export async function connectToGaiaHub(
 ): Promise<GaiaHubConfig> {
   Logger.debug(`connectToGaiaHub: ${gaiaHubUrl}/hub_info`)
 
-  const response = await fetch(`${gaiaHubUrl}/hub_info`)
+  const response = await fetchPrivate(`${gaiaHubUrl}/hub_info`)
   const hubInfo = await response.json()
   const readURL = hubInfo.read_url_prefix
   const token = makeV1GaiaAuthToken(hubInfo, challengeSignerHex, gaiaHubUrl, associationToken)
@@ -175,7 +176,7 @@ export async function connectToGaiaHub(
  */
 export async function getBucketUrl(gaiaHubUrl: string, appPrivateKey: string): Promise<string> {
   const challengeSigner = bitcoin.ECPair.fromPrivateKey(Buffer.from(appPrivateKey, 'hex'))
-  const response = await fetch(`${gaiaHubUrl}/hub_info`)
+  const response = await fetchPrivate(`${gaiaHubUrl}/hub_info`)
   const responseText = await response.text()
   const responseJSON = JSON.parse(responseText)
   const readURL = responseJSON.read_url_prefix

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -19,6 +19,7 @@ import {
 import { Logger } from '../logger'
 
 import { UserSession } from '../auth/userSession'
+import { fetchPrivate } from '../fetchUtil'
 
 /**
  * Specify a valid MIME type, encryption, and whether to sign the [[UserSession.putFile]].
@@ -246,7 +247,7 @@ function getFileContents(path: string, app: string, username: string | undefined
       const opts = { app, username, zoneFileLookupURL }
       return getFileUrl(path, opts, caller)
     })
-    .then(readUrl => fetch(readUrl))
+    .then(readUrl => fetchPrivate(readUrl))
     .then<string | ArrayBuffer | null>((response) => {
       if (response.status !== 200) {
         if (response.status === 404) {
@@ -630,7 +631,7 @@ async function listFilesLoop(
       },
       body: pageRequest
     }
-    response = await fetch(`${hubConfig.server}/list-files/${hubConfig.address}`, fetchOptions)
+    response = await fetchPrivate(`${hubConfig.server}/list-files/${hubConfig.address}`, fetchOptions)
     if (!response.ok) {
       throw new Error(`listFiles failed with HTTP status ${response.status}`)
     }


### PR DESCRIPTION
Add the `Referrer-Policy: no-referrer` header to our usages of `fetch()`. 

This prevents potentially sensitive app URLs from being leaked via the http `referer` headers. 
See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy

The Gaiahub and Blockstack API endpoints are the notable services that will no longer be leaked this data. 