### PR TITLE
fix: delegateStx invalid argument error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Changed
 - export `cvToValue` function
+- fix `delegateStx` function
 
 ## [21.1.1] - 2020-08-24
 ### Changed

--- a/packages/stacking/src/index.ts
+++ b/packages/stacking/src/index.ts
@@ -378,7 +378,7 @@ export class StackingClient {
       untilBurnBlockHeight,
       poxAddress,
     });
-    
+
     const tx = await makeContractCall({
       ...txOptions,
       senderKey: privateKey,

--- a/packages/stacking/src/index.ts
+++ b/packages/stacking/src/index.ts
@@ -378,6 +378,7 @@ export class StackingClient {
       untilBurnBlockHeight,
       poxAddress,
     });
+    
     const tx = await makeContractCall({
       ...txOptions,
       senderKey: privateKey,
@@ -546,7 +547,7 @@ export class StackingClient {
       functionArgs: [
         uintCV(amountMicroStx.toString(10)),
         standardPrincipalCV(delegateTo),
-        untilBurnBlockHeight ? uintCV(untilBurnBlockHeight) : noneCV(),
+        untilBurnBlockHeight ? someCV(uintCV(untilBurnBlockHeight)) : noneCV(),
         address ? address : noneCV(),
       ],
       validateWithAbi: true,

--- a/packages/stacking/tests/stacking.test.ts
+++ b/packages/stacking/tests/stacking.test.ts
@@ -296,7 +296,7 @@ test('delegate stx', async () => {
     functionArgs: [
       uintCV(amountMicroStx.toString(10)),
       standardPrincipalCV(delegateTo),
-      uintCV(untilBurnBlockHeight),
+      someCV(uintCV(untilBurnBlockHeight)),
       someCV(poxAddressCV),
     ],
     validateWithAbi: true,

--- a/packages/transactions/src/builders.ts
+++ b/packages/transactions/src/builders.ts
@@ -179,15 +179,16 @@ export async function broadcastRawTransaction(
   url: string,
   attachment?: Buffer
 ): Promise<TxBroadcastResult> {
-
   const options = {
     method: 'POST',
     headers: { 'Content-Type': attachment ? 'application/json' : 'application/octet-stream' },
-    body: attachment ? JSON.stringify({
-      tx: rawTx.toString('hex'),
-      attachment: attachment.toString('hex'),
-    }) : rawTx,
-  }
+    body: attachment
+      ? JSON.stringify({
+          tx: rawTx.toString('hex'),
+          attachment: attachment.toString('hex'),
+        })
+      : rawTx,
+  };
 
   const response = await fetchPrivate(url, options);
   if (!response.ok) {


### PR DESCRIPTION
contract-call for `delegate-stx` should be passed an `(optional uint)` for `until-burn-ht` arg

issue: #955 