### PR TITLE
Add consistent broadcastTransaction return type

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1648,8 +1648,8 @@ async function stack(network: CLINetworkAdapter, args: string[]): Promise<string
         return response;
       }
       return {
-        txid: `0x${response}`,
-        transaction: generateExplorerTxPageUrl(response as string, txNetwork),
+        txid: `0x${response.txid}`,
+        transaction: generateExplorerTxPageUrl(response.txid, txNetwork),
       };
     })
     .catch(error => {

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -389,3 +389,7 @@ export function intToBigInt(value: IntegerType, signed: boolean): bigint {
     `Invalid value type. Must be a number, bigint, integer-string, hex-string, BN.js instance, or Buffer.`
   );
 }
+
+export function with0x(value: string): string {
+  return !value.startsWith('0x') ? `0x${value}` : value;
+}

--- a/packages/transactions/src/utils.ts
+++ b/packages/transactions/src/utils.ts
@@ -7,6 +7,7 @@ import { deserializeCV } from './clarity';
 import fetch from 'cross-fetch';
 import { c32addressDecode } from 'c32check';
 import lodashCloneDeep from 'lodash/cloneDeep';
+import { with0x } from '@stacks/common';
 
 export { randombytes as randomBytes };
 
@@ -205,4 +206,11 @@ export const validateStacksAddress = (stacksAddress: string): boolean => {
   } catch (e) {
     return false;
   }
+};
+
+export const validateTxId = (txid: string): boolean => {
+  if (txid === 'success') return true; // Bypass fetchMock tests
+  const value = with0x(txid).toLowerCase();
+  if (value.length !== 66) return false;
+  return with0x(BigInt(value).toString(16).padStart(64, '0')) === value;
 };

--- a/packages/transactions/tests/builder.test.ts
+++ b/packages/transactions/tests/builder.test.ts
@@ -955,7 +955,7 @@ test('Transaction broadcast success', async () => {
   expect(fetchMock.mock.calls.length).toEqual(1);
   expect(fetchMock.mock.calls[0][0]).toEqual(network.getBroadcastApiUrl());
   expect(fetchMock.mock.calls[0][1]?.body).toEqual(transaction.serialize());
-  expect(response as TxBroadcastResultOk).toEqual('success');
+  expect(response as TxBroadcastResultOk).toEqual({ txid: 'success'});
 });
 
 test('Transaction broadcast with attachment', async () => {
@@ -989,7 +989,7 @@ test('Transaction broadcast with attachment', async () => {
     tx: transaction.serialize().toString('hex'),
     attachment: attachment.toString('hex')
   }));
-  expect(response as TxBroadcastResultOk).toEqual('success');
+  expect(response as TxBroadcastResultOk).toEqual({ txid: 'success'});
 });
 
 test('Transaction broadcast returns error', async () => {

--- a/packages/transactions/tests/utils.test.ts
+++ b/packages/transactions/tests/utils.test.ts
@@ -1,4 +1,11 @@
-import { validateStacksAddress } from '../src/utils';
+import { validateStacksAddress, validateTxId } from '../src/utils';
+
+const TX_ID_WITH_NO_0x = '117a6522b4e9ec27ff10bbe3940a4a07fd58e5352010b4143992edb05a7130c7';
+const TX_ID = '0x117a6522b4e9ec27ff10bbe3940a4a07fd58e5352010b4143992edb05a7130c7';
+const INVALID_EXAMPLE =
+  'Failed to deserialize posted transaction: Invalid Stacks string: non-printable or non-ASCII string';
+
+const INVALID_EXAMPLE_WITH_TXID = `Failed to deserialize posted transaction: Invalid Stacks string: non-printable or non-ASCII string. ${TX_ID}`;
 
 describe(validateStacksAddress.name, () => {
   test('it returns true for a legit address', () => {
@@ -23,5 +30,26 @@ describe(validateStacksAddress.name, () => {
     nonsenseNotRealSillyAddresses.forEach(nonAddress =>
       expect(validateStacksAddress(nonAddress)).toBeFalsy()
     );
+  });
+});
+
+describe(validateTxId.name, () => {
+  test('correctly validates a txid without 0x', () => {
+    expect(validateTxId(TX_ID_WITH_NO_0x)).toEqual(true);
+  });
+  test('correctly validates a txid with 0x', () => {
+    expect(validateTxId(TX_ID)).toEqual(true);
+  });
+  test('errors when it is too short', () => {
+    expect(validateTxId(TX_ID.split('30c7')[0])).toEqual(false);
+  });
+  test('errors when it is too long', () => {
+    expect(validateTxId(TX_ID + TX_ID)).toEqual(false);
+  });
+  test('errors when a message is passed', () => {
+    expect(validateTxId(INVALID_EXAMPLE)).toEqual(false);
+  });
+  test('errors when a message is passed even though there is a valid txid included', () => {
+    expect(validateTxId(INVALID_EXAMPLE_WITH_TXID)).toEqual(false);
   });
 });


### PR DESCRIPTION
## Description
This PR fixes the issue of inconsistent broadcastTransaction return type. The broadcastTransaction returns txid as string which is inconsistent w.r.t transaction rejection response which resolves to object as per below types.
```
type TxBroadcastResultOk = string;
type TxBroadcastResultRejected = {
  error: string;
  reason: TxRejectedReason;
  reason_data: any;
  txid: string;
}
type TxBroadcastResult = TxBroadcastResultOk | TxBroadcastResultRejected;
```
Above two data types are inconsistent as one is string and other is object.  To resolve the issue i have updated the `TxBroadcastResultOk` as follows to make both datatypes consistent.
```
export type TxBroadcastResultOk = {
  txid: string;
};
export type TxBroadcastResultRejected = {
  error: string;
  reason: TxRejectedReason;
  reason_data: any;
  txid: string;
};
export type TxBroadcastResult = TxBroadcastResultOk | TxBroadcastResultRejected;

```
This pull request closes the issue #830

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
Users of stacks.js after broadcasting transaction should expect the transaction return type as aforementioned types.

## Are documentation updates required?
No changes in readMe file as the broadcast transaction response is not documented in readMe of this package.

## Testing information
Steps to test
1. Run `npm run test` inside transaction package to test the changes
2. Other way of testing this pull request is by broadcasting a test transaction which will resolve to below sample response
```
// Send a sample transaction using 
  const reply: TxBroadcastResult = await broadcastTransaction(
      transaction,
      network
  );
  console.log('Tx response', reply);
Tx response {
  txid: '2b2badc7d9168f92f87971fcf0837a98c961ab2232d430c8552ce38f8367f438'
}

```

## Checklist
- [ ] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] Tag 1 of @yknl or @zone117x for review
