### PR TITLE
feat: persist etags in UserSession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Persist etags in UserSession store so they don't always need to be fetched when the page is loaded.
+
 ## [21.1.0] - 2020-06-05
 ### Changed
 - Static `storage/` functions used by `UserSession` are no longer globally exported, as they are wrapped by publicly accessible `UserSession` methods. Functions that are no longer accesible are `getFileUrl`, `getFileContents`, `getFile`, `putFile`, `deleteFile`, and `listFiles`. 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To securely use the latest distribution of blockstack.js from a CDN, use the fol
 
 <!-- cdn -->
 ```html
-<script src="https://unpkg.com/blockstack@21.1.0/dist/blockstack.js" integrity="sha384-Q1+BMI0BUKW3cBc3ChRpJslh5pRxWutZjdd9MM/QKyPd0hevS2k4Sh+FstA7A6Zz" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/blockstack@21.1.0/dist/blockstack.js" integrity="sha384-qv8/td2FU/FhJ588BGhJ18iXM7ByyDyjnisQpXgqMQEFlvPgN11wR231w1M9fr+1" crossorigin="anonymous"></script>
 ```
 <!-- cdnstop -->
 

--- a/src/auth/sessionData.ts
+++ b/src/auth/sessionData.ts
@@ -5,10 +5,13 @@ import { UserData } from './authApp'
 
 const SESSION_VERSION = '1.0.0'
 
+type EtagMap = { [key: string]: string; };
+
 export interface SessionOptions {
   coreNode?: string,
   userData?: UserData,
   transitKey?: string,
+  etags?: EtagMap,
   localStorageKey?: string,
   storeOptions?: {
     localStorageKey?: string
@@ -27,10 +30,13 @@ export class SessionData {
   // window.localStorage.setItem(BLOCKSTACK_STORAGE_LABEL, JSON.stringify(userData))
   userData?: UserData
 
+  etags?: EtagMap
+
   constructor(options: SessionOptions) {
     this.version = SESSION_VERSION
     this.userData = options.userData
     this.transitKey = options.transitKey
+    this.etags = options.etags ? options.etags : {}
   }
 
   getGaiaHubConfig(): GaiaHubConfig {
@@ -48,7 +54,8 @@ export class SessionData {
     const options: SessionOptions = {
       coreNode: json.coreNode,
       userData: json.userData,
-      transitKey: json.transitKey
+      transitKey: json.transitKey,
+      etags: json.etags
     }
     return new SessionData(options)
   }


### PR DESCRIPTION
## Description

This PR moves the etag map to the UserSession store so the etags persist across sessions.

Issue: #760

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Testing information

Tested with this sample app: https://blockstack-bin.reedr.vercel.app
Source: https://github.com/reedrosenbluth/bin/tree/persist

Steps:
1. Click `load` to load saved text (if there is any)
2. Modify text in text box
3. Click `save` to overwrite the text and load the new etag
4. Refresh the page and don't `load` the text
5. Enter new text in the text box and click `save`

These steps can be executed without error. This shows that the etag was properly persisted from the previous session (before the refresh).

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [x] Changelog is updated
- [x] Tag 1 of @yknl or @zone117x for review
