### PR TITLE
feat: hardware signing with make bitcoin spend

### DIFF
--- a/dist/blockstack.js
+++ b/dist/blockstack.js
@@ -3840,7 +3840,6 @@ var PubkeyHashSigner = exports.PubkeyHashSigner = function () {
     _classCallCheck(this, PubkeyHashSigner);
 
     this.ecPair = ecPair;
-    this.inputIndexesToSign = [];
   }
 
   _createClass(PubkeyHashSigner, [{
@@ -5654,6 +5653,8 @@ function makeTokenTransfer(recipientAddress, tokenType, tokenAmount, scratchArea
  * @param {boolean} buildIncomplete - optional boolean, defaults to false,
  * indicating whether the function should attempt to return an unsigned (or not fully signed)
  * transaction. Useful for passing around a TX for multi-sig input signing.
+ * @param {boolean} hardwareSign - optional boolean, defaults to false,
+ * indicating whether a hardware signer should be used
  * @returns {Promise} - a promise which resolves to the hex-encoded transaction.
  * @private
  */
@@ -5664,8 +5665,6 @@ function makeBitcoinSpend(destinationAddress, paymentKeyIn, amount) {
   if (amount <= 0) {
     return Promise.reject(new _errors.InvalidParameterError('amount', 'amount must be greater than zero'));
   }
-
-  console.log('making a bitcoin spend ########');
 
   var network = _config.config.network;
 
@@ -5978,9 +5977,6 @@ function signInputs(txB, defaultSigner, otherSigners) {
 }
 
 function signInputsUsingHardware(txB, defaultSigner) {
-  var signerArray = txB.__tx.ins.map(function () {
-    return defaultSigner;
-  });
   var signingPromise = Promise.resolve();
   // ignore input index when signing with hardware
   return signingPromise.then(function () {

--- a/docs.json
+++ b/docs.json
@@ -5608,7 +5608,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/auth/authApp.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/auth/authApp.js"
     },
     "augments": [],
     "examples": [],
@@ -5941,7 +5941,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/auth/authApp.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/auth/authApp.js"
     },
     "augments": [],
     "examples": [],
@@ -6215,7 +6215,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/auth/authApp.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/auth/authApp.js"
     },
     "augments": [],
     "examples": [],
@@ -6620,7 +6620,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/auth/authApp.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/auth/authApp.js"
     },
     "augments": [],
     "examples": [],
@@ -6792,7 +6792,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/auth/authApp.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/auth/authApp.js"
     },
     "augments": [],
     "examples": [],
@@ -7029,7 +7029,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/auth/authApp.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/auth/authApp.js"
     },
     "augments": [],
     "examples": [],
@@ -7441,7 +7441,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/auth/authMessages.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/auth/authMessages.js"
     },
     "augments": [],
     "examples": [],
@@ -8007,7 +8007,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/auth/authApp.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/auth/authApp.js"
     },
     "augments": [],
     "examples": [],
@@ -8312,7 +8312,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/auth/authApp.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/auth/authApp.js"
     },
     "augments": [],
     "examples": [],
@@ -8594,7 +8594,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/auth/authApp.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/auth/authApp.js"
     },
     "augments": [],
     "examples": [],
@@ -10699,7 +10699,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/profiles/profileTokens.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/profiles/profileTokens.js"
     },
     "augments": [],
     "examples": [],
@@ -11085,7 +11085,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/profiles/profileTokens.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/profiles/profileTokens.js"
     },
     "augments": [],
     "examples": [],
@@ -11440,7 +11440,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/profiles/profileTokens.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/profiles/profileTokens.js"
     },
     "augments": [],
     "examples": [],
@@ -12074,7 +12074,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/profiles/profileTokens.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/profiles/profileTokens.js"
     },
     "augments": [],
     "examples": [],
@@ -12470,7 +12470,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/profiles/profileProofs.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/profiles/profileProofs.js"
     },
     "augments": [],
     "examples": [],
@@ -12851,7 +12851,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/profiles/profileLookup.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/profiles/profileLookup.js"
     },
     "augments": [],
     "examples": [],
@@ -13954,7 +13954,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/storage/index.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/storage/index.js"
     },
     "augments": [],
     "examples": [],
@@ -14722,7 +14722,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/storage/index.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/storage/index.js"
     },
     "augments": [],
     "examples": [],
@@ -15340,7 +15340,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/storage/index.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/storage/index.js"
     },
     "augments": [],
     "examples": [],
@@ -15802,7 +15802,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/storage/index.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/storage/index.js"
     },
     "augments": [],
     "examples": [],
@@ -16203,7 +16203,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/storage/index.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/storage/index.js"
     },
     "augments": [],
     "examples": [],
@@ -16546,7 +16546,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/storage/index.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/storage/index.js"
     },
     "augments": [],
     "examples": [],
@@ -16984,7 +16984,7 @@
           "column": 3
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/network.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/network.js"
     },
     "augments": [],
     "examples": [],
@@ -17241,7 +17241,7 @@
           "column": 3
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/network.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/network.js"
     },
     "augments": [],
     "examples": [],
@@ -17492,7 +17492,7 @@
           "column": 3
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/network.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/network.js"
     },
     "augments": [],
     "examples": [],
@@ -17677,7 +17677,7 @@
           "column": 3
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/network.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/network.js"
     },
     "augments": [],
     "examples": [],
@@ -17928,7 +17928,7 @@
           "column": 3
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/network.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/network.js"
     },
     "augments": [],
     "examples": [],
@@ -18179,7 +18179,7 @@
           "column": 3
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/network.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/network.js"
     },
     "augments": [],
     "examples": [],
@@ -18426,7 +18426,7 @@
           "column": 3
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/network.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/network.js"
     },
     "augments": [],
     "examples": [],
@@ -18677,7 +18677,7 @@
           "column": 3
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/network.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/network.js"
     },
     "augments": [],
     "examples": [],
@@ -18938,7 +18938,7 @@
           "column": 3
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/network.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/network.js"
     },
     "augments": [],
     "examples": [],
@@ -19260,7 +19260,7 @@
           "column": 3
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/network.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/network.js"
     },
     "augments": [],
     "examples": [],
@@ -19588,7 +19588,7 @@
           "column": 3
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/network.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/network.js"
     },
     "augments": [],
     "examples": [],
@@ -19900,7 +19900,7 @@
           "column": 3
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/network.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/network.js"
     },
     "augments": [],
     "examples": [],
@@ -20165,7 +20165,7 @@
           "column": 3
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/network.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/network.js"
     },
     "augments": [],
     "examples": [],
@@ -20527,7 +20527,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/operations/txbuild.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/operations/txbuild.js"
     },
     "augments": [],
     "examples": [],
@@ -21094,7 +21094,7 @@
           "column": 1
         }
       },
-      "file": "/Users/larry/git/blockstack.js/src/storage/index.js"
+      "file": "/Users/Yukan/Desktop/work/blockstack/blockstack.js/src/storage/index.js"
     },
     "augments": [],
     "examples": [],

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset='utf-8' />
-  <title>blockstack 18.1.0 | Documentation</title>
+  <title>blockstack 18.1.1 | Documentation</title>
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <link href='assets/bass.css' type='text/css' rel='stylesheet' />
   <link href='assets/style.css' type='text/css' rel='stylesheet' />
@@ -14,7 +14,7 @@
       <div id='split-left' class='overflow-auto fs0 height-viewport-100'>
         <div class='py1 px2'>
           <h3 class='mb0 no-anchor'>blockstack</h3>
-          <div class='mb1'><code>18.1.0</code></div>
+          <div class='mb1'><code>18.1.1</code></div>
           <input
             placeholder='Filter'
             id='filter-input'

--- a/package-lock.json
+++ b/package-lock.json
@@ -541,13 +541,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
@@ -1741,7 +1743,7 @@
     "base": {
       "version": "0.11.2",
       "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
-      "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "dev": true,
       "requires": {
         "cache-base": "^1.0.1",
@@ -1794,9 +1796,9 @@
       }
     },
     "base-x": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
-      "integrity": "sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+      "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -1816,9 +1818,9 @@
       }
     },
     "bech32": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.3.tgz",
-      "integrity": "sha512-yuVFUvrNcoJi0sv5phmqc6P+Fl1HjRDRNOOkHY2X/3LBy2bIGNSFx4fZ95HMaXHupuS7cZR15AsvtmCIF4UEyg=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
+      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
     },
     "bigi": {
       "version": "1.4.2",
@@ -1832,14 +1834,17 @@
       "dev": true
     },
     "bindings": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
-      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "bip32": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bip32/-/bip32-1.0.2.tgz",
-      "integrity": "sha512-kedLYj8yvYzND+EfzeoMSlGiN7ImiRBF/MClJSZPkMfcU+OQO7ZpL5L/Yg+TunebBZIHhunstiQF//KLKSF5rg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/bip32/-/bip32-1.0.4.tgz",
+      "integrity": "sha512-8T21eLWylZETolyqCPgia+MNp+kY37zFr7PTFDTPObHeNi9JlfG4qGIh8WzerIJidtwoK+NsWq2I5i66YfHoIw==",
       "requires": {
         "bs58check": "^2.1.1",
         "create-hash": "^1.2.0",
@@ -1875,12 +1880,12 @@
       "integrity": "sha512-pef6gxZFztEhaE9RY9HmWVmiIHqCb2OyS4HPKkpc6CIiiOa3Qmuoylxc5P2EkU3w+5eTSifI9SEZC88idAIGow=="
     },
     "bitcoinjs-lib": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-4.0.1.tgz",
-      "integrity": "sha512-weum3uRYWxGhAvRk+2Ch7Z3x5tKBfeuzVyoGdP1CMrGJ5Nw6plj1GVA3A+RejLDii7UM7OxgOfXgPZhLmI7+vQ==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-4.0.5.tgz",
+      "integrity": "sha512-gYs7K2hiY4Xb96J8AIF+Rx+hqbwjVlp5Zt6L6AnHOdzfe/2tODdmDxsEytnaxVCdhOUg0JnsGpl+KowBpGLxtA==",
       "requires": {
         "bech32": "^1.1.2",
-        "bip32": "^1.0.0",
+        "bip32": "^1.0.4",
         "bip66": "^1.1.0",
         "bitcoin-ops": "^1.4.0",
         "bs58check": "^2.0.0",
@@ -3183,9 +3188,9 @@
       },
       "dependencies": {
         "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         }
       }
     },
@@ -3222,7 +3227,7 @@
     "cache-base": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
-      "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "dev": true,
       "requires": {
         "collection-visit": "^1.0.0",
@@ -4961,6 +4966,11 @@
         "object-assign": "^4.0.1"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+    },
     "filename-regex": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
@@ -5178,7 +5188,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5199,12 +5210,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5219,17 +5232,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5346,7 +5362,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5358,6 +5375,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5372,6 +5390,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5379,12 +5398,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5403,6 +5424,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5483,7 +5505,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5495,6 +5518,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5580,7 +5604,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5616,6 +5641,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5635,6 +5661,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5678,12 +5705,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -5805,13 +5834,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
@@ -6659,7 +6690,7 @@
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
       "requires": {
         "isobject": "^3.0.1"
@@ -7638,7 +7669,9 @@
     "nan": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+      "dev": true,
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -7856,6 +7889,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -8798,7 +8832,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -10212,7 +10247,8 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-glob": {
           "version": "2.0.1",
@@ -11323,7 +11359,7 @@
     "snapdragon-node": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
-      "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "dev": true,
       "requires": {
         "define-property": "^1.0.0",
@@ -11374,7 +11410,7 @@
     "snapdragon-util": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
-      "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "dev": true,
       "requires": {
         "kind-of": "^3.2.0"
@@ -11478,7 +11514,7 @@
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
-      "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "dev": true,
       "requires": {
         "extend-shallow": "^3.0.0"
@@ -12121,15 +12157,22 @@
       }
     },
     "tiny-secp256k1": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.0.0.tgz",
-      "integrity": "sha512-Wd4YPIQUtNmFoszG9f4PAkpCTurF5deVrbS1KuIZ9LTo9AHmXwbl1iNTrDqT3/xI62TRi0OcVs6eXk+8OcDziQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.5.tgz",
+      "integrity": "sha512-duE2hSLSQIpHGzmK48OgRrGTi+4OTkXLC6aa86uOYQ6LLCYZSarVKIAvEtY7MoXjoL6bOXMSerEGMzrvW4SkDw==",
       "requires": {
         "bindings": "^1.3.0",
         "bn.js": "^4.11.8",
         "create-hmac": "^1.1.7",
         "elliptic": "^6.4.0",
-        "nan": "^2.10.0"
+        "nan": "^2.13.2"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.14.1",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+          "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
+        }
       }
     },
     "tmp": {
@@ -12304,9 +12347,9 @@
       "dev": true
     },
     "typeforce": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.12.0.tgz",
-      "integrity": "sha512-fvnkvueAOFLhtAqDgIA/wMP21SMwS/NQESFKZuwVrj5m/Ew6eK2S0z0iB++cwtROPWDOhaT6OUfla8UwMw4Adg=="
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
+      "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
     },
     "unc-path-regex": {
       "version": "0.1.2",
@@ -12584,9 +12627,9 @@
       "dev": true
     },
     "varuint-bitcoin": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.0.tgz",
-      "integrity": "sha512-jCEPG+COU/1Rp84neKTyDJQr478/hAfVp5xxYn09QEH0yBjbmPeMfuuQIrp+BUD83hybtYZKhr5elV3bvdV1bA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.2.tgz",
+      "integrity": "sha512-4EVb+w4rx+YfVM32HQX42AbbT7/1f5zwAYhIujKXKk8NQK+JfRVl3pqT3hjNn/L+RstigmGGKVwHA/P0wgITZw==",
       "requires": {
         "safe-buffer": "^5.1.1"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blockstack",
-  "version": "18.1.0",
+  "version": "18.1.1",
   "description": "The Blockstack Javascript library for authentication, identity, and storage.",
   "main": "lib/index",
   "scripts": {
@@ -109,9 +109,9 @@
     "ajv": "^4.11.5",
     "babel-runtime": "^6.26.0",
     "bigi": "^1.4.2",
-    "bip32": "^1.0.2",
+    "bip32": "^1.0.4",
     "bip39": "^2.5.0",
-    "bitcoinjs-lib": "^4",
+    "bitcoinjs-lib": "^4.0.5",
     "cheerio": "^0.22.0",
     "cross-fetch": "^2.2.2",
     "custom-protocol-detection-blockstack": "1.1.4",

--- a/src/operations/signers.js
+++ b/src/operations/signers.js
@@ -33,6 +33,7 @@ export class PubkeyHashSigner implements TransactionSigner {
 
   constructor(ecPair: bitcoinjs.ECPair) {
     this.ecPair = ecPair
+    this.inputIndexesToSign = [];
   }
 
   static fromHexString(keyHex: string) {

--- a/src/operations/signers.js
+++ b/src/operations/signers.js
@@ -33,7 +33,6 @@ export class PubkeyHashSigner implements TransactionSigner {
 
   constructor(ecPair: bitcoinjs.ECPair) {
     this.ecPair = ecPair
-    this.inputIndexesToSign = [];
   }
 
   static fromHexString(keyHex: string) {

--- a/src/operations/txbuild.js
+++ b/src/operations/txbuild.js
@@ -1111,6 +1111,8 @@ function makeTokenTransfer(recipientAddress: string, tokenType: string,
  * @param {boolean} buildIncomplete - optional boolean, defaults to false,
  * indicating whether the function should attempt to return an unsigned (or not fully signed)
  * transaction. Useful for passing around a TX for multi-sig input signing.
+ * @param {boolean} hardwareSign - optional boolean, defaults to false,
+ * indicating whether a hardware signer should be used
  * @returns {Promise} - a promise which resolves to the hex-encoded transaction.
  * @private
  */
@@ -1123,7 +1125,7 @@ function makeBitcoinSpend(destinationAddress: string,
   if (amount <= 0) {
     return Promise.reject(new InvalidParameterError('amount', 'amount must be greater than zero'))
   }
-  
+
   const network = config.network
 
   const paymentKey = getTransactionSigner(paymentKeyIn)
@@ -1168,7 +1170,7 @@ function makeBitcoinSpend(destinationAddress: string,
         txB.__tx.outs[destinationIndex].value = outputAmount
 
         // ready to sign.
-        if(hardwareSign) {
+        if (hardwareSign) {
           return signInputsUsingHardware(txB, paymentKey)
         } else {
           return signInputs(txB, paymentKey)

--- a/src/operations/utils.js
+++ b/src/operations/utils.js
@@ -193,8 +193,7 @@ export function signInputs(txB: bitcoinjs.TransactionBuilder,
 
 export function signInputsUsingHardware(txB: bitcoinjs.TransactionBuilder,
                                         defaultSigner: TransactionSigner) {
-  const signerArray = txB.__tx.ins.map(() => defaultSigner)
-  let signingPromise = Promise.resolve()
+  const signingPromise = Promise.resolve()
   // ignore input index when signing with hardware
   return signingPromise
     .then(() => defaultSigner.signTransaction(txB, -1))

--- a/src/operations/utils.js
+++ b/src/operations/utils.js
@@ -190,3 +190,13 @@ export function signInputs(txB: bitcoinjs.TransactionBuilder,
   }
   return signingPromise.then(() => txB)
 }
+
+export function signInputsUsingHardware(txB: bitcoinjs.TransactionBuilder,
+                                        defaultSigner: TransactionSigner) {
+  const signerArray = txB.__tx.ins.map(() => defaultSigner)
+  let signingPromise = Promise.resolve()
+  // ignore input index when signing with hardware
+  return signingPromise
+    .then(() => defaultSigner.signTransaction(txB, -1))
+    .then(() => txB)
+}


### PR DESCRIPTION
## Description

NOTE: This PR adds a hardware wallet specific signing function to transaction builder for Bitcoin transactions. This is a support update based off of v18.1.0 (which is what the Stacks wallet is using). 

The PR adds a `signInputsUsingHardware` function which ignores the input index for signing, since signing inputs one by one causes HW wallets to repeatedly sign the same transaction. This was not a major problem for STX token transactions since the number of BTC inputs were low.

For details refer to issue #123

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
List the APIs or describe the functionality that this PR breaks.
No

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] Tag 1 of @yknl or @zone117x for review
