### PR TITLE
fix(cli): add typescript as dependency

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -111,6 +111,7 @@
     "node-fetch": "^2.6.0",
     "ripemd160": "^2.0.1",
     "ts-node": "^8.10.2",
+    "typescript": "^4.0.3",
     "winston": "^3.2.1",
     "zone-file": "^0.2.2"
   },


### PR DESCRIPTION
## Description

Add `typescript` as a dependency for `@stacks/cli` to avoid `Error: Cannot find module 'typescript'` when installing and running `@stacks/cli`

The error occurs because `ts-node` has typescript as a `peerDependency`, and peer dependencies are not installed by default in NPM v3-v6. NPM 7 reintroduced the automatic installation of peer dependencies. The issue is no longer present on the latest NPM version. 

fixes #964 #985



## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Testing information

Make sure to run the following on NPM versions `<7`. You can use nvm to switch to node `<15`, which should come with `npm < 7`

1. Go to `packages/cli`
2. run `npm pack`
3. make sure `typescript` is not installed globally (uninstall it if it is)
4. `npm i -g stacks-cli-1.3.4.tgz`
5. run `stx`, it should run correctly without throwing `Error: Cannot find module 'typescript'`