### PR TITLE
Update toBuffer() to toArrayLike(Buffer)

### DIFF
--- a/packages/stacking/src/index.ts
+++ b/packages/stacking/src/index.ts
@@ -614,7 +614,7 @@ export class StackingClient {
     rewardCycle: number;
   }) {
     const { hashMode, data } = decodeBtcAddress(poxAddress);
-    const hashModeBuffer = bufferCV(new BN(hashMode, 10).toBuffer());
+    const hashModeBuffer = bufferCV(new BN(hashMode, 10).toArrayLike(Buffer));
     const hashbytes = bufferCV(data);
     const address = tupleCV({
       hashbytes,
@@ -708,7 +708,7 @@ export class StackingClient {
   modifyLockTxFee({ tx, amountMicroStx }: { tx: StacksTransaction; amountMicroStx: BN }) {
     const fee = tx.auth.getFee() as BN;
     (tx.payload as ContractCallPayload).functionArgs[0] = uintCV(
-      new BN(amountMicroStx.toString(10), 10).sub(fee).toBuffer()
+      new BN(amountMicroStx.toString(10), 10).sub(fee).toArrayLike(Buffer)
     );
     return tx;
   }


### PR DESCRIPTION
### Description
When using the method `.stackAggregationCommit` I get an error `Assertion Failed`

After some debugging, it looks like the error is coming from this call
https://github.com/blockstack/stacks.js/blob/master/packages/stacking/src/index.ts#L617
https://github.com/blockstack/stacks.js/blob/master/packages/stacking/src/index.ts#L711

hashMode returned by const { hashMode, data } = decodeBtcAddress(poxAddress); is 0 and calling bn.js new BN(hashMode, 10).toBuffer() to get the buffer on 0 is throwing an error

**Related issue/pull-request:**
https://github.com/blockstack/stacks.js/pull/925
https://github.com/blockstack/stacks.js/pull/968

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Testing information

Provide context on how tests should be performed.

1. Is testing required for this change?
The related pull request manages to fix the error.

2. If it’s a bug fix, list steps to reproduce the bug

```
const rewardCycle = 12;
const network = new StacksTestnet();
const delegateeClient = new StackingClient(delegateeAddress, network);

    delegateeClient
      .stackAggregationCommit({
        poxAddress: delegateeBtcAddress,
        rewardCycle,
        privateKey: delegateePrivateKey,
      })
      .then((res) => {
        console.log(res);
      })
      .catch((err) => {
        console.log(err);
      });
```



## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [ ] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @yknl or @zone117x for review