### PR TITLE
PoX address details to BTC address

### DIFF
--- a/packages/stacking/tests/stacking.test.ts
+++ b/packages/stacking/tests/stacking.test.ts
@@ -14,6 +14,8 @@ import {
   trueCV,
   responseErrorCV,
   intCV,
+  TupleCV,
+  ClarityType,
 } from '@stacks/transactions';
 import { address as btcAddress } from 'bitcoinjs-lib';
 import { decodeBtcAddress, getAddressHashMode, InvalidAddressError, poxAddressToBtcAddress } from '../src/utils';
@@ -940,5 +942,26 @@ test('pox address to btc address', () => {
     const decodedAddress = decodeBtcAddress(btcAddress);
     expect(decodedAddress.hashMode).toBe(item.version[0]);
     expect(decodedAddress.data.toString('hex')).toBe(item.hashBytes.toString('hex'));
+  });
+
+  vectors.forEach(item => {
+    const clarityValue: TupleCV = {
+      type: ClarityType.Tuple,
+      data: {
+        version: {
+          type: ClarityType.Buffer,
+          buffer: item.version,
+        },
+        hashbytes: {
+          type: ClarityType.Buffer,
+          buffer: item.hashBytes,
+        },
+      },
+    };
+    const btcAddress = poxAddressToBtcAddress(clarityValue, item.network);
+    expect(btcAddress).toBe(item.expectedBtcAddr);
+    const decodedAddress = decodeBtcAddress(btcAddress);
+    expect(decodedAddress.hashMode).toBe(item.version[0]);
+    expect(decodedAddress.data.toString('hex')).toBe(item.hashBytes.toString('hex')); 
   });
 });


### PR DESCRIPTION
Closes https://github.com/blockstack/stacks.js/issues/1018

Implement a new function in the `@stacks/stacking` lib to convert Clarity PoX address details to a BTC address.

```ts
poxAddressToBtcAddress(version: Buffer, hashBytes: Buffer, network: "mainnet" | "testnet"): string;
```

The function also accepts a `ClarityValue` with the shape `(tuple (hashbytes (buff 20)) (version (buff 1)))`:
```ts
poxAddressToBtcAddress(poxAddrClarityValue: ClarityValue, network: "mainnet" | "testnet"): string;
```

There's an existing function in this lib called `getBTCAddress` which is somewhat misleading, because it expects the `version` argument to be already converted from a STX address version to a BTC address network version, which isn't very obvious given the context in how this lib is used. I'd like to remove it but that would create a breaking change for anything actually using it. 