### PR TITLE
Fix: generate sponsored transactions with uncompressed keys

### DIFF
--- a/packages/transactions/src/authorization.ts
+++ b/packages/transactions/src/authorization.ts
@@ -376,11 +376,13 @@ function makeSigHashPostSign(
   // * the signature
   const hashLength = 32 + 1 + RECOVERABLE_ECDSA_SIG_LENGTH_BYTES;
 
-  const pubKeyEncoding = isCompressed(pubKey) ? PubKeyEncoding.Compressed : PubKeyEncoding.Uncompressed;
+  const pubKeyEncoding = isCompressed(pubKey)
+    ? PubKeyEncoding.Compressed
+    : PubKeyEncoding.Uncompressed;
 
   const sigHash = curSigHash + leftPadHex(pubKeyEncoding.toString(16)) + signature.data;
 
-  const sigHashBuffer = Buffer.from(sigHash, 'hex')
+  const sigHashBuffer = Buffer.from(sigHash, 'hex');
   if (sigHashBuffer.byteLength > hashLength) {
     throw Error('Invalid signature hash length');
   }
@@ -421,7 +423,9 @@ export function nextVerification(
 ) {
   const sigHashPreSign = makeSigHashPreSign(initialSigHash, authType, fee, nonce);
 
-  const publicKey = createStacksPublicKey(publicKeyFromSignature(sigHashPreSign, signature, pubKeyEncoding));
+  const publicKey = createStacksPublicKey(
+    publicKeyFromSignature(sigHashPreSign, signature, pubKeyEncoding)
+  );
 
   const nextSigHash = makeSigHashPostSign(sigHashPreSign, publicKey, signature);
 

--- a/packages/transactions/src/builders.ts
+++ b/packages/transactions/src/builders.ts
@@ -1136,7 +1136,7 @@ export async function sponsorTransaction(
         break;
       default:
         throw new Error(
-          `Spnsored transactions not supported for transaction type ${
+          `Sponsored transactions not supported for transaction type ${
             PayloadType[options.transaction.payload.payloadType]
           }`
         );

--- a/packages/transactions/src/keys.ts
+++ b/packages/transactions/src/keys.ts
@@ -60,7 +60,11 @@ export function createStacksPublicKey(key: string): StacksPublicKey {
   };
 }
 
-export function publicKeyFromSignature(message: string, messageSignature: MessageSignature, pubKeyEncoding = PubKeyEncoding.Compressed) {
+export function publicKeyFromSignature(
+  message: string,
+  messageSignature: MessageSignature,
+  pubKeyEncoding = PubKeyEncoding.Compressed
+) {
   const ec = new EC('secp256k1');
   const messageBN = ec.keyFromPrivate(message, 'hex').getPrivate().toString(10);
 

--- a/packages/transactions/src/keys.ts
+++ b/packages/transactions/src/keys.ts
@@ -1,26 +1,27 @@
 import {
+  AddressHashMode,
+  AddressVersion,
   COMPRESSED_PUBKEY_LENGTH_BYTES,
   UNCOMPRESSED_PUBKEY_LENGTH_BYTES,
   StacksMessageType,
-  AddressHashMode,
   TransactionVersion,
+  PubKeyEncoding,
 } from './constants';
 
 import {
   BufferArray,
-  leftPadHexToLength,
-  intToHexString,
-  randomBytes,
   hash160,
   hashP2PKH,
   hexStringToInt,
+  intToHexString,
+  leftPadHexToLength,
+  randomBytes,
 } from './utils';
 
 import { ec as EC } from 'elliptic';
 
 import { MessageSignature, createMessageSignature } from './authorization';
 import { BufferReader } from './bufferReader';
-import { AddressVersion } from './constants';
 import { c32address } from 'c32check';
 import { addressHashModeToVersion, addressFromVersionHash, addressToString } from './types';
 
@@ -59,7 +60,7 @@ export function createStacksPublicKey(key: string): StacksPublicKey {
   };
 }
 
-export function publicKeyFromSignature(message: string, messageSignature: MessageSignature) {
+export function publicKeyFromSignature(message: string, messageSignature: MessageSignature, pubKeyEncoding = PubKeyEncoding.Compressed) {
   const ec = new EC('secp256k1');
   const messageBN = ec.keyFromPrivate(message, 'hex').getPrivate().toString(10);
 
@@ -70,7 +71,11 @@ export function publicKeyFromSignature(message: string, messageSignature: Messag
     parsedSignature,
     parsedSignature.recoveryParam,
     'hex'
-  ) as { encodeCompressed: (enc: string) => string };
+  );
+
+  if (pubKeyEncoding == PubKeyEncoding.Uncompressed) {
+    return publicKey.encode('hex');
+  }
 
   return publicKey.encodeCompressed('hex');
 }

--- a/packages/transactions/tests/keys.test.ts
+++ b/packages/transactions/tests/keys.test.ts
@@ -1,17 +1,22 @@
 import {
-  pubKeyfromPrivKey,
-  publicKeyToString,
-  StacksPublicKey,
-  makeRandomPrivKey,
+  compressPublicKey,
   createStacksPrivateKey,
-  getPublicKey,
-  privateKeyToString,
   getAddressFromPrivateKey,
   getAddressFromPublicKey,
-} from '../src/keys';
+  getPublicKey,
+  makeRandomPrivKey,
+  privateKeyToString,
+  pubKeyfromPrivKey,
+  publicKeyFromSignature,
+  publicKeyToString,
+  signWithKey,
+  StacksPublicKey,
+  PubKeyEncoding,
+  StacksMessageType,
+  TransactionVersion
+} from '../src';
 
 import { serializeDeserialize } from './macros';
-import { StacksMessageType, TransactionVersion } from '../src/constants';
 
 test('Stacks public key and private keys', () => {
   const privKeyString = 'edf9aee84d9b7abc145504dde6726c64f369d37ee34ded868fabd876c26570bc';
@@ -53,4 +58,23 @@ test('Stacks public key and private keys', () => {
   expect(
     getAddressFromPublicKey(Buffer.from(pubKeyString, 'hex'), TransactionVersion.Testnet)
   ).toBe('STZG6BAY4JVR9RNAB1HY92B7Q208ZYY4HZG8ZXFM');
+
+  const compressedPubKey = compressPublicKey(pubKey.data).data.toString('hex');
+  expect(compressedPubKey).toBe('03ef788b3830c00abe8f64f62dc32fc863bc0b2cafeb073b6c8e1c7657d9c2c3ab');
 });
+
+test('Retrieve public key from signature', () => {
+  const privKey = createStacksPrivateKey('edf9aee84d9b7abc145504dde6726c64f369d37ee34ded868fabd876c26570bc');
+  const uncompressedPubKey =
+    '04ef788b3830c00abe8f64f62dc32fc863bc0b2cafeb073b6c8e1c7657d9c2c3ab5b435d20ea91337cdd8c30dd7427bb098a5355e9c9bfad43797899b8137237cf';
+  const compressedPubKey = '03ef788b3830c00abe8f64f62dc32fc863bc0b2cafeb073b6c8e1c7657d9c2c3ab';
+
+  const message = 'hello world';
+  const sig = signWithKey(privKey, message);
+
+  const uncompressedPubKeyFromSig = publicKeyFromSignature(message, sig, PubKeyEncoding.Uncompressed)
+  const compressedPubKeyFromSig = publicKeyFromSignature(message, sig, PubKeyEncoding.Compressed)
+
+  expect(uncompressedPubKeyFromSig).toBe(uncompressedPubKey);
+  expect(compressedPubKeyFromSig).toBe(compressedPubKey);
+})


### PR DESCRIPTION
Issue: #935 

This is a fix for sponsored transaction signing with uncompressed keys.