### PR TITLE
feat: add cvToJSON

### DIFF
--- a/packages/transactions/src/clarity/clarityValue.ts
+++ b/packages/transactions/src/clarity/clarityValue.ts
@@ -96,7 +96,7 @@ export function cvToString(val: ClarityValue, encoding: 'tryAscii' | 'hex' = 'he
   }
 }
 
-export function cvToValue(val: ClarityValue): any {
+function cvToValue(val: ClarityValue): any {
   switch (val.type) {
     case ClarityType.BoolTrue:
       return true;

--- a/packages/transactions/src/clarity/index.ts
+++ b/packages/transactions/src/clarity/index.ts
@@ -1,4 +1,4 @@
-import { ClarityValue, ClarityType, getCVTypeString, cvToString } from './clarityValue';
+import { ClarityValue, ClarityType, getCVTypeString, cvToString, cvToJSON } from './clarityValue';
 import { BooleanCV, TrueCV, FalseCV, trueCV, falseCV } from './types/booleanCV';
 import { IntCV, UIntCV, intCV, uintCV } from './types/intCV';
 import { BufferCV, bufferCV, bufferCVFromString } from './types/bufferCV';
@@ -82,4 +82,4 @@ export {
 export { serializeCV, deserializeCV };
 
 // toString
-export { cvToString };
+export { cvToString, cvToJSON };


### PR DESCRIPTION
## Description

Developers of web apps want to use values of the transaction results

This PR
* adds `cvToJSON`
* fixes #861

Developers can then use e.g.
`cvToJSON(hexToCV(tx.tx_result.hex))`

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Testing information
Additional tests have been added to `clarity.test.ts`.

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] Tag 1 of @yknl or @zone117x for review
