### PR TITLE
Adds expiry time to authToken header sent in connectToGaiaHub call

### DIFF
--- a/tests/unitTests/src/unitTestsStorage.ts
+++ b/tests/unitTests/src/unitTestsStorage.ts
@@ -1099,6 +1099,53 @@ export function runStorageTests() {
       })
   })
 
+  test('connectToGaiaHub with tokenValidityBufferTime', (t) => {
+    t.plan(8)
+
+    const hubServer = 'hub.testblockstack.org'
+
+    const hubInfo = {
+      read_url_prefix: 'gaia.testblockstack.org',
+      challenge_text: 'please-sign',
+      latest_auth_version: 'v1'
+    }
+
+    const privateKey = 'a5c61c6ca7b3e7e55edee68566aeab22e4da26baa285c7bd10e8d2218aa3b229'
+    const address = '1NZNxhoxobqwsNvTb16pdeiqvFvce3Yg8U'
+    const publicKey = '027d28f9951ce46538951e3697c62588a87f1f1f295de4a14fdd4c780fc52cfe69'
+
+    FetchMock.get(`${hubServer}/hub_info`,
+        JSON.stringify(hubInfo))
+
+    const appConfig = new AppConfig(['store_write'], 'http://localhost:3000')
+    const blockstack = new UserSession({ appConfig })
+    blockstack.store.getSessionData().userData = <any>{
+      appPrivateKey: privateKey
+    } // manually set for testing
+    const tokenValidityBufferTime = 120;
+    const minimumExpectedExpiry = Date.now()/1000 + tokenValidityBufferTime;
+
+    connectToGaiaHub(hubServer, privateKey, undefined, tokenValidityBufferTime)
+        .then((config) => {
+          t.ok(config, 'Config returned by connectToGaiaHub()')
+          t.equal(hubInfo.read_url_prefix, config.url_prefix)
+          t.equal(address, config.address)
+          t.equal(hubServer, config.server)
+          const jsonTokenPart = config.token.slice('v1:'.length)
+          const maximumExpectedExpiry = Date.now()/1000 + tokenValidityBufferTime;
+          const decodeJsonTokenPart = decodeToken(jsonTokenPart)
+          const verified = new TokenVerifier('ES256K', publicKey)
+              .verify(jsonTokenPart)
+          t.ok(verified, 'Verified token')
+
+          t.equal(hubServer, decodeJsonTokenPart.payload.hubUrl, 'Intended hubUrl')
+          // testing the range of expiry
+          t.ok(minimumExpectedExpiry < decodeJsonTokenPart.payload.exp, 'Intended exp')
+          t.ok(decodeJsonTokenPart.payload.exp < maximumExpectedExpiry, 'Intended exp')
+          console.log(verified)
+        })
+  })
+
   test('getBucketUrl', (t) => {
     t.plan(2)
     const hubServer = 'hub2.testblockstack.org'


### PR DESCRIPTION
Use the following template to create your pull request

## Description

With the current state of code it feels like the token returned by `makeV1GaiaAuthToken` has the possibility of reuse and thus hides the optional functionality of expiry of token which can be set as specified by Gaia.
If the `payload` has the optional `exp` params while creating the token using `makeV1GaiaAuthToken` then gaia's [validate token](https://github.com/blockstack/gaia/blob/73409ca31e0f203d352e9f4851adf3898b0f21da/hub/src/server/authentication.ts#L362) function can correctly identify if token is expired/reuse is possible.

By this change no current applications will be impacted but as a Blockstack developer who wish to create token with higher security bar(by specifying its expiry) can do so, thus preventing any misuse of token via replay attacks. This functionality is particularly useful for creating apps which requires privateKeyHolders approval for each gaia upload call.

For details refer to issue #123

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
n/a

## Are documentation updates required?
Yes

## Testing information

Provide context on how tests should be performed.

This can be tested for making a gaia upload call with token which is already expired (i.e call `connectToGaiaHub` with negative `tokenValidityBufferTime`) and it should return 401 with response similar to 
```
{
    "message": "Expired authentication token: expire time of xxxxxxx (secs since epoch)",
    "error": "ValidationError"
}
```
Also testing that `connectToGaiaHub` call without `tokenValidityBufferTime` remains as it is.


## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] Tag 1 of @yknl or @zone117x for review
