### PR TITLE
added no-cache header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5660,6 +5660,79 @@
         "handlebars": "^4.1.2"
       }
     },
+    "istanbul-lib-report": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
+      "integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
+      "dev": true,
+      "requires": {
+        "istanbul-lib-coverage": "^2.0.5",
+        "make-dir": "^2.1.0",
+        "supports-color": "^6.1.0"
+      },
+      "dependencies": {
+        "istanbul-lib-coverage": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+          "integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "istanbul-lib-source-maps": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
+      "integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^2.0.5",
+        "make-dir": "^2.1.0",
+        "rimraf": "^2.6.3",
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "istanbul-lib-coverage": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+          "integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
+    "istanbul-reports": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
+      "integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
+      "dev": true,
+      "requires": {
+        "handlebars": "^4.1.2"
+      }
+    },
     "jquery": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",

--- a/src/fetchUtil.ts
+++ b/src/fetchUtil.ts
@@ -4,6 +4,7 @@ import 'cross-fetch/polyfill'
 export async function fetchPrivate(input: RequestInfo, init?: RequestInit): Promise<Response> {
   const fetchOpts = init || { }
   fetchOpts.referrerPolicy = 'no-referrer'
+  fetchOpts.cache = 'no-cache'
   const fetchResult = await fetch(input, fetchOpts)
   return fetchResult
 }

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -238,7 +238,8 @@ async function getFileContents(path: string, app: string, username: string | und
                                caller?: UserSession): Promise<string | ArrayBuffer | null> {
   const opts = { app, username, zoneFileLookupURL }
   const readUrl = await getFileUrl(path, opts, caller)
-  const response = await fetchPrivate(readUrl)
+  const headers = { 'Cache-Control': 'no-cache' }
+  const response = await fetchPrivate(readUrl, { headers })
   if (!response.ok) {
     throw await getBlockstackErrorFromResponse(response, `getFile ${path} failed.`)
   }

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -238,8 +238,7 @@ async function getFileContents(path: string, app: string, username: string | und
                                caller?: UserSession): Promise<string | ArrayBuffer | null> {
   const opts = { app, username, zoneFileLookupURL }
   const readUrl = await getFileUrl(path, opts, caller)
-  const headers = { 'Cache-Control': 'no-cache' }
-  const response = await fetchPrivate(readUrl, { headers })
+  const response = await fetchPrivate(readUrl)
   if (!response.ok) {
     throw await getBlockstackErrorFromResponse(response, `getFile ${path} failed.`)
   }


### PR DESCRIPTION
## Description

Fixes #732

Use the `no-cache` directive when fetching data from Gaia. This prevents Gaia from returning stale data.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Testing

Tested with:
- ❌Banter
  - couldn't login with either this branch, or `develop`
- ✅ Publik
- ✅ Blockstack Browser
- ✅ Contacts App
  - still some occasional weird caching behavior that I think is related to react-router and the way we are navigating between views.

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] Tag 1 of @yknl or @zone117x for review
