### PR TITLE
feat: Multisig transactions with uncompressed keys

### DIFF
--- a/packages/transactions/src/keys.ts
+++ b/packages/transactions/src/keys.ts
@@ -101,6 +101,13 @@ export function pubKeyfromPrivKey(privateKey: string | Buffer): StacksPublicKey 
   return createStacksPublicKey(pubKey);
 }
 
+export function compressPublicKey(publicKey: string | Buffer): StacksPublicKey {
+  const ec = new EC('secp256k1');
+  const key = ec.keyFromPublic(publicKey);
+  const pubKey = key.getPublic(true, 'hex');
+  return createStacksPublicKey(pubKey);
+}
+
 export function deserializePublicKey(bufferReader: BufferReader): StacksPublicKey {
   const fieldId = bufferReader.readUInt8();
   const keyLength =
@@ -156,8 +163,7 @@ export function signWithKey(privateKey: StacksPrivateKey, input: string): Messag
   }
   const recoveryParam = intToHexString(signature.recoveryParam, 1);
   const recoverableSignatureString = recoveryParam + r + s;
-  const recoverableSignature = createMessageSignature(recoverableSignatureString);
-  return recoverableSignature;
+  return createMessageSignature(recoverableSignatureString);
 }
 
 export function getSignatureRecoveryParam(signature: string) {

--- a/packages/transactions/tests/authorization.test.ts
+++ b/packages/transactions/tests/authorization.test.ts
@@ -1,23 +1,19 @@
 import {
-  SingleSigSpendingCondition,
-  createSingleSigSpendingCondition,
-  serializeSpendingCondition,
-  deserializeSpendingCondition,
   createMessageSignature,
-  emptyMessageSignature,
   createMultiSigSpendingCondition,
+  createSingleSigSpendingCondition,
   createTransactionAuthField,
+  deserializeSpendingCondition,
+  emptyMessageSignature,
+  serializeSpendingCondition,
+  SingleSigSpendingCondition,
 } from '../src/authorization';
 
-import { AddressHashMode, PubKeyEncoding } from '../src/constants';
+import {AddressHashMode, PubKeyEncoding} from '../src/constants';
 
 import BigNum from 'bn.js';
-import { BufferReader } from '../src/bufferReader';
-import {
-  createStacksPrivateKey,
-  signWithKey,
-  createStacksPublicKey,
-} from '../src/keys';
+import {BufferReader} from '../src/bufferReader';
+import {createStacksPrivateKey, createStacksPublicKey, signWithKey,} from '../src/keys';
 
 test('ECDSA recoverable signature', () => {
   const privKeyString = 'edf9aee84d9b7abc145504dde6726c64f369d37ee34ded868fabd876c26570bc';
@@ -106,7 +102,7 @@ test('Multi sig spending condition uncompressed', () => {
 
   const signature = createMessageSignature('ff'.repeat(65));
   const fields = [signature, signature, createStacksPublicKey(pubKeys[2])];
-  spendingCondition.fields = fields.map(createTransactionAuthField);
+  spendingCondition.fields = fields.map(sig => createTransactionAuthField(PubKeyEncoding.Compressed, sig));
 
   const serializedSpendingCondition = serializeSpendingCondition(spendingCondition);
 


### PR DESCRIPTION
This PR enables stacks.js to properly sign multi-sig P2SH transactions with uncompressed keys.

fixes #961 

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No
