### PR TITLE
Fixes the incorrect private key derivation path config

### DIFF
--- a/packages/wallet-sdk/src/derive.ts
+++ b/packages/wallet-sdk/src/derive.ts
@@ -8,7 +8,7 @@ import { Account } from './models/account';
 import { WalletKeys } from './models/wallet';
 
 const DATA_DERIVATION_PATH = `m/888'/0'`;
-const WALLET_CONFIG_PATH = `m/44/5757'/0'/1`;
+const WALLET_CONFIG_PATH = `m/44'/5757'/0'/1`;
 const STX_DERIVATION_PATH = `m/44'/5757'/0'/0`;
 
 export const deriveWalletKeys = async (rootNode: BIP32Interface): Promise<WalletKeys> => {


### PR DESCRIPTION
Wallet config private key uses incorrect BIP44 derivation path. BIP44 states `m / purpose' / coin_type' / account' / change / address_index`.

We use here (`m/44/5757'/0'/1`) while it should be `m/44'/5757'/0'/1` (44 should be hardened)

This change will allow us to conform to the standard.