### PR TITLE
feat(transactions): export cvToHex, hexToCV, parseReadOnlyResponse

### DIFF
--- a/packages/transactions/src/index.ts
+++ b/packages/transactions/src/index.ts
@@ -29,3 +29,5 @@ export * from './types';
 export * from './constants';
 export * from './contract-abi';
 export * from './signer';
+
+export { cvToHex, parseReadOnlyResponse, hexToCV } from './utils';

--- a/packages/transactions/src/utils.ts
+++ b/packages/transactions/src/utils.ts
@@ -160,12 +160,24 @@ export async function fetchPrivate(input: RequestInfo, init?: RequestInit): Prom
   const fetchResult = await fetch(input, fetchOpts);
   return fetchResult;
 }
-
+/**
+ * Converts a clarity value to a hex encoded string with `0x` prefix
+ * @param {ClarityValue} cv  - the clarity value to convert
+ */
 export function cvToHex(cv: ClarityValue) {
   const serialized = serializeCV(cv);
   return `0x${serialized.toString('hex')}`;
 }
 
+/**
+ * Converts a hex encoded string to a clarity value
+ * @param {string} hex - the hex encoded string with or without `0x` prefix
+ */
+export function hexToCV(hex: string) {
+  const hexWithoutPrefix = hex.startsWith('0x') ? hex.slice(2) : hex;
+  const bufferCV = Buffer.from(hexWithoutPrefix, 'hex');
+  return deserializeCV(bufferCV);
+}
 /**
  * Read only function response object
  *
@@ -178,10 +190,14 @@ export interface ReadOnlyFunctionResponse {
   result: string;
 }
 
-export const parseReadOnlyResponse = ({ result }: ReadOnlyFunctionResponse): ClarityValue => {
-  const hex = result.slice(2);
-  const bufferCV = Buffer.from(hex, 'hex');
-  return deserializeCV(bufferCV);
+/**
+ * Converts the response of a read-only function call into its Clarity Value
+ * @param param
+ */
+export const parseReadOnlyResponse = ({
+  result
+}: ReadOnlyFunctionResponse): ClarityValue => {
+  return hexToCV(result);
 };
 
 export const validateStacksAddress = (stacksAddress: string): boolean => {


### PR DESCRIPTION

## Description
## Description

As a blockstack developer, I would like to use the blockstack-api-client library. The method `SmartContractsApi.callReadOnlyFunction` requires to hex encode clarity values, the result of that method needs to be parsed. In  this library (`stacks-transactions-js`) these methods already exists.

These methods, defined in `utils.ts` are now exported.

For details refer to issue https://github.com/blockstack/stacks-transactions-js/issues/126

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
yes, documentation for new methods needs to be published

## Testing information
No code features changed.

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` in transactions passes
- [ ] Changelog is updated - where is that?
- [x] Tag @yknl for review
