### PR TITLE
chore: add code coverage report

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -35,7 +35,6 @@ jobs:
       - name: Build
         run: yarn build
       - name: Tests
-        run: yarn lerna run test --stream --parallel -- -- --coverage=false
-      # TODO: setup jest for a lerna monorepo, 
-      # - name: Upload code coverage
-      #   run: yarn lerna run codecovUpload --stream
+        run: yarn lerna run test --stream --parallel -- -- --coverage
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -37,7 +37,6 @@ jobs:
       - name: Build
         run: yarn build
       - name: Tests
-        run: yarn lerna run test --stream --parallel -- -- --coverage=false
-      # TODO: setup jest for a lerna monorepo, 
-      # - name: Upload code coverage
-      #   run: yarn lerna run codecovUpload --stream
+        run: yarn lerna run test --stream --parallel -- -- --coverage
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1


### PR DESCRIPTION
The 16.43% decrease against `master` is not real, since it's not comparing against the current `master` branch, but against [d691c09](https://github.com/blockstack/stacks.js/commit/d691c098f9b37db15253869e59829c597b1cfd0b) (Jan 26).

Once this PR is merged, code coverage should work correctly. Afterwards, I'll add a few tests in another branch, open a PR and we'll know for sure.

As it can be seen [here](https://codecov.io/gh/blockstack/stacks.js/tree/2a67ce119c629103df8471769efc06e004832790/packages) it is picking up correctly coverage reports from `packages/*`

closes #856 