### PR TITLE
fix: update cross-fetch to v3.0.6

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -40,7 +40,7 @@
     "url": "https://github.com/blockstack/blockstack.js/issues"
   },
   "dependencies": {
-    "cross-fetch": "^3.0.5"
+    "cross-fetch": "^3.0.6"
   },
   "devDependencies": {
     "@types/jest": "^24.9.0",


### PR DESCRIPTION
Update the cross-fetch dependency to v3.0.6 to fix https://github.com/blockstack/stacks.js/issues/868

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [x] Other

## Does this introduce a breaking change?
no

## Are documentation updates required?
no

## Testing information
unit tests pass

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [x] Changelog is updated
- [x] Tag 1 of @yknl or @zone117x for review
