### PR TITLE
Transactions: broadcastTransaction to use network set in options #828

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -585,7 +585,7 @@ async function sendTokens(network: CLINetworkAdapter, args: string[]): Promise<s
     return Promise.resolve(tx.serialize().toString('hex'));
   }
 
-  return broadcastTransaction(tx, txNetwork)
+  return broadcastTransaction(tx)
     .then((response: TxBroadcastResult) => {
       if (response.hasOwnProperty('error')) {
         return response;
@@ -645,7 +645,7 @@ async function contractDeploy(network: CLINetworkAdapter, args: string[]): Promi
     return Promise.resolve(tx.serialize().toString('hex'));
   }
 
-  return broadcastTransaction(tx, txNetwork)
+  return broadcastTransaction(tx)
     .then(response => {
       if (response.hasOwnProperty('error')) {
         return response;
@@ -731,7 +731,7 @@ async function contractFunctionCall(network: CLINetworkAdapter, args: string[]):
         return Promise.resolve(tx.serialize().toString('hex'));
       }
 
-      return broadcastTransaction(tx, txNetwork)
+      return broadcastTransaction(tx)
         .then(response => {
           if (response.hasOwnProperty('error')) {
             return response;

--- a/packages/stacking/src/index.ts
+++ b/packages/stacking/src/index.ts
@@ -352,7 +352,7 @@ export class StackingClient {
       senderKey: privateKey,
     });
 
-    return broadcastTransaction(tx, txOptions.network as StacksNetwork);
+    return broadcastTransaction(tx);
   }
 
   /**
@@ -385,7 +385,7 @@ export class StackingClient {
       senderKey: privateKey,
     });
 
-    return broadcastTransaction(tx, txOptions.network as StacksNetwork);
+    return broadcastTransaction(tx);
   }
 
   /**
@@ -421,7 +421,7 @@ export class StackingClient {
       senderKey: privateKey,
     });
 
-    return broadcastTransaction(tx, txOptions.network as StacksNetwork);
+    return broadcastTransaction(tx);
   }
 
   /**
@@ -449,7 +449,7 @@ export class StackingClient {
       senderKey: privateKey,
     });
 
-    return broadcastTransaction(tx, txOptions.network as StacksNetwork);
+    return broadcastTransaction(tx);
   }
 
   /**
@@ -470,7 +470,7 @@ export class StackingClient {
       senderKey: privateKey,
     });
 
-    return broadcastTransaction(tx, txOptions.network as StacksNetwork);
+    return broadcastTransaction(tx);
   }
 
   getStackOptions({

--- a/packages/stacking/tests/stacking.test.ts
+++ b/packages/stacking/tests/stacking.test.ts
@@ -238,7 +238,7 @@ test('stack stx', async () => {
   expect(makeContractCall).toHaveBeenCalledTimes(1);
   expect(makeContractCall).toHaveBeenCalledWith(expectedContractCallOptions);
   expect(broadcastTransaction).toHaveBeenCalledTimes(1);
-  expect(broadcastTransaction).toHaveBeenCalledWith(transaction, network);
+  expect(broadcastTransaction).toHaveBeenCalledWith(transaction);
   expect(stackingResults).toEqual(broadcastResponse);
 })
 
@@ -315,7 +315,7 @@ test('delegate stx', async () => {
   expect(makeContractCall).toHaveBeenCalledTimes(1);
   expect(makeContractCall).toHaveBeenCalledWith(expectedContractCallOptions);
   expect(broadcastTransaction).toHaveBeenCalledTimes(1);
-  expect(broadcastTransaction).toHaveBeenCalledWith(transaction, network);
+  expect(broadcastTransaction).toHaveBeenCalledWith(transaction);
   expect(delegateResults).toEqual(broadcastResponse);
 })
 
@@ -384,7 +384,7 @@ test('delegate stx with empty optional parameters', async () => {
   expect(makeContractCall).toHaveBeenCalledTimes(1);
   expect(makeContractCall).toHaveBeenCalledWith(expectedContractCallOptions);
   expect(broadcastTransaction).toHaveBeenCalledTimes(1);
-  expect(broadcastTransaction).toHaveBeenCalledWith(transaction, network);
+  expect(broadcastTransaction).toHaveBeenCalledWith(transaction);
   expect(delegateResults).toEqual(broadcastResponse);
 })
 
@@ -473,7 +473,7 @@ test('delegate stack stx with one delegator', async () => {
   expect(makeContractCall).toHaveBeenCalledTimes(1);
   expect(makeContractCall).toHaveBeenCalledWith(expectedContractCallOptions);
   expect(broadcastTransaction).toHaveBeenCalledTimes(1);
-  expect(broadcastTransaction).toHaveBeenCalledWith(transaction, network);
+  expect(broadcastTransaction).toHaveBeenCalledWith(transaction);
   expect(delegateResults).toEqual(broadcastResponse);
 })
 
@@ -565,7 +565,7 @@ test('delegate stack stx with set nonce', async () => {
   expect(makeContractCall).toHaveBeenCalledTimes(1);
   expect(makeContractCall).toHaveBeenCalledWith(expectedContractCallOptions);
   expect(broadcastTransaction).toHaveBeenCalledTimes(1);
-  expect(broadcastTransaction).toHaveBeenCalledWith(transaction, network);
+  expect(broadcastTransaction).toHaveBeenCalledWith(transaction);
   expect(delegateResults).toEqual(broadcastResponse);
 })
 
@@ -635,7 +635,7 @@ test('delegator commit', async () => {
   expect(makeContractCall).toHaveBeenCalledTimes(1);
   expect(makeContractCall).toHaveBeenCalledWith(expectedContractCallOptions);
   expect(broadcastTransaction).toHaveBeenCalledTimes(1);
-  expect(broadcastTransaction).toHaveBeenCalledWith(transaction, network);
+  expect(broadcastTransaction).toHaveBeenCalledWith(transaction);
   expect(delegateResults).toEqual(broadcastResponse);
 })
 
@@ -689,7 +689,7 @@ test('revoke delegate stx', async () => {
   expect(makeContractCall).toHaveBeenCalledTimes(1);
   expect(makeContractCall).toHaveBeenCalledWith(expectedContractCallOptions);
   expect(broadcastTransaction).toHaveBeenCalledTimes(1);
-  expect(broadcastTransaction).toHaveBeenCalledWith(transaction, network);
+  expect(broadcastTransaction).toHaveBeenCalledWith(transaction);
   expect(revokeDelegateResults).toEqual(broadcastResponse);
 })
 

--- a/packages/transactions/src/builders.ts
+++ b/packages/transactions/src/builders.ts
@@ -158,11 +158,10 @@ export type TxBroadcastResult = TxBroadcastResultOk | TxBroadcastResultRejected;
  */
 export async function broadcastTransaction(
   transaction: StacksTransaction,
-  network: StacksNetwork,
   attachment?: Buffer
 ): Promise<TxBroadcastResult> {
   const rawTx = transaction.serialize();
-  const url = network.getBroadcastApiUrl();
+  const url = transaction.network.getBroadcastApiUrl();
 
   return broadcastRawTransaction(rawTx, url, attachment);
 }
@@ -357,6 +356,7 @@ export async function makeUnsignedSTXTokenTransfer(
 
   const lpPostConditions = createLPList(postConditions);
   const transaction = new StacksTransaction(
+    options.network,
     options.network.version,
     authorization,
     payload,
@@ -557,6 +557,7 @@ export async function makeContractDeploy(
 
   const lpPostConditions = createLPList(postConditions);
   const transaction = new StacksTransaction(
+    options.network,
     options.network.version,
     authorization,
     payload,
@@ -770,6 +771,7 @@ export async function makeUnsignedContractCall(
 
   const lpPostConditions = createLPList(postConditions);
   const transaction = new StacksTransaction(
+    options.network,
     options.network.version,
     authorization,
     payload,

--- a/packages/transactions/src/transaction.ts
+++ b/packages/transactions/src/transaction.ts
@@ -33,6 +33,7 @@ import { BufferReader } from './bufferReader';
 
 import BigNum from 'bn.js';
 import { SerializationError, SigningError } from './errors';
+import { StacksNetwork, StacksTestnet } from '@stacks/network';
 
 export class StacksTransaction {
   version: TransactionVersion;
@@ -42,8 +43,9 @@ export class StacksTransaction {
   payload: Payload;
   postConditionMode: PostConditionMode;
   postConditions: LengthPrefixedList;
-
+  network: StacksNetwork;
   constructor(
+    network: StacksNetwork,
     version: TransactionVersion,
     auth: Authorization,
     payload: Payload,
@@ -58,6 +60,7 @@ export class StacksTransaction {
     this.chainId = chainId ?? DEFAULT_CHAIN_ID;
     this.postConditionMode = postConditionMode ?? PostConditionMode.Deny;
     this.postConditions = postConditions ?? createLPList([]);
+    this.network = network;
 
     if (anchorMode) {
       this.anchorMode = anchorMode;
@@ -277,6 +280,7 @@ export function deserializeTransaction(data: BufferReader | Buffer | string) {
   const payload = deserializePayload(bufferReader);
 
   return new StacksTransaction(
+    new StacksTestnet(),
     version,
     auth,
     payload,

--- a/packages/transactions/tests/builder.test.ts
+++ b/packages/transactions/tests/builder.test.ts
@@ -941,6 +941,7 @@ test('Transaction broadcast success', async () => {
   const network = new StacksMainnet();
 
   const transaction = await makeSTXTokenTransfer({
+    network,
     recipient,
     amount,
     senderKey,
@@ -952,7 +953,7 @@ test('Transaction broadcast success', async () => {
 
   fetchMock.mockOnce('success');
 
-  const response: TxBroadcastResult = await broadcastTransaction(transaction, network);
+  const response: TxBroadcastResult = await broadcastTransaction(transaction);
 
   expect(fetchMock.mock.calls.length).toEqual(1);
   expect(fetchMock.mock.calls[0][0]).toEqual(network.getBroadcastApiUrl());
@@ -972,6 +973,7 @@ test('Transaction broadcast with attachment', async () => {
   const network = new StacksMainnet();
 
   const transaction = await makeSTXTokenTransfer({
+    network,
     recipient,
     amount,
     senderKey,
@@ -983,7 +985,7 @@ test('Transaction broadcast with attachment', async () => {
 
   fetchMock.mockOnce('success');
 
-  const response: TxBroadcastResult = await broadcastTransaction(transaction, network, attachment);
+  const response: TxBroadcastResult = await broadcastTransaction(transaction, attachment);
 
   expect(fetchMock.mock.calls.length).toEqual(1);
   expect(fetchMock.mock.calls[0][0]).toEqual(network.getBroadcastApiUrl());
@@ -1005,6 +1007,7 @@ test('Transaction broadcast returns error', async () => {
   const network = new StacksMainnet();
 
   const transaction = await makeSTXTokenTransfer({
+    network,
     recipient,
     amount,
     senderKey,
@@ -1028,7 +1031,7 @@ test('Transaction broadcast returns error', async () => {
 
   fetchMock.mockOnce(JSON.stringify(rejection), { status: 400 });
 
-  const result = await broadcastTransaction(transaction, network);
+  const result = await broadcastTransaction(transaction);
   expect((result as TxBroadcastResultRejected).reason).toEqual(TxRejectedReason.BadNonce);
   expect((result as TxBroadcastResultRejected).reason_data).toEqual(rejection.reason_data);
 });
@@ -1044,6 +1047,7 @@ test('Transaction broadcast fails', async () => {
   const network = new StacksMainnet();
 
   const transaction = await makeSTXTokenTransfer({
+    network,
     recipient,
     amount,
     senderKey,
@@ -1055,7 +1059,7 @@ test('Transaction broadcast fails', async () => {
 
   fetchMock.mockOnce('test', { status: 400 });
 
-  await expect(broadcastTransaction(transaction, network)).rejects.toThrow();
+  await expect(broadcastTransaction(transaction)).rejects.toThrow();
 });
 
 test('Make contract-call with network ABI validation', async () => {

--- a/packages/transactions/tests/transaction.test.ts
+++ b/packages/transactions/tests/transaction.test.ts
@@ -1,4 +1,5 @@
 import { StacksTransaction, deserializeTransaction } from '../src/transaction';
+import { StacksTestnet } from '@stacks/network';
 
 import {
   StandardAuthorization,
@@ -77,6 +78,7 @@ test('STX token transfer transaction serialization and deserialization', () => {
 
   const postConditions = createLPList([postCondition]);
   const transaction = new StacksTransaction(
+    new StacksTestnet(),
     transactionVersion,
     authorization,
     payload,
@@ -153,6 +155,7 @@ test('STX token transfer transaction fee setting', () => {
   const postConditions = createLPList([postCondition]);
 
   const transaction = new StacksTransaction(
+    new StacksTestnet(),
     transactionVersion,
     authorization,
     payload,
@@ -239,7 +242,7 @@ test('STX token transfer transaction multi-sig serialization and deserialization
 
   const payload = createTokenTransferPayload(recipientCV, amount, memo);
 
-  const transaction = new StacksTransaction(transactionVersion, originAuth, payload);
+  const transaction = new StacksTransaction(new StacksTestnet(), transactionVersion, originAuth, payload);
 
   const signer = new TransactionSigner(transaction);
   signer.signOrigin(privKeys[0]);
@@ -307,7 +310,7 @@ test('STX token transfer transaction multi-sig uncompressed keys serialization a
 
   const payload = createTokenTransferPayload(recipientCV, amount, memo);
 
-  const transaction = new StacksTransaction(transactionVersion, originAuth, payload);
+  const transaction = new StacksTransaction(new StacksTestnet(), transactionVersion, originAuth, payload);
 
   const signer = new TransactionSigner(transaction);
   signer.signOrigin(privKeys[0]);
@@ -382,7 +385,7 @@ test('Sponsored STX token transfer transaction serialization and deserialization
   const authType = AuthType.Sponsored;
   const authorization = new SponsoredAuthorization(spendingCondition, sponsorSpendingCondition);
 
-  const transaction = new StacksTransaction(transactionVersion, authorization, payload);
+  const transaction = new StacksTransaction(new StacksTestnet(), transactionVersion, authorization, payload);
 
   const signer = new TransactionSigner(transaction);
   signer.signOrigin(createStacksPrivateKey(secretKey));


### PR DESCRIPTION
## Description
The `broadcastTransaction` method requires a transaction and a network param. The transaction is usually created with a network property already, so we could use the network set and avoid requiring a second parameter for the method call.

```
  const txOptions = {
    contractAddress,
    contractName,
    functionName,
    functionArgs,
    senderKey,
    validateWithAbi,
    network, // THIS IS SET
  };

  const transaction = await makeContractCall(txOptions);

  const contractCall = await broadcastTransaction(transaction, network); // SETTING IT AGAIN HERE
  // could be just: broadcastTransaction(transaction)
```

For PR closes the issue #828

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
Yes. `broadcastTransaction` function signature is changed as per aforementioned description. That's why its a breaking change.

## Are documentation updates required?
No

## Testing information
Steps to test:
- `npm run test` inside transaction package
- Other way of testing this PR is to broadcast a transaction. Now `broadcastTransaction` will only take one parameter which is transaction.

## Checklist
- [ ] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] Tag 1 of @yknl or @zone117x for review
