### PR TITLE
fix: broken types following diverged network config changes

### DIFF
--- a/packages/network/src/index.ts
+++ b/packages/network/src/index.ts
@@ -1,6 +1,7 @@
 import { TransactionVersion, ChainID, fetchPrivate } from '@stacks/common';
 
 export const HIRO_MAINNET_DEFAULT = 'https://stacks-node-api.mainnet.stacks.co';
+export const HIRO_REGTEST_DEFAULT = 'https://stacks-node-api.regtest.stacks.co';
 export const HIRO_TESTNET_DEFAULT = 'https://stacks-node-api.testnet.stacks.co';
 export const HIRO_MOCKNET_DEFAULT = 'http://localhost:3999';
 
@@ -134,5 +135,8 @@ export class StacksMocknet extends StacksMainnet implements StacksNetwork {
 export class StacksRegtest extends StacksMainnet implements StacksNetwork {
   version = TransactionVersion.Testnet;
   chainId = ChainID.Testnet;
-  coreApiUrl = 'https://stacks-node-api.regtest.stacks.co';
+
+  constructor(networkUrl: NetworkConfig = { url: HIRO_REGTEST_DEFAULT }) {
+    super(networkUrl);
+  }
 }


### PR DESCRIPTION
Two changes merged parallel into `master` broke our types. Not sure how this could happen, as we have "branch must be up to date" rule for `master`.

This PR makes @agraebe's regtest changes fit the new format.