### PR TITLE
[HotFix] github action for generating updated docs on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,18 +3,21 @@ name: Release
 on:
   push:
     branches:
-      - '**'
+      - master
     tags-ignore:
       - '**'
     paths-ignore:
       - '**/CHANGELOG.md'
       - '**/package.json'
+      - 'docs/**'
   pull_request:
   workflow_dispatch:
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    # Only run on non-PR events or only PRs that aren't from forks
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v2
       - name: Set Node Version
@@ -36,8 +39,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_OPTIONS: --max-old-space-size=4096
+          SEMANTIC_RELEASE_PACKAGE: ${{ github.event.repository.name }} # Always needed
         with:
           extra_plugins: |
             @semantic-release/changelog
             @semantic-release/git
-            @semantic-release/exec

--- a/package.json
+++ b/package.json
@@ -12,20 +12,24 @@
   ],
   "release": {
     "branches": [
-      "master",
-      "next"
+      "master"
     ],
     "plugins": [
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",
+      [
+        "@semantic-release/npm",
+        {
+          "npmPublish": false
+        }
+      ],
       "@semantic-release/changelog",
       [
         "@semantic-release/git",
         {
           "assets": [
             "docs"
-          ],
-          "message": "chore(release docs): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+          ]
         }
       ]
     ]


### PR DESCRIPTION
## Description
This PR fixes some missed commits in a previous [PR](https://github.com/blockstack/stacks.js/pull/1062) which is already merged. 

Changes in this PR were already reviewed by @CharlieC3. I cannot see these changes after merge that's why i pushed these again.. may be missed somehow from my side or might be push was not successful. 

cc: @agraebe Need to merge these changes so that `release` ci job should not fail.  

This PR closes #1047

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Testing information

Provide context on how tests should be performed.
For each new commits added to one of the release branches (for example master, next, beta), with git push or by merging a pull request or merging from another branch, a CI build is triggered and runs the semantic-release command to make a release if there are codebase changes since the last release that affect the package functionalities
Reference: `https://github.com/semantic-release/semantic-release`
## Checklist
- [X] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [X] `npm run test` passes
- [ ] Changelog is updated
- [X] Tag 1 of @yknl or @zone117x for review
