### PR TITLE
fix: avoid use of getters to enable safer serialization

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -377,8 +377,9 @@ function balance(network: CLINetworkAdapter, args: string[]): Promise<string> {
   }
 
   // temporary hack to use network config from stacks-transactions lib
-  const txNetwork = network.isMainnet() ? new StacksMainnet() : new StacksTestnet();
-  txNetwork.coreApiUrl = network.legacyNetwork.blockstackAPIUrl;
+  const txNetwork = network.isMainnet()
+    ? new StacksMainnet({ url: network.legacyNetwork.blockstackAPIUrl })
+    : new StacksTestnet({ url: network.legacyNetwork.blockstackAPIUrl });
 
   return fetch(txNetwork.getAccountApiUrl(address))
     .then(response => {
@@ -570,8 +571,9 @@ async function sendTokens(network: CLINetworkAdapter, args: string[]): Promise<s
   }
 
   // temporary hack to use network config from stacks-transactions lib
-  const txNetwork = network.isMainnet() ? new StacksMainnet() : new StacksTestnet();
-  txNetwork.coreApiUrl = network.legacyNetwork.blockstackAPIUrl;
+  const txNetwork = network.isMainnet()
+    ? new StacksMainnet({ url: network.legacyNetwork.blockstackAPIUrl })
+    : new StacksTestnet({ url: network.legacyNetwork.blockstackAPIUrl });
 
   const options: SignedTokenTransferOptions = {
     recipient: recipientAddress,
@@ -630,8 +632,9 @@ async function contractDeploy(network: CLINetworkAdapter, args: string[]): Promi
   const source = fs.readFileSync(sourceFile).toString();
 
   // temporary hack to use network config from stacks-transactions lib
-  const txNetwork = network.isMainnet() ? new StacksMainnet() : new StacksTestnet();
-  txNetwork.coreApiUrl = network.legacyNetwork.blockstackAPIUrl;
+  const txNetwork = network.isMainnet()
+    ? new StacksMainnet({ url: network.legacyNetwork.blockstackAPIUrl })
+    : new StacksTestnet({ url: network.legacyNetwork.blockstackAPIUrl });
 
   const options: ContractDeployOptions = {
     contractName,
@@ -690,8 +693,9 @@ async function contractFunctionCall(network: CLINetworkAdapter, args: string[]):
   const privateKey = args[5];
 
   // temporary hack to use network config from stacks-transactions lib
-  const txNetwork = network.isMainnet() ? new StacksMainnet() : new StacksTestnet();
-  txNetwork.coreApiUrl = network.legacyNetwork.blockstackAPIUrl;
+  const txNetwork = network.isMainnet()
+    ? new StacksMainnet({ url: network.legacyNetwork.blockstackAPIUrl })
+    : new StacksTestnet({ url: network.legacyNetwork.blockstackAPIUrl });
 
   let abi: ClarityAbi;
   let abiArgs: ClarityFunctionArg[];
@@ -776,8 +780,9 @@ async function readOnlyContractFunctionCall(
   const senderAddress = args[3];
 
   // temporary hack to use network config from stacks-transactions lib
-  const txNetwork = network.isMainnet() ? new StacksMainnet() : new StacksTestnet();
-  txNetwork.coreApiUrl = network.legacyNetwork.blockstackAPIUrl;
+  const txNetwork = network.isMainnet()
+    ? new StacksMainnet({ url: network.legacyNetwork.blockstackAPIUrl })
+    : new StacksTestnet({ url: network.legacyNetwork.blockstackAPIUrl });
 
   let abi: ClarityAbi;
   let abiArgs: ClarityFunctionArg[];

--- a/packages/keychain/src/wallet/signer.ts
+++ b/packages/keychain/src/wallet/signer.ts
@@ -67,9 +67,7 @@ export class WalletSigner {
   }
 
   getNetwork() {
-    const network = new StacksTestnet();
-    network.coreApiUrl = 'https://sidecar.staging.blockstack.xyz';
-    return network;
+    return new StacksTestnet();
   }
 
   async fetchAccount({

--- a/packages/network/src/index.ts
+++ b/packages/network/src/index.ts
@@ -57,18 +57,13 @@ export class StacksMainnet implements StacksNetwork {
   accountEndpoint = '/v2/accounts';
   contractAbiEndpoint = '/v2/contracts/interface';
   readOnlyFunctionCallEndpoint = '/v2/contracts/call-read';
-  private _coreApiUrl: string;
 
-  get coreApiUrl() {
-    return this._coreApiUrl;
-  }
-  set coreApiUrl(_url: string) {
-    throw new Error('Cannot modify property `coreApiUrl` after object initialization');
-  }
+  readonly coreApiUrl: string;
 
   constructor(networkUrl: NetworkConfig = { url: HIRO_MAINNET_DEFAULT }) {
-    this._coreApiUrl = networkUrl.url;
+    this.coreApiUrl = networkUrl.url;
   }
+
   isMainnet = () => this.version === TransactionVersion.Mainnet;
   getBroadcastApiUrl = () => `${this.coreApiUrl}${this.broadcastEndpoint}`;
   getTransferFeeEstimateApiUrl = () => `${this.coreApiUrl}${this.transferFeeEstimateEndpoint}`;

--- a/packages/network/tests/network.test.ts
+++ b/packages/network/tests/network.test.ts
@@ -25,10 +25,4 @@ describe('Setting coreApiUrl', () => {
     const customNET = new StacksMainnet({ url: customURL });
     expect(customNET.coreApiUrl).toEqual(customURL);
   });
-  test('it prevents changing url after initialisation', () => {
-    const network = new StacksMainnet({ url: 'https://legiturl.com' });
-    // @ts-ignore
-    expect(() => (network.coreApiUrl = 'https://dodgyurl.com')).toThrowError();
-    expect(network.coreApiUrl).toEqual('https://legiturl.com');
-  });
 });


### PR DESCRIPTION
One side effect of using a getter/setter to prohibit mutability of the `coreApiUrl` property is that, when serialised, it's visible as its private name `_coreApiUrl`.

This is problematic in the extension wallet, for example. The initialised network instance is passed from `@stacks/connect` through to the extension, which is in a different js context with postMessage, where it's implicitly serialised (causing issues as we expect the other name).

This PR favours a `readonly` property, which results in better serialisability. A type error is thrown, rather than a runtime error, if a user tries to mutate the property.