### PR TITLE
feat: construct TransactionSigner with partially signed multi-sig tx

### DIFF
--- a/packages/transactions/src/signer.ts
+++ b/packages/transactions/src/signer.ts
@@ -2,7 +2,7 @@ import { StacksTransaction } from './transaction';
 
 import { StacksPrivateKey, StacksPublicKey } from './keys';
 import { isSingleSig, nextVerification, SpendingConditionOpts } from './authorization';
-import { cloneDeep } from './utils';
+import { cloneDeep, txidFromData } from './utils';
 import { AuthType, PubKeyEncoding, StacksMessageType } from './constants';
 import { SigningError } from './errors';
 
@@ -26,10 +26,14 @@ export class TransactionSigner {
     if (spendingCondition && !isSingleSig(spendingCondition)) {
       spendingCondition.fields.forEach(field => {
         if (field.contents.type === StacksMessageType.MessageSignature) {
+          if (!transaction.auth.authType) {
+            throw Error('"transaction.auth.authType" not defined');
+          }
+
           const signature = field.contents;
           const nextVerify = nextVerification(
             this.sigHash,
-            transaction.auth.authType!,
+            transaction.auth.authType,
             spendingCondition!.fee,
             spendingCondition!.nonce,
             PubKeyEncoding.Compressed, // always compressed for multisig

--- a/packages/transactions/src/signer.ts
+++ b/packages/transactions/src/signer.ts
@@ -24,6 +24,11 @@ export class TransactionSigner {
     // auth fields and reconstruct sigHash
     let spendingCondition = transaction.auth.spendingCondition;
     if (spendingCondition && !isSingleSig(spendingCondition)) {
+
+      if (spendingCondition.fields.length >= spendingCondition.signaturesRequired) {
+        throw new Error('SpendingCondition has more signatures than are expected');
+      }
+
       spendingCondition.fields.forEach(field => {
         if (field.contents.type === StacksMessageType.MessageSignature) {
           if (!transaction.auth.authType) {

--- a/packages/transactions/src/signer.ts
+++ b/packages/transactions/src/signer.ts
@@ -2,7 +2,7 @@ import { StacksTransaction } from './transaction';
 
 import { StacksPrivateKey, StacksPublicKey } from './keys';
 import { isSingleSig, nextVerification, SpendingConditionOpts } from './authorization';
-import { cloneDeep, txidFromData } from './utils';
+import { cloneDeep } from './utils';
 import { AuthType, PubKeyEncoding, StacksMessageType } from './constants';
 import { SigningError } from './errors';
 
@@ -24,8 +24,11 @@ export class TransactionSigner {
     // auth fields and reconstruct sigHash
     let spendingCondition = transaction.auth.spendingCondition;
     if (spendingCondition && !isSingleSig(spendingCondition)) {
-
-      if (spendingCondition.fields.length >= spendingCondition.signaturesRequired) {
+      if (
+        spendingCondition.fields.filter(
+          field => field.contents.type === StacksMessageType.MessageSignature
+        ).length >= spendingCondition.signaturesRequired
+      ) {
         throw new Error('SpendingCondition has more signatures than are expected');
       }
 
@@ -42,11 +45,11 @@ export class TransactionSigner {
             spendingCondition!.fee,
             spendingCondition!.nonce,
             PubKeyEncoding.Compressed, // always compressed for multisig
-            signature,
+            signature
           );
           this.sigHash = nextVerify.nextSigHash;
         }
-      }); 
+      });
     }
   }
 

--- a/packages/transactions/tests/builder.test.ts
+++ b/packages/transactions/tests/builder.test.ts
@@ -250,11 +250,23 @@ test('Make Multi-Sig STX token transfer', async () => {
   expect(deserializedPayload.amount.toString()).toBe(amount.toString());
 
   const signer = new TransactionSigner(deserializedTx);
+  // sign once
   signer.signOrigin(privKeys[0]);
-  signer.signOrigin(privKeys[1]);
-  signer.appendOrigin(pubKeys[2]);
 
-  const serializedSignedTx = deserializedTx.serialize();
+  // serialize
+  const partiallySignedSerialized = deserializedTx.serialize();
+
+  // deserialize
+  const bufferReader2 = new BufferReader(partiallySignedSerialized);
+  const partiallySigned = deserializeTransaction(bufferReader2);
+
+  // finish signing with new TransactionSigner
+  const signer2 = new TransactionSigner(partiallySigned);
+  signer2.signOrigin(privKeys[1]);
+  signer2.appendOrigin(pubKeys[2]);
+
+  const serializedSignedTx = partiallySigned.serialize();
+
   const signedTx =
     '00000000010401a23ea89d6529ac48ac766f720e480beec7f19273000000000000000000000000000000000' +
     '00000030200dc8061e63a8ed7ca4712c257299b4bdc3938e34ccc01ce979dd74e5483c4f971053a12680cbf' +

--- a/packages/transactions/tests/builder.test.ts
+++ b/packages/transactions/tests/builder.test.ts
@@ -250,6 +250,78 @@ test('Make Multi-Sig STX token transfer', async () => {
   expect(deserializedPayload.amount.toString()).toBe(amount.toString());
 
   const signer = new TransactionSigner(deserializedTx);
+  signer.signOrigin(privKeys[0]);
+  signer.signOrigin(privKeys[1]);
+  signer.appendOrigin(pubKeys[2]);
+
+  const serializedSignedTx = deserializedTx.serialize();
+  const signedTx =
+    '00000000010401a23ea89d6529ac48ac766f720e480beec7f19273000000000000000000000000000000000' +
+    '00000030200dc8061e63a8ed7ca4712c257299b4bdc3938e34ccc01ce979dd74e5483c4f971053a12680cbf' +
+    'bea87976543a94500314c9a1eaf33986aef97821eb65fb0c604202018ff7d2d8cd4e43498912bfc2c30be1f' +
+    'd58bef8d819e1371a0f5afa5e4b58ff6e498bd67b58c32bf670f0d8bcb399fa141e5c5cc21e57d30a091395' +
+    'c95c9e05580003661ec7479330bf1ef7a4c9d1816f089666a112e72d671048e5424fc528ca5153000203020' +
+    '0000000000516df0ba3e79792be7be5e50a370289accfc8c9e03200000000002625a074657374206d656d6f' +
+    '00000000000000000000000000000000000000000000000000';
+
+  expect(serializedSignedTx.toString('hex')).toBe(signedTx);
+});
+
+test('Make Multi-Sig STX token transfer with two transaction signers', async () => {
+  const recipient = standardPrincipalCV('SP3FGQ8Z7JY9BWYZ5WM53E0M9NK7WHJF0691NZ159');
+  const amount = 2500000;
+  const fee = 0;
+  const nonce = 0;
+  const memo = 'test memo';
+
+  const authType = AuthType.Standard;
+  const addressHashMode = AddressHashMode.SerializeP2SH;
+
+  const privKeyStrings = [
+    '6d430bb91222408e7706c9001cfaeb91b08c2be6d5ac95779ab52c6b431950e001',
+    '2a584d899fed1d24e26b524f202763c8ab30260167429f157f1c119f550fa6af01',
+    'd5200dee706ee53ae98a03fba6cf4fdcc5084c30cfa9e1b3462dcdeaa3e0f1d201',
+  ];
+  const privKeys = privKeyStrings.map(createStacksPrivateKey);
+
+  const pubKeys = privKeyStrings.map(pubKeyfromPrivKey);
+  const pubKeyStrings = pubKeys.map(publicKeyToString);
+
+  const transaction = await makeUnsignedSTXTokenTransfer({
+    recipient,
+    amount,
+    fee,
+    nonce,
+    memo: memo,
+    numSignatures: 2,
+    publicKeys: pubKeyStrings,
+    anchorMode: AnchorMode.Any
+  });
+
+  const serializedTx = transaction.serialize();
+
+  const tx =
+    '00000000010401a23ea89d6529ac48ac766f720e480beec7f1927300000000000000000000000000000000' +
+    '000000000002030200000000000516df0ba3e79792be7be5e50a370289accfc8c9e03200000000002625a0' +
+    '74657374206d656d6f00000000000000000000000000000000000000000000000000';
+
+  expect(serializedTx.toString('hex')).toBe(tx);
+
+  const bufferReader = new BufferReader(serializedTx);
+  const deserializedTx = deserializeTransaction(bufferReader);
+
+  expect(deserializedTx.auth.authType).toBe(authType);
+
+  expect(deserializedTx.auth.spendingCondition!.hashMode).toBe(addressHashMode);
+  expect(deserializedTx.auth.spendingCondition!.nonce.toString()).toBe(nonce.toString());
+  expect(deserializedTx.auth.spendingCondition!.fee.toString()).toBe(fee.toString());
+  expect(deserializedTx.auth.spendingCondition!.signer).toEqual(
+    'a23ea89d6529ac48ac766f720e480beec7f19273'
+  );
+  const deserializedPayload = deserializedTx.payload as TokenTransferPayload;
+  expect(deserializedPayload.amount.toString()).toBe(amount.toString());
+
+  const signer = new TransactionSigner(deserializedTx);
   // sign once
   signer.signOrigin(privKeys[0]);
 


### PR DESCRIPTION
issue: #1077

This PR makes it possible to construct a `TransactionSigner` from a partially signed multi-sig transaction, enabling multiple parties to sign a transaction with different instances of `TransactionSigner`.