### PR TITLE
feat: undo exporting connect from auth

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-beta.18",
+  "version": "1.0.0-alpha.19",
   "registry": "https://registry.npmjs.org/",
   "publishConfig": {
     "access": "public"

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-alpha.19",
+  "version": "1.0.0-beta.19",
   "registry": "https://registry.npmjs.org/",
   "publishConfig": {
     "access": "public"

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/auth",
-  "version": "1.0.0-alpha.19",
+  "version": "1.0.0-beta.19",
   "description": "Authentication for Stacks apps.",
   "keywords": [
     "Stacks",
@@ -45,10 +45,10 @@
     "url": "https://github.com/blockstack/blockstack.js/issues"
   },
   "dependencies": {
-    "@stacks/common": "^1.0.0-alpha.19",
-    "@stacks/encryption": "^1.0.0-alpha.19",
-    "@stacks/network": "^1.0.0-alpha.19",
-    "@stacks/profile": "^1.0.0-alpha.19",
+    "@stacks/common": "^1.0.0-beta.19",
+    "@stacks/encryption": "^1.0.0-beta.19",
+    "@stacks/network": "^1.0.0-beta.19",
+    "@stacks/profile": "^1.0.0-beta.19",
     "codecov": "^3.7.2",
     "cross-fetch": "^3.0.5",
     "jsontokens": "^3.0.0",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -46,7 +46,6 @@
   },
   "dependencies": {
     "@stacks/common": "^1.0.0-beta.18",
-    "@stacks/connect": "^4.0.0",
     "@stacks/encryption": "^1.0.0-beta.18",
     "@stacks/network": "^1.0.0-beta.18",
     "@stacks/profile": "^1.0.0-beta.18",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/auth",
-  "version": "1.0.0-beta.18",
+  "version": "1.0.0-alpha.19",
   "description": "Authentication for Stacks apps.",
   "keywords": [
     "Stacks",
@@ -45,10 +45,10 @@
     "url": "https://github.com/blockstack/blockstack.js/issues"
   },
   "dependencies": {
-    "@stacks/common": "^1.0.0-beta.18",
-    "@stacks/encryption": "^1.0.0-beta.18",
-    "@stacks/network": "^1.0.0-beta.18",
-    "@stacks/profile": "^1.0.0-beta.18",
+    "@stacks/common": "^1.0.0-alpha.19",
+    "@stacks/encryption": "^1.0.0-alpha.19",
+    "@stacks/network": "^1.0.0-alpha.19",
+    "@stacks/profile": "^1.0.0-alpha.19",
     "codecov": "^3.7.2",
     "cross-fetch": "^3.0.5",
     "jsontokens": "^3.0.0",

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -18,4 +18,3 @@ export { UserSession } from './userSession';
 export * from './constants';
 export * from './profile';
 export * from './userData';
-export * from '@stacks/connect';

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/cli",
-  "version": "1.0.0-beta.18",
+  "version": "1.0.0-alpha.19",
   "description": "Stacks command line tool",
   "keywords": [
     "stacks",
@@ -90,12 +90,12 @@
     "tsdx": "^0.14.0"
   },
   "dependencies": {
-    "@stacks/auth": "^1.0.0-beta.18",
+    "@stacks/auth": "^1.0.0-alpha.19",
     "@stacks/blockchain-api-client": "^0.34.1",
-    "@stacks/network": "^1.0.0-beta.18",
-    "@stacks/stacking": "^1.0.0-beta.18",
-    "@stacks/storage": "^1.0.0-beta.18",
-    "@stacks/transactions": "^1.0.0-beta.18",
+    "@stacks/network": "^1.0.0-alpha.19",
+    "@stacks/stacking": "^1.0.0-alpha.19",
+    "@stacks/storage": "^1.0.0-alpha.19",
+    "@stacks/transactions": "^1.0.0-alpha.19",
     "ajv": "^4.11.5",
     "bip32": "^2.0.4",
     "bip39": "^3.0.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/cli",
-  "version": "1.0.0-alpha.19",
+  "version": "1.0.0-beta.19",
   "description": "Stacks command line tool",
   "keywords": [
     "stacks",
@@ -90,12 +90,12 @@
     "tsdx": "^0.14.0"
   },
   "dependencies": {
-    "@stacks/auth": "^1.0.0-alpha.19",
+    "@stacks/auth": "^1.0.0-beta.19",
     "@stacks/blockchain-api-client": "^0.34.1",
-    "@stacks/network": "^1.0.0-alpha.19",
-    "@stacks/stacking": "^1.0.0-alpha.19",
-    "@stacks/storage": "^1.0.0-alpha.19",
-    "@stacks/transactions": "^1.0.0-alpha.19",
+    "@stacks/network": "^1.0.0-beta.19",
+    "@stacks/stacking": "^1.0.0-beta.19",
+    "@stacks/storage": "^1.0.0-beta.19",
+    "@stacks/transactions": "^1.0.0-beta.19",
     "ajv": "^4.11.5",
     "bip32": "^2.0.4",
     "bip39": "^3.0.2",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/common",
-  "version": "1.0.0-alpha.19",
+  "version": "1.0.0-beta.19",
   "description": "Common Stacks utilities",
   "author": "yknl <yukanliao@gmail.com>",
   "homepage": "https://blockstack.org",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/common",
-  "version": "1.0.0-beta.18",
+  "version": "1.0.0-alpha.19",
   "description": "Common Stacks utilities",
   "author": "yknl <yukanliao@gmail.com>",
   "homepage": "https://blockstack.org",

--- a/packages/encryption/package.json
+++ b/packages/encryption/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/encryption",
-  "version": "1.0.0-alpha.19",
+  "version": "1.0.0-beta.19",
   "description": "Encryption utilities for Stacks",
   "author": "yknl <yukanliao@gmail.com>",
   "homepage": "https://blockstack.org",
@@ -37,7 +37,7 @@
     "url": "https://github.com/blockstack/blockstack.js/issues"
   },
   "dependencies": {
-    "@stacks/common": "^1.0.0-alpha.19",
+    "@stacks/common": "^1.0.0-beta.19",
     "bip39": "^3.0.2",
     "bitcoinjs-lib": "^5.1.10",
     "bn.js": "^5.1.2",

--- a/packages/encryption/package.json
+++ b/packages/encryption/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/encryption",
-  "version": "1.0.0-beta.18",
+  "version": "1.0.0-alpha.19",
   "description": "Encryption utilities for Stacks",
   "author": "yknl <yukanliao@gmail.com>",
   "homepage": "https://blockstack.org",
@@ -37,7 +37,7 @@
     "url": "https://github.com/blockstack/blockstack.js/issues"
   },
   "dependencies": {
-    "@stacks/common": "^1.0.0-beta.18",
+    "@stacks/common": "^1.0.0-alpha.19",
     "bip39": "^3.0.2",
     "bitcoinjs-lib": "^5.1.10",
     "bn.js": "^5.1.2",

--- a/packages/keychain/package.json
+++ b/packages/keychain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/keychain",
-  "version": "1.0.0-alpha.19",
+  "version": "1.0.0-beta.19",
   "description": "A package for managing Stacks keychains",
   "keywords": [
     "Stacks",
@@ -77,10 +77,10 @@
   },
   "dependencies": {
     "@blockstack/rpc-client": "^0.3.0-alpha.11",
-    "@stacks/common": "^1.0.0-alpha.19",
-    "@stacks/encryption": "^1.0.0-alpha.19",
-    "@stacks/storage": "^1.0.0-alpha.19",
-    "@stacks/transactions": "^1.0.0-alpha.19",
+    "@stacks/common": "^1.0.0-beta.19",
+    "@stacks/encryption": "^1.0.0-beta.19",
+    "@stacks/storage": "^1.0.0-beta.19",
+    "@stacks/transactions": "^1.0.0-beta.19",
     "bip32": "^2.0.4",
     "bip39": "^3.0.2",
     "bitcoinjs-lib": "^5.1.6",

--- a/packages/keychain/package.json
+++ b/packages/keychain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/keychain",
-  "version": "1.0.0-beta.18",
+  "version": "1.0.0-alpha.19",
   "description": "A package for managing Stacks keychains",
   "keywords": [
     "Stacks",
@@ -77,10 +77,10 @@
   },
   "dependencies": {
     "@blockstack/rpc-client": "^0.3.0-alpha.11",
-    "@stacks/common": "^1.0.0-beta.18",
-    "@stacks/encryption": "^1.0.0-beta.18",
-    "@stacks/storage": "^1.0.0-beta.18",
-    "@stacks/transactions": "^1.0.0-beta.18",
+    "@stacks/common": "^1.0.0-alpha.19",
+    "@stacks/encryption": "^1.0.0-alpha.19",
+    "@stacks/storage": "^1.0.0-alpha.19",
+    "@stacks/transactions": "^1.0.0-alpha.19",
     "bip32": "^2.0.4",
     "bip39": "^3.0.2",
     "bitcoinjs-lib": "^5.1.6",

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/network",
-  "version": "1.0.0-alpha.19",
+  "version": "1.0.0-beta.19",
   "description": "Library for Stacks network operations",
   "keywords": [
     "stacks",
@@ -44,7 +44,7 @@
     "url": "https://github.com/blockstack/blockstack.js/issues"
   },
   "dependencies": {
-    "@stacks/common": "^1.0.0-alpha.19"
+    "@stacks/common": "^1.0.0-beta.19"
   },
   "devDependencies": {
     "@types/jest": "^24.9.0",

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/network",
-  "version": "1.0.0-beta.18",
+  "version": "1.0.0-alpha.19",
   "description": "Library for Stacks network operations",
   "keywords": [
     "stacks",
@@ -44,7 +44,7 @@
     "url": "https://github.com/blockstack/blockstack.js/issues"
   },
   "dependencies": {
-    "@stacks/common": "^1.0.0-beta.18"
+    "@stacks/common": "^1.0.0-alpha.19"
   },
   "devDependencies": {
     "@types/jest": "^24.9.0",

--- a/packages/profile/package.json
+++ b/packages/profile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/profile",
-  "version": "1.0.0-alpha.19",
+  "version": "1.0.0-beta.19",
   "description": "Library for Stacks profiles",
   "keywords": [
     "stacks",
@@ -41,9 +41,9 @@
     "url": "https://github.com/blockstack/blockstack.js/issues"
   },
   "dependencies": {
-    "@stacks/common": "^1.0.0-alpha.19",
-    "@stacks/encryption": "^1.0.0-alpha.19",
-    "@stacks/network": "^1.0.0-alpha.19",
+    "@stacks/common": "^1.0.0-beta.19",
+    "@stacks/encryption": "^1.0.0-beta.19",
+    "@stacks/network": "^1.0.0-beta.19",
     "bitcoinjs-lib": "^5.1.10",
     "jsontokens": "^3.0.0",
     "schema-inspector": "^1.7.0",

--- a/packages/profile/package.json
+++ b/packages/profile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/profile",
-  "version": "1.0.0-beta.18",
+  "version": "1.0.0-alpha.19",
   "description": "Library for Stacks profiles",
   "keywords": [
     "stacks",
@@ -41,9 +41,9 @@
     "url": "https://github.com/blockstack/blockstack.js/issues"
   },
   "dependencies": {
-    "@stacks/common": "^1.0.0-beta.18",
-    "@stacks/encryption": "^1.0.0-beta.18",
-    "@stacks/network": "^1.0.0-beta.18",
+    "@stacks/common": "^1.0.0-alpha.19",
+    "@stacks/encryption": "^1.0.0-alpha.19",
+    "@stacks/network": "^1.0.0-alpha.19",
     "bitcoinjs-lib": "^5.1.10",
     "jsontokens": "^3.0.0",
     "schema-inspector": "^1.7.0",

--- a/packages/stacking/package.json
+++ b/packages/stacking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/stacking",
-  "version": "1.0.0-beta.18",
+  "version": "1.0.0-alpha.19",
   "description": "Library for Stacking.",
   "keywords": [
     "Stacks",
@@ -41,8 +41,8 @@
     "url": "https://github.com/blockstack/blockstack.js/issues"
   },
   "dependencies": {
-    "@stacks/network": "^1.0.0-beta.18",
-    "@stacks/transactions": "^1.0.0-beta.18",
+    "@stacks/network": "^1.0.0-alpha.19",
+    "@stacks/transactions": "^1.0.0-alpha.19",
     "axios": "^0.21.0",
     "bignumber.js": "^9.0.1",
     "bitcoinjs-lib": "^5.2.0",

--- a/packages/stacking/package.json
+++ b/packages/stacking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/stacking",
-  "version": "1.0.0-alpha.19",
+  "version": "1.0.0-beta.19",
   "description": "Library for Stacking.",
   "keywords": [
     "Stacks",
@@ -41,8 +41,8 @@
     "url": "https://github.com/blockstack/blockstack.js/issues"
   },
   "dependencies": {
-    "@stacks/network": "^1.0.0-alpha.19",
-    "@stacks/transactions": "^1.0.0-alpha.19",
+    "@stacks/network": "^1.0.0-beta.19",
+    "@stacks/transactions": "^1.0.0-beta.19",
     "axios": "^0.21.0",
     "bignumber.js": "^9.0.1",
     "bitcoinjs-lib": "^5.2.0",

--- a/packages/storage/package-lock.json
+++ b/packages/storage/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/storage",
-  "version": "1.0.0-beta.18",
+  "version": "1.0.0-alpha.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/storage/package-lock.json
+++ b/packages/storage/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/storage",
-  "version": "1.0.0-alpha.19",
+  "version": "1.0.0-beta.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/storage",
-  "version": "1.0.0-alpha.19",
+  "version": "1.0.0-beta.19",
   "description": "Stacks storage library",
   "author": "yknl <yukanliao@gmail.com>",
   "homepage": "https://blockstack.org",
@@ -37,9 +37,9 @@
     "url": "https://github.com/blockstack/blockstack.js/issues"
   },
   "dependencies": {
-    "@stacks/auth": "^1.0.0-alpha.19",
-    "@stacks/common": "^1.0.0-alpha.19",
-    "@stacks/encryption": "^1.0.0-alpha.19"
+    "@stacks/auth": "^1.0.0-beta.19",
+    "@stacks/common": "^1.0.0-beta.19",
+    "@stacks/encryption": "^1.0.0-beta.19"
   },
   "devDependencies": {
     "@types/jest": "^24.9.0",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/storage",
-  "version": "1.0.0-beta.18",
+  "version": "1.0.0-alpha.19",
   "description": "Stacks storage library",
   "author": "yknl <yukanliao@gmail.com>",
   "homepage": "https://blockstack.org",
@@ -37,9 +37,9 @@
     "url": "https://github.com/blockstack/blockstack.js/issues"
   },
   "dependencies": {
-    "@stacks/auth": "^1.0.0-beta.18",
-    "@stacks/common": "^1.0.0-beta.18",
-    "@stacks/encryption": "^1.0.0-beta.18"
+    "@stacks/auth": "^1.0.0-alpha.19",
+    "@stacks/common": "^1.0.0-alpha.19",
+    "@stacks/encryption": "^1.0.0-alpha.19"
   },
   "devDependencies": {
     "@types/jest": "^24.9.0",

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/transactions",
-  "version": "1.0.0-beta.18",
+  "version": "1.0.0-alpha.19",
   "description": "Javascript library for constructing transactions on the Stacks blockchain.",
   "homepage": "https://blockstack.org",
   "license": "GPL-3.0-or-later",
@@ -55,8 +55,8 @@
     "typescript": "^3.7.2"
   },
   "dependencies": {
-    "@stacks/common": "^1.0.0-beta.18",
-    "@stacks/network": "^1.0.0-beta.18",
+    "@stacks/common": "^1.0.0-alpha.19",
+    "@stacks/network": "^1.0.0-alpha.19",
     "@types/bn.js": "^4.11.6",
     "@types/elliptic": "^6.4.12",
     "@types/randombytes": "^2.0.0",

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/transactions",
-  "version": "1.0.0-alpha.19",
+  "version": "1.0.0-beta.19",
   "description": "Javascript library for constructing transactions on the Stacks blockchain.",
   "homepage": "https://blockstack.org",
   "license": "GPL-3.0-or-later",
@@ -55,8 +55,8 @@
     "typescript": "^3.7.2"
   },
   "dependencies": {
-    "@stacks/common": "^1.0.0-alpha.19",
-    "@stacks/network": "^1.0.0-alpha.19",
+    "@stacks/common": "^1.0.0-beta.19",
+    "@stacks/network": "^1.0.0-beta.19",
     "@types/bn.js": "^4.11.6",
     "@types/elliptic": "^6.4.12",
     "@types/randombytes": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -984,25 +984,6 @@
     sha.js "^2.4.11"
     smart-buffer "^4.1.0"
 
-"@blockstack/stacks-transactions@0.7.0":
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/@blockstack/stacks-transactions/-/stacks-transactions-0.7.0.tgz#c587f69879b1903bada87769f1d6d1217479336a"
-  integrity sha512-9IUR641PJpigYDCWdtKFgBIk0Oxyoc2M2XVdyaEOEcRhI+4lcacDhsuseAmGbkB9FhJgJcNicWPujUPNFl1XCw==
-  dependencies:
-    "@types/bn.js" "^4.11.6"
-    "@types/elliptic" "^6.4.12"
-    "@types/randombytes" "^2.0.0"
-    "@types/sha.js" "^2.4.0"
-    bn.js "^4.11.9"
-    c32check "^1.1.1"
-    cross-fetch "^3.0.5"
-    elliptic "^6.5.2"
-    lodash "^4.17.20"
-    randombytes "^2.1.0"
-    ripemd160-min "^0.0.6"
-    sha.js "^2.4.11"
-    smart-buffer "^4.1.0"
-
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.4.tgz#f864ae85004d0fcab6f50be9141c4da368d1656a"
@@ -2385,29 +2366,6 @@
     eventemitter3 "^4.0.4"
     jsonrpc-lite "^2.2.0"
     ws "^7.3.1"
-
-"@stacks/connect-ui@^2.14.0":
-  version "2.14.0"
-  resolved "https://registry.yarnpkg.com/@stacks/connect-ui/-/connect-ui-2.14.0.tgz#d5fbbb8622a8117038a500430f93e2073d118afa"
-  integrity sha512-hASEJIjRtl0sNi1yl5v3KjPP73xaletz5dOzhVQDufrPjl27+HLum3pEuCUnd1K+vfdsUfybk9Jbwx+lfejDTA==
-  dependencies:
-    "@stencil/core" "^1.17.3"
-
-"@stacks/connect@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@stacks/connect/-/connect-4.0.0.tgz#2c351600d711a2d36431b60117d00e0572057da8"
-  integrity sha512-gfpy39fYAL5L/Q2NmwkHqRGEF3saPDy6F8uRpclkbAQBQHQrCQbYkI9kCToJb1lOuU248KqviM6aOIxZBGaxZg==
-  dependencies:
-    "@blockstack/stacks-transactions" "0.7.0"
-    "@stacks/connect-ui" "^2.14.0"
-    jsontokens "^3.0.0"
-
-"@stencil/core@^1.17.3":
-  version "1.17.4"
-  resolved "https://registry.yarnpkg.com/@stencil/core/-/core-1.17.4.tgz#f7beb16ecb3344c80e053fece013ae499adc7c54"
-  integrity sha512-dmuNYM6fnHPvE2ptHoUBQtjcpXqrHnkDtdyUD6/JrZWcJt6jBtrykewObOxzpDCMLs+NT7668ussRagdVL03gQ==
-  dependencies:
-    typescript "3.9.7"
 
 "@tootallnate/once@1":
   version "1.1.2"
@@ -13199,7 +13157,7 @@ typeforce@^1.11.3, typeforce@^1.11.5:
   resolved "https://registry.yarnpkg.com/typeforce/-/typeforce-1.18.0.tgz#d7416a2c5845e085034d70fcc5b6cc4a90edbfdc"
   integrity sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g==
 
-typescript@3.9.7, typescript@^3.7.2, typescript@^3.7.3, typescript@^3.9.7:
+typescript@^3.7.2, typescript@^3.7.3, typescript@^3.9.7:
   version "3.9.7"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==


### PR DESCRIPTION
This PR undos a previous decision to export connect from the auth package in favour of a new structure to be outlined shortly.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [x] Other

## Does this introduce a breaking change?
Yes, tutorials will be updated to reflect new usage.

## Are documentation updates required?
Yes

## Testing information

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [x] Changelog is updated
- [x] Tag 1 of @yknl or @zone117x for review
