### PR TITLE
Fix toBuffer() to toArrayLike(Buffer))

### DIFF
--- a/packages/stacking/src/index.ts
+++ b/packages/stacking/src/index.ts
@@ -527,7 +527,7 @@ export class StackingClient {
 
     if (poxAddress) {
       const { hashMode, data } = decodeBtcAddress(poxAddress);
-      const hashModeBuffer = bufferCV(new BN(hashMode, 10).toBuffer());
+      const hashModeBuffer = bufferCV(new BN(hashMode, 10).toArrayLike(Buffer));
       const hashbytes = bufferCV(data);
       address = someCV(
         tupleCV({
@@ -573,7 +573,7 @@ export class StackingClient {
     nonce?: BN;
   }) {
     const { hashMode, data } = decodeBtcAddress(poxAddress);
-    const hashModeBuffer = bufferCV(new BN(hashMode, 10).toBuffer());
+    const hashModeBuffer = bufferCV(new BN(hashMode, 10).toArrayLike(Buffer));
     const hashbytes = bufferCV(data);
     const address = tupleCV({
       hashbytes,


### PR DESCRIPTION
### Description
When using the method `.delegateStackStx` and `.getDelegateStackOptions` I get an error `Assertion Failed`

After some debugging, it looks like the error is coming from this call
https://github.com/blockstack/stacks.js/blob/a6fab4e5c3038cf4eaa7bd997b7d4c5104ca6858/packages/stacking/src/index.ts#L530
https://github.com/blockstack/stacks.js/blob/a6fab4e5c3038cf4eaa7bd997b7d4c5104ca6858/packages/stacking/src/index.ts#L576

hashMode returned by const { hashMode, data } = decodeBtcAddress(poxAddress); is 0 and calling bn.js new BN(hashMode, 10).toBuffer() to get the buffer on 0 is throwing an error

**Related issue/pull-request:**
https://github.com/blockstack/stacks.js/pull/925

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Testing information

Provide context on how tests should be performed.

1. Is testing required for this change?
The related pull request manages to fix the error.

2. If it’s a bug fix, list steps to reproduce the bug
```
const network = new StacksTestnet();
const delegateeClient = new StackingClient(delegateeAddress, network);

getNonce(delegateeAddress, network)
      .then((res) => {
        return res.add(new BN(1));
      })
      .then((res) => {
        return delegateeClient.delegateStackStx({
          stacker: delegatorAddress,
          amountMicroStx: amountMicroStx,
          poxAddress: delegateeBtcAddress,
          burnBlockHeight: burnBlockHeight,
          cycles: cycles,
          privateKey: delegateePrivateKey,
          nonce: res, // optional
        });
      })
      .then((res) => {
        console.log(res);
      })
      .catch((err) => {
        console.log(err);
      });
```

and

```
const network = new StacksTestnet();
const delegateeClient = new StackingClient(delegateeAddress, network);

delegateeClient.getDelegateStackOptions({
        contract:"ST000000000000000000002AMW42H.pox",
        stacker: delegatorAddress,
        amountMicroStx: new BN(1000),
        poxAddress: delegateeBtcAddress,
        burnBlockHeight: 100,
        cycles: 1,
      }).then((res) => {
        console.log(res);
      })
      .catch((err) => {
        console.log(err);
      });
```


## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [ ] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @yknl or @zone117x for review