### PR TITLE
fix(keychain): do not use default import

### DIFF
--- a/packages/keychain/src/nodes/identity-address-owner-node.ts
+++ b/packages/keychain/src/nodes/identity-address-owner-node.ts
@@ -1,7 +1,8 @@
 import { BIP32Interface } from 'bitcoinjs-lib';
 import { publicKeyToAddress, hashSha256Sync, hashCode } from '@stacks/encryption';
+import { fromBase58 } from 'bip32';
+
 import { getAddress } from '../utils';
-import bip32 from 'bip32';
 
 const APPS_NODE_INDEX = 0;
 const SIGNING_NODE_INDEX = 1;
@@ -61,8 +62,7 @@ export default class IdentityAddressOwnerNode {
     const hashBuffer = hashSha256Sync(Buffer.from(`${appDomain}${this.salt}`));
     const hash = hashBuffer.toString('hex');
     const appIndex = hashCode(hash);
-    const appNodeInstance =
-      typeof this.hdNode === 'string' ? bip32.fromBase58(this.hdNode) : this.hdNode;
+    const appNodeInstance = typeof this.hdNode === 'string' ? fromBase58(this.hdNode) : this.hdNode;
     return appNodeInstance.deriveHardened(appIndex);
   }
 


### PR DESCRIPTION
Ran into issues using esm package in Stacks Wallet


```
{moduleIdentifier: "/Users/kyranjamie/dev/hiro/stacks-wallet/app/node_…ain/dist/nodes/identity-address-owner-node.esm.js", moduleName: "./app/node_modules/@stacks/keychain/dist/nodes/identity-address-owner-node.esm.js", loc: "62:60-76", message: "export 'default' (imported as 'bip32') was not fou…mBase58, fromPrivateKey, fromPublicKey, fromSeed)"}
loc: "62:60-76"
message: "export 'default' (imported as 'bip32') was not found in 'bip32' (possible exports: __esModule, fromBase58, fromPrivateKey, fromPublicKey, fromSeed)"
moduleIdentifier: "/Users/kyranjamie/dev/hiro/stacks-wallet/app/node_modules/@stacks/keychain/dist/nodes/identity-address-owner-node.esm.js"
moduleName: "./app/node_modules/@stacks/keychain/dist/nodes/identity-address-owner-node.esm.js"
__proto__: Object
```