### PR TITLE
fix: check okay before parsing result

### DIFF
--- a/packages/transactions/src/utils.ts
+++ b/packages/transactions/src/utils.ts
@@ -1,5 +1,5 @@
 import { sha256, sha512 } from 'sha.js';
-import { ClarityValue, noneCV, responseErrorCV, serializeCV } from './clarity';
+import { ClarityValue, serializeCV } from './clarity';
 import RIPEMD160 from 'ripemd160-min';
 import randombytes from 'randombytes';
 import { deserializeCV } from './clarity';

--- a/packages/transactions/src/utils.ts
+++ b/packages/transactions/src/utils.ts
@@ -173,20 +173,29 @@ export function hexToCV(hex: string) {
  * @param {string} result - serialized hex clarity value
  */
 
-export interface ReadOnlyFunctionResponse {
-  okay: boolean;
+export interface ReadOnlyFunctionSuccessResponse {
+  okay: true;
   result: string;
 }
+
+export interface ReadOnlyFunctionErrorResponse {
+  okay: false;
+  cause: string;
+}
+
+export type ReadOnlyFunctionResponse =
+  | ReadOnlyFunctionSuccessResponse
+  | ReadOnlyFunctionErrorResponse;
 
 /**
  * Converts the response of a read-only function call into its Clarity Value
  * @param param
  */
-export const parseReadOnlyResponse = ({ okay, result }: ReadOnlyFunctionResponse): ClarityValue => {
-  if (okay) {
-    return hexToCV(result);
+export const parseReadOnlyResponse = (response: ReadOnlyFunctionResponse): ClarityValue => {
+  if (response.okay) {
+    return hexToCV(response.result);
   } else {
-    return responseErrorCV(noneCV());
+    throw new Error(response.cause);
   }
 };
 

--- a/packages/transactions/src/utils.ts
+++ b/packages/transactions/src/utils.ts
@@ -1,5 +1,5 @@
 import { sha256, sha512 } from 'sha.js';
-import { ClarityValue, serializeCV } from './clarity';
+import { ClarityValue, noneCV, responseErrorCV, serializeCV } from './clarity';
 import RIPEMD160 from 'ripemd160-min';
 import randombytes from 'randombytes';
 import { deserializeCV } from './clarity';
@@ -182,8 +182,12 @@ export interface ReadOnlyFunctionResponse {
  * Converts the response of a read-only function call into its Clarity Value
  * @param param
  */
-export const parseReadOnlyResponse = ({ result }: ReadOnlyFunctionResponse): ClarityValue => {
-  return hexToCV(result);
+export const parseReadOnlyResponse = ({ okay, result }: ReadOnlyFunctionResponse): ClarityValue => {
+  if (okay) {
+    return hexToCV(result);
+  } else {
+    return responseErrorCV(noneCV());
+  }
 };
 
 export const validateStacksAddress = (stacksAddress: string): boolean => {


### PR DESCRIPTION
## Description
if a read only function fails in `callReadOnlyFunction` then the result is a `TypeError`.
 
This PR 
* adds a check in `parseReadOnlyResponse` whether the response is `okay`
* fixes #894 

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
## Checklist
- [x] Tag 1 of @yknl or @zone117x for review
