### PR TITLE
Fix comment that doesn't match constructor

### DIFF
--- a/src/auth/appConfig.ts
+++ b/src/auth/appConfig.ts
@@ -9,7 +9,7 @@ import { DEFAULT_CORE_NODE, DEFAULT_SCOPE, DEFAULT_BLOCKSTACK_HOST } from './aut
  * class without any arguments will use
  * `window.location.origin` as the app domain.
  * On non-browser platforms, you need to
- * specify an app domain as the first argument.
+ * specify an app domain as the second argument.
  * 
  */
 export class AppConfig {


### PR DESCRIPTION
The comment on AppConfig says that on non-browser platform one needs to specify the app domain as the first argument to the constructor when it is actually the second. 

Trying to follow the instructions I wrote last year and finding bugs. :-) 

I'm not sure if you want to merge this hotfix into master or develop. Feel free to change.