### PR TITLE
fix: make `lookupProfile` work with newest stacks API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "stacks.js",
 			"version": "1.4.1",
 			"workspaces": [
 				"packages/**"
@@ -16063,6 +16064,7 @@
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.6.tgz",
 			"integrity": "sha512-FmqJZGduTyvsr2cF3375fqGHUovSwDi/QytexX1Se4BPuPZpTE5Ftp5fg+EFSuEf3lhZqgCRjEG3ydUQ/aNiwA==",
+			"hasInstallScript": true,
 			"dependencies": {
 				"bindings": "^1.3.0",
 				"bn.js": "^4.11.8",
@@ -18161,9 +18163,8 @@
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@stacks/common": "^2.0.0-beta.0",
-				"@stacks/encryption": "^2.0.0-beta.0",
 				"@stacks/network": "^1.2.2",
-				"bitcoinjs-lib": "^5.2.0",
+				"@stacks/transactions": "^2.0.0-beta.0",
 				"jsontokens": "^3.0.0",
 				"schema-inspector": "^2.0.1",
 				"zone-file": "^1.0.0"
@@ -21803,10 +21804,9 @@
 			"version": "file:packages/profile",
 			"requires": {
 				"@stacks/common": "^2.0.0-beta.0",
-				"@stacks/encryption": "^2.0.0-beta.0",
 				"@stacks/network": "^1.2.2",
+				"@stacks/transactions": "^2.0.0-beta.0",
 				"@types/jest": "^26.0.22",
-				"bitcoinjs-lib": "^5.2.0",
 				"jest": "^26.6.3",
 				"jest-fetch-mock": "^3.0.3",
 				"jest-module-name-mapper": "^0.1.5",

--- a/packages/auth/tests/auth.test.ts
+++ b/packages/auth/tests/auth.test.ts
@@ -499,7 +499,7 @@ test('profileLookUp', async () => {
   const mockZonefile = {
     zonefile:
       '$ORIGIN ryan.id\n$TTL 3600\n_http._tcp IN URI 10 1 "https://blockstack.s3.amazonaws.com/ryan.id"\n',
-    address: '19MoWG8u88L6t766j7Vne21Mg4wHsCQ7vk',
+    address: 'SP3AMDH2ZZB8XQK467V9HV5CRQF2RPBZ4MDMSBHJZ',
   };
 
   fetchMock

--- a/packages/profile/package.json
+++ b/packages/profile/package.json
@@ -36,9 +36,8 @@
   },
   "dependencies": {
     "@stacks/common": "^2.0.0-beta.0",
-    "@stacks/encryption": "^2.0.0-beta.0",
     "@stacks/network": "^1.2.2",
-    "bitcoinjs-lib": "^5.2.0",
+    "@stacks/transactions": "^2.0.0-beta.0",
     "jsontokens": "^3.0.0",
     "schema-inspector": "^2.0.1",
     "zone-file": "^1.0.0"

--- a/packages/profile/src/profileTokens.ts
+++ b/packages/profile/src/profileTokens.ts
@@ -1,9 +1,7 @@
-import { Buffer } from '@stacks/common';
-import { ECPair } from 'bitcoinjs-lib';
 import { decodeToken, SECP256K1Client, TokenSigner, TokenVerifier } from 'jsontokens';
 import { TokenInterface } from 'jsontokens/lib/decode';
 import { nextYear, makeUUID4 } from '@stacks/common';
-import { ecPairToAddress } from '@stacks/encryption';
+import { getAddressFromPublicKey } from '@stacks/transactions';
 
 /**
  * Signs a profile token
@@ -105,18 +103,11 @@ export function verifyProfileToken(token: string, publicKeyOrAddress: string): T
   }
 
   const issuerPublicKey = (payload.issuer as Record<string, string>).publicKey;
-  const publicKeyBuffer = Buffer.from(issuerPublicKey, 'hex');
-
-  const compressedKeyPair = ECPair.fromPublicKey(publicKeyBuffer, { compressed: true });
-  const compressedAddress = ecPairToAddress(compressedKeyPair);
-  const uncompressedKeyPair = ECPair.fromPublicKey(publicKeyBuffer, { compressed: false });
-  const uncompressedAddress = ecPairToAddress(uncompressedKeyPair);
+  const address = getAddressFromPublicKey(issuerPublicKey);
 
   if (publicKeyOrAddress === issuerPublicKey) {
     // pass
-  } else if (publicKeyOrAddress === compressedAddress) {
-    // pass
-  } else if (publicKeyOrAddress === uncompressedAddress) {
+  } else if (publicKeyOrAddress === address) {
     // pass
   } else {
     throw new Error('Token issuer public key does not match the verifying value');

--- a/packages/profile/tests/schema.test.ts
+++ b/packages/profile/tests/schema.test.ts
@@ -98,7 +98,7 @@ test('legacyFormat', () => {
 
 test('resolveZoneFileToPerson', () => {
   const zoneFile = '$ORIGIN ryan.id\n$TTL 3600\n_http._tcp IN URI 10 1 "https://blockstack.s3.amazonaws.com/ryan.id"\n'
-  const ownerAddress = '19MoWG8u88L6t766j7Vne21Mg4wHsCQ7vk'
+  const ownerAddress = 'SP3AMDH2ZZB8XQK467V9HV5CRQF2RPBZ4MDMSBHJZ'
   fetchMock.once(JSON.stringify(sampleTokenFiles.ryan.body))
 
   resolveZoneFileToPerson(zoneFile, ownerAddress, (profile) => {

--- a/packages/profile/tests/verifyToken.test.ts
+++ b/packages/profile/tests/verifyToken.test.ts
@@ -8,16 +8,12 @@ const tokenFile = sampleTokenFiles.ryan_apr20.body
 const token = tokenFile[0].token
 
 const publicKey = '02413d7c51118104cfe1b41e540b6c2acaaf91f1e2e22316df7448fb6070d582ec'
-const compressedAddress = '1BTku19roxQs2d54kbYKVTv21oBCuHEApF'
-const uncompressedAddress = '12wes6TQpDF2j8zqvAbXV9KNCGQVF2y7G5'
+const address = 'SPAMWCETADJ9R8D0BXVJKKN3NDMNZ517JSGAG6YX'
 
 test('verifyToken', () => {
   const decodedToken1 = verifyProfileToken(token, publicKey)
   expect(decodedToken1).toBeTruthy()
 
-  const decodedToken2 = verifyProfileToken(token, compressedAddress)
+  const decodedToken2 = verifyProfileToken(token, address)
   expect(decodedToken2).toBeTruthy()
-
-  const decodedToken3 = verifyProfileToken(token, uncompressedAddress)
-  expect(decodedToken3).toBeTruthy()
 })

--- a/packages/profile/tsconfig.build.json
+++ b/packages/profile/tsconfig.build.json
@@ -12,10 +12,10 @@
       "path": "../common/tsconfig.build.json"
     },
     {
-      "path": "../encryption/tsconfig.build.json"
+      "path": "../network/tsconfig.build.json"
     },
     {
-      "path": "../network/tsconfig.build.json"
+      "path": "../transactions/tsconfig.build.json"
     }
   ],
   "include": ["src/**/*"]

--- a/packages/storage/tests/storage.test.ts
+++ b/packages/storage/tests/storage.test.ts
@@ -339,7 +339,7 @@ test('getFile unencrypted, unsigned - multi-reader', async () => {
     expire_block: 581432,
     blockchain: 'bitcoin',
     last_txid: 'f7fa811518566b1914a098c3bd61a810aee56390815bd608490b0860ac1b5b4d',
-    address: '16zVUoP7f15nfTiHw2UNiX8NT5SWYqwNv3',
+    address: 'SP10VG75GE4PE0VBA3KD3NVKSYEMM3YV9V17HJ32N',
     zonefile_hash: '98f42e11026d42d394b3424d4d7f0cccd6f376e2',
   };
   const nameRecordContent = JSON.stringify(nameRecord);


### PR DESCRIPTION
## Description

In the latest version of the SDK, `lookupProfile` is throwing an error when you call it to query old or new usernames.

I faced this issue when migrating Sigle to the newest SDK version.

- the old SDK version is calling https://core.blockstack.org/v1/names/sigleapp.id.blockstack that returns the `address` field as a BTC address
- the new SDK version is calling https://stacks-node-api.mainnet.stacks.co/v1/names/sigleapp.id.blockstack returns the `address` field as a STX address

When you call `lookupProfile`, internally the `verifyProfileToken` function is called.
If you take a look here https://github.com/blockstack/stacks.js/blob/626c5fccb4dff213f000923ab69c7ed4f5eb48a0/packages/profile/src/profileTokens.ts#L115-L123
`publicKeyOrAddress` is the STX address returned by the new API and we compare it with the BTC address that we got from the public key so the check is failing.

For details refer to issue https://github.com/blockstack/stacks.js/issues/1016

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?

There is a breaking change in the `verifyProfileToken` function only if a user uses it directly. By looking at the code it looks like `lookupProfile` is the only part where it is called.

## Testing information

I tested this patch directly into the Sigle codebase and it solved the issue that I am facing.
