### PR TITLE
fix: remove typing path to non-existant directory

### DIFF
--- a/packages/keychain/package.json
+++ b/packages/keychain/package.json
@@ -7,8 +7,14 @@
     "Blockstack",
     "Keychain"
   ],
+  "sideEffects": false,
+  "main": "dist/index.js",
+  "module": "dist/index.esm.js",
+  "umd:main": "dist/keychain.umd.production.js",
+  "unpkg": "dist/keychain.cjs.production.min.js",
+  "gitHead": "77b4d6d531b74996e4b7a0cbd1cf5b8358a690ce",
   "author": "Hank Stoever",
-  "types": "./dist/index.d.ts",
+  "typings": "./dist/index.d.ts",
   "homepage": "https://blockstack.org",
   "contributors": [
     {
@@ -29,6 +35,9 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/blockstack/blockstack.js.git"
+  },
+  "bugs": {
+    "url": "https://github.com/blockstack/blockstack.js/issues"
   },
   "scripts": {
     "lint": "yarn lint:eslint && yarn lint:prettier",
@@ -81,15 +90,5 @@
     "prettier": "^2.0.5",
     "triplesec": "^3.0.27",
     "zone-file": "^1.0.0"
-  },
-  "bugs": {
-    "url": "https://github.com/blockstack/blockstack.js/issues"
-  },
-  "sideEffects": false,
-  "main": "dist/index.js",
-  "module": "dist/index.esm.js",
-  "typings": "dist/keychain/src/index.d.ts",
-  "umd:main": "dist/keychain.umd.production.js",
-  "unpkg": "dist/keychain.cjs.production.min.js",
-  "gitHead": "77b4d6d531b74996e4b7a0cbd1cf5b8358a690ce"
+  }
 }


### PR DESCRIPTION
Moved more relevant properties to top of file, but most importantly removed:

`"typings": "dist/keychain/src/index.d.ts",`

which pointed the typings to a file that doesn't exist. No types = broken builds

A `types` property, that does the same, remains at the top of the file.