### PR TITLE
ci: improve ci jobs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,12 +1,12 @@
-name: stacks.js
+name: Lint
 
 on:
   push:
-  pull_request:
+    branches:
+      - '**'
 
 jobs:
-  code_checks:
-    name: Code Checks
+  lint:
     runs-on: ubuntu-latest
     env:
       NODE_OPTIONS: --max-old-space-size=4096
@@ -23,7 +23,7 @@ jobs:
         with:
           path: |
             node_modules
-            */*/node_modules
+            packages/*/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
 
       - name: Install dependencies
@@ -34,15 +34,3 @@ jobs:
 
       - name: Lint
         run: npm run lint
-
-      - name: Typecheck
-        run: npm run typecheck
-
-      - name: Build
-        run: npm run build
-
-      - name: Tests
-        run: npm run lerna run test --stream --parallel -- -- --coverage
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,42 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - '**'
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: --max-old-space-size=4096
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set Node Version
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+
+      - name: Restore lerna cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            node_modules
+            packages/*/node_modules
+          key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Install dependencies
+        run: npm i
+
+      - name: Bootstrap
+        run: npm run bootstrap
+
+      - name: Build
+        run: npm run build
+
+      - name: Tests
+        run: npm run lerna run test --stream --parallel -- -- --coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,36 @@
+name: Typecheck
+
+on:
+  push:
+    branches:
+      - '**'
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: --max-old-space-size=4096
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set Node Version
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+
+      - name: Restore lerna cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            node_modules
+            packages/*/node_modules
+          key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Install dependencies
+        run: npm i
+
+      - name: Bootstrap
+        run: npm run bootstrap
+
+      - name: Typecheck
+        run: npm run typecheck


### PR DESCRIPTION
These changes break the 1 "code checks" into more specific CI tasks.

While there's some duplication of the job scaffolding/caching etc, this is much more developer-friendly. 

- It's faster as they run in parallel
- You can see if multiple checks fail (rather than it exiting immediately when the first fails)
- You get easier insights into what breaks "linting" rather than generic "code checks" 