### PR TITLE
Fix project language reporting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+docs/* linguist-documentation
+docs-theme/* linguist-documentation
+docs/* linguist-vendored
+docs-theme/* linguist-vendored
+tests/**/*.html linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,7 @@
 docs/* linguist-documentation
 docs-theme/* linguist-documentation
-docs/* linguist-vendored
-docs-theme/* linguist-vendored
-tests/**/*.html linguist-vendored
+docs/* linguist-documentation
+docs-theme/* linguist-documentation
+
+# Skipping explicit file types
+*.html linguist-vendored


### PR DESCRIPTION
## Description

When seeing the blockstack.js repo in github it displays as an `html` project:

![image](https://user-images.githubusercontent.com/1447546/63601316-30236080-c593-11e9-8640-f825b4674f62.png)

---

![image](https://user-images.githubusercontent.com/1447546/63601135-e175c680-c592-11e9-9d90-7f855ba5cd94.png)

---

This adds a [`.gitattributes`](https://github.com/github/linguist#using-gitattributes) with `linguist` exclusions for the offending html files. 


## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [x] Other

## Does this introduce a breaking change?
n/a

## Are documentation updates required?
n/a
## Testing information
n/a

## Checklist
~~- [ ] Code is commented where needed~~
~~- [ ] Unit test coverage for new or modified code paths~~
~~- [ ] `npm run test` passes~~
~~- [ ] Changelog is updated~~
- [x] Tag 1 of @yknl or @zone117x for review
