### PR TITLE
fix: unit test urls

### DIFF
--- a/packages/auth/tests/auth.test.ts
+++ b/packages/auth/tests/auth.test.ts
@@ -34,7 +34,7 @@ beforeEach(() => {
 
 const privateKey = 'a5c61c6ca7b3e7e55edee68566aeab22e4da26baa285c7bd10e8d2218aa3b229'
 const publicKey = '027d28f9951ce46538951e3697c62588a87f1f1f295de4a14fdd4c780fc52cfe69'
-const nameLookupURL = 'https://core.blockstack.org/v1/names/'
+const nameLookupURL = 'https://stacks-node-api.mainnet.stacks.co/v1/names/'
 
 test('makeAuthRequest && verifyAuthRequest', async () => {
 
@@ -486,6 +486,6 @@ test('profileLookUp', async () => {
     expect(fetchMock.mock.calls.length).toEqual(4)
     expect(fetchMock.mock.calls[0][0]).toEqual('http://potato:6270/v1/names/ryan.id')
     expect(fetchMock.mock.calls[1][0]).toEqual(sampleTokenFiles.ryan.url)
-    expect(fetchMock.mock.calls[2][0]).toEqual('https://core.blockstack.org/v1/names/ryan.id')
+    expect(fetchMock.mock.calls[2][0]).toEqual('https://stacks-node-api.mainnet.stacks.co/v1/names/ryan.id')
     expect(fetchMock.mock.calls[3][0]).toEqual(sampleTokenFiles.ryan.url)
 })

--- a/packages/storage/tests/storage.test.ts
+++ b/packages/storage/tests/storage.test.ts
@@ -263,7 +263,7 @@ test('core node preferences respected for name lookups', async () => {
     gaiaHubConfig
   }
 
-  const defaultCoreNode = 'https://core.blockstack.org'
+  const defaultCoreNode = 'https://stacks-node-api.mainnet.stacks.co'
   const appSpecifiedCoreNode = 'https://app-specified-core-node.local'
   const userSpecifiedCoreNode = 'https://user-specified-core-node.local'
 

--- a/packages/transactions/src/constants.ts
+++ b/packages/transactions/src/constants.ts
@@ -14,7 +14,7 @@ const RECOVERABLE_ECDSA_SIG_LENGTH_BYTES = 65;
 const COMPRESSED_PUBKEY_LENGTH_BYTES = 32;
 const UNCOMPRESSED_PUBKEY_LENGTH_BYTES = 64;
 const MEMO_MAX_LENGTH_BYTES = 34;
-const DEFAULT_CORE_NODE_API_URL = 'https://core.blockstack.org';
+const DEFAULT_CORE_NODE_API_URL = 'https://stacks-node-api.mainnet.stacks.co';
 
 enum StacksMessageType {
   Address,


### PR DESCRIPTION
This PR fixes failing unit tests due to updated mainnet URLs

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Testing information

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [x] Changelog is updated
- [x] Tag 1 of @yknl or @zone117x for review
