### PR TITLE
fix(stacking): fix "Assertion failed" error when calling `.stack` and `.canStack`

### DIFF
--- a/packages/stacking/src/index.ts
+++ b/packages/stacking/src/index.ts
@@ -234,7 +234,7 @@ export class StackingClient {
     return Promise.all([balancePromise, poxInfoPromise])
       .then(([balance, poxInfo]) => {
         const { hashMode, data } = decodeBtcAddress(poxAddress);
-        const hashModeBuffer = bufferCV(new BN(hashMode, 10).toBuffer());
+        const hashModeBuffer = bufferCV(new BN(hashMode, 10).toArrayLike(Buffer));
         const hashbytes = bufferCV(data);
         const poxAddressCV = tupleCV({
           hashbytes,
@@ -316,7 +316,7 @@ export class StackingClient {
     burnBlockHeight: number;
   }) {
     const { hashMode, data } = decodeBtcAddress(poxAddress);
-    const hashModeBuffer = bufferCV(new BN(hashMode, 10).toBuffer());
+    const hashModeBuffer = bufferCV(new BN(hashMode, 10).toArrayLike(Buffer));
     const hashbytes = bufferCV(data);
     const address = tupleCV({
       hashbytes,


### PR DESCRIPTION
## Description

When integrating the new @stacks/stacking npm package I am having an issue with the client.stack  and the client.canStack methods, both are throwing [Error: Assertion failed].

After some debugging, it looks like the error is coming from this call https://github.com/blockstack/stacks.js/blob/a6b7da0586caa893c7cdf2ef4a3011de3248afe8/packages/stacking/src/index.ts#L319.
hashMode returned by const { hashMode, data } = decodeBtcAddress(poxAddress); is 0 and calling bn.js new BN(hashMode, 10).toBuffer() to get the buffer on 0 is throwing an error

Related issue https://github.com/blockstack/stacks.js/issues/898.

Example:

Following the stacking tutorial and doing a simple operation like this:

```ts
const stackingClient = new StackingClient(
  "STRW09277YXKS1GZFT7QQSQ7GNWS2M4S3CG5V6ZT",
  new StacksTestnet()
);

const stackingEligibility = await stackingClient.canStack({
  poxAddress: "tb1qa96uwhml8rxfees4ggn98z55xlmdxnrxhe60n2jl29vyg5txcnts36xrr2",
  cycles: 1,
});
```

For details refer to issue #123

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?

No

## Are documentation updates required?

No

## Testing information

Provide context on how tests should be performed.

1. Is testing required for this change?

I tested to manually patch the file in my project and the error was fixed with this change.

2. If it’s a bug fix, list steps to reproduce the bug

```ts
const stackingClient = new StackingClient(
  "STRW09277YXKS1GZFT7QQSQ7GNWS2M4S3CG5V6ZT",
  new StacksTestnet()
);

const stackingEligibility = await stackingClient.canStack({
  poxAddress: "tb1qa96uwhml8rxfees4ggn98z55xlmdxnrxhe60n2jl29vyg5txcnts36xrr2",
  cycles: 1,
});
```

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [ ] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @yknl or @zone117x for review
