### PR TITLE
Update network package default mainnet URLs

### DIFF
--- a/packages/network/src/index.ts
+++ b/packages/network/src/index.ts
@@ -38,7 +38,7 @@ export interface StacksNetwork {
 export class StacksMainnet implements StacksNetwork {
   version = TransactionVersion.Mainnet;
   chainId = ChainID.Mainnet;
-  coreApiUrl = 'https://core.blockstack.org';
+  coreApiUrl = 'https://stacks-node-api.mainnet.stacks.co';
   broadcastEndpoint = '/v2/transactions';
   transferFeeEstimateEndpoint = '/v2/fees/transfer';
   accountEndpoint = '/v2/accounts';
@@ -97,7 +97,7 @@ export class StacksMainnet implements StacksNetwork {
 export class StacksTestnet extends StacksMainnet implements StacksNetwork {
   version = TransactionVersion.Testnet;
   chainId = ChainID.Testnet;
-  coreApiUrl = 'https://stacks-node-api.blockstack.org';
+  coreApiUrl = 'https://stacks-node-api.testnet.stacks.co';
 }
 
 export class StacksMocknet extends StacksMainnet implements StacksNetwork {

--- a/packages/stacking/package.json
+++ b/packages/stacking/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@stacks/network": "^1.0.0-beta.20",
     "@stacks/transactions": "^1.0.0-beta.20",
-    "axios": "^0.21.0",
+    "axios": "^0.21.1",
     "bignumber.js": "^9.0.1",
     "bitcoinjs-lib": "^5.2.0",
     "bn.js": "^4.11.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3590,10 +3590,10 @@ axe-core@^3.5.4:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.5.5.tgz#84315073b53fa3c0c51676c588d59da09a192227"
   integrity sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q==
 
-axios@^0.21.0:
-  version "0.21.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.0.tgz#26df088803a2350dff2c27f96fef99fe49442aca"
-  integrity sha512-fmkJBknJKoZwem3/IKSSLpkdNXZeBu5Q7GA/aRsr2btgrptmSCxi2oFjZHqGdK9DoTil9PIHlPIZw2EcRJXRvw==
+axios@^0.21.1:
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
+  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
   dependencies:
     follow-redirects "^1.10.0"
 


### PR DESCRIPTION
This PR updates the network packages default URLs for mainnet.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Testing information

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [x] Changelog is updated
- [x] Tag 1 of @yknl or @zone117x for review
