### PR TITLE
GH action for generating updated docs on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - '**'
+    tags-ignore:
+      - '**'
+    paths-ignore:
+      - '**/CHANGELOG.md'
+      - '**/package.json'
+  pull_request:
+  workflow_dispatch:
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set Node Version
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+      - name: Install dependencies
+        run: npm i
+
+      - name: Bootstrap
+        run: npm run bootstrap
+
+      - name: Generate docs
+        run: npm run build:docs
+
+      - name: Semantic Release
+        uses: cycjimmy/semantic-release-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_OPTIONS: --max-old-space-size=4096
+        with:
+          extra_plugins: |
+            @semantic-release/changelog
+            @semantic-release/git
+            @semantic-release/exec

--- a/package.json
+++ b/package.json
@@ -10,6 +10,26 @@
   "workspaces": [
     "packages/**"
   ],
+  "release": {
+    "branches": [
+      "master",
+      "next"
+    ],
+    "plugins": [
+      "@semantic-release/commit-analyzer",
+      "@semantic-release/release-notes-generator",
+      "@semantic-release/changelog",
+      [
+        "@semantic-release/git",
+        {
+          "assets": [
+            "docs"
+          ],
+          "message": "chore(release docs): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+        }
+      ]
+    ]
+  },
   "devDependencies": {
     "@stacks/eslint-config": "^1.0.9",
     "@stacks/prettier-config": "0.0.8",

--- a/tsconfig.typedoc.json
+++ b/tsconfig.typedoc.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "target": "ES2017",
+    "target": "ES2020",
     "module": "ES6"
   },
   "typedocOptions": {


### PR DESCRIPTION
## Description
There should be a github action in this repo to generate up to date docs whenever a new release is cut

This PR closes #1047

## Type of Change
- [X] New feature
- [ ] Bug fix
- [X] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Testing information

Provide context on how tests should be performed.
For each new commits added to one of the release branches (for example master, next, beta), with git push or by merging a pull request or merging from another branch, a CI build is triggered and runs the semantic-release command to make a release if there are codebase changes since the last release that affect the package functionalities
Reference: `https://github.com/semantic-release/semantic-release`
## Checklist
- [X] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [X] `npm run test` passes
- [ ] Changelog is updated
- [X] Tag 1 of @yknl or @zone117x for review
