### PR TITLE
feat: improve `StackerInfo` type

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1487,13 +1487,13 @@ async function stackingStatus(network: CLINetworkAdapter, args: string[]): Promi
     .then((status: StackerInfo) => {
       if (status.stacked) {
         return {
-          amount_microstx: status.details!.amount_microstx,
-          first_reward_cycle: status.details!.first_reward_cycle,
-          lock_period: status.details!.lock_period,
-          unlock_height: status.details!.unlock_height,
+          amount_microstx: status.details.amount_microstx,
+          first_reward_cycle: status.details.first_reward_cycle,
+          lock_period: status.details.lock_period,
+          unlock_height: status.details.unlock_height,
           pox_address: {
-            version: status.details!.pox_address.version.toString('hex'),
-            hashbytes: status.details!.pox_address.hashbytes.toString('hex'),
+            version: status.details.pox_address.version.toString('hex'),
+            hashbytes: status.details.pox_address.hashbytes.toString('hex'),
           },
         };
       } else {

--- a/packages/stacking/src/index.ts
+++ b/packages/stacking/src/index.ts
@@ -37,19 +37,23 @@ export interface PoxInfo {
   rejection_votes_left_required: number;
 }
 
-export interface StackerInfo {
-  stacked: boolean;
-  details?: {
-    amount_microstx: string;
-    first_reward_cycle: number;
-    lock_period: number;
-    unlock_height: number;
-    pox_address: {
-      version: Buffer;
-      hashbytes: Buffer;
+export type StackerInfo =
+  | {
+      stacked: false;
+    }
+  | {
+      stacked: true;
+      details: {
+        amount_microstx: string;
+        first_reward_cycle: number;
+        lock_period: number;
+        unlock_height: number;
+        pox_address: {
+          version: Buffer;
+          hashbytes: Buffer;
+        };
+      };
     };
-  };
-}
 
 export interface BlockTimeInfo {
   mainnet: {


### PR DESCRIPTION
## Description

When trying to integrate the `StackingClient.getStatus()` function in my project I saw that the type could be improved.

Before the following code was throwing an error

```ts
const status = await stackingClient.getStatus();

if (status.stacked) {
    // Throw an error as details can be undefined based on the type currently in the codebase
	console.log(status.details.amount_microstx);
}
```

After this change, the type is more correct

```ts
const status = await stackingClient.getStatus();

if (status.stacked) {
    // No error, can access safely
	console.log(status.details.amount_microstx);
}
if (!status.stacked) {
    // Typescript error
	console.log(status.details.amount_microstx);
}
```

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
List the APIs or describe the functionality that this PR breaks.
Workarounds for or expected timeline for deprecation

## Are documentation updates required?
<!-- 
  DOCUMENTATION
  Consider if this PR makes changes that require documentation updates:
    - API changes
    - Renamed methods
    - Change in instructions inside tutorials/guides
    - etc...

   The best way to find these is by searching inside the docs at https://github.com/blockstack/docs
-->
- [ ] Link to documentation updates: 

## Testing information

Provide context on how tests should be performed.

1. Is testing required for this change?
2. If it’s a bug fix, list steps to reproduce the bug
3. Briefly mention affected code paths
4. List other affected projects if possible
5. Things to watch out for when testing

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [ ] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @yknl or @zone117x for review
