### PR TITLE
Include attachment with transaction broadcast

### DIFF
--- a/packages/transactions/src/builders.ts
+++ b/packages/transactions/src/builders.ts
@@ -1,3 +1,5 @@
+import _ from 'lodash';
+
 import { StacksTransaction } from './transaction';
 
 import { StacksNetwork, StacksMainnet, StacksTestnet } from '@stacks/network';
@@ -185,7 +187,7 @@ export async function broadcastRawTransaction(
   };
 
   if (attachment) {
-    options = Object.assign(options, {
+    options = _.assign(options, {
       headers: {
         'Content-Type': 'application/json',
       },
@@ -195,7 +197,7 @@ export async function broadcastRawTransaction(
       })
     })
   } else {
-    options = Object.assign(options, {
+    options = _.assign(options, {
       headers: {
         'Content-Type': 'application/octet-stream',
       },

--- a/packages/transactions/src/builders.ts
+++ b/packages/transactions/src/builders.ts
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 import { StacksTransaction } from './transaction';
 
 import { StacksNetwork, StacksMainnet, StacksTestnet } from '@stacks/network';
@@ -186,7 +184,7 @@ export async function broadcastRawTransaction(
   };
 
   if (attachment) {
-    options = _.assign(options, {
+    options = Object.assign(options, {
       headers: {
         'Content-Type': 'application/json',
       },
@@ -196,7 +194,7 @@ export async function broadcastRawTransaction(
       }),
     });
   } else {
-    options = _.assign(options, {
+    options = Object.assign(options, {
       headers: {
         'Content-Type': 'application/octet-stream',
       },

--- a/packages/transactions/src/builders.ts
+++ b/packages/transactions/src/builders.ts
@@ -181,7 +181,6 @@ export async function broadcastRawTransaction(
   url: string,
   attachment?: Buffer
 ): Promise<TxBroadcastResult> {
-
   let options = {
     method: 'POST',
   };
@@ -193,16 +192,16 @@ export async function broadcastRawTransaction(
       },
       body: JSON.stringify({
         tx: rawTx.toString('hex'),
-        attachment: attachment.toString('hex')
-      })
-    })
+        attachment: attachment.toString('hex'),
+      }),
+    });
   } else {
     options = _.assign(options, {
       headers: {
         'Content-Type': 'application/octet-stream',
       },
       body: rawTx,
-    })
+    });
   }
 
   const response = await fetchPrivate(url, options);

--- a/packages/transactions/tests/builder.test.ts
+++ b/packages/transactions/tests/builder.test.ts
@@ -939,6 +939,39 @@ test('Transaction broadcast success', async () => {
   expect(response as TxBroadcastResultOk).toEqual('success');
 });
 
+test.only('Transaction broadcast with attachment', async () => {
+  const recipient = standardPrincipalCV('SP3FGQ8Z7JY9BWYZ5WM53E0M9NK7WHJF0691NZ159');
+  const amount = new BigNum(12345);
+  const fee = new BigNum(0);
+  const nonce = new BigNum(0);
+  const senderKey = 'edf9aee84d9b7abc145504dde6726c64f369d37ee34ded868fabd876c26570bc01';
+  const memo = 'test memo';
+  const attachment = Buffer.from('this is an attachment...');
+
+  const network = new StacksMainnet();
+
+  const transaction = await makeSTXTokenTransfer({
+    recipient,
+    amount,
+    senderKey,
+    fee,
+    nonce,
+    memo,
+  });
+
+  fetchMock.mockOnce('success');
+
+  const response: TxBroadcastResult = await broadcastTransaction(transaction, network, attachment);
+
+  expect(fetchMock.mock.calls.length).toEqual(1);
+  expect(fetchMock.mock.calls[0][0]).toEqual(network.getBroadcastApiUrl());
+  expect(fetchMock.mock.calls[0][1]?.body).toEqual(JSON.stringify({
+    tx: transaction.serialize().toString('hex'),
+    attachment: attachment.toString('hex')
+  }));
+  expect(response as TxBroadcastResultOk).toEqual('success');
+});
+
 test('Transaction broadcast returns error', async () => {
   const recipient = standardPrincipalCV('SP3FGQ8Z7JY9BWYZ5WM53E0M9NK7WHJF0691NZ159');
   const amount = new BigNum(12345);


### PR DESCRIPTION
Enable attachments to be included when broadcasting transactions

Issue: #893 