### PR TITLE
fix: remove console.log

### DIFF
--- a/packages/encryption/src/keys.ts
+++ b/packages/encryption/src/keys.ts
@@ -44,8 +44,6 @@ export function getPublicKeyFromPrivate(privateKey: string | Buffer) {
     : Buffer.from(privateKey, 'hex');
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const realBuffer = require('buffer').Buffer;
-  const isBuffer1 = realBuffer.isBuffer(privateKeyBuffer);
-  console.log(isBuffer1);
   const keyPair = ECPair.fromPrivateKey(privateKeyBuffer);
   return keyPair.publicKey.toString('hex');
 }


### PR DESCRIPTION
During some test writing in `stacks-wallet-web`, I noticed this was logging. must have accidentally been added and commited.