### PR TITLE
Export GaiaHubConfig from storage/index.ts

### DIFF
--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -5,7 +5,6 @@ import {
   connectToGaiaHub, uploadToGaiaHub, getBucketUrl, BLOCKSTACK_GAIA_HUB_LABEL, 
   GaiaHubConfig
 } from './hub'
-// export { type GaiaHubConfig } from './hub'
 
 import {
   encryptECIES, decryptECIES, signECDSA, verifyECDSA
@@ -685,4 +684,4 @@ export function listFiles(
   return listFilesLoop(caller, null, null, 0, 0, callback)
 }
 
-export { connectToGaiaHub, uploadToGaiaHub, BLOCKSTACK_GAIA_HUB_LABEL }
+export { connectToGaiaHub, uploadToGaiaHub, BLOCKSTACK_GAIA_HUB_LABEL, GaiaHubConfig }


### PR DESCRIPTION
Solves #670, re:

> Using `blockstack.js` latest, v19.1.0
> 
> For some reason the interface `GaiaHubConfig` is no longer available via the normal
> ```ts
> import { GaiaHubConfig } from 'blockstack';
> ```
> but now has to be specified via
> ```ts
> import { GaiaHubConfig } from 'blockstack/lib/storage/hub';
> ```
> 
> Was this on purpose and so the issue can be dismissed, or could it possibly be fixed for ease-of-use for those of us who make third party browsers and the like?