### PR TITLE
fix: #973 stacking lib only allow p2pkh and p2sh btc addresses

### DIFF
--- a/packages/stacking/tests/stacking.test.ts
+++ b/packages/stacking/tests/stacking.test.ts
@@ -16,7 +16,7 @@ import {
   intCV,
 } from '@stacks/transactions';
 import { address as btcAddress } from 'bitcoinjs-lib';
-import { getAddressHashMode } from '../src/utils';
+import { decodeBtcAddress, getAddressHashMode, InvalidAddressError } from '../src/utils';
 
 beforeEach(() => {
   fetchMock.resetMocks();
@@ -867,27 +867,29 @@ test('pox address hash mode', async () => {
   const p2pkhTestnet = 'n4RKBLKb6n9v68yMRUYm6xRCx2YkkxpSQm';
   const p2sh = '3EktnHQD7RiAE6uzMj2ZifT9YgRrkSgzQX';
   const p2shTestnet = '2MzQwSSnBHWHqSAqtTVQ6v47XtaisrJa1Vc';
-  const p2wpkh = 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4';
-  const p2wpkhTestnet = 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx';
-  const p2wsh = 'bc1qup6umurcl7s6zw42gcxfzl346psazws74x72ty6gmlvkaxz6kv4sqsth99';
-  const p2wshTestnet = 'tb1qup6umurcl7s6zw42gcxfzl346psazws74x72ty6gmlvkaxz6kv4shcacl2';
 
   const p2pkhAddrHashmode = getAddressHashMode(p2pkh);
   const p2pkhTestnetAddrHashmode = getAddressHashMode(p2pkhTestnet);
   const p2shAddrHashmode = getAddressHashMode(p2sh);
   const p2shTestnetAddrHashmode = getAddressHashMode(p2shTestnet);
-  const p2wpkhAddrHashmode = getAddressHashMode(p2wpkh);
-  const p2wpkhTestnetAddrHashmode = getAddressHashMode(p2wpkhTestnet);
-  const p2wshAddrHashmode = getAddressHashMode(p2wsh);
-  const p2wshTestnetAddrHashmode = getAddressHashMode(p2wshTestnet);
 
   expect(p2pkhAddrHashmode).toEqual(AddressHashMode.SerializeP2PKH);
   expect(p2pkhTestnetAddrHashmode).toEqual(AddressHashMode.SerializeP2PKH);
   expect(p2shAddrHashmode).toEqual(AddressHashMode.SerializeP2SH);
   expect(p2shTestnetAddrHashmode).toEqual(AddressHashMode.SerializeP2SH);
 
-  expect(p2wpkhAddrHashmode).toEqual(AddressHashMode.SerializeP2WPKH);
-  expect(p2wpkhTestnetAddrHashmode).toEqual(AddressHashMode.SerializeP2WPKH);
-  expect(p2wshAddrHashmode).toEqual(AddressHashMode.SerializeP2WSH);
-  expect(p2wshTestnetAddrHashmode).toEqual(AddressHashMode.SerializeP2WSH);
+  const p2wpkh = 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4';
+  const p2wpkhTestnet = 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx';
+  const p2wsh = 'bc1qup6umurcl7s6zw42gcxfzl346psazws74x72ty6gmlvkaxz6kv4sqsth99';
+  const p2wshTestnet = 'tb1qup6umurcl7s6zw42gcxfzl346psazws74x72ty6gmlvkaxz6kv4shcacl2';
+  
+  expect(() => getAddressHashMode(p2wpkh)).toThrowError(InvalidAddressError);
+  expect(() => getAddressHashMode(p2wpkhTestnet)).toThrowError(InvalidAddressError);
+  expect(() => getAddressHashMode(p2wsh)).toThrowError(InvalidAddressError);
+  expect(() => getAddressHashMode(p2wshTestnet)).toThrowError(InvalidAddressError);
+
+  expect(() => decodeBtcAddress(p2wpkh)).toThrowError(InvalidAddressError);
+  expect(() => decodeBtcAddress(p2wpkhTestnet)).toThrowError(InvalidAddressError);
+  expect(() => decodeBtcAddress(p2wsh)).toThrowError(InvalidAddressError);
+  expect(() => decodeBtcAddress(p2wshTestnet)).toThrowError(InvalidAddressError);
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -4096,7 +4096,7 @@ braces@^3.0.1, braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
-brorand@^1.0.1:
+brorand@^1.0.1, brorand@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
   integrity sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=
@@ -5677,6 +5677,19 @@ elliptic@^6.4.0, elliptic@^6.4.1, elliptic@^6.5.2, elliptic@^6.5.3:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
+elliptic@^6.5.4:
+  version "6.5.4"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
+  integrity sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==
+  dependencies:
+    bn.js "^4.11.9"
+    brorand "^1.1.0"
+    hash.js "^1.0.0"
+    hmac-drbg "^1.0.1"
+    inherits "^2.0.4"
+    minimalistic-assert "^1.0.1"
+    minimalistic-crypto-utils "^1.0.1"
+
 emoji-regex@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
@@ -7219,7 +7232,7 @@ highlight.js@^10.2.0:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.4.0.tgz#ef3ce475e5dfa7a48484260b49ea242ddab823a0"
   integrity sha512-EfrUGcQ63oLJbj0J0RI9ebX6TAITbsDBLbsjr881L/X5fMO9+oadKzEF21C7R3ULKG6Gv3uoab2HiqVJa/4+oA==
 
-hmac-drbg@^1.0.0:
+hmac-drbg@^1.0.0, hmac-drbg@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
   integrity sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=


### PR DESCRIPTION
Fixes https://github.com/blockstack/stacks.js/issues/973

Passing in a bech32 address to either `decodeBtcAddress` or `getAddressHashMode` now results in a `InvalidAddressError` being thrown.

Example:
```
decodeBtcAddress('bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4');

---

InvalidAddressError: bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4 is not a valid P2PKH or P2SH address -- native P2WPKH and native P2WSH are not supported in PoX.
at Object.decodeBtcAddress (/Users/matt/Projects/stacks.js/packages/stacking/src/utils.ts:1250:11)
at Object.<anonymous> (/Users/matt/Projects/stacks.js/packages/stacking/tests/stacking.test.ts:897:5)
at processTicksAndRejections (internal/process/task_queues.js:93:5) {
innerError: Error: Non-base58 character
  at Object.decode (/Users/matt/Projects/stacks.js/node_modules/base-x/src/index.js:115:11)
  at Object.decode (/Users/matt/Projects/stacks.js/node_modules/bs58check/base.js:39:25)
  at Object.fromBase58Check (/Users/matt/Projects/stacks.js/node_modules/bitcoinjs-lib/src/address.js:11:29)
  at Object.decodeBtcAddress (/Users/matt/Projects/stacks.js/packages/stacking/src/utils.ts:1246:41)
}
```