### PR TITLE
Handle null list-file entry array items

### DIFF
--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -686,21 +686,27 @@ async function listFilesLoop(
     // (i.e. the data is malformed)
     throw new Error('Bad listFiles response: no entries')
   }
+  let entriesLength = 0
   for (let i = 0; i < entries.length; i++) {
-    const rc = callback(entries[i])
-    if (!rc) {
-      // callback indicates that we're done
-      return fileCount + i
+    // An entry array can have null entries, signifying a filtered entry and that there may be
+    // additional pages
+    if (entries[i] !== null) {
+      entriesLength++
+      const rc = callback(entries[i])
+      if (!rc) {
+        // callback indicates that we're done
+        return fileCount + i
+      }
     }
   }
   if (nextPage && entries.length > 0) {
     // keep going -- have more entries
     return listFilesLoop(
-      caller, hubConfig, nextPage, callCount + 1, fileCount + entries.length, callback
+      caller, hubConfig, nextPage, callCount + 1, fileCount + entriesLength, callback
     )
   } else {
     // no more entries -- end of data
-    return fileCount + entries.length
+    return fileCount + entriesLength
   }
 }
 

--- a/tests/unitTests/src/unitTestsStorage.ts
+++ b/tests/unitTests/src/unitTestsStorage.ts
@@ -1280,8 +1280,10 @@ export function runStorageTests() {
       }
       callCount += 1
       if (callCount === 1) {
-        return { entries: [path], page: callCount }
+        return { entries: [null], page: callCount }
       } else if (callCount === 2) {
+        return { entries: [path], page: callCount }
+      } else if (callCount === 3) {
         return { entries: [], page: callCount }
       } else {
         throw new Error('Called too many times')


### PR DESCRIPTION
Context: https://github.com/blockstack/gaia/pull/248#discussion_r310333986

Gaia hub can now return `null` entries in the list-files response, as a result of item filtering. This is to prevent returning empty arrays and signal that there are more pages available. 

This PR correctly handles the `null` entries and continues pagination. 

### Acceptance criteria

Ensure the public `listFiles` function performs as expected:
* `listFiles` performed within an app bucket with no files returns an empty array. 
* `listFiles` performed within an app bucket with _less_ files than the Gaia hub's configured `pageSize` limit returns all the account's files with a single network request to `/list-files/` gaia hub endpoint.
* Similarity, `listFiles` performed when there are _more_ files than the `pageSize` limit, multiple network requests are made to the `list-files` endpoint. 