### PR TITLE
feat: match authResponse username with 2.0 bns lookup

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@stacks/common": "^1.2.2",
     "@stacks/encryption": "^1.2.3",
-    "@stacks/network": "^1.2.2",
+    "@stacks/network": "^1.3.0-beta.1",
     "@stacks/profile": "^1.2.3",
     "c32check": "1.1.2",
     "codecov": "^3.7.2",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/auth",
-  "version": "1.2.3",
+  "version": "1.3.0-beta-1",
   "description": "Authentication for Stacks apps.",
   "keywords": [
     "Stacks",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/auth",
-  "version": "1.3.0-beta-1",
+  "version": "1.3.0-beta-2",
   "description": "Authentication for Stacks apps.",
   "keywords": [
     "Stacks",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -49,6 +49,7 @@
     "@stacks/encryption": "^1.2.3",
     "@stacks/network": "^1.2.2",
     "@stacks/profile": "^1.2.3",
+    "c32check": "1.1.2",
     "codecov": "^3.7.2",
     "cross-fetch": "^3.0.5",
     "jsontokens": "^3.0.0",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/auth",
-  "version": "1.3.0-beta-2",
+  "version": "1.3.0-beta-3",
   "description": "Authentication for Stacks apps.",
   "keywords": [
     "Stacks",

--- a/packages/auth/src/userSession.ts
+++ b/packages/auth/src/userSession.ts
@@ -250,7 +250,10 @@ export class UserSession {
 
     const nameLookupURL = `${coreNode}${NAME_LOOKUP_PATH}`;
 
-    const fallbackLookupURLs = [`https://stacks-node-api.stacks.co${NAME_LOOKUP_PATH}`];
+    const fallbackLookupURLs = [
+      `https://stacks-node-api.stacks.co${NAME_LOOKUP_PATH}`,
+      `https://registrar.stacks.co${NAME_LOOKUP_PATH}`,
+    ].filter(url => url !== nameLookupURL);
 
     const isValid = await verifyAuthResponse(authResponseToken, nameLookupURL, fallbackLookupURLs);
     if (!isValid) {

--- a/packages/auth/src/userSession.ts
+++ b/packages/auth/src/userSession.ts
@@ -250,14 +250,7 @@ export class UserSession {
 
     const nameLookupURL = `${coreNode}${NAME_LOOKUP_PATH}`;
 
-    // Temporarily use fallback lookup URLs
-    // Remove after these two are fixed:
-    // https://github.com/blockstack/stacks-blockchain-api/issues/534
-    // https://github.com/blockstack/stacks-blockchain-api/issues/517
-    const fallbackLookupURLs = [
-      `https://stacks-node-api.testnet.stacks.co${NAME_LOOKUP_PATH}`,
-      `https://registrar.testnet.stacks.co${NAME_LOOKUP_PATH}`,
-    ];
+    const fallbackLookupURLs = [`https://stacks-node-api.stacks.co${NAME_LOOKUP_PATH}`];
 
     const isValid = await verifyAuthResponse(authResponseToken, nameLookupURL, fallbackLookupURLs);
     if (!isValid) {

--- a/packages/auth/src/userSession.ts
+++ b/packages/auth/src/userSession.ts
@@ -250,7 +250,16 @@ export class UserSession {
 
     const nameLookupURL = `${coreNode}${NAME_LOOKUP_PATH}`;
 
-    const isValid = await verifyAuthResponse(authResponseToken, nameLookupURL);
+    // Temporarily use fallback lookup URLs
+    // Remove after these two are fixed:
+    // https://github.com/blockstack/stacks-blockchain-api/issues/534
+    // https://github.com/blockstack/stacks-blockchain-api/issues/517
+    const fallbackLookupURLs = [
+      `https://stacks-node-api.testnet.stacks.co${NAME_LOOKUP_PATH}`,
+      `https://registrar.testnet.stacks.co${NAME_LOOKUP_PATH}`,
+    ];
+
+    const isValid = await verifyAuthResponse(authResponseToken, nameLookupURL, fallbackLookupURLs);
     if (!isValid) {
       throw new LoginFailedError('Invalid authentication response.');
     }

--- a/packages/auth/src/verification.ts
+++ b/packages/auth/src/verification.ts
@@ -3,6 +3,7 @@ import { getAddressFromDID } from './dids';
 import { publicKeyToAddress } from '@stacks/encryption';
 import { fetchPrivate, isSameOriginAbsoluteUrl } from '@stacks/common';
 import { fetchAppManifest } from './provider';
+import { c32ToB58 } from 'c32check';
 
 /**
  * Checks if the ES256k signature on passed `token` match the claimed public key
@@ -106,8 +107,9 @@ export async function doPublicKeysMatchUsername(
     const responseJSON = JSON.parse(responseText);
     if (responseJSON.hasOwnProperty('address')) {
       const nameOwningAddress = responseJSON.address;
+      const nameOwningAddressBtc = c32ToB58(nameOwningAddress);
       const addressFromIssuer = getAddressFromDID(payload.iss);
-      if (nameOwningAddress === addressFromIssuer) {
+      if (nameOwningAddressBtc === addressFromIssuer) {
         return true;
       } else {
         return false;

--- a/packages/auth/src/verification.ts
+++ b/packages/auth/src/verification.ts
@@ -107,7 +107,7 @@ export async function doPublicKeysMatchUsername(
     const responseJSON = JSON.parse(responseText);
     if (responseJSON.hasOwnProperty('address')) {
       const nameOwningAddress = responseJSON.address;
-      const nameOwningAddressBtc = c32ToB58(nameOwningAddress);
+      const nameOwningAddressBtc = c32ToB58(nameOwningAddress, 0);
       const addressFromIssuer = getAddressFromDID(payload.iss);
       if (nameOwningAddressBtc === addressFromIssuer) {
         return true;

--- a/packages/auth/src/verification.ts
+++ b/packages/auth/src/verification.ts
@@ -291,6 +291,6 @@ export async function verifyAuthResponse(
       .concat(fallbackLookupURLs || [])
       .map(url => doPublicKeysMatchUsername(token, url))
   );
-  const someUsernameMatches = usernameMatchings.find(doesMatch => doesMatch);
+  const someUsernameMatches = usernameMatchings.includes(true);
   return !!someUsernameMatches && values.every(val => val);
 }

--- a/packages/auth/tests/auth.test.ts
+++ b/packages/auth/tests/auth.test.ts
@@ -286,7 +286,7 @@ test('handlePendingSignIn with authResponseToken', async () => {
 
   expect(fail).toBeCalledTimes(0);
   expect(pass).toBeCalledTimes(1);
-  expect(fetchMock.mock.calls.length).toEqual(1);
+  expect(fetchMock.mock.calls.length).toEqual(3);
   expect(fetchMock.mock.calls[0][0]).toEqual(url);
 });
 
@@ -319,7 +319,7 @@ test('handlePendingSignIn 2', async () => {
   await blockstack.handlePendingSignIn(authResponse).then(pass).catch(fail);
   expect(fail).toBeCalledTimes(0);
   expect(pass).toBeCalledTimes(1);
-  expect(fetchMock.mock.calls.length).toEqual(1);
+  expect(fetchMock.mock.calls.length).toEqual(3);
   expect(fetchMock.mock.calls[0][0]).toEqual(url);
 });
 

--- a/packages/auth/tests/auth.test.ts
+++ b/packages/auth/tests/auth.test.ts
@@ -286,7 +286,7 @@ test('handlePendingSignIn with authResponseToken', async () => {
 
   expect(fail).toBeCalledTimes(0);
   expect(pass).toBeCalledTimes(1);
-  expect(fetchMock.mock.calls.length).toEqual(2);
+  expect(fetchMock.mock.calls.length).toEqual(3);
   expect(fetchMock.mock.calls[0][0]).toEqual(url);
 });
 
@@ -319,7 +319,7 @@ test('handlePendingSignIn 2', async () => {
   await blockstack.handlePendingSignIn(authResponse).then(pass).catch(fail);
   expect(fail).toBeCalledTimes(0);
   expect(pass).toBeCalledTimes(1);
-  expect(fetchMock.mock.calls.length).toEqual(2);
+  expect(fetchMock.mock.calls.length).toEqual(3);
   expect(fetchMock.mock.calls[0][0]).toEqual(url);
 });
 

--- a/packages/auth/tests/auth.test.ts
+++ b/packages/auth/tests/auth.test.ts
@@ -30,7 +30,7 @@ beforeEach(() => {
 
 const privateKey = 'a5c61c6ca7b3e7e55edee68566aeab22e4da26baa285c7bd10e8d2218aa3b229';
 const publicKey = '027d28f9951ce46538951e3697c62588a87f1f1f295de4a14fdd4c780fc52cfe69';
-const nameLookupURL = 'https://core.blockstack.org/v1/names/';
+const nameLookupURL = 'https://stacks-node-api.mainnet.stacks.co/v1/names/';
 
 test('makeAuthRequest && verifyAuthRequest', async () => {
   const appConfig = new AppConfig(['store_write'], 'http://localhost:3000');
@@ -286,7 +286,7 @@ test('handlePendingSignIn with authResponseToken', async () => {
 
   expect(fail).toBeCalledTimes(0);
   expect(pass).toBeCalledTimes(1);
-  expect(fetchMock.mock.calls.length).toEqual(3);
+  expect(fetchMock.mock.calls.length).toEqual(2);
   expect(fetchMock.mock.calls[0][0]).toEqual(url);
 });
 
@@ -319,7 +319,7 @@ test('handlePendingSignIn 2', async () => {
   await blockstack.handlePendingSignIn(authResponse).then(pass).catch(fail);
   expect(fail).toBeCalledTimes(0);
   expect(pass).toBeCalledTimes(1);
-  expect(fetchMock.mock.calls.length).toEqual(3);
+  expect(fetchMock.mock.calls.length).toEqual(2);
   expect(fetchMock.mock.calls[0][0]).toEqual(url);
 });
 
@@ -522,6 +522,8 @@ test('profileLookUp', async () => {
   expect(fetchMock.mock.calls.length).toEqual(4);
   expect(fetchMock.mock.calls[0][0]).toEqual('http://potato:6270/v1/names/ryan.id');
   expect(fetchMock.mock.calls[1][0]).toEqual(sampleTokenFiles.ryan.url);
-  expect(fetchMock.mock.calls[2][0]).toEqual('https://core.blockstack.org/v1/names/ryan.id');
+  expect(fetchMock.mock.calls[2][0]).toEqual(
+    'https://stacks-node-api.mainnet.stacks.co/v1/names/ryan.id'
+  );
   expect(fetchMock.mock.calls[3][0]).toEqual(sampleTokenFiles.ryan.url);
 });

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/network",
-  "version": "1.2.2",
+  "version": "1.3.0-beta-1",
   "description": "Library for Stacks network operations",
   "keywords": [
     "stacks",

--- a/packages/network/src/index.ts
+++ b/packages/network/src/index.ts
@@ -40,8 +40,7 @@ export class StacksMainnet implements StacksNetwork {
   version = TransactionVersion.Mainnet;
   chainId = ChainID.Mainnet;
   coreApiUrl = 'https://stacks-node-api.mainnet.stacks.co';
-  // TODO: change this when mainnet is live. BNS endpoints are not live yet.
-  bnsLookupUrl = 'https://core.blockstack.org';
+  bnsLookupUrl = 'https://stacks-node-api.mainnet.stacks.co';
   broadcastEndpoint = '/v2/transactions';
   transferFeeEstimateEndpoint = '/v2/fees/transfer';
   accountEndpoint = '/v2/accounts';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4601,15 +4601,7 @@ bytes@3.1.0:
   resolved "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz"
   integrity sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==
 
-c32check@^0.0.6:
-  version "0.0.6"
-  resolved "https://registry.npmjs.org/c32check/-/c32check-0.0.6.tgz"
-  integrity sha512-aXUFQML0sRvR/aBn9cpBGmP/m8t5JmfgaQ4O4/zdphTpLTEaDx0+RbuzDGkps2rAk3Ck69nswR8fknIZSI5rUg==
-  dependencies:
-    base58check "^2.0.0"
-    ripemd160 "^2.0.1"
-
-c32check@^1.0.1, c32check@^1.1.1:
+c32check@1.1.2, c32check@^1.0.1, c32check@^1.1.1:
   version "1.1.2"
   resolved "https://registry.npmjs.org/c32check/-/c32check-1.1.2.tgz"
   integrity sha512-YgmbvOQ9HfoH7ptW80JP6WJdgoHJFGqFjxaFYvwD+bU5i3dJ44a1LI0yxdiA2n/tVKq9W92tYcFjTP5hGlvhcg==
@@ -4617,6 +4609,14 @@ c32check@^1.0.1, c32check@^1.1.1:
     base-x "^3.0.8"
     buffer "^5.6.0"
     cross-sha256 "^1.1.2"
+
+c32check@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/c32check/-/c32check-0.0.6.tgz#9b5bac1c6b73fc12f5ec7114d372daa079cf5509"
+  integrity sha512-aXUFQML0sRvR/aBn9cpBGmP/m8t5JmfgaQ4O4/zdphTpLTEaDx0+RbuzDGkps2rAk3Ck69nswR8fknIZSI5rUg==
+  dependencies:
+    base58check "^2.0.0"
+    ripemd160 "^2.0.1"
 
 cacache@^12.0.0, cacache@^12.0.2, cacache@^12.0.3:
   version "12.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2598,6 +2598,13 @@
     jsonrpc-lite "^2.2.0"
     ws "^7.3.1"
 
+"@stacks/network@1.2.2", "@stacks/network@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@stacks/network/-/network-1.2.2.tgz#30ca87ad6339f32eb04ed3a9dbcc2e39ed933604"
+  integrity sha512-xcWwuRrLJn9qqi3PEBcP2UPZHQztTZd31C0aVlzYHttNMir/sY9SrUqSnw45z2Jo4O9pIYYPIiPRtdV91Ho3fw==
+  dependencies:
+    "@stacks/common" "^1.2.2"
+
 "@stacks/prettier-config@^0.0.7":
   version "0.0.7"
   resolved "https://registry.npmjs.org/@stacks/prettier-config/-/prettier-config-0.0.7.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2572,6 +2572,20 @@
   resolved "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz"
   integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
 
+"@stacks/auth@^1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@stacks/auth/-/auth-1.2.3.tgz#7318436b5c69a3f65a52450470ae5c0f8c2ff65a"
+  integrity sha512-EDXX1hiQ9UnAjrX4D1UyeVZQF647RdtC6EYAIxzgn2L6XxARACGpn+d/fRpE1q411y94lF/2Oqj8MPSwDb/NHQ==
+  dependencies:
+    "@stacks/common" "^1.2.2"
+    "@stacks/encryption" "^1.2.3"
+    "@stacks/network" "^1.2.2"
+    "@stacks/profile" "^1.2.3"
+    codecov "^3.7.2"
+    cross-fetch "^3.0.5"
+    jsontokens "^3.0.0"
+    query-string "^6.13.1"
+
 "@stacks/blockchain-api-client@^0.34.1":
   version "0.34.1"
   resolved "https://registry.npmjs.org/@stacks/blockchain-api-client/-/blockchain-api-client-0.34.1.tgz"


### PR DESCRIPTION
Fixes #953 

This is the start of the work that will allow apps to handle an `authResponse` properly with 2.0 BNS.

After authentication, `@stacks/auth` calls `verifyAuthResponse`. This function runs a few checks, and also runs a check to ensure that the auth response is signed by the owner of the username provided in the payload.

Right now, you need to use a specific `AppConfig` to have a custom `coreNodeUrl`. When provided, it uses a different BNS lookup URL. For testing, I'm using our testnet registrar.