### PR TITLE
fix: try to ignore wordlists for bip39

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ dist
 .rts2_cache_umd/
 .idea
 
+.yarnrc
+.yarn

--- a/packages/keychain/tsdx.config.js
+++ b/packages/keychain/tsdx.config.js
@@ -1,5 +1,24 @@
+const emptyFile = 'export default {}';
+const emptyFileName = '\0empty_module';
+
+function ignore(list) {
+  return {
+    resolveId(importee) {
+      return (
+        list.some(function(regex) {
+          return regex.test(importee);
+        }) && emptyFileName
+      );
+    },
+    load(id) {
+      return id === emptyFileName ? emptyFile : null;
+    },
+  };
+}
+
 module.exports = {
   rollup(config, options) {
+    config.plugins.push(ignore([/\.\/wordlists\/(?!english\.json)/]));
     if (options.format === 'esm') {
       config.output = {
         ...config.output,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7497,6 +7497,13 @@ is-ci@^2.0.0:
   dependencies:
     ci-info "^2.0.0"
 
+is-core-module@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.0.0.tgz#58531b70aed1db7c0e8d4eb1a0a2d1ddd64bd12d"
+  integrity sha512-jq1AH6C8MuteOoBPwkxHafmByhL9j5q4OaPGdbuD+ZtQJVzH+i6E3BJDQcBA09k57i2Hh2yQbEG8yObZ0jdlWw==
+  dependencies:
+    has "^1.0.3"
+
 is-data-descriptor@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz#0b5ee648388e2c860282e793f1856fec3f301b56"
@@ -11535,7 +11542,15 @@ resolve@1.15.1:
   dependencies:
     path-parse "^1.0.6"
 
-resolve@1.x, resolve@^1.1.6, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.3.2, resolve@^1.8.1, resolve@~1.17.0:
+resolve@1.x:
+  version "1.18.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.18.1.tgz#018fcb2c5b207d2a6424aee361c5a266da8f4130"
+  integrity sha512-lDfCPaMKfOJXjy0dPayzPdF1phampNWr3qFCjAu+rw/qbQmr5jWH5xN2hwh9QKfw9E5v4hwV7A+jrCmL8yjjqA==
+  dependencies:
+    is-core-module "^2.0.0"
+    path-parse "^1.0.6"
+
+resolve@^1.1.6, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.3.2, resolve@^1.8.1, resolve@~1.17.0:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
   integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==


### PR DESCRIPTION
This PR brings over the equivalent of this change https://github.com/blockstack/stacks.js/pull/683 but for rollup. The bundle size of the keychain lib is pretty big, mostly due to these wordlists being included as far as i can tell.