### PR TITLE
fix: don't multiply with cycleDuration (#937)

### DIFF
--- a/packages/stacking/src/index.ts
+++ b/packages/stacking/src/index.ts
@@ -244,8 +244,7 @@ export class StackingClient {
           poxInfo.reward_cycle_length -
           ((coreInfo.burn_block_height - poxInfo.first_burnchain_block_height) %
             poxInfo.reward_cycle_length);
-        const cycleDuration = poxInfo.reward_cycle_length * targetBlockTime;
-        return blocksToNextCycle * cycleDuration;
+        return blocksToNextCycle * targetBlockTime;
       }
     );
   }

--- a/packages/stacking/tests/stacking.test.ts
+++ b/packages/stacking/tests/stacking.test.ts
@@ -826,6 +826,41 @@ test('get account balance', async () => {
   expect(fetchMock.mock.calls[0][0]).toEqual(network.getAccountApiUrl(address));
   expect(responseBalanceInfo.toString()).toEqual(new BN(balanceInfo.balance.substr(2), 'hex').toString());
 })
+test('get seconds until next cycle', async () => {
+  const address = 'ST3XKKN4RPV69NN1PHFDNX3TYKXT7XPC4N8KC1ARH';
+  const network = new StacksTestnet();
+
+  fetchMock
+    .mockResponseOnce(() => {
+      return Promise.resolve({
+        body: JSON.stringify(poxInfo),
+        status: 200,
+      });
+    })
+    .mockResponseOnce(() => {
+      return Promise.resolve({
+        body: JSON.stringify(blocktimeInfo),
+        status: 200,
+      });
+    })
+    .mockResponseOnce(() => {
+      return Promise.resolve({
+        body: JSON.stringify(coreInfo),
+        status: 200,
+      });
+    });
+
+  const { StackingClient } = require('../src');
+  const client = new StackingClient(address, network);
+
+  const responseSecondsUntilNextCycle = await client.getSecondsUntilNextCycle();
+  expect(fetchMock.mock.calls[0][0]).toEqual(network.getPoxInfoUrl());
+  expect(fetchMock.mock.calls[1][0]).toEqual(network.getBlockTimeInfoUrl());
+  expect(fetchMock.mock.calls[2][0]).toEqual(network.getInfoUrl());
+
+  // next reward cycle in 10 blocks
+  expect(responseSecondsUntilNextCycle.toString()).toEqual((10 * 120).toString());
+});
 
 test('pox address hash mode', async () => {
   const p2pkh = '1Xik14zRm29UsyS6DjhYg4iZeZqsDa8D3';


### PR DESCRIPTION


## Description

This PR
* corrects the calculation of seconds until next cycle
* fixes #937 
## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
Yes, the result of StackingClient.getSecondsUntilNextCycle returns different values for the same state of the blockchain.

## Are documentation updates required?
No

## Testing information
Unit test has been added

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [ ] `npm run test` passes
- [ ] Changelog is updated
- [x] Tag 1 of @yknl or @zone117x for review
