### PR TITLE
Network expose coreApiUrl

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1673,7 +1673,10 @@ function faucetCall(_: CLINetworkAdapter, args: string[]): Promise<string> {
     .then((faucetTx: any) => {
       return JSONStringify({
         txid: faucetTx.txId!,
-        transaction: generateExplorerTxPageUrl(faucetTx.txId!.replace(/^0x/, ''), new StacksTestnet()),
+        transaction: generateExplorerTxPageUrl(
+          faucetTx.txId!.replace(/^0x/, ''),
+          new StacksTestnet()
+        ),
       });
     })
     .catch((error: any) => error.toString());

--- a/packages/network/src/index.ts
+++ b/packages/network/src/index.ts
@@ -13,6 +13,7 @@ export interface StacksNetwork {
   version: TransactionVersion;
   chainId: ChainID;
   bnsLookupUrl: string;
+  readonly coreApiUrl: string;
   broadcastEndpoint: string;
   transferFeeEstimateEndpoint: string;
   accountEndpoint: string;


### PR DESCRIPTION
## Description
This PR exposes the `coreApiUrl ` from the network interface because  currently `coreApiUrl` is no longer accessible on a given network instance.

```
const foo = (network: StacksNetwork) => {
  console.log(network.coreApiUrl);       // Not possible to access coreApiUrl on network interface
}
```
After applying the fix in this PR its possible execute `network.coreApiUrl` on given network interface

This PR closes issue #1065

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No
## Testing information
`coreApiUrl` can be accessed on given network interface

```
const foo = (network: StacksNetwork) => {
  console.log(network.coreApiUrl);       // possible to access coreApiUrl on network interface
  return network.coreApiUrl;
}
```

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [X] `npm run test` passes
- [ ] Changelog is updated
- [X] Tag 1 of @yknl or @zone117x for review
