### PR TITLE
fix(transactions): add handling of trait_reference

### DIFF
--- a/packages/transactions/tests/abi.test.ts
+++ b/packages/transactions/tests/abi.test.ts
@@ -86,6 +86,29 @@ test('ABI validation buffer', () => {
   );
 });
 
+test('ABI validation trait reference', () => {
+  const contractAddress = 'ST3KC0MTNW34S1ZXD36JYKFD3JJMWA01M55DSJ4JE';
+  const contractName = 'test';
+  const functionName = 'trait-test';
+
+  const payloadCorrectTrait = createContractCallPayload(
+    contractAddress,
+    contractName,
+    functionName,
+    [contractPrincipalCV('ST3KC0MTNW34S1ZXD36JYKFD3JJMWA01M55DSJ4JE', 'test')]
+  );
+
+  validateContractCall(payloadCorrectTrait, TEST_ABI);
+
+  const payloadWrongTrait = createContractCallPayload(contractAddress, contractName, functionName, [
+    standardPrincipalCV('ST3KC0MTNW34S1ZXD36JYKFD3JJMWA01M55DSJ4JE'),
+  ]);
+
+  expect(() => validateContractCall(payloadWrongTrait, TEST_ABI)).toThrow(
+    'Clarity function `trait-test` expects argument 1 to be of type trait_reference, not principal'
+  );
+});
+
 test('ABI validation fail, tuple mistyped', () => {
   const contractAddress = 'ST3KC0MTNW34S1ZXD36JYKFD3JJMWA01M55DSJ4JE';
   const contractName = 'test';

--- a/packages/transactions/tests/abi/test-abi.json
+++ b/packages/transactions/tests/abi/test-abi.json
@@ -33,6 +33,11 @@
       "args": [
         { "name": "arg1", "type": { "buffer": { "length": 6 } } }
       ],
+    },
+    {
+      "name": "trait-test",
+      "access": "public",
+      "args": [{ "name": "arg1", "type": "trait_reference" }],
       "outputs": { "type": { "response": { "ok": "bool", "error": "none" } } }
     }
   ],

--- a/packages/transactions/tests/abi/test-abi.json
+++ b/packages/transactions/tests/abi/test-abi.json
@@ -30,9 +30,7 @@
     {
       "name": "buffer-test",
       "access": "public",
-      "args": [
-        { "name": "arg1", "type": { "buffer": { "length": 6 } } }
-      ],
+      "args": [{ "name": "arg1", "type": { "buffer": { "length": 6 } } }]
     },
     {
       "name": "trait-test",


### PR DESCRIPTION
## Description

Contracts function parameters can be of type `trait_reference` . This was not supported by transactions library.

For details refer to issue #872 

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No
## Are documentation updates required?
No

## Testing information
Unit test has been added

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [x] Changelog is updated
- [x] Tag 1 of @yknl or @zone117x for review
