### PR TITLE
feat: builder for unsigned contract call

### DIFF
--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -1,11 +1,13 @@
-# `auth`
+# @stacks/auth
 
-> TODO: description
+Construct and decode authentication requests for Stacks apps.
+
+## Installation
+
+```
+npm install @stacks/auth
+```
 
 ## Usage
 
-```
-const auth = require('auth');
-
-// TODO: DEMONSTRATE API
-```
+See [documentation](https://docs.blockstack.org/authentication/building-todo-app)

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,11 +1,13 @@
-# `@stacks/cli`
+# @stacks/cli
 
-> TODO: description
+Command line interface to interact with auth, storage and Stacks transactions.
+
+## Installation
+
+```
+npm install @stacks/cli
+```
 
 ## Usage
 
-```
-const cli = require('@stacks/cli');
-
-// TODO: DEMONSTRATE API
-```
+See [documentation](https://docs.blockstack.org/references/blockstack-cli)

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -23,7 +23,7 @@ import {
   estimateContractFunctionCall,
   SignedTokenTransferOptions,
   ContractDeployOptions,
-  ContractCallOptions,
+  SignedContractCallOptions,
   ReadOnlyFunctionOptions,
   ContractCallPayload,
   ClarityValue,
@@ -670,7 +670,7 @@ async function contractFunctionCall(network: CLINetworkAdapter, args: string[]):
     .then(answers => {
       functionArgs = parseClarityFunctionArgAnswers(answers, abiArgs);
 
-      const options: ContractCallOptions = {
+      const options: SignedContractCallOptions = {
         contractAddress,
         contractName,
         functionName,

--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -1,11 +1,9 @@
-# `common`
+# @stacks/common
 
-> TODO: description
+Common utilities used by Stacks.js packages.
 
-## Usage
+## Installation
 
 ```
-const common = require('common');
-
-// TODO: DEMONSTRATE API
+npm install @stacks/common
 ```

--- a/packages/encryption/README.md
+++ b/packages/encryption/README.md
@@ -1,11 +1,9 @@
-# `encryption`
+# @stacks/encryption
 
-> TODO: description
+Encryption functions used by Stacks.js packages.
 
-## Usage
+## Installation
 
 ```
-const encryption = require('encryption');
-
-// TODO: DEMONSTRATE API
+npm install @stacks/cli
 ```

--- a/packages/keychain/README.md
+++ b/packages/keychain/README.md
@@ -1,11 +1,9 @@
-# `keychain`
+# @stacks/keychain
 
-> TODO: description
+Create and manage keys/wallets for the Stacks blockchain.
 
-## Usage
+## Installation
 
 ```
-const keychain = require('keychain');
-
-// TODO: DEMONSTRATE API
+npm install @stacks/keychain
 ```

--- a/packages/network/README.md
+++ b/packages/network/README.md
@@ -1,11 +1,9 @@
-# `network`
+# @stacks/network
 
-> TODO: description
+Network and API library for working with Stacks blockchain nodes.
 
-## Usage
+## Installation
 
 ```
-const network = require('network');
-
-// TODO: DEMONSTRATE API
+npm install @stacks/network
 ```

--- a/packages/profile/README.md
+++ b/packages/profile/README.md
@@ -1,11 +1,9 @@
-# `profile`
+# @stacks/profile
 
-> TODO: description
+Functions for manipulating user profiles.
 
-## Usage
+## Installation
 
 ```
-const profile = require('profile');
-
-// TODO: DEMONSTRATE API
+npm install @stacks/profile
 ```

--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -1,11 +1,9 @@
-# `storage`
+# @stacks/storage
 
-> TODO: description
+Store and fetch files with Gaia, the decentralized storage system.
 
-## Usage
+## Installation
 
 ```
-const storage = require('storage');
-
-// TODO: DEMONSTRATE API
+npm install @stacks/storage
 ```

--- a/packages/transactions/README.md
+++ b/packages/transactions/README.md
@@ -1,5 +1,5 @@
-# Stacks Transactions JS [![npm](https://img.shields.io/npm/v/@stacks/transactions?color=red)](https://www.npmjs.com/package/@stacks/transactions)
-The JavaScript library for generating Stacks (v2.0) transactions. 
+# @stacks/transactions [![npm](https://img.shields.io/npm/v/@stacks/transactions?color=red)](https://www.npmjs.com/package/@stacks/transactions)
+Construct, decode transactions and work with Clarity smart contracts on the Stacks blockchain.
 
 ## Installation
 


### PR DESCRIPTION
Migrated stacks-transaction-js PR from @hstove: https://github.com/blockstack/stacks-transactions-js/pull/131

## Description

Adds `makeUnsignedContractCall` function. This is built to be almost identical to the `makeUnsignedStacksTokenTransfer` function, which can accept one or more public keys. The actual `makeContractCall`, similarly, uses the unsigned variant to build the transaction, and then it simply signs the TX.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] Tag 1 of @yknl, @zone117x, @reedrosenbluth for review
