### PR TITLE
[Network] Implement StacksNetwork API

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -337,7 +337,6 @@ async function makeKeychain(network: CLINetworkAdapter, args: string[]): Promise
   if (args[0]) {
     mnemonic = await getBackupPhrase(args[0]);
   } else {
-    // eslint-disable-next-line @typescript-eslint/await-thenable
     mnemonic = await bip39.generateMnemonic(
       STX_WALLET_COMPATIBLE_SEED_STRENGTH,
       crypto.randomBytes

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -337,6 +337,7 @@ async function makeKeychain(network: CLINetworkAdapter, args: string[]): Promise
   if (args[0]) {
     mnemonic = await getBackupPhrase(args[0]);
   } else {
+    // eslint-disable-next-line @typescript-eslint/await-thenable
     mnemonic = await bip39.generateMnemonic(
       STX_WALLET_COMPATIBLE_SEED_STRENGTH,
       crypto.randomBytes

--- a/packages/network/src/index.ts
+++ b/packages/network/src/index.ts
@@ -1,9 +1,17 @@
 import { TransactionVersion, ChainID, fetchPrivate } from '@stacks/common';
 
+export const HIRO_MAINNET_DEFAULT = 'https://stacks-node-api.mainnet.stacks.co';
+export const HIRO_TESTNET_DEFAULT = 'https://stacks-node-api.testnet.stacks.co';
+export const HIRO_MOCKNET_DEFAULT = 'http://localhost:3999';
+
+export interface NetworkUrl {
+  url: string;
+}
+
 export interface StacksNetwork {
   version: TransactionVersion;
   chainId: ChainID;
-  coreApiUrl: string;
+  readonly coreApiUrl: string;
   bnsLookupUrl: string;
   broadcastEndpoint: string;
   transferFeeEstimateEndpoint: string;
@@ -39,13 +47,17 @@ export interface StacksNetwork {
 export class StacksMainnet implements StacksNetwork {
   version = TransactionVersion.Mainnet;
   chainId = ChainID.Mainnet;
-  coreApiUrl = 'https://stacks-node-api.mainnet.stacks.co';
+  readonly coreApiUrl;
   bnsLookupUrl = 'https://stacks-node-api.mainnet.stacks.co';
   broadcastEndpoint = '/v2/transactions';
   transferFeeEstimateEndpoint = '/v2/fees/transfer';
   accountEndpoint = '/v2/accounts';
   contractAbiEndpoint = '/v2/contracts/interface';
   readOnlyFunctionCallEndpoint = '/v2/contracts/call-read';
+
+  constructor(networkUrl: NetworkUrl = { url: HIRO_MAINNET_DEFAULT }) {
+    this.coreApiUrl = networkUrl.url;
+  }
 
   isMainnet = () => this.version === TransactionVersion.Mainnet;
   getBroadcastApiUrl = () => `${this.coreApiUrl}${this.broadcastEndpoint}`;
@@ -99,11 +111,17 @@ export class StacksMainnet implements StacksNetwork {
 export class StacksTestnet extends StacksMainnet implements StacksNetwork {
   version = TransactionVersion.Testnet;
   chainId = ChainID.Testnet;
-  coreApiUrl = 'https://stacks-node-api.testnet.stacks.co';
+
+  constructor(networkUrl: NetworkUrl = { url: HIRO_TESTNET_DEFAULT }) {
+    super(networkUrl);
+  }
 }
 
 export class StacksMocknet extends StacksMainnet implements StacksNetwork {
   version = TransactionVersion.Testnet;
   chainId = ChainID.Testnet;
-  coreApiUrl = 'http://localhost:3999';
+
+  constructor(networkUrl: NetworkUrl = { url: HIRO_MOCKNET_DEFAULT }) {
+    super(networkUrl);
+  }
 }

--- a/packages/network/src/index.ts
+++ b/packages/network/src/index.ts
@@ -4,14 +4,13 @@ export const HIRO_MAINNET_DEFAULT = 'https://stacks-node-api.mainnet.stacks.co';
 export const HIRO_TESTNET_DEFAULT = 'https://stacks-node-api.testnet.stacks.co';
 export const HIRO_MOCKNET_DEFAULT = 'http://localhost:3999';
 
-export interface NetworkUrl {
+export interface NetworkConfig {
   url: string;
 }
 
 export interface StacksNetwork {
   version: TransactionVersion;
   chainId: ChainID;
-  readonly coreApiUrl: string;
   bnsLookupUrl: string;
   broadcastEndpoint: string;
   transferFeeEstimateEndpoint: string;
@@ -47,18 +46,24 @@ export interface StacksNetwork {
 export class StacksMainnet implements StacksNetwork {
   version = TransactionVersion.Mainnet;
   chainId = ChainID.Mainnet;
-  readonly coreApiUrl;
   bnsLookupUrl = 'https://stacks-node-api.mainnet.stacks.co';
   broadcastEndpoint = '/v2/transactions';
   transferFeeEstimateEndpoint = '/v2/fees/transfer';
   accountEndpoint = '/v2/accounts';
   contractAbiEndpoint = '/v2/contracts/interface';
   readOnlyFunctionCallEndpoint = '/v2/contracts/call-read';
+  private _coreApiUrl: string;
 
-  constructor(networkUrl: NetworkUrl = { url: HIRO_MAINNET_DEFAULT }) {
-    this.coreApiUrl = networkUrl.url;
+  get coreApiUrl() {
+    return this._coreApiUrl;
+  }
+  set coreApiUrl(_url: string) {
+    throw new Error('Cannot modify property `coreApiUrl` after object initialization');
   }
 
+  constructor(networkUrl: NetworkConfig = { url: HIRO_MAINNET_DEFAULT }) {
+    this._coreApiUrl = networkUrl.url;
+  }
   isMainnet = () => this.version === TransactionVersion.Mainnet;
   getBroadcastApiUrl = () => `${this.coreApiUrl}${this.broadcastEndpoint}`;
   getTransferFeeEstimateApiUrl = () => `${this.coreApiUrl}${this.transferFeeEstimateEndpoint}`;
@@ -112,7 +117,7 @@ export class StacksTestnet extends StacksMainnet implements StacksNetwork {
   version = TransactionVersion.Testnet;
   chainId = ChainID.Testnet;
 
-  constructor(networkUrl: NetworkUrl = { url: HIRO_TESTNET_DEFAULT }) {
+  constructor(networkUrl: NetworkConfig = { url: HIRO_TESTNET_DEFAULT }) {
     super(networkUrl);
   }
 }
@@ -121,7 +126,7 @@ export class StacksMocknet extends StacksMainnet implements StacksNetwork {
   version = TransactionVersion.Testnet;
   chainId = ChainID.Testnet;
 
-  constructor(networkUrl: NetworkUrl = { url: HIRO_MOCKNET_DEFAULT }) {
+  constructor(networkUrl: NetworkConfig = { url: HIRO_MOCKNET_DEFAULT }) {
     super(networkUrl);
   }
 }

--- a/packages/network/tests/network.test.ts
+++ b/packages/network/tests/network.test.ts
@@ -7,17 +7,28 @@ import {
   StacksTestnet,
 } from '@stacks/network';
 
-test('network test-- coreApiUrl', () => {
-  const mainnet = new StacksMainnet();
-  expect(mainnet.coreApiUrl).toBe(HIRO_MAINNET_DEFAULT);
-
-  const testnet = new StacksTestnet();
-  expect(testnet.coreApiUrl).toBe(HIRO_TESTNET_DEFAULT);
-
-  const mocknet = new StacksMocknet();
-  expect(mocknet.coreApiUrl).toBe(HIRO_MOCKNET_DEFAULT);
-
-  const customURL = 'customeURL';
-  const customNET = new StacksMainnet({ url: customURL });
-  expect(customNET.coreApiUrl).toBe(customURL);
+describe('Setting coreApiUrl', () => {
+  test('it sets mainnet default url', () => {
+    const mainnet = new StacksMainnet();
+    expect(mainnet.coreApiUrl).toEqual(HIRO_MAINNET_DEFAULT);
+  });
+  test('it sets testnet url', () => {
+    const testnet = new StacksTestnet();
+    expect(testnet.coreApiUrl).toEqual(HIRO_TESTNET_DEFAULT);
+  });
+  test('it sets mocknet url', () => {
+    const mocknet = new StacksMocknet();
+    expect(mocknet.coreApiUrl).toEqual(HIRO_MOCKNET_DEFAULT);
+  });
+  test('it sets custom url', () => {
+    const customURL = 'https://customurl.com';
+    const customNET = new StacksMainnet({ url: customURL });
+    expect(customNET.coreApiUrl).toEqual(customURL);
+  });
+  test('it prevents changing url after initialisation', () => {
+    const network = new StacksMainnet({ url: 'https://legiturl.com' });
+    // @ts-ignore
+    expect(() => (network.coreApiUrl = 'https://dodgyurl.com')).toThrowError();
+    expect(network.coreApiUrl).toEqual('https://legiturl.com');
+  });
 });

--- a/packages/network/tests/network.test.ts
+++ b/packages/network/tests/network.test.ts
@@ -1,4 +1,23 @@
-test('test', () => {
-  expect(true).toBeTruthy()
-})
+import {
+  HIRO_MAINNET_DEFAULT,
+  HIRO_MOCKNET_DEFAULT,
+  HIRO_TESTNET_DEFAULT,
+  StacksMainnet,
+  StacksMocknet,
+  StacksTestnet,
+} from '@stacks/network';
 
+test('network test-- coreApiUrl', () => {
+  const mainnet = new StacksMainnet();
+  expect(mainnet.coreApiUrl).toBe(HIRO_MAINNET_DEFAULT);
+
+  const testnet = new StacksTestnet();
+  expect(testnet.coreApiUrl).toBe(HIRO_TESTNET_DEFAULT);
+
+  const mocknet = new StacksMocknet();
+  expect(mocknet.coreApiUrl).toBe(HIRO_MOCKNET_DEFAULT);
+
+  const customURL = 'customeURL';
+  const customNET = new StacksMainnet({ url: customURL });
+  expect(customNET.coreApiUrl).toBe(customURL);
+});


### PR DESCRIPTION
## Description
The PR addresses issue #895.
closes #895 

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [x] Other

## Does this introduce a breaking change?
The `coreApiUrl` in `StacksNetwork , StacksMainnet, StacksTestnet, StacksMocknet`  is now `readonly`.  Now, this field can only be initialized in the constructor. 

## Are documentation updates required?


## Testing information
added a test case for this scenario 
`cd packages/network && npm run test `

## Checklist
- [ ] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] Tag 1 of @yknl or @zone117x for review

@reedrosenbluth @kyranjamie should we include `bnsLookupUrl` as well?
