### PR TITLE
feat: support concrete ClarityValue types

### DIFF
--- a/packages/transactions/src/clarity/clarityValue.ts
+++ b/packages/transactions/src/clarity/clarityValue.ts
@@ -1,7 +1,6 @@
 import { Buffer } from '@stacks/common';
 import {
   BooleanCV,
-  OptionalCV,
   BufferCV,
   IntCV,
   UIntCV,
@@ -13,6 +12,8 @@ import {
   TupleCV,
   StringAsciiCV,
   StringUtf8CV,
+  NoneCV,
+  SomeCV,
 } from '.';
 
 import { principalToString } from './types/principalCV';
@@ -42,7 +43,6 @@ export enum ClarityType {
 
 export type ClarityValue =
   | BooleanCV
-  | OptionalCV
   | BufferCV
   | IntCV
   | UIntCV
@@ -50,6 +50,8 @@ export type ClarityValue =
   | ContractPrincipalCV
   | ResponseErrorCV
   | ResponseOkCV
+  | NoneCV
+  | SomeCV
   | ListCV
   | TupleCV
   | StringAsciiCV

--- a/packages/transactions/src/clarity/types/listCV.ts
+++ b/packages/transactions/src/clarity/types/listCV.ts
@@ -1,11 +1,11 @@
 import { ClarityValue, ClarityType } from '../clarityValue';
 
-interface ListCV {
+interface ListCV<T extends ClarityValue = ClarityValue> {
   type: ClarityType.List;
-  list: ClarityValue[];
+  list: T[];
 }
 
-function listCV<T extends ClarityValue>(values: T[]): ListCV {
+function listCV<T extends ClarityValue = ClarityValue>(values: T[]): ListCV<T> {
   return { type: ClarityType.List, list: values };
 }
 

--- a/packages/transactions/src/clarity/types/optionalCV.ts
+++ b/packages/transactions/src/clarity/types/optionalCV.ts
@@ -1,24 +1,30 @@
 import { ClarityType, ClarityValue } from '../clarityValue';
 
-type OptionalCV = NoneCV | SomeCV;
+type OptionalCV<T extends ClarityValue = ClarityValue> = NoneCV | SomeCV<T>;
 
 interface NoneCV {
   readonly type: ClarityType.OptionalNone;
 }
 
-interface SomeCV {
+interface SomeCV<T extends ClarityValue = ClarityValue> {
   readonly type: ClarityType.OptionalSome;
-  readonly value: ClarityValue;
+  readonly value: T;
 }
 
-const noneCV = (): OptionalCV => ({ type: ClarityType.OptionalNone });
-const someCV = (value: ClarityValue): OptionalCV => ({ type: ClarityType.OptionalSome, value });
-const optionalCVOf = (value?: ClarityValue): OptionalCV => {
+function noneCV(): NoneCV {
+  return { type: ClarityType.OptionalNone };
+}
+
+function someCV<T extends ClarityValue = ClarityValue>(value: T): OptionalCV<T> {
+  return { type: ClarityType.OptionalSome, value };
+}
+
+function optionalCVOf<T extends ClarityValue = ClarityValue>(value?: T): OptionalCV<T> {
   if (value) {
     return someCV(value);
   } else {
     return noneCV();
   }
-};
+}
 
 export { OptionalCV, NoneCV, SomeCV, noneCV, someCV, optionalCVOf };

--- a/packages/transactions/src/clarity/types/responseCV.ts
+++ b/packages/transactions/src/clarity/types/responseCV.ts
@@ -2,21 +2,21 @@ import { ClarityType, ClarityValue } from '../clarityValue';
 
 type ResponseCV = ResponseErrorCV | ResponseOkCV;
 
-interface ResponseErrorCV {
+interface ResponseErrorCV<T extends ClarityValue = ClarityValue> {
   readonly type: ClarityType.ResponseErr;
-  readonly value: ClarityValue;
+  readonly value: T;
 }
 
-interface ResponseOkCV {
+interface ResponseOkCV<T extends ClarityValue = ClarityValue> {
   readonly type: ClarityType.ResponseOk;
-  readonly value: ClarityValue;
+  readonly value: T;
 }
 
-function responseErrorCV(value: ClarityValue): ResponseErrorCV {
+function responseErrorCV<T extends ClarityValue = ClarityValue>(value: T): ResponseErrorCV<T> {
   return { type: ClarityType.ResponseErr, value };
 }
 
-function responseOkCV(value: ClarityValue): ResponseOkCV {
+function responseOkCV<T extends ClarityValue = ClarityValue>(value: T): ResponseOkCV<T> {
   return { type: ClarityType.ResponseOk, value };
 }
 

--- a/packages/transactions/src/clarity/types/tupleCV.ts
+++ b/packages/transactions/src/clarity/types/tupleCV.ts
@@ -1,14 +1,14 @@
 import { ClarityType, ClarityValue } from '../clarityValue';
 import { isClarityName } from '../../utils';
 
-type TupleData = { [key: string]: ClarityValue };
+type TupleData<T extends ClarityValue = ClarityValue> = { [key: string]: T };
 
-interface TupleCV {
+interface TupleCV<T extends TupleData = TupleData> {
   type: ClarityType.Tuple;
-  data: TupleData;
+  data: T;
 }
 
-function tupleCV(data: TupleData): TupleCV {
+function tupleCV<T extends ClarityValue = ClarityValue>(data: TupleData<T>): TupleCV<TupleData<T>> {
   for (const key in data) {
     if (!isClarityName(key)) {
       throw new Error(`"${key}" is not a valid Clarity name`);

--- a/packages/transactions/src/utils.ts
+++ b/packages/transactions/src/utils.ts
@@ -163,9 +163,7 @@ export function cvToHex(cv: ClarityValue) {
  * @param {string} hex - the hex encoded string with or without `0x` prefix
  */
 export function hexToCV(hex: string) {
-  const hexWithoutPrefix = hex.startsWith('0x') ? hex.slice(2) : hex;
-  const bufferCV = Buffer.from(hexWithoutPrefix, 'hex');
-  return deserializeCV(bufferCV);
+  return deserializeCV(hex);
 }
 /**
  * Read only function response object


### PR DESCRIPTION
This PR adds support for passing specific Clarity value types when deserializing or reading data out of an otherwise opaque `ClarityValue` object.

This helps alleviate one of the pain points that myself and others have experienced while trying to extract data from a Clarity value. 

The following example code should be illustrative of what this feature does. This is taken from the BNS namespace parsing code from the API, showing the before and after code:

```ts
// The old way of deserializing without type generics - verbose, hard to read, frustrating to define 🤢
function parseWithManualTypeAssertions() {
  const deserializedCv = deserializeCV(serializedClarityValue);
  const clVal = deserializedCv as TupleCV;
  const namespaceCV = clVal.data['namespace'] as BufferCV;
  const statusCV = clVal.data['status'] as StringAsciiCV;
  const properties = clVal.data['properties'] as TupleCV;
  const launchedAtCV = properties.data['launched-at'] as SomeCV;
  const launchAtIntCV = launchedAtCV.value as UIntCV;
  const lifetimeCV = properties.data['lifetime'] as IntCV;
  const revealedAtCV = properties.data['revealed-at'] as IntCV;
  const addressCV = properties.data[
    'namespace-import'
  ] as StandardPrincipalCV;
  const priceFunction = properties.data['price-function'] as TupleCV;
  const baseCV = priceFunction.data['base'] as IntCV;
  const coeffCV = priceFunction.data['coeff'] as IntCV;
  const noVowelDiscountCV = priceFunction.data['no-vowel-discount'] as IntCV;
  const nonalphaDiscountCV = priceFunction.data['nonalpha-discount'] as IntCV;
  const bucketsCV = priceFunction.data['buckets'] as ListCV;
  const buckets: number[] = [];
  const listCV = bucketsCV.list;
  for (let i = 0; i < listCV.length; i++) {
    const cv = listCV[i] as UIntCV;
    buckets.push(cv.value.toNumber());
  }
  return {
    namespace: namespaceCV.buffer.toString(),
    status: statusCV.data,
    launchedAt: launchAtIntCV.value.toNumber(),
    lifetime: lifetimeCV.value.toNumber(),
    revealedAt: revealedAtCV.value.toNumber(),
    address: addressToString(addressCV.address),
    base: baseCV.value.toNumber(),
    coeff: coeffCV.value.toNumber(),
    noVowelDiscount: noVowelDiscountCV.value.toNumber(),
    nonalphaDiscount: nonalphaDiscountCV.value.toNumber(),
    buckets
  };
}

// The new way of deserializing with type generics 🙂
function parseWithTypeDefinition() {
  // (tuple
  //   (namespace (buff 3)) 
  //   (status (string-ascii 5))
  //   (properties (tuple
  //     (launched-at (optional uint))
  //     (namespace-import principal)
  //     (lifetime uint)
  //     (revealed-at uint)
  //     (price-function (tuple
  //       (base uint) 
  //       (coeff uint)
  //       (no-vowel-discount uint)
  //       (nonalpha-discount uint)
  //       (buckets (list 16 uint))
  // 
  // Easily map the Clarity type string above to the Typescript definition:
  type BnsNamespaceCV = TupleCV<{
    ['namespace']: BufferCV;
    ['status']: StringAsciiCV;
    ['properties']: TupleCV<{
      ['launched-at']: SomeCV<UIntCV>;
      ['namespace-import']: StandardPrincipalCV;
      ['lifetime']: IntCV;
      ['revealed-at']: IntCV;
      ['price-function']: TupleCV<{
        ['base']: IntCV;
        ['coeff']: IntCV;
        ['no-vowel-discount']: IntCV;
        ['nonalpha-discount']: IntCV;
        ['buckets']: ListCV<UIntCV>;
      }>;
    }>;
  }>;
  const cv = deserializeCV<BnsNamespaceCV>(serializedClarityValue);
  // easy, fully-typed access into the Clarity value properties
  const namespaceProps = cv.data.properties.data;
  const priceProps = namespaceProps['price-function'].data;
  return {
    namespace: cv.data.namespace.buffer.toString(),
    status: cv.data.status.data,
    launchedAt: namespaceProps['launched-at'].value.value.toNumber(),
    lifetime: namespaceProps.lifetime.value.toNumber(),
    revealedAt: namespaceProps['revealed-at'].value.toNumber(),
    address: addressToString(namespaceProps['namespace-import'].address),
    base: priceProps.base.value.toNumber(),
    coeff: priceProps.coeff.value.toNumber(),
    noVowelDiscount: priceProps['no-vowel-discount'].value.toNumber(),
    nonalphaDiscount: priceProps['nonalpha-discount'].value.toNumber(),
    buckets: priceProps.buckets.list.map(b => b.value.toNumber()),
  };
}
```