### PR TITLE
Throw error on user session overwrite

### DIFF
--- a/src/auth/authApp.ts
+++ b/src/auth/authApp.ts
@@ -284,6 +284,13 @@ export async function handlePendingSignIn(
   if (!caller) {
     caller = new UserSession()
   }
+
+  const sessionData = caller.store.getSessionData()
+
+  if (sessionData.userData) {
+    throw new LoginFailedError('Existing user session found.')
+  }
+
   if (!transitKey) {
     transitKey = caller.store.getSessionData().transitKey
   }
@@ -372,7 +379,6 @@ export async function handlePendingSignIn(
     userData.profile = tokenPayload.profile
   }
   
-  const sessionData = caller.store.getSessionData()
   sessionData.userData = userData
   caller.store.setSessionData(sessionData)
   

--- a/tests/unitTests/src/unitTestsAuth.ts
+++ b/tests/unitTests/src/unitTestsAuth.ts
@@ -389,7 +389,6 @@ export function runAuthTests() {
         t.fail('Should not overwrite existing user');
       })
       .catch((err) => {
-        console.log(err.stack)
         t.pass('Should throw error when overwriting existing user session during handle pending sign in')
       })
   })

--- a/tests/unitTests/src/unitTestsAuth.ts
+++ b/tests/unitTests/src/unitTestsAuth.ts
@@ -352,6 +352,47 @@ export function runAuthTests() {
       })
   })
 
+  test('handlePendingSignIn with existing user session', (t) => {
+    t.plan(1)
+
+    const url = `${nameLookupURL}ryan.id`
+
+    FetchMock.get(url, sampleNameRecords.ryan)
+
+    const appPrivateKey = makeECPrivateKey()
+    const transitPrivateKey = makeECPrivateKey()
+    const transitPublicKey = getPublicKeyFromPrivate(transitPrivateKey)
+    const metadata = {}
+
+    const appConfig = new AppConfig(['store_write'], 'http://localhost:3000')
+    const blockstack = new UserSession({ appConfig })
+    blockstack.store.getSessionData().transitKey = transitPrivateKey
+
+    const sessionData = blockstack.store.getSessionData()
+    sessionData.userData = {
+      decentralizedID: 'blockstack.id',
+      username: 'blockstack.id',
+      identityAddress: 'identityaddress',
+      appPrivateKey: appPrivateKey,
+      hubUrl: '',
+      authResponseToken: '',
+      profile: ''
+    }
+    blockstack.store.setSessionData(sessionData)
+
+    const authResponse = makeAuthResponse(privateKey, sampleProfiles.ryan, 'ryan.id',
+                                          metadata, undefined, appPrivateKey, undefined,
+                                          transitPublicKey)
+
+    blockstack.handlePendingSignIn(authResponse)
+      .then(() => {
+        t.fail('Should not overwrite existing user');
+      })
+      .catch((err) => {
+        console.log(err.stack)
+        t.pass('Should throw error when overwriting existing user session during handle pending sign in')
+      })
+  })
 
   test('app config defaults app domain to origin', (t) => {
     t.plan(5);


### PR DESCRIPTION
`handlePendingSignIn` now throws an error when a user session already exists in local storage. Addresses https://github.com/blockstack/blockstack.js/issues/680

Testing:
1. Use any Blockstack app and link with this branch
2. Sign in to app 
3. Go back to sign in page on app and click sign in again, choose identity to use
4. App should error out