### PR TITLE
fix(cli): support testnet address in convert_address

### DIFF
--- a/packages/cli/src/argparse.ts
+++ b/packages/cli/src/argparse.ts
@@ -416,13 +416,39 @@ export const CLI_ARGS = {
         '\n' +
         '    $ stx convert_address 12qdRgXxgNBNPnDeEChy3fYTbSHQ8nfZfD\n' +
         '    {\n' +
-        '      "STACKS": "SPA2MZWV9N67TBYVWTE0PSSKMJ2F6YXW7CBE6YPW",\n' +
-        '      "BTC": "12qdRgXxgNBNPnDeEChy3fYTbSHQ8nfZfD"\n' +
+        '      "mainnet": {\n' +
+        '        "STACKS": "SPA2MZWV9N67TBYVWTE0PSSKMJ2F6YXW7CBE6YPW",\n' +
+        '        "BTC": "12qdRgXxgNBNPnDeEChy3fYTbSHQ8nfZfD"\n' +
+        '      }\n' +
         '    }\n' +
         '    $ stx convert_address SPA2MZWV9N67TBYVWTE0PSSKMJ2F6YXW7CBE6YPW\n' +
         '    {\n' +
-        '      "STACKS": "SPA2MZWV9N67TBYVWTE0PSSKMJ2F6YXW7CBE6YPW",\n' +
-        '      "BTC": "12qdRgXxgNBNPnDeEChy3fYTbSHQ8nfZfD"\n' +
+        '      "mainnet": {\n' +
+        '        "STACKS": "SPA2MZWV9N67TBYVWTE0PSSKMJ2F6YXW7CBE6YPW",\n' +
+        '        "BTC": "12qdRgXxgNBNPnDeEChy3fYTbSHQ8nfZfD"\n' +
+        '      }\n' +
+        '    }\n' +
+        '    $ stx convert_address SPA2MZWV9N67TBYVWTE0PSSKMJ2F6YXW7CBE6YPW -t\n' +
+        '    {\n' +
+        '      "mainnet": {\n' +
+        '        "STACKS": "SPA2MZWV9N67TBYVWTE0PSSKMJ2F6YXW7CBE6YPW",\n' +
+        '        "BTC": "12qdRgXxgNBNPnDeEChy3fYTbSHQ8nfZfD"\n' +
+        '      },\n' +
+        '      "testnet": {\n' +
+        '        "STACKS": "STA2MZWV9N67TBYVWTE0PSSKMJ2F6YXW7DX96QAM",\n' +
+        '        "BTC": "mhMaijcwVPcdAthFwmgLsaknTRt72GqQYo"\n' +
+        '      }\n' +
+        '    }\n' +
+        '    $ stx convert_address STA2MZWV9N67TBYVWTE0PSSKMJ2F6YXW7DX96QAM\n' +
+        '    {\n' +
+        '      "mainnet": {\n' +
+        '        "STACKS": "SPA2MZWV9N67TBYVWTE0PSSKMJ2F6YXW7CBE6YPW",\n' +
+        '        "BTC": "12qdRgXxgNBNPnDeEChy3fYTbSHQ8nfZfD"\n' +
+        '      },\n' +
+        '      "testnet": {\n' +
+        '        "STACKS": "STA2MZWV9N67TBYVWTE0PSSKMJ2F6YXW7DX96QAM",\n' +
+        '        "BTC": "mhMaijcwVPcdAthFwmgLsaknTRt72GqQYo"\n' +
+        '      }\n' +
         '    }\n',
       group: 'Account Management',
     },

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1915,3 +1915,11 @@ export function CLIMain() {
       });
   }
 }
+
+/* test only exports */
+export const testables =
+  process.env.NODE_ENV === 'test'
+    ? {
+        addressConvert,
+      }
+    : undefined;

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -897,3 +897,8 @@ export function generateExplorerTxPageUrl(txid: string, network: StacksNetwork):
     return `https://explorer.stacks.co/txid/0x${txid}?chain=mainnet`;
   }
 }
+
+export function isTestnetAddress(address: string) {
+  const addressInfo = bitcoinjs.address.fromBase58Check(address);
+  return addressInfo.version === bitcoinjs.networks.testnet.pubKeyHash;
+}

--- a/packages/cli/tests/cli.fixture.ts
+++ b/packages/cli/tests/cli.fixture.ts
@@ -1,0 +1,76 @@
+type ConvertAddressResult = {
+  mainnet: {
+    STACKS: string;
+    BTC: string;
+  };
+  testnet?: {
+    STACKS: string;
+    BTC: string;
+  };
+};
+type ConvertAddressTestData = Array<[string, boolean, ConvertAddressResult]>;
+
+export const convertAddress: ConvertAddressTestData = [
+  [
+    'SP3RBZ4TZ3EK22SZRKGFZYBCKD7WQ5B8FFS0AYVF7', // input
+    false, // testnet (-t)
+    {
+      mainnet: {
+        STACKS: 'SP3RBZ4TZ3EK22SZRKGFZYBCKD7WQ5B8FFS0AYVF7',
+        BTC: '1Nwxfx7VoYAg2mEN35dTRw4H7gte8ajFki',
+      },
+    },
+  ],
+  [
+    '1Nwxfx7VoYAg2mEN35dTRw4H7gte8ajFki', // input
+    false, // testnet (-t)
+    {
+      mainnet: {
+        STACKS: 'SP3RBZ4TZ3EK22SZRKGFZYBCKD7WQ5B8FFS0AYVF7',
+        BTC: '1Nwxfx7VoYAg2mEN35dTRw4H7gte8ajFki',
+      },
+    },
+  ],
+  [
+    'SPA2MZWV9N67TBYVWTE0PSSKMJ2F6YXW7CBE6YPW', // input
+    true, // testnet (-t)
+    {
+      mainnet: {
+        STACKS: 'SPA2MZWV9N67TBYVWTE0PSSKMJ2F6YXW7CBE6YPW',
+        BTC: '12qdRgXxgNBNPnDeEChy3fYTbSHQ8nfZfD',
+      },
+      testnet: {
+        STACKS: 'STA2MZWV9N67TBYVWTE0PSSKMJ2F6YXW7DX96QAM',
+        BTC: 'mhMaijcwVPcdAthFwmgLsaknTRt72GqQYo',
+      },
+    },
+  ],
+  [
+    'STA2MZWV9N67TBYVWTE0PSSKMJ2F6YXW7DX96QAM', // input
+    false, // testnet (-t)
+    {
+      mainnet: {
+        STACKS: 'SPA2MZWV9N67TBYVWTE0PSSKMJ2F6YXW7CBE6YPW',
+        BTC: '12qdRgXxgNBNPnDeEChy3fYTbSHQ8nfZfD',
+      },
+      testnet: {
+        STACKS: 'STA2MZWV9N67TBYVWTE0PSSKMJ2F6YXW7DX96QAM',
+        BTC: 'mhMaijcwVPcdAthFwmgLsaknTRt72GqQYo',
+      },
+    },
+  ],
+  [
+    'mhMaijcwVPcdAthFwmgLsaknTRt72GqQYo', // input
+    false, // testnet (-t)
+    {
+      mainnet: {
+        STACKS: 'SPA2MZWV9N67TBYVWTE0PSSKMJ2F6YXW7CBE6YPW',
+        BTC: '12qdRgXxgNBNPnDeEChy3fYTbSHQ8nfZfD',
+      },
+      testnet: {
+        STACKS: 'STA2MZWV9N67TBYVWTE0PSSKMJ2F6YXW7DX96QAM',
+        BTC: 'mhMaijcwVPcdAthFwmgLsaknTRt72GqQYo',
+      },
+    },
+  ],
+];

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -1,4 +1,25 @@
-test('test', () => {
-  expect(true).toBeTruthy()
-})
+import { testables } from '../src/cli';
+import { getNetwork, CLINetworkAdapter, CLI_NETWORK_OPTS } from '../src/network';
+import { CLI_CONFIG_TYPE } from '../src/argparse';
 
+import * as fixtures from './cli.fixture';
+
+const { addressConvert } = testables as any;
+
+const mainnetNetwork = new CLINetworkAdapter(
+  getNetwork({} as CLI_CONFIG_TYPE, false),
+  {} as CLI_NETWORK_OPTS
+);
+
+const testnetNetwork = new CLINetworkAdapter(
+  getNetwork({} as CLI_CONFIG_TYPE, true),
+  {} as CLI_NETWORK_OPTS
+);
+
+describe('convert_address', () => {
+  test.each(fixtures.convertAddress)('%p - testnet: %p', async (input, testnet, expectedResult) => {
+    const network = testnet ? testnetNetwork : mainnetNetwork;
+    const result = await addressConvert(network, [input]);
+    expect(JSON.parse(result)).toEqual(expectedResult);
+  });
+});


### PR DESCRIPTION
## Description

fixes https://github.com/blockstack/stacks.js/issues/920

For details refer to issue #920

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Testing information

`convert_address` command should convert correctly testnet and mainnet address. 
The output should contain `testnet` property when `-t` arg is passed or if the address is a testnet address


