### PR TITLE
feat(cli): gen keychain with custom path

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -339,7 +339,12 @@ async function makeKeychain(network: CLINetworkAdapter, args: string[]): Promise
     );
   }
 
-  const stacksKeyInfo = await getStacksWalletKeyInfo(network, mnemonic);
+  let derivationPath: string | undefined;
+  if (arg[1]) {
+    derivationPath = arg[1]
+  }
+
+  const stacksKeyInfo = await getStacksWalletKeyInfo(network, mnemonic, derivationPath);
   return JSONStringify({
     mnemonic: mnemonic,
     keyInfo: stacksKeyInfo,

--- a/packages/cli/src/keys.ts
+++ b/packages/cli/src/keys.ts
@@ -132,11 +132,12 @@ export async function getPaymentKeyInfo(
  */
 export async function getStacksWalletKeyInfo(
   network: CLINetworkAdapter,
-  mnemonic: string
+  mnemonic: string,
+  derivationPath = "m/44'/5757'/0'/0/0"
 ): Promise<StacksKeyInfoType> {
   const seed = await bip39.mnemonicToSeed(mnemonic);
   const master = bip32.fromSeed(seed);
-  const child = master.derivePath("m/44'/5757'/0'/0/0"); // taken from stacks-wallet. See https://github.com/blockstack/stacks-wallet
+  const child = master.derivePath(derivationPath); // taken from stacks-wallet. See https://github.com/blockstack/stacks-wallet
   const ecPair = bitcoin.ECPair.fromPrivateKey(child.privateKey!);
   const privkey = blockstack.ecPairToHexString(ecPair);
 


### PR DESCRIPTION
@CharlieC3 we need something like this to support custom derivation paths

Ideally the cli could use some arg parsing library than arg indexes, I guess this came from the previous version.

I have not tested this code. Wanted to make as a quick placeholder PR for solving issue mentioned here https://github.com/blockstack/stacks-wallet/issues/544