### PR TITLE
fix: fix #1026 [BNS] Incorrect optional argument encoding

### DIFF
--- a/packages/bns/src/index.ts
+++ b/packages/bns/src/index.ts
@@ -15,6 +15,8 @@ import {
   ResponseErrorCV,
   StacksTransaction,
   standardPrincipalCV,
+  someCV,
+  noneCV,
   UnsignedContractCallOptions,
 } from '@stacks/transactions';
 
@@ -677,12 +679,9 @@ export async function buildTransferNameTx({
   const functionArgs = [
     bufferCVFromString(namespace),
     bufferCVFromString(name),
-    bufferCVFromString(newOwnerAddress),
+    standardPrincipalCV(newOwnerAddress),
+    zonefile ? someCV(bufferCV(getZonefileHash(zonefile))): noneCV()
   ];
-
-  if (zonefile) {
-    functionArgs.push(bufferCV(getZonefileHash(zonefile)));
-  }
 
   return makeBnsContractCall({
     functionName: bnsFunctionName,
@@ -784,16 +783,9 @@ export async function buildRenewNameTx({
     bufferCVFromString(namespace),
     bufferCVFromString(name),
     uintCVFromBN(stxToBurn),
+    newOwnerAddress ? someCV(standardPrincipalCV(newOwnerAddress)) : noneCV(),
+    zonefile ? someCV(bufferCV(getZonefileHash(zonefile))): noneCV()
   ];
-
-  if (newOwnerAddress) {
-    functionArgs.push(bufferCVFromString(newOwnerAddress));
-  }
-
-  if (zonefile) {
-    const zonefileHash = getZonefileHash(zonefile);
-    functionArgs.push(bufferCV(zonefileHash));
-  }
 
   return makeBnsContractCall({
     functionName: bnsFunctionName,

--- a/packages/bns/tests/bns.test.ts
+++ b/packages/bns/tests/bns.test.ts
@@ -9,7 +9,8 @@ import {
   bufferCV,
   hash160,
   standardPrincipalCV,
-  AnchorMode,
+  noneCV,
+  AnchorMode, someCV,
 } from '@stacks/transactions';
 
 import {
@@ -725,6 +726,8 @@ test('transferName', async () => {
   jest.mock('@stacks/transactions', () => ({
     makeUnsignedContractCall,
     bufferCV: jest.requireActual('@stacks/transactions').bufferCV,
+    someCV: jest.requireActual('@stacks/transactions').someCV,
+    standardPrincipalCV: jest.requireActual('@stacks/transactions').standardPrincipalCV,
     hash160: jest.requireActual('@stacks/transactions').hash160,
     AnchorMode: jest.requireActual('@stacks/transactions').AnchorMode,
   }));
@@ -749,8 +752,60 @@ test('transferName', async () => {
     functionArgs: [
       bufferCVFromString(namespace),
       bufferCVFromString(name),
-      bufferCVFromString(newOwnerAddress),
-      bufferCV(getZonefileHash(zonefile)),
+      standardPrincipalCV(newOwnerAddress),
+      someCV(bufferCV(getZonefileHash(zonefile))),
+    ],
+    publicKey,
+    network,
+    validateWithAbi: false,
+    anchorMode: AnchorMode.Any,
+  };
+
+  expect(makeUnsignedContractCall).toHaveBeenCalledTimes(1);
+  expect(makeUnsignedContractCall).toHaveBeenCalledWith(expectedBNSContractCallOptions);
+});
+
+test('transferName optionalArguments', async () => {
+  const fullyQualifiedName = 'test.id';
+  const newOwnerAddress = 'SPF0324DSC4K505TP6A8C7GAK4R95E38TGNZP7RE';
+  const zonefile = undefined;
+  const publicKey = '03ef788b3830c00abe8f64f62dc32fc863bc0b2cafeb073b6c8e1c7657d9c2c3ab';
+
+  const makeUnsignedContractCall = jest.fn().mockResolvedValue({});
+
+  const network = new StacksTestnet();
+
+  jest.mock('@stacks/transactions', () => ({
+    makeUnsignedContractCall,
+    bufferCV: jest.requireActual('@stacks/transactions').bufferCV,
+    noneCV: jest.requireActual('@stacks/transactions').noneCV,
+    standardPrincipalCV: jest.requireActual('@stacks/transactions').standardPrincipalCV,
+    hash160: jest.requireActual('@stacks/transactions').hash160,
+    AnchorMode: jest.requireActual('@stacks/transactions').AnchorMode,
+  }));
+
+  const { buildTransferNameTx } = require('../src');
+  await buildTransferNameTx({
+    fullyQualifiedName,
+    newOwnerAddress,
+    publicKey,
+    zonefile,
+    network
+  });
+
+  const bnsFunctionName = 'name-transfer';
+
+  const { namespace, name } = decodeFQN(fullyQualifiedName);
+
+  const expectedBNSContractCallOptions = {
+    contractAddress: BnsContractAddress.testnet,
+    contractName: BNS_CONTRACT_NAME,
+    functionName: bnsFunctionName,
+    functionArgs: [
+      bufferCVFromString(namespace),
+      bufferCVFromString(name),
+      standardPrincipalCV(newOwnerAddress),
+      noneCV(),
     ],
     publicKey,
     network,
@@ -820,6 +875,8 @@ test('renewName', async () => {
   jest.mock('@stacks/transactions', () => ({
     makeUnsignedContractCall,
     bufferCV: jest.requireActual('@stacks/transactions').bufferCV,
+    someCV: jest.requireActual('@stacks/transactions').someCV,
+    standardPrincipalCV: jest.requireActual('@stacks/transactions').standardPrincipalCV,
     uintCV: jest.requireActual('@stacks/transactions').uintCV,
     hash160: jest.requireActual('@stacks/transactions').hash160,
     AnchorMode: jest.requireActual('@stacks/transactions').AnchorMode,
@@ -847,8 +904,63 @@ test('renewName', async () => {
       bufferCVFromString(namespace),
       bufferCVFromString(name),
       uintCVFromBN(stxToBurn),
-      bufferCVFromString(newOwnerAddress),
-      bufferCV(getZonefileHash(zonefile))
+      someCV(standardPrincipalCV(newOwnerAddress)),
+      someCV(bufferCV(getZonefileHash(zonefile)))
+    ],
+    publicKey,
+    network,
+    validateWithAbi: false,
+    anchorMode: AnchorMode.Any,
+  };
+
+  expect(makeUnsignedContractCall).toHaveBeenCalledTimes(1);
+  expect(makeUnsignedContractCall).toHaveBeenCalledWith(expectedBNSContractCallOptions);
+});
+
+test('renewName optionalArguments', async () => {
+  const fullyQualifiedName = 'test.id';
+  const stxToBurn = new BN(10);
+  const newOwnerAddress = undefined;
+  const zonefile = undefined;
+  const publicKey = '03ef788b3830c00abe8f64f62dc32fc863bc0b2cafeb073b6c8e1c7657d9c2c3ab';
+
+  const makeUnsignedContractCall = jest.fn().mockResolvedValue({});
+
+  const network = new StacksTestnet();
+
+  jest.mock('@stacks/transactions', () => ({
+    makeUnsignedContractCall,
+    bufferCV: jest.requireActual('@stacks/transactions').bufferCV,
+    noneCV: jest.requireActual('@stacks/transactions').noneCV,
+    uintCV: jest.requireActual('@stacks/transactions').uintCV,
+    hash160: jest.requireActual('@stacks/transactions').hash160,
+    AnchorMode: jest.requireActual('@stacks/transactions').AnchorMode,
+  }));
+
+  const { buildRenewNameTx } = require('../src');
+  await buildRenewNameTx({
+    fullyQualifiedName,
+    stxToBurn,
+    newOwnerAddress,
+    zonefile,
+    publicKey,
+    network
+  });
+
+  const bnsFunctionName = 'name-renewal';
+
+  const { namespace, name } = decodeFQN(fullyQualifiedName);
+
+  const expectedBNSContractCallOptions = {
+    contractAddress: BnsContractAddress.testnet,
+    contractName: BNS_CONTRACT_NAME,
+    functionName: bnsFunctionName,
+    functionArgs: [
+      bufferCVFromString(namespace),
+      bufferCVFromString(name),
+      uintCVFromBN(stxToBurn),
+      noneCV(),
+      noneCV()
     ],
     publicKey,
     network,


### PR DESCRIPTION
## Description
This PR fixes the issue of optional argument encoding in BNS package in `buildTransferNameTx` and `buildRenewNameTx` functions. The onwerAddress and zonefile parameters are incorrectly encoded which results in the created transactions being rejected (either not enough arguments, or a TypeError is thrown because the optional arguments are of the wrong type)
Below is the script to reproduce the issue
```
void (async () => {
  const fullyQualifiedName = 'test.id';
  const newOwnerAddress = '<Owner address>';
  const pk = '<private key>';
  const zonefile = 'zonefile';
  const publicKey = publicKeyToString(pubKeyfromPrivKey(pk));
  const network = new StacksTestnet();
  const unsignedTransaction = await buildTransferNameTx({
    fullyQualifiedName,
    newOwnerAddress,
    publicKey,
    zonefile,
    network
  });
  const signer = new TransactionSigner(unsignedTransaction);
  signer.signOrigin(createStacksPrivateKey(pk));
  const reply: TxBroadcastResult = await broadcastTransaction(
      signer.transaction,
      network
  );
  console.log(reply);
})();
// This will result in TypeError and transaction will be rejected.
```

For details refer to issue #1026 

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No breaking changes. 

## Are documentation updates required?
No

## Testing information
The existing test cases related to `buildTransferNameTx` and  `buildRenewNameTx` are updated to include the optional types. And two new test cases are added to test the optional type parameters particularly. This change can be seen in BNS test cases in this PR. 

Steps to test
1. Run `npm run test` inside BNS package to test changes
2. Other way of testing this pr is making the contract calls to `buildTransferNameTx` and `buildRenewNameTx` using the script mentioned in the aforementioned script in the description section 

## Checklist
- [ ] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @yknl or @zone117x for review
