### PR TITLE
Exclude unused bip39 wordlists from dist bundle

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -80,15 +80,8 @@ module.exports = (env, argv) => {
       globalObject: 'this'
     },
     plugins: [
-      // Can't get this regex exclusion to work...
-      // new webpack.IgnorePlugin(/\.\/wordlists\/(?!.*english.*)\.json/)
-      new webpack.IgnorePlugin(/\.\/wordlists\/chinese_simplified.json/),
-      new webpack.IgnorePlugin(/\.\/wordlists\/chinese_traditional.json/),
-      new webpack.IgnorePlugin(/\.\/wordlists\/korean.json/),
-      new webpack.IgnorePlugin(/\.\/wordlists\/french.json/),
-      new webpack.IgnorePlugin(/\.\/wordlists\/italian.json/),
-      new webpack.IgnorePlugin(/\.\/wordlists\/spanish.json/),
-      new webpack.IgnorePlugin(/\.\/wordlists\/japanese.json/)
+      // BIP39 includes ~240KB of non-english json that we don't currently use.
+      new webpack.IgnorePlugin(/\.\/wordlists\/(?!english\.json)/)
     ]
   }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const fs = require('fs');
+const webpack = require('webpack');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 const WebpackAssetsManifest = require('webpack-assets-manifest');
 
@@ -78,7 +79,17 @@ module.exports = (env, argv) => {
       libraryTarget: 'umd',
       globalObject: 'this'
     },
-    plugins: []
+    plugins: [
+      // Can't get this regex exclusion to work...
+      // new webpack.IgnorePlugin(/\.\/wordlists\/(?!.*english.*)\.json/)
+      new webpack.IgnorePlugin(/\.\/wordlists\/chinese_simplified.json/),
+      new webpack.IgnorePlugin(/\.\/wordlists\/chinese_traditional.json/),
+      new webpack.IgnorePlugin(/\.\/wordlists\/korean.json/),
+      new webpack.IgnorePlugin(/\.\/wordlists\/french.json/),
+      new webpack.IgnorePlugin(/\.\/wordlists\/italian.json/),
+      new webpack.IgnorePlugin(/\.\/wordlists\/spanish.json/),
+      new webpack.IgnorePlugin(/\.\/wordlists\/japanese.json/)
+    ]
   }
 
   if (isEnvAnalyze) {


### PR DESCRIPTION
Reduce blockstack.js dist bundle size https://github.com/blockstack/blockstack.js/issues/582

Exclude unused bip39 wordlists from dist bundle. Removes around 240KB (uncompressed) of data. 

![image](https://user-images.githubusercontent.com/1447546/62470394-5a3deb80-b768-11e9-9cfb-c15c89a6a14d.png)

Acceptance criteria:
* Ensure the `dist/blockstack.js` bundle still works normally in web apps -- that is the only file this PR changes. 