### PR TITLE
Add reward methods for set address in stacking

### DIFF
--- a/packages/network/src/index.ts
+++ b/packages/network/src/index.ts
@@ -23,6 +23,9 @@ export interface StacksNetwork {
   getInfoUrl: () => string;
   getBlockTimeInfoUrl: () => string;
   getPoxInfoUrl: () => string;
+  getRewardsUrl: (address: string, options?: any) => string;
+  getRewardHoldersUrl: (address: string, options?: any) => string;
+  getRewardsTotalUrl: (address: string) => string;
   getStackerInfoUrl: (contractAddress: string, contractName: string) => string;
 
   /**
@@ -65,6 +68,22 @@ export class StacksMainnet implements StacksNetwork {
   getInfoUrl = () => `${this.coreApiUrl}/v2/info`;
   getBlockTimeInfoUrl = () => `${this.coreApiUrl}/extended/v1/info/network_block_times`;
   getPoxInfoUrl = () => `${this.coreApiUrl}/v2/pox`;
+  getRewardsUrl = (address: string, options?: any) => {
+    let url = `${this.coreApiUrl}/extended/v1/burnchain/rewards/${address}`;
+    if (options) {
+      url = `${url}?limit=${options.limit}&offset=${options.offset}`;
+    }
+    return url;
+  };
+  getRewardsTotalUrl = (address: string) =>
+    `${this.coreApiUrl}/extended/v1/burnchain/rewards/${address}/total`;
+  getRewardHoldersUrl = (address: string, options?: any) => {
+    let url = `${this.coreApiUrl}/extended/v1/burnchain/reward_slot_holders/${address}`;
+    if (options) {
+      url = `${url}?limit=${options.limit}&offset=${options.offset}`;
+    }
+    return url;
+  };
   getStackerInfoUrl = (contractAddress: string, contractName: string) =>
     `${this.coreApiUrl}${this.readOnlyFunctionCallEndpoint}
     ${contractAddress}/${contractName}/get-stacker-info`;

--- a/packages/stacking/package.json
+++ b/packages/stacking/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@stacks/common": "^2.0.0-beta.0",
     "@stacks/network": "^1.2.2",
+    "@stacks/stacks-blockchain-api-types": "^0.61.0",
     "@stacks/transactions": "^2.0.0-beta.1",
     "@types/bn.js": "^4.11.6",
     "bitcoinjs-lib": "^5.2.0",

--- a/packages/stacking/src/index.ts
+++ b/packages/stacking/src/index.ts
@@ -23,6 +23,11 @@ import {
   validateStacksAddress,
   AnchorMode,
 } from '@stacks/transactions';
+import {
+  BurnchainRewardListResponse,
+  BurnchainRewardsTotal,
+  BurnchainRewardSlotHolderListResponse,
+} from '@stacks/stacks-blockchain-api-types';
 import { StacksNetwork } from '@stacks/network';
 import BN from 'bn.js';
 import { StackingErrors } from './constants';
@@ -76,6 +81,15 @@ export interface CoreInfo {
 export interface BalanceInfo {
   balance: string;
   nonce: number;
+}
+
+export interface RewardsError {
+  error: string;
+}
+
+export interface RewardOptions {
+  limit: number;
+  offset: number;
 }
 
 export interface StackingEligibility {
@@ -228,6 +242,40 @@ export class StackingClient {
         return poxInfo.reward_cycle_length * targetBlockTime;
       }
     );
+  }
+
+  /**
+   * Get the total burnchain rewards total for the set address
+   *
+   * @returns {Promise<TotalRewardsResponse | RewardsError>} that resolves to TotalRewardsResponse or RewardsError
+   */
+  async getRewardsTotalForBtcAddress(): Promise<BurnchainRewardsTotal | RewardsError> {
+    const url = this.network.getRewardsTotalUrl(this.address);
+    return fetchPrivate(url).then(res => res.json());
+  }
+
+  /**
+   * Get burnchain rewards for the set address
+   *
+   * @returns {Promise<RewardsResponse | RewardsError>} that resolves to RewardsResponse or RewardsError
+   */
+  async getRewardsForBtcAddress(
+    options?: RewardOptions
+  ): Promise<BurnchainRewardListResponse | RewardsError> {
+    const url = `${this.network.getRewardsUrl(this.address, options)}`;
+    return fetchPrivate(url).then(res => res.json());
+  }
+
+  /**
+   * Get burnchain rewards holders for the set address
+   *
+   * @returns {Promise<RewardHoldersResponse | RewardsError>} that resolves to RewardHoldersResponse or RewardsError
+   */
+  async getRewardHoldersForBtcAddress(
+    options?: RewardOptions
+  ): Promise<BurnchainRewardSlotHolderListResponse | RewardsError> {
+    const url = `${this.network.getRewardHoldersUrl(this.address, options)}`;
+    return fetchPrivate(url).then(res => res.json());
   }
 
   /**

--- a/packages/stacking/tests/stacking.test.ts
+++ b/packages/stacking/tests/stacking.test.ts
@@ -61,6 +61,58 @@ const coreInfo = {
   "exit_at_block_height": null
 }
 
+const rewardsTotalInfo = {
+  reward_recipient: 'myfTfju9XSMRusaY2qTitSEMSchsWRA441',
+  reward_amount: '450000'
+};
+
+const rewardsInfo = {
+  limit: 2,
+  offset: 0,
+  results: [
+    {
+      canonical: true,
+      burn_block_hash: '0x000000000000002083ca8303a2262d09a824cecb34b78f13a04787e4f05441d3',
+      burn_block_height: 2004622,
+      burn_amount: '0',
+      reward_recipient: 'myfTfju9XSMRusaY2qTitSEMSchsWRA441',
+      reward_amount: '20000',
+      reward_index: 0
+    },
+    {
+      canonical: true,
+      burn_block_hash: '0x000000000000002f72213de621f9daf60d76aed3902a811561d06373b2fa6123',
+      burn_block_height: 2004621,
+      burn_amount: '0',
+      reward_recipient: 'myfTfju9XSMRusaY2qTitSEMSchsWRA441',
+      reward_amount: '20000',
+      reward_index: 0
+    }
+  ]
+};
+
+const rewardHoldersInfo = {
+  limit: 2,
+  offset: 0,
+  total: 46,
+  results: [
+    {
+      canonical: true,
+      burn_block_hash: '0x000000000000002083ca8303a2262d09a824cecb34b78f13a04787e4f05441d3',
+      burn_block_height: 2004622,
+      address: 'myfTfju9XSMRusaY2qTitSEMSchsWRA441',
+      slot_index: 1
+    },
+    {
+      canonical: true,
+      burn_block_hash: '0x000000000000002083ca8303a2262d09a824cecb34b78f13a04787e4f05441d3',
+      burn_block_height: 2004622,
+      address: 'myfTfju9XSMRusaY2qTitSEMSchsWRA441',
+      slot_index: 0
+    }
+  ]
+};
+
 const blocktimeInfo = {
   testnet: {
     target_block_time: 120
@@ -803,6 +855,66 @@ test('get pox info', async () => {
   expect(fetchMock.mock.calls[0][0]).toEqual(network.getPoxInfoUrl());
   expect(responsePoxInfo).toEqual(poxInfo);
 })
+
+test('get a list of burnchain rewards for the set address', async () => {
+  const address = 'myfTfju9XSMRusaY2qTitSEMSchsWRA441';
+  const network = new StacksTestnet();
+
+  fetchMock.mockResponse(() => {
+    return Promise.resolve({
+      body: JSON.stringify(rewardsInfo),
+      status: 200
+    })
+  })
+
+  const { StackingClient } = require('../src');
+  const client = new StackingClient(address, network);
+  const options = {limit: 2, offset: 0};
+  const response = await client.getRewardsForBtcAddress(options);
+
+  expect(fetchMock.mock.calls[0][0]).toEqual(network.getRewardsUrl(address, options));
+  expect(response).toEqual(rewardsInfo);
+});
+
+test('get the burnchain rewards total for the set address', async () => {
+  const address = 'myfTfju9XSMRusaY2qTitSEMSchsWRA441';
+  const network = new StacksTestnet();
+
+  fetchMock.mockResponse(() => {
+    return Promise.resolve({
+      body: JSON.stringify(rewardsTotalInfo),
+      status: 200
+    })
+  });
+
+  const { StackingClient } = require('../src');
+  const client = new StackingClient(address, network);
+  const response = await client.getRewardsTotalForBtcAddress();
+
+  expect(fetchMock.mock.calls[0][0]).toEqual(network.getRewardsTotalUrl(address));
+  expect(response).toEqual(rewardsTotalInfo);
+});
+
+test('get a list of burnchain reward holders for the set address ', async () => {
+  const address = 'myfTfju9XSMRusaY2qTitSEMSchsWRA441';
+  const network = new StacksTestnet();
+
+  fetchMock.mockResponse(() => {
+    return Promise.resolve({
+      body: JSON.stringify(rewardHoldersInfo),
+      status: 200
+    })
+  })
+
+  const { StackingClient } = require('../src');
+  const client = new StackingClient(address, network);
+  const options = {limit: 2, offset: 0};
+  const response = await client.getRewardHoldersForBtcAddress(options);
+
+  expect(fetchMock.mock.calls[0][0]).toEqual(network.getRewardHoldersUrl(address, options));
+  expect(response).toEqual(rewardHoldersInfo);
+});
+
 
 test('get target block time info', async () => {
   const address = 'ST3XKKN4RPV69NN1PHFDNX3TYKXT7XPC4N8KC1ARH';


### PR DESCRIPTION
## Description
This PR introduces following new methods in stacking package:
* `getRewardsForBtcAddress`
* `getRewardsTotalForBtcAddress`
* `getRewardHoldersForBtcAddress`

The stacking library can provide methods to get the rewards for a set address as the API returns burnchain rewards now: Reference: https://blockstack.github.io/stacks-blockchain-api/#tag/Burnchain.

This pull request closes the issue #929

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No breaking changes. 

## Are documentation updates required?
No

## Testing information
The test cases related to aforementioned functions are included in the pull request. This change can be seen in stacking test cases in this PR.

Steps to test
1. Run `npm run test` inside stacking package to test changes
2. Other way of testing this pull request is by calling the  aforementioned functions using the script.
Here is the sample script:
```
import { StackingClient } from './stacks.js/packages/stacking';
import {
  StacksTestnet
} from './stacks.js/packages/network';

void (async () => {
  const network = new StacksTestnet();
  const address = 'myfTfju9XSMRusaY2qTitSEMSchsWRA441';
  const client = new StackingClient(address, network);
  const rewards = await client.getRewardsForBtcAddress();
  const rewardHolders = await client.getRewardHoldersForBtcAddress();
  const rewardTotal = await client.getRewardsTotalForBtcAddress();
  console.log('Result: ', rewards, rewardHolders, rewardTotal);
})();
```

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] Tag 1 of @yknl or @zone117x for review
