### PR TITLE
fix loss of compression byte in private key leading to incorrect stx addresses

### DIFF
--- a/packages/keychain/src/wallet/index.ts
+++ b/packages/keychain/src/wallet/index.ts
@@ -64,7 +64,7 @@ export interface ConstructorOptions {
   encryptedBackupPhrase: string;
   identities: Identity[];
   configPrivateKey: string;
-  stacksPrivateKey: string;
+  stacksPrivateKey: Buffer;
   walletConfig?: WalletConfig;
 }
 
@@ -78,7 +78,7 @@ export class Wallet {
   identityPublicKeychain: string;
   identities: Identity[];
   configPrivateKey: string;
-  stacksPrivateKey: string;
+  stacksPrivateKey: Buffer;
   walletConfig?: WalletConfig;
 
   constructor({
@@ -158,14 +158,15 @@ export class Wallet {
       throw new TypeError('Unable to derive config key for wallet identities');
     }
     const configPrivateKey = derivedIdentitiesKey.toString('hex');
-    const { childKey: stxAddressKeychain } = deriveStxAddressChain(chain)(rootNode);
+    const stacksPrivateKey = Buffer.from(deriveStxAddressChain(chain)(rootNode).privateKey, 'hex');
+
     const walletAttrs = await getBlockchainIdentities(rootNode, identitiesToGenerate);
 
     return new Wallet({
       ...walletAttrs,
       chain,
       configPrivateKey,
-      stacksPrivateKey: stxAddressKeychain.toBase58(),
+      stacksPrivateKey,
       encryptedBackupPhrase,
     });
   }

--- a/packages/keychain/src/wallet/signer.ts
+++ b/packages/keychain/src/wallet/signer.ts
@@ -14,8 +14,6 @@ import {
 } from '@stacks/network';
 
 import RPCClient from '@blockstack/rpc-client';
-import { bip32 } from 'bitcoinjs-lib';
-import { assertIsTruthy } from '../utils';
 import BN from 'bn.js';
 
 interface ContractCallOptions {
@@ -51,9 +49,9 @@ interface STXTransferOptions {
 }
 
 export class WalletSigner {
-  privateKey: string;
+  privateKey: Buffer;
 
-  constructor({ privateKey }: { privateKey: string }) {
+  constructor({ privateKey }: { privateKey: Buffer }) {
     this.privateKey = privateKey;
   }
 
@@ -61,10 +59,8 @@ export class WalletSigner {
     return getAddressFromPrivateKey(this.getSTXPrivateKey(), version);
   }
 
-  getSTXPrivateKey() {
-    const node = bip32.fromBase58(this.privateKey);
-    assertIsTruthy<Buffer>(node.privateKey);
-    return node.privateKey;
+  getSTXPrivateKey(): Buffer {
+    return this.privateKey;
   }
 
   getNetwork() {

--- a/packages/keychain/tests/wallet-signer.test.ts
+++ b/packages/keychain/tests/wallet-signer.test.ts
@@ -10,9 +10,9 @@ const getSigner = async () => {
 test('can get a STX address', async () => {
   const signer = await getSigner();
   expect(signer.getSTXAddress(TransactionVersion.Mainnet)).toEqual(
-    'SP1GZ804XH4240T4JT2GQ34GG0DMT6B3BQ5NV18PD'
+    'SP384CVPNDTYA0E92TKJZQTYXQHNZSWGCAG7SAPVB'
   );
   expect(signer.getSTXAddress(TransactionVersion.Testnet)).toEqual(
-    'ST1GZ804XH4240T4JT2GQ34GG0DMT6B3BQ5YQX2WX'
+    'ST384CVPNDTYA0E92TKJZQTYXQHNZSWGCAH0ER64E'
   );
 });


### PR DESCRIPTION
Given the same passphrase, the wallet signer in stacks.js does not generate the same STX addresses (compared to the stacks wallet, blockstack-cli, stacks-gen).

The reason is that 

```
key !== bip32.fromBase58(stxAddressKeychain.toBase58(key))
```

And this is because of the use of 33 bytes private keys, not 32 bytes, the 33rd byte is used to represent whether they key is compressed or not, but is not taken into account by `toBase58`.

Solution is to store the private key as the original buffer, not in encoded base58 format which does not encode the compression.  This also has the benefit that the key does not need to be decoded each time it is used.

Now the STX addresses will match what the other tools will do



## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No.  The addresses people are used to when they use connect will change, for the better, but given that testnet gets reset often, this will have no negative effect.

## Are documentation updates required?
no documentation update needed

## Testing information
manually testing the passphrase now generates the same addresses as the wallet, blockstack-cli, stacks-gen would be nice (I did for the testnet passphrase I use most) and I finally get the expected address 😂 

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] Tag 1 of @yknl or @zone117x for review
