### PR TITLE
Fix stx balance command crash on bitcoin or invalid address

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -370,7 +370,15 @@ function balance(network: CLINetworkAdapter, args: string[]): Promise<string> {
   txNetwork.coreApiUrl = network.legacyNetwork.blockstackAPIUrl;
 
   return fetch(txNetwork.getAccountApiUrl(address))
-    .then(response => response.json())
+    .then(response => {
+      if (response.status === 404) {
+        return Promise.reject({
+          status: response.status,
+          error: response.statusText,
+        });
+      }
+      return response.json();
+    })
     .then(response => {
       let balanceHex = response.balance;
       if (response.balance.startsWith('0x')) {
@@ -390,7 +398,8 @@ function balance(network: CLINetworkAdapter, args: string[]): Promise<string> {
         nonce: response.nonce,
       };
       return Promise.resolve(JSONStringify(res));
-    });
+    })
+    .catch(error => error);
 }
 
 /*


### PR DESCRIPTION
## Description
This PR fixes the issue of stx balance command crash on bitcoin or any invalid address input. Current behaviour of balance output on bitcoin address input:
```
 command: stx balance 16pm276FpJYpm7Dv3GEaRqTVvGPTdceoY4
 Output:
 FetchError: invalid json response body at https://stacks-node-api.stacks.co/v2/accounts/16pm276FpJYpm7Dv3GEaRqTVvGPTdceoY4?proof=0 reason: Unexpected token / in JSON at position 0
    at /Users/tintash/Desktop/projects/stacks/node_modules/node-fetch/lib/index.js:272:32
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
invalid json response body at https://stacks-node-api.stacks.co/v2/accounts/16pm276FpJYpm7Dv3GEaRqTVvGPTdceoY4?proof=0 reason: Unexpected token / in JSON at position 0
 
```
I have added the error handling code to handle this scenario. After applying the fix, correct output is below:
```
Command: stx balance 16pm276FpJYpm7Dv3GEaRqTVvGPTdceoY4
Output:
{ status: 404, error: 'Not Found' }
```

For details refer to issue #987

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
Yes. 
The documentation of `stx balance help` needs to be updated in `stacks.js/packages/cli/src/argparse.ts` file on line number 250. 
Note: The documentation update is not the part of this pull request because documentation content is required from stacks content management team.

## Testing information
Steps to test:
Execute `stx balance 16pm276FpJYpm7Dv3GEaRqTVvGPTdc` in terminal to test the balance command.
Sample Output:
```
{ status: 404, error: 'Not Found' }
```
## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @yknl or @zone117x for review
