### PR TITLE
feat: add hex string and Buffer support to `deserializedTransaction`

### DIFF
--- a/packages/transactions/src/transaction.ts
+++ b/packages/transactions/src/transaction.ts
@@ -233,7 +233,22 @@ export class StacksTransaction {
   }
 }
 
-export function deserializeTransaction(bufferReader: BufferReader) {
+/**
+ * @param data Buffer or hex string
+ */
+export function deserializeTransaction(data: BufferReader | Buffer | string) {
+  let bufferReader: BufferReader;
+  if (typeof data === 'string') {
+    if (data.slice(0, 2).toLowerCase() === '0x') {
+      bufferReader = new BufferReader(Buffer.from(data.slice(2), 'hex'));
+    } else {
+      bufferReader = new BufferReader(Buffer.from(data, 'hex'));
+    }
+  } else if (Buffer.isBuffer(data)) {
+    bufferReader = new BufferReader(data);
+  } else {
+    bufferReader = data;
+  }
   const version = bufferReader.readUInt8Enum(TransactionVersion, n => {
     throw new Error(`Could not parse ${n} as TransactionVersion`);
   });

--- a/packages/transactions/tests/transaction.test.ts
+++ b/packages/transactions/tests/transaction.test.ts
@@ -91,6 +91,13 @@ test('STX token transfer transaction serialization and deserialization', () => {
 
   const serialized = transaction.serialize();
   const deserialized = deserializeTransaction(new BufferReader(serialized));
+  
+  const serializedHexString = serialized.toString('hex');
+  expect(deserializeTransaction(serializedHexString).serialize().toString('hex')).toEqual(serialized.toString('hex'));
+
+  const serializedHexStringPrefixed = '0x' + serializedHexString;
+  expect(deserializeTransaction(serializedHexStringPrefixed).serialize().toString('hex')).toEqual(serialized.toString('hex'));
+
   expect(deserialized.version).toBe(transactionVersion);
   expect(deserialized.chainId).toBe(chainId);
   expect(deserialized.auth.authType).toBe(authType);


### PR DESCRIPTION
Make deserializing a tx easier.

Old:
```js
const stxTx = require('@stacks/transactions');
const hex = '0x80800000000400164247d6f2b425ac5771423ae6c80c754f7172b0000000000000000000000000000000b400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003020000000000051a43596b5386f466863e25658ddf94bd0fadab0048000000000007a12000000000000000000000000000000000000000000000000000000000000000000000';
const tx = stxTx.deserializeTransaction(new stxTx.BufferReader(Buffer.from(hex.slice(2), 'hex')));
```

New:
```js
const stxTx = require('@stacks/transactions');
const hex = '0x80800000000400164247d6f2b425ac5771423ae6c80c754f7172b0000000000000000000000000000000b400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003020000000000051a43596b5386f466863e25658ddf94bd0fadab0048000000000007a12000000000000000000000000000000000000000000000000000000000000000000000';
const tx = stxTx.deserializeTransaction(hex);
```