### PR TITLE
Fix/1033

### DIFF
--- a/packages/common/src/errors.ts
+++ b/packages/common/src/errors.ts
@@ -57,8 +57,8 @@ export class BlockstackError extends Error {
     } else {
       bugDetails += `Stack Trace:\n${stack}`;
     }
-    message += `\nIf you believe this exception is caused by a bug in blockstack.js,
-      please file a bug report: https://github.com/blockstack/blockstack.js/issues\n\n${bugDetails}`;
+    message += `\nIf you believe this exception is caused by a bug in stacks.js,
+      please file a bug report: https://github.com/blockstack/stacks.js/issues\n\n${bugDetails}`;
     this.message = message;
     this.code = error.code;
     this.parameter = error.parameter ? error.parameter : undefined;

--- a/packages/transactions/src/clarity/clarityValue.ts
+++ b/packages/transactions/src/clarity/clarityValue.ts
@@ -171,7 +171,7 @@ export function getCVTypeString(val: ClarityValue): string {
     case ClarityType.PrincipalContract:
       return 'principal';
     case ClarityType.List:
-      return `(list ${val.list.length} ${getCVTypeString(val.list[0])})`;
+      return `(list ${val.list.length} ${val.list.length ? getCVTypeString(val.list[0]) : "UnknownType"})`;
     case ClarityType.Tuple:
       return `(tuple ${Object.keys(val.data)
         .map(key => `(${key} ${getCVTypeString(val.data[key])})`)

--- a/packages/transactions/src/clarity/clarityValue.ts
+++ b/packages/transactions/src/clarity/clarityValue.ts
@@ -171,7 +171,9 @@ export function getCVTypeString(val: ClarityValue): string {
     case ClarityType.PrincipalContract:
       return 'principal';
     case ClarityType.List:
-      return `(list ${val.list.length} ${val.list.length ? getCVTypeString(val.list[0]) : "UnknownType"})`;
+      return `(list ${val.list.length} ${
+        val.list.length ? getCVTypeString(val.list[0]) : 'UnknownType'
+      })`;
     case ClarityType.Tuple:
       return `(tuple ${Object.keys(val.data)
         .map(key => `(${key} ${getCVTypeString(val.data[key])})`)

--- a/packages/transactions/tests/clarity.test.ts
+++ b/packages/transactions/tests/clarity.test.ts
@@ -32,7 +32,7 @@ import {
   StandardPrincipalCV,
 } from '../src/clarity';
 import { BufferReader } from '../src/bufferReader';
-import { cvToString, cvToJSON } from '../src/clarity/clarityValue';
+import { cvToString, cvToJSON, getCVTypeString } from '../src/clarity/clarityValue';
 
 const ADDRESS = 'SP2JXKMSH007NPYAQHKJPQMAQYAD90NQGTVJVQ02B';
 
@@ -545,4 +545,48 @@ describe('Clarity Types', () => {
       );
     });
   });
+
+  describe('Clarity Types to String', () => {
+    test('Complex Tuple', () => {
+      const tuple = tupleCV({
+        a: intCV(-1),
+        b: uintCV(1),
+        c: bufferCV(Buffer.from('test')),
+        d: trueCV(),
+        e: someCV(trueCV()),
+        f: noneCV(),
+        g: standardPrincipalCV(ADDRESS),
+        h: contractPrincipalCV(ADDRESS, 'test'),
+        i: responseOkCV(trueCV()),
+        j: responseErrorCV(falseCV()),
+        k: listCV([trueCV(), falseCV()]),
+        l: tupleCV({
+          a: trueCV(),
+          b: falseCV(),
+        }),
+        m: stringAsciiCV('hello world'),
+        n: stringUtf8CV('hello \u{1234}'),
+        o: listCV([])
+      });
+      const typeString = getCVTypeString(tuple)
+      expect(typeString).toEqual(oneLineTrim`
+      (tuple 
+        (a int) 
+        (b uint) 
+        (c (buff 4)) 
+        (d bool) 
+        (e (optional bool)) 
+        (f (optional none)) 
+        (g principal) 
+        (h principal) 
+        (i (response bool UnknownType)) 
+        (j (response UnknownType bool)) 
+        (k (list 2 bool)) 
+        (l (tuple (a bool) (b bool))) 
+        (m (string-ascii 11)) 
+        (n (string-utf8 9)) 
+        (o (list 0 UnknownType)))
+      `)
+    })
+  })
 });


### PR DESCRIPTION
## Description
This PR 
* adds handling of empty list clarity values in `getCVTypeString
* fixes #1033 
* replaces blockstack.js by stacks.js in error message

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [x] Tag 1 of @yknl or @zone117x for review
