### PR TITLE
Exposing the Blockstack network

### DIFF
--- a/mdincludes/script-dist-file.md
+++ b/mdincludes/script-dist-file.md
@@ -1,3 +1,3 @@
 ```html
-<script src="https://unpkg.com/blockstack@19.4.0-beta.1/dist/blockstack.js" integrity="sha384-UnkhaTA3XqTl/a79lTWO+C85bbXyM8IIUYtSLfrkkNQJcCxocVZv8nHaMzrvS9ZH" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/blockstack@19.2.5/dist/blockstack.js" integrity="sha384-MYwahltZZI72RAIXkFpR3LDRoAJX+NtRVEaLhxAJS6c2fStuiDhbzbJbhH+lUI7g" crossorigin="anonymous"></script>
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -4023,9 +4023,15 @@
       },
       "dependencies": {
         "graceful-fs": {
+<<<<<<< HEAD
           "version": "4.2.2",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
           "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
+=======
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.1.tgz",
+          "integrity": "sha512-b9usnbDGnD928gJB3LrCmxoibr3VE4U2SMo5PBuBnokWyDADTqDPXg4YpwKF1trpH+UbGp7QLicO3+aWEy0+mw==",
+>>>>>>> 73c9abcc... Remove jsdoc types from network.ts
           "dev": true
         }
       }
@@ -4100,7 +4106,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4121,12 +4128,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4141,17 +4150,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4268,7 +4280,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4280,6 +4293,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4294,6 +4308,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4301,12 +4316,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4325,6 +4342,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4405,7 +4423,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4417,6 +4436,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4502,7 +4522,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4538,6 +4559,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4557,6 +4579,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4600,12 +4623,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -4867,9 +4892,15 @@
       }
     },
     "highlight.js": {
+<<<<<<< HEAD
       "version": "9.15.10",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.10.tgz",
       "integrity": "sha512-RoV7OkQm0T3os3Dd2VHLNMoaoDVx77Wygln3n9l5YV172XonWG6rgQD3XnF/BuFFZw9A0TJgmMSO8FEWQgvcXw==",
+=======
+      "version": "9.15.9",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.9.tgz",
+      "integrity": "sha512-M0zZvfLr5p0keDMCAhNBp03XJbKBxUx5AfyfufMdFMEP4N/Xj6dh0IqC75ys7BAzceR34NgcvXjupRVaHBPPVQ==",
+>>>>>>> 73c9abcc... Remove jsdoc types from network.ts
       "dev": true
     },
     "hmac-drbg": {
@@ -5395,79 +5426,6 @@
         "@babel/types": "^7.0.0",
         "istanbul-lib-coverage": "^2.0.3",
         "semver": "^5.5.0"
-      }
-    },
-    "istanbul-lib-report": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
-      "integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
-      "dev": true,
-      "requires": {
-        "istanbul-lib-coverage": "^2.0.5",
-        "make-dir": "^2.1.0",
-        "supports-color": "^6.1.0"
-      },
-      "dependencies": {
-        "istanbul-lib-coverage": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
-          "integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
-    },
-    "istanbul-lib-source-maps": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
-      "integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
-      "dev": true,
-      "requires": {
-        "debug": "^4.1.1",
-        "istanbul-lib-coverage": "^2.0.5",
-        "make-dir": "^2.1.0",
-        "rimraf": "^2.6.3",
-        "source-map": "^0.6.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "istanbul-lib-coverage": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
-          "integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        }
-      }
-    },
-    "istanbul-reports": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
-      "integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
-      "dev": true,
-      "requires": {
-        "handlebars": "^4.1.2"
       }
     },
     "jquery": {
@@ -8808,6 +8766,12 @@
         "typescript": "3.5.x"
       },
       "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        },
         "progress": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -8840,9 +8804,9 @@
       "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
     },
     "typescript": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.2.tgz",
-      "integrity": "sha512-Og2Vn6Mk7JAuWA1hQdDQN/Ekm/SchX80VzLhjKN9ETYrIepBFAd8PkOdOTK2nKt0FCkmMZKBJvQ1dV1gIxPu/A==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "ts-loader": "^5.3.3",
     "ts-node": "^8.0.2",
     "typedoc": "^0.15.0",
-    "typescript": "^3.3.3333",
+    "typescript": "^3.5.3",
     "webpack": "^4.29.6",
     "webpack-assets-manifest": "^3.1.1",
     "webpack-bundle-analyzer": "^3.4.1",

--- a/src/network.ts
+++ b/src/network.ts
@@ -8,14 +8,25 @@ import { Logger } from './logger'
 import { config } from './config'
 import { fetchPrivate } from './fetchUtil'
 
-/**
- * @ignore
- */
-export type UTXO = {
-  value?: number,
-  confirmations?: number,
-  tx_hash: string,
-  tx_output_n: number
+export interface UTXO {
+  value?: number;
+  confirmations?: number;
+  tx_hash: string;
+  tx_output_n: number;
+}
+
+export interface PriceInfo {
+  units: string;
+  amount: BN;
+}
+
+export interface AccountTokens {
+  tokens: string[];
+}
+
+export interface TransactionInfo {
+  block_height: number;
+  [key: string]: any;
 }
 
 const SATOSHIS_PER_BTC = 1e8
@@ -36,31 +47,32 @@ export class BitcoinNetwork {
     return Promise.reject(new Error('Not implemented, getBlockHeight()'))
   }
 
-  getTransactionInfo(txid: string): Promise<{block_height: number}> {
+  getTransactionInfo(txid: string): Promise<TransactionInfo> {
     return Promise.reject(new Error(`Not implemented, getTransactionInfo(${txid})`))
   }
 
-  getNetworkedUTXOs(address: string): Promise<Array<UTXO>> {
+  getNetworkedUTXOs(address: string): Promise<UTXO[]> {
     return Promise.reject(new Error(`Not implemented, getNetworkedUTXOs(${address})`))
   }
 }
-
 /**
- * @private
- * @ignore
+ * Use the methods in class to build third-party wallets or in DApps that register names. 
  */
 export class BlockstackNetwork {
   blockstackAPIUrl: string
 
   broadcastServiceUrl: string
 
+  /**
+   * @ignore
+   */
   layer1: Network
 
   DUST_MINIMUM: number
 
   includeUtxoMap: {[address: string]: UTXO[]}
 
-  excludeUtxoSet: Array<UTXO>
+  excludeUtxoSet: UTXO[]
 
   btc: BitcoinNetwork
 
@@ -80,6 +92,9 @@ export class BlockstackNetwork {
     this.MAGIC_BYTES = 'id'
   }
 
+  /**
+   * @ignore
+   */
   coerceAddress(address: string) {
     const { hash, version } = bjsAddress.fromBase58Check(address)
     const scriptHashes = [networks.bitcoin.scriptHash,
@@ -98,19 +113,20 @@ export class BlockstackNetwork {
   }
 
   /**
-  * @ignore
-  */
+   * This is intended for use in third-party wallets or in DApps that register names.
+   */
   getDefaultBurnAddress() {
     return this.coerceAddress('1111111111111111111114oLvT2')
   }
 
   /**
-   * Get the price of a name via the legacy /v1/prices API endpoint.
-   * @param {String} fullyQualifiedName the name to query
-   * @return {Promise} a promise to an Object with { units: String, amount: BigInteger }
+   * Get the price of a name via the legacy /v1/prices API endpoint. This is 
+   * intended for use in third-party wallets or in DApps that register names.
+   * @param fullyQualifiedName the name to query
+   * @return a promise to an Object with { units: String, amount: BigInteger }
    * @private
    */
-  getNamePriceV1(fullyQualifiedName: string): Promise<{units: string, amount: BN}> {
+  getNamePriceV1(fullyQualifiedName: string): Promise<PriceInfo> {
     // legacy code path
     return fetchPrivate(`${this.blockstackAPIUrl}/v1/prices/names/${fullyQualifiedName}`)
       .then((resp) => {
@@ -139,12 +155,13 @@ export class BlockstackNetwork {
   }
 
   /**
-   * Get the price of a namespace via the legacy /v1/prices API endpoint.
-   * @param {String} namespaceID the namespace to query
-   * @return {Promise} a promise to an Object with { units: String, amount: BigInteger }
+   * Get the price of a namespace via the legacy /v1/prices API endpoint. This is intended for 
+   * use in third-party wallets or in DApps that register names.
+   * @param namespaceID the namespace to query
+   * @return a promise to an Object with { units: String, amount: BigInteger }
    * @private
    */
-  getNamespacePriceV1(namespaceID: string): Promise<{units: string, amount: BN}> {
+  getNamespacePriceV1(namespaceID: string): Promise<PriceInfo> {
     // legacy code path
     return fetchPrivate(`${this.blockstackAPIUrl}/v1/prices/namespaces/${namespaceID}`)
       .then((resp) => {
@@ -170,12 +187,13 @@ export class BlockstackNetwork {
   }
   
   /**
-   * Get the price of a name via the /v2/prices API endpoint.
-   * @param {String} fullyQualifiedName the name to query
-   * @return {Promise} a promise to an Object with { units: String, amount: BigInteger }
+   * Get the price of a name via the /v2/prices API endpoint. This is intended 
+   * for use in third-party wallets or in DApps that register names.
+   * @param fullyQualifiedName the name to query
+   * @return a promise to an Object with { units: String, amount: BigInteger }
    * @private
    */
-  getNamePriceV2(fullyQualifiedName: string): Promise<{units: string, amount: BN}> {
+  getNamePriceV2(fullyQualifiedName: string): Promise<PriceInfo> {
     return fetchPrivate(`${this.blockstackAPIUrl}/v2/prices/names/${fullyQualifiedName}`)
       .then((resp) => {
         if (resp.status !== 200) {
@@ -209,11 +227,12 @@ export class BlockstackNetwork {
 
   /**
    * Get the price of a namespace via the /v2/prices API endpoint.
-   * @param {String} namespaceID the namespace to query
-   * @return {Promise} a promise to an Object with { units: String, amount: BigInteger }
+   * This is intended for use in third-party wallets or in DApps that register names.
+   * @param namespaceID the namespace to query
+   * @return a promise to an Object with { units: String, amount: BigInteger }
    * @private
    */
-  getNamespacePriceV2(namespaceID: string): Promise<{units: string, amount: BN}> {
+  getNamespacePriceV2(namespaceID: string): Promise<PriceInfo> {
     return fetchPrivate(`${this.blockstackAPIUrl}/v2/prices/namespaces/${namespaceID}`)
       .then((resp) => {
         if (resp.status !== 200) {
@@ -243,30 +262,33 @@ export class BlockstackNetwork {
   }
 
   /**
-   * Get the price of a name.
-   * @param {String} fullyQualifiedName the name to query
-   * @return {Promise} a promise to an Object with { units: String, amount: BigInteger }, where
+   * Get the price of a name. This is intended for 
+   * use in third-party wallets or in DApps that register names.
+   * This is intended for use in third-party wallets or in DApps that register names.
+   * @param fullyQualifiedName the name to query
+   * @return a promise to an Object with { units: String, amount: BigInteger }, where
    *   .units encodes the cryptocurrency units to pay (e.g. BTC, STACKS), and
    *   .amount encodes the number of units, in the smallest denominiated amount
    *   (e.g. if .units is BTC, .amount will be satoshis; if .units is STACKS, 
    *   .amount will be microStacks)
    */
-  getNamePrice(fullyQualifiedName: string): Promise<{units: string, amount: BN}> {
+  getNamePrice(fullyQualifiedName: string): Promise<PriceInfo> {
     // handle v1 or v2 
     return Promise.resolve().then(() => this.getNamePriceV2(fullyQualifiedName))
       .catch(() => this.getNamePriceV1(fullyQualifiedName))
   }
 
   /**
-   * Get the price of a namespace
-   * @param {String} namespaceID the namespace to query
-   * @return {Promise} a promise to an Object with { units: String, amount: BigInteger }, where
+   * Get the price of a namespace. This is intended for use in third-party 
+   * wallets or in DApps that register names.
+   * @param namespaceID the namespace to query
+   * @return a promise to an Object with { units: String, amount: BigInteger }, where
    *   .units encodes the cryptocurrency units to pay (e.g. BTC, STACKS), and
    *   .amount encodes the number of units, in the smallest denominiated amount
    *   (e.g. if .units is BTC, .amount will be satoshis; if .units is STACKS, 
    *   .amount will be microStacks)
    */
-  getNamespacePrice(namespaceID: string): Promise<{units: string, amount: BN}> {
+  getNamespacePrice(namespaceID: string): Promise<PriceInfo> {
     // handle v1 or v2 
     return Promise.resolve().then(() => this.getNamespacePriceV2(namespaceID))
       .catch(() => this.getNamespacePriceV1(namespaceID))
@@ -274,18 +296,20 @@ export class BlockstackNetwork {
 
   /**
    * How many blocks can pass between a name expiring and the name being able to be
-   * re-registered by a different owner?
-   * @param {string} fullyQualifiedName unused
-   * @return {Promise} a promise to the number of blocks
+   * re-registered by a different owner. This is intended for 
+   * use in third-party wallets or in DApps that register names.
+   * @param fullyQualifiedName unused
+   * @return a promise to the number of blocks
    */
   getGracePeriod(fullyQualifiedName?: string) {
     return Promise.resolve(5000)
   }
 
   /**
-   * Get the names -- both on-chain and off-chain -- owned by an address.
-   * @param {String} address the blockchain address (the hash of the owner public key)
-   * @return {Promise} a promise that resolves to a list of names (Strings)
+   * Get the names -- both on-chain and off-chain -- owned by an address. This is intended for 
+   * use in third-party wallets or in DApps that register names.
+   * @param address the blockchain address (the hash of the owner public key)
+   * @return a promise that resolves to a list of names (Strings)
    */
   getNamesOwned(address: string): Promise<string[]> {
     const networkAddress = this.coerceAddress(address)
@@ -296,11 +320,13 @@ export class BlockstackNetwork {
 
   /**
    * Get the blockchain address to which a name's registration fee must be sent
-   * (the address will depend on the namespace in which it is registered.)
-   * @param {String} namespace the namespace ID
-   * @return {Promise} a promise that resolves to an address (String)
+   * (the address will depend on the namespace in which it is registered.) 
+   * 
+   * This is intended for use in third-party wallets or in DApps that register names.
+   * @param namespace the namespace ID
+   * @return a promise that resolves to an address (String)
    */
-  getNamespaceBurnAddress(namespace: string) {
+  getNamespaceBurnAddress(namespace: string): Promise<string> {
     return Promise.all([
       fetchPrivate(`${this.blockstackAPIUrl}/v1/namespaces/${namespace}`),
       this.getBlockHeight()
@@ -328,8 +354,10 @@ export class BlockstackNetwork {
   /**
    * Get WHOIS-like information for a name, including the address that owns it,
    * the block at which it expires, and the zone file anchored to it (if available).
-   * @param {String} fullyQualifiedName the name to query.  Can be on-chain of off-chain.
-   * @return {Promise} a promise that resolves to the WHOIS-like information 
+   * 
+   * This is intended for use in third-party wallets or in DApps that register names.
+   * @param fullyQualifiedName the name to query.  Can be on-chain of off-chain.
+   * @return a promise that resolves to the WHOIS-like information 
    */
   getNameInfo(fullyQualifiedName: string) {
     Logger.debug(this.blockstackAPIUrl)
@@ -358,9 +386,10 @@ export class BlockstackNetwork {
   }
 
   /**
-   * Get the pricing parameters and creation history of a namespace.
-   * @param {String} namespaceID the namespace to query
-   * @return {Promise} a promise that resolves to the namespace information.
+   * Get the pricing parameters and creation history of a namespace. This is intended for 
+   * use in third-party wallets or in DApps that register names.
+   * @param namespaceID the namespace to query
+   * @return a promise that resolves to the namespace information.
    */
   getNamespaceInfo(namespaceID: string) {
     return fetchPrivate(`${this.blockstackAPIUrl}/v1/namespaces/${namespaceID}`)
@@ -390,11 +419,14 @@ export class BlockstackNetwork {
 
   /**
    * Get a zone file, given its hash.  Throws an exception if the zone file
-   * obtained does not match the hash.
-   * @param {String} zonefileHash the ripemd160(sha256) hash of the zone file
-   * @return {Promise} a promise that resolves to the zone file's text
+   * obtained does not match the hash. 
+   * 
+   * This is intended for use in third-party wallets or in DApps that register names.
+   * 
+   * @param zonefileHash the ripemd160(sha256) hash of the zone file
+   * @return a promise that resolves to the zone file's text
    */
-  getZonefile(zonefileHash: string) {
+  getZonefile(zonefileHash: string): Promise<string> {
     return fetchPrivate(`${this.blockstackAPIUrl}/v1/zonefiles/${zonefileHash}`)
       .then((resp) => {
         if (resp.status === 200) {
@@ -415,10 +447,12 @@ export class BlockstackNetwork {
 
   /**
    * Get the status of an account for a particular token holding.  This includes its total number of
-   * expenditures and credits, lockup times, last txid, and so on.
-   * @param {String} address the account
-   * @param {String} tokenType the token type to query
-   * @return {Promise} a promise that resolves to an object representing the state of the account
+   * expenditures and credits, lockup times, last `txid`, and so on. 
+   * 
+   * This is intended for use in third-party wallets or in DApps that register names.
+   * @param address the account
+   * @param tokenType the token type to query
+   * @return a promise that resolves to an object representing the state of the account
    *   for this token
    */
   getAccountStatus(address: string, tokenType: string) {
@@ -444,10 +478,11 @@ export class BlockstackNetwork {
   
   
   /**
-   * Get a page of an account's transaction history.
-   * @param {String} address the account's address
-   * @param {number} page the page number.  Page 0 is the most recent transactions
-   * @return {Promise} a promise that resolves to an Array of Objects, where each Object encodes
+   * Get a page of an account's transaction history. This is intended for use in 
+   * third-party wallets or in DApps that register names.
+   * @param address the account's address
+   * @param page the page number.  Page 0 is the most recent transactions
+   * @return a promise that resolves to an Array of Objects, where each Object encodes
    *   states of the account at various block heights (e.g. prior balances, txids, etc)
    */
   getAccountHistoryPage(address: string,
@@ -481,9 +516,11 @@ export class BlockstackNetwork {
    * Get the state(s) of an account at a particular block height.  This includes the state of the
    * account beginning with this block's transactions, as well as all of the states the account
    * passed through when this block was processed (if any).
-   * @param {String} address the account's address
-   * @param {Integer} blockHeight the block to query
-   * @return {Promise} a promise that resolves to an Array of Objects, where each Object encodes
+   * 
+   * This is intended for use in third-party wallets or in DApps that register names.
+   * @param address the account's address
+   * @param blockHeight the block to query
+   * @return a promise that resolves to an Array of Objects, where each Object encodes
    *   states of the account at this block.
    */
   getAccountAt(address: string, blockHeight: number): Promise<any[]> {
@@ -513,12 +550,13 @@ export class BlockstackNetwork {
   }
 
   /**
-   * Get the set of token types that this account owns
-   * @param {String} address the account's address
-   * @return {Promise} a promise that resolves to an Array of Strings, where each item encodes the 
+   * Get the set of token types that this account owns. This is intended for use 
+   * in third-party wallets or in DApps that register names.
+   * @param address the account's address
+   * @return a promise that resolves to an Array of Strings, where each item encodes the 
    *   type of token this account holds (excluding the underlying blockchain's tokens)
    */
-  getAccountTokens(address: string): Promise<{tokens: string[]}> {
+  getAccountTokens(address: string): Promise<AccountTokens> {
     return fetchPrivate(`${this.blockstackAPIUrl}/v1/accounts/${address}/tokens`)
       .then((resp) => {
         if (resp.status === 404) {
@@ -539,10 +577,12 @@ export class BlockstackNetwork {
 
   /**
    * Get the number of tokens owned by an account.  If the account does not exist or has no
-   * tokens of this type, then 0 will be returned.
-   * @param {String} address the account's address
-   * @param {String} tokenType the type of token to query.
-   * @return {Promise} a promise that resolves to a BigInteger that encodes the number of tokens 
+   * tokens of this type, then 0 will be returned. 
+   * 
+   * This is intended for use in third-party wallets or in DApps that register names.
+   * @param address the account's address
+   * @param tokenType the type of token to query.
+   * @return a promise that resolves to a BigInteger that encodes the number of tokens 
    *   held by this account.
    */
   getAccountBalance(address: string, tokenType: string): Promise<BN> {
@@ -571,10 +611,11 @@ export class BlockstackNetwork {
 
 
   /**
-   * Performs a POST request to the given URL
-   * @param  {String} endpoint  the name of
-   * @param  {String} body [description]
-   * @return {Promise<Object|Error>} Returns a `Promise` that resolves to the object requested.
+   * Performs a POST request to the given URL. This is intended for 
+   * use in third-party wallets or in DApps that register names.
+   * @param endpoint  the name of
+   * @param body [description]
+   * @return Returns a `Promise` that resolves to the object requested.
    * In the event of an error, it rejects with:
    * * a `RemoteServiceError` if there is a problem
    * with the transaction broadcast service
@@ -607,24 +648,26 @@ export class BlockstackNetwork {
   }
 
   /**
-  * Broadcasts a signed bitcoin transaction to the network optionally waiting to broadcast the
-  * transaction until a second transaction has a certain number of confirmations.
-  *
-  * @param  {string} transaction the hex-encoded transaction to broadcast
-  * @param  {string} transactionToWatch the hex transaction id of the transaction to watch for
-  * the specified number of confirmations before broadcasting the `transaction`
-  * @param  {number} confirmations the number of confirmations `transactionToWatch` must have
-  * before broadcasting `transaction`.
-  * @return {Promise<Object|Error>} Returns a Promise that resolves to an object with a
-  * `transaction_hash` key containing the transaction hash of the broadcasted transaction.
-  *
-  * In the event of an error, it rejects with:
-  * * a `RemoteServiceError` if there is a problem
-  *   with the transaction broadcast service
-  * * `MissingParameterError` if you call the function without a required
-  *   parameter
-  * @private
-  */
+   * Broadcasts a signed bitcoin transaction to the network optionally waiting to broadcast the
+   * transaction until a second transaction has a certain number of confirmations.
+   * 
+   * This is intended for use in third-party wallets or in DApps that register names.
+   *
+   * @param transaction the hex-encoded transaction to broadcast
+   * @param transactionToWatch the hex transaction id of the transaction to watch for
+   * the specified number of confirmations before broadcasting the `transaction`
+   * @param confirmations the number of confirmations `transactionToWatch` must have
+   * before broadcasting `transaction`.
+   * @return Returns a Promise that resolves to an object with a
+   * `transaction_hash` key containing the transaction hash of the broadcasted transaction.
+   *
+   * In the event of an error, it rejects with:
+   * * a `RemoteServiceError` if there is a problem
+   *   with the transaction broadcast service
+   * * `MissingParameterError` if you call the function without a required
+   *   parameter
+   * @private
+   */
   broadcastTransaction(
     transaction: string,
     transactionToWatch: string = null,
@@ -666,11 +709,12 @@ export class BlockstackNetwork {
 
   /**
    * Broadcasts a zone file to the Atlas network via the transaction broadcast service.
+   * This is intended for use in third-party wallets or in DApps that register names.
    *
-   * @param  {String} zoneFile the zone file to be broadcast to the Atlas network
-   * @param  {String} transactionToWatch the hex transaction id of the transaction
+   * @param zoneFile the zone file to be broadcast to the Atlas network
+   * @param transactionToWatch the hex transaction id of the transaction
    * to watch for confirmation before broadcasting the zone file to the Atlas network
-   * @return {Promise<Object|Error>} Returns a Promise that resolves to an object with a
+   * @return Returns a Promise that resolves to an object with a
    * `transaction_hash` key containing the transaction hash of the broadcasted transaction.
    *
    * In the event of an error, it rejects with:
@@ -739,8 +783,8 @@ export class BlockstackNetwork {
 
   /**
    * Sends the preorder and registration transactions and zone file
-   * for a Blockstack name registration
-   * along with the to the transaction broadcast service.
+   * for a Blockstack name registration along with the to the transaction
+   *  broadcast service.
    *
    * The transaction broadcast:
    *
@@ -749,13 +793,15 @@ export class BlockstackNetwork {
    * has an appropriate number of confirmations
    * * broadcasts the zone file to the Atlas network after the register transaction
    * has an appropriate number of confirmations
+   * 
+   * This is intended for use in third-party wallets or in DApps that register names.
    *
-   * @param  {String} preorderTransaction the hex-encoded, signed preorder transaction generated
+   * @param preorderTransaction the hex-encoded, signed preorder transaction generated
    * using the `makePreorder` function
-   * @param  {String} registerTransaction the hex-encoded, signed register transaction generated
+   * @param registerTransaction the hex-encoded, signed register transaction generated
    * using the `makeRegister` function
-   * @param  {String} zoneFile the zone file to be broadcast to the Atlas network
-   * @return {Promise<Object|Error>} Returns a Promise that resolves to an object with a
+   * @param zoneFile the zone file to be broadcast to the Atlas network
+   * @return Returns a Promise that resolves to an object with a
    * `transaction_hash` key containing the transaction hash of the broadcasted transaction.
    *
    * In the event of an error, it rejects with:
@@ -825,7 +871,7 @@ export class BlockstackNetwork {
   /**
    * @ignore
    */
-  getUTXOs(address: string): Promise<Array<UTXO>> {
+  getUTXOs(address: string): Promise<UTXO[]> {
     return this.getNetworkedUTXOs(address)
       .then((networkedUTXOs) => {
         let returnSet = networkedUTXOs.concat()
@@ -853,16 +899,18 @@ export class BlockstackNetwork {
   /**
    * This will modify the network's utxo set to include UTXOs
    *  from the given transaction and exclude UTXOs *spent* in
-   *  that transaction
-   * @param {String} txHex - the hex-encoded transaction to use
-   * @return {void} no return value, this modifies the UTXO config state
+   *  that transaction. 
+   * 
+   * This is intended for use in third-party wallets or in DApps that register names.
+   * @param txHex - the hex-encoded transaction to use
+   * @return no return value, this modifies the UTXO config state
    * @private
    * @ignore
    */
   modifyUTXOSetFrom(txHex: string) {
     const tx = Transaction.fromHex(txHex)
 
-    const excludeSet: Array<UTXO> = this.excludeUtxoSet.concat()
+    const excludeSet: UTXO[] = this.excludeUtxoSet.concat()
 
     tx.ins.forEach((utxoUsed) => {
       const reverseHash = Buffer.from(utxoUsed.hash)
@@ -907,21 +955,24 @@ export class BlockstackNetwork {
     })
   }
 
+  /**
+   * @ignore
+   */
   resetUTXOs(address: string) {
     delete this.includeUtxoMap[address]
     this.excludeUtxoSet = []
   }
 
   /**
-  * @ignore
-  */
+   * @ignore
+   */
   getConsensusHash() {
     return fetchPrivate(`${this.blockstackAPIUrl}/v1/blockchains/bitcoin/consensus`)
       .then(resp => resp.json())
       .then(x => x.consensus_hash)
   }
 
-  getTransactionInfo(txHash: string): Promise<{block_height: number}> {
+  getTransactionInfo(txHash: string): Promise<TransactionInfo> {
     return this.btc.getTransactionInfo(txHash)
   }
 
@@ -932,7 +983,7 @@ export class BlockstackNetwork {
     return this.btc.getBlockHeight()
   }
 
-  getNetworkedUTXOs(address: string): Promise<Array<UTXO>> {
+  getNetworkedUTXOs(address: string): Promise<UTXO[]> {
     return this.btc.getNetworkedUTXOs(address)
   }
 }
@@ -1003,7 +1054,7 @@ export class BitcoindAPI extends BitcoinNetwork {
       .then(respObj => respObj.result)
   }
 
-  getTransactionInfo(txHash: string): Promise<{block_height: number}> {
+  getTransactionInfo(txHash: string): Promise<TransactionInfo> {
     const jsonRPC = {
       jsonrpc: '1.0',
       method: 'gettransaction',
@@ -1044,7 +1095,7 @@ export class BitcoindAPI extends BitcoinNetwork {
       })
   }
 
-  getNetworkedUTXOs(address: string): Promise<Array<UTXO>> {
+  getNetworkedUTXOs(address: string): Promise<UTXO[]> {
     const jsonRPCImport = {
       jsonrpc: '1.0',
       method: 'importaddress',
@@ -1115,7 +1166,7 @@ export class InsightClient extends BitcoinNetwork {
       .then(status => status.blocks)
   }
 
-  getTransactionInfo(txHash: string): Promise<{block_height: number}> {
+  getTransactionInfo(txHash: string): Promise<TransactionInfo> {
     return fetchPrivate(`${this.apiUrl}/tx/${txHash}`)
       .then(resp => resp.json())
       .then((transactionInfo) => {
@@ -1128,7 +1179,7 @@ export class InsightClient extends BitcoinNetwork {
       .then(blockInfo => ({ block_height: blockInfo.height }))
   }
 
-  getNetworkedUTXOs(address: string): Promise<Array<UTXO>> {
+  getNetworkedUTXOs(address: string): Promise<UTXO[]> {
     return fetchPrivate(`${this.apiUrl}/addr/${address}/utxo`)
       .then(resp => resp.json())
       .then(utxos => utxos.map(
@@ -1160,7 +1211,7 @@ export class BlockchainInfoApi extends BitcoinNetwork {
       .then(blockObj => blockObj.height)
   }
 
-  getNetworkedUTXOs(address: string): Promise<Array<UTXO>> {
+  getNetworkedUTXOs(address: string): Promise<UTXO[]> {
     return fetchPrivate(`${this.utxoProviderUrl}/unspent?format=json&active=${address}&cors=true`)
       .then((resp) => {
         if (resp.status === 500) {
@@ -1186,7 +1237,7 @@ export class BlockchainInfoApi extends BitcoinNetwork {
       ))
   }
 
-  getTransactionInfo(txHash: string): Promise<{block_height: number}> {
+  getTransactionInfo(txHash: string): Promise<TransactionInfo> {
     return fetchPrivate(`${this.utxoProviderUrl}/rawtx/${txHash}?cors=true`)
       .then((resp) => {
         if (resp.status === 200) {
@@ -1237,9 +1288,9 @@ const LOCAL_REGTEST = new LocalRegtest(
 )
 
 /**
-* @ignore
+* Instance of [[BlockstackNetwork]] set to the default endpoints. 
 */
-const MAINNET_DEFAULT = new BlockstackNetwork(
+export const MAINNET_DEFAULT = new BlockstackNetwork(
   'https://core.blockstack.org',
   'https://broadcast.blockstack.org',
   new BlockchainInfoApi()
@@ -1247,9 +1298,10 @@ const MAINNET_DEFAULT = new BlockstackNetwork(
 
 /**
  * Get WHOIS-like information for a name, including the address that owns it,
- * the block at which it expires, and the zone file anchored to it (if available).
- * @param {String} fullyQualifiedName the name to query.  Can be on-chain of off-chain.
- * @return {Promise} a promise that resolves to the WHOIS-like information 
+ * the block at which it expires, and the zone file anchored to it (if available). 
+ * This is intended for use in third-party wallets or in DApps that register names.
+ * @param fullyQualifiedName the name to query.  Can be on-chain of off-chain.
+ * @return a promise that resolves to the WHOIS-like information 
  */
 export function getNameInfo(fullyQualifiedName: string) {
   return config.network.getNameInfo(fullyQualifiedName)

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -35,8 +35,10 @@ export interface PutFileOptions {
    */
   encrypt?: boolean | string;
   /**
-   * Sign the data using ECDSA on SHA256 hashes with the user's app private key. 
-   * If a string is specified, it is used as the private key. 
+   *
+   * If set to `true` the data is signed using ECDSA on SHA256 hashes with the user's
+   * app private key. If a string is specified, it is used as the private key instead
+   * of the user's app private key. 
    * @default false
    */
   sign?: boolean | string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -252,7 +252,7 @@ interface GetGlobalObjectOptions {
  * @see https://developer.mozilla.org/en-US/docs/Web/API/Window/self
  * @ignore
  */
-export function getGlobalObject<K extends keyof Window>(
+export function getGlobalObject<K extends Extract<keyof Window, string>>(
   name: K, 
   { throwIfUnavailable, usageDesc, returnEmptyObject }: GetGlobalObjectOptions = { }
 ): Window[K] {
@@ -287,7 +287,7 @@ export function getGlobalObject<K extends keyof Window>(
  * @see https://developer.mozilla.org/en-US/docs/Web/API/Window/self
  * @ignore
  */
-export function getGlobalObjects<K extends keyof Window>(
+export function getGlobalObjects<K extends Extract<keyof Window, string>>(
   names: K[], 
   { throwIfUnavailable, usageDesc, returnEmptyObject }: GetGlobalObjectOptions = {}
 ): Pick<Window, K> {

--- a/tsconfig.typedoc.json
+++ b/tsconfig.typedoc.json
@@ -18,6 +18,7 @@
     "excludePrivate": true,
     "excludeProtected": true,
     "excludeExternals": true,
+    "excludeNotExported": false,
     "includes" : "mdincludes",
     "includeDeclarations": false,
     "gitRevision": "master",


### PR DESCRIPTION
Exposing the Blockstack network. Adding the caveat to the getName* "T…his is intended for use in third-party wallets or in DApps that register names."  Also, this exposes AuthScope.

Signed-off-by: Mary Anthony <mary@blockstack.com>