### PR TITLE
Fix generated explorer URL for faucet command

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1673,7 +1673,7 @@ function faucetCall(_: CLINetworkAdapter, args: string[]): Promise<string> {
     .then((faucetTx: any) => {
       return JSONStringify({
         txid: faucetTx.txId!,
-        transaction: generateExplorerTxPageUrl(faucetTx.txId!.substr(2), new StacksTestnet()),
+        transaction: generateExplorerTxPageUrl(faucetTx.txId!.replace(/^0x/, ''), new StacksTestnet()),
       });
     })
     .catch((error: any) => error.toString());

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1673,7 +1673,7 @@ function faucetCall(_: CLINetworkAdapter, args: string[]): Promise<string> {
     .then((faucetTx: any) => {
       return JSONStringify({
         txid: faucetTx.txId!,
-        transaction: generateExplorerTxPageUrl(faucetTx.txId!, new StacksTestnet()),
+        transaction: generateExplorerTxPageUrl(faucetTx.txId!.substr(2), new StacksTestnet()),
       });
     })
     .catch((error: any) => error.toString());


### PR DESCRIPTION
## Description

When running faucet command from cli, the URL generated has an extra "0x"

Example:
```
> stx faucet BLAH -t
{
  "txid": "...",
  "transaction": "https://explorer.stacks.co/txid/0x0x6a4d9...?chain=testnet"
}
ac":"e73..."}
```
## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
no

## Are documentation updates required?
no

## Testing information
```
> stx faucet ST1HP8ZEGKKRD8P5XS6B5EK0JGE19SG62M5KR0S4Z  -t 
```

## Checklist
- [X] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [X] `npm run test` passes
- [] Changelog is updated
- [ ] Tag 1 of @yknl or @zone117x for review
