### PR TITLE
Update stacking lib status response to include burn chain unlock block

### DIFF
--- a/packages/stacking/src/index.ts
+++ b/packages/stacking/src/index.ts
@@ -45,7 +45,7 @@ export interface StackerInfo {
     amount_microstx: string;
     first_reward_cycle: number;
     lock_period: number;
-    unlock_height: number;
+    burnchain_unlock_height: number;
     pox_address: {
       version: Buffer;
       hashbytes: Buffer;
@@ -390,7 +390,7 @@ export class StackingClient {
             amount_microstx: amountMicroStx.value.toString(),
             first_reward_cycle: firstRewardCycle.value.toNumber(),
             lock_period: lockPeriod.value.toNumber(),
-            unlock_height: account.unlock_height,
+            burnchain_unlock_height: account.burnchain_unlock_height,
             pox_address: {
               version: version.buffer,
               hashbytes: hashbytes.buffer

--- a/packages/stacking/tests/stacking.test.ts
+++ b/packages/stacking/tests/stacking.test.ts
@@ -34,7 +34,11 @@ const balanceInfo = {
   balance: "90000000000000",
   total_sent: "0",
   total_received: "90000000000000",
-  unlock_height: 1000
+  lock_tx_id: "0xec94e7d20af8979b44d17a0520c126bf742b999a0fc7ddbcbe0ab21b228ecc8c",
+  locked: "50000",
+  lock_height: 100,
+  burnchain_lock_height: 100,
+  burnchain_unlock_height: 200
 }
 
 const coreInfo = {
@@ -293,7 +297,7 @@ test('get stacking status', async () => {
   expect(stackingStatus.details.amount_microstx).toEqual(amountMicrostx.toString());
   expect(stackingStatus.details.first_reward_cycle).toEqual(firstRewardCycle);
   expect(stackingStatus.details.lock_period).toEqual(lockPeriod);
-  expect(stackingStatus.details.unlock_height).toEqual(balanceInfo.unlock_height);
+  expect(stackingStatus.details.burnchain_unlock_height).toEqual(balanceInfo.burnchain_unlock_height);
   expect(stackingStatus.details.pox_address.version.toString()).toEqual(version);
   expect(stackingStatus.details.pox_address.hashbytes.toString()).toEqual(hashbytes);
 })


### PR DESCRIPTION
This PR updates the stacking lib `getStatus()` response to include burn chain unlock block height. 

Using updated balance api response https://github.com/blockstack/stacks-blockchain-api/pull/346

New result shape:
```
{
stacked: true,
details: {
     amount_microstx: '80000000000000',
     first_reward_cycle: 18,
     lock_period: 10,
     burnchain_unlock_height: 3020,
     pox_address: {
       version: '00',
       hashbytes: '05cf52a44bf3e6829b4f8c221cc675355bf83b7d'
     }
  }
}
```

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [x] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
Yes

## Testing information

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @yknl or @zone117x for review
