### PR TITLE
Refactor: transaction broadcast request options construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- export `cvToValue` function
+
 ## [21.1.1] - 2020-08-24
 ### Changed
 - Persist etags in UserSession store so they don't always need to be fetched when the page is loaded.

--- a/packages/transactions/src/builders.ts
+++ b/packages/transactions/src/builders.ts
@@ -179,27 +179,14 @@ export async function broadcastRawTransaction(
   url: string,
   attachment?: Buffer
 ): Promise<TxBroadcastResult> {
-  let options = {
-    method: 'POST',
-  };
 
-  if (attachment) {
-    options = Object.assign(options, {
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        tx: rawTx.toString('hex'),
-        attachment: attachment.toString('hex'),
-      }),
-    });
-  } else {
-    options = Object.assign(options, {
-      headers: {
-        'Content-Type': 'application/octet-stream',
-      },
-      body: rawTx,
-    });
+  const options = {
+    method: 'POST',
+    headers: { 'Content-Type': attachment ? 'application/json' : 'application/octet-stream' },
+    body: attachment ? JSON.stringify({
+      tx: rawTx.toString('hex'),
+      attachment: attachment.toString('hex'),
+    }) : rawTx,
   }
 
   const response = await fetchPrivate(url, options);

--- a/packages/transactions/src/clarity/clarityValue.ts
+++ b/packages/transactions/src/clarity/clarityValue.ts
@@ -96,7 +96,7 @@ export function cvToString(val: ClarityValue, encoding: 'tryAscii' | 'hex' = 'he
   }
 }
 
-function cvToValue(val: ClarityValue): any {
+export function cvToValue(val: ClarityValue): any {
   switch (val.type) {
     case ClarityType.BoolTrue:
       return true;


### PR DESCRIPTION
Small PR to refactor the way that the transaction broadcast request's options are constructed.

Also includes a change to export the `cvToValue` function.