### PR TITLE
fix: remove unused const

### DIFF
--- a/packages/encryption/src/keys.ts
+++ b/packages/encryption/src/keys.ts
@@ -42,8 +42,6 @@ export function getPublicKeyFromPrivate(privateKey: string | Buffer) {
   const privateKeyBuffer = Buffer.isBuffer(privateKey)
     ? privateKey
     : Buffer.from(privateKey, 'hex');
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const realBuffer = require('buffer').Buffer;
   const keyPair = ECPair.fromPrivateKey(privateKeyBuffer);
   return keyPair.publicKey.toString('hex');
 }


### PR DESCRIPTION
@reedrosenbluth looks like there was one more const related to the console.log from yesterday (https://github.com/blockstack/stacks.js/pull/1050), sorry about that!