### PR TITLE
Some etags in sessionData might not be deleted in deleteFile

### DIFF
--- a/packages/storage/src/storage.ts
+++ b/packages/storage/src/storage.ts
@@ -636,29 +636,32 @@ export class Storage {
   ) {
     const gaiaHubConfig = await this.getOrSetLocalGaiaHubConnection();
     const opts = Object.assign({}, options);
-    const sessionData = this.userSession.store.getSessionData();
     if (opts.wasSigned) {
       // If signed, delete both the content file and the .sig file
       try {
         await deleteFromGaiaHub(path, gaiaHubConfig);
         await deleteFromGaiaHub(`${path}${SIGNATURE_FILE_SUFFIX}`, gaiaHubConfig);
+        const sessionData = this.userSession.store.getSessionData();
         delete sessionData.etags![path];
         this.userSession.store.setSessionData(sessionData);
       } catch (error) {
         const freshHubConfig = await this.setLocalGaiaHubConnection();
         await deleteFromGaiaHub(path, freshHubConfig);
         await deleteFromGaiaHub(`${path}${SIGNATURE_FILE_SUFFIX}`, gaiaHubConfig);
+        const sessionData = this.userSession.store.getSessionData();
         delete sessionData.etags![path];
         this.userSession.store.setSessionData(sessionData);
       }
     } else {
       try {
         await deleteFromGaiaHub(path, gaiaHubConfig);
+        const sessionData = this.userSession.store.getSessionData();
         delete sessionData.etags![path];
         this.userSession.store.setSessionData(sessionData);
       } catch (error) {
         const freshHubConfig = await this.setLocalGaiaHubConnection();
         await deleteFromGaiaHub(path, freshHubConfig);
+        const sessionData = this.userSession.store.getSessionData();
         delete sessionData.etags![path];
         this.userSession.store.setSessionData(sessionData);
       }


### PR DESCRIPTION
## Description
This PR fixes the issue: `Some etags in sessionData might not be deleted in deleteFile`

This PR closes the issue #888


## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No
## Testing information
Provide context on how tests should be performed.
* `npm run test` in `storage`
* `Use the below attached snippet to test the behaviour`
```
import { UserSession, AppConfig, LOCALSTORAGE_SESSION_KEY } from './packages/auth';
import { Storage } from '@stacks/storage';
import * as jsdom from 'jsdom';

void(async () => {
  const dom = new jsdom.JSDOM('', { url: 'https://example.org/' }).window;
  const globalAPIs: { [key: string]: any } = {
    localStorage: dom.localStorage,
    location: dom.location,
    self: dom,
  };
  for (const globalAPI of Object.keys(globalAPIs)) {
    (global as any)[globalAPI] = globalAPIs[globalAPI];
  }
  const privateKey = '896adae13a1bf88db0b2ec94339b62382ec6f34cd7e2ff8abae7ec271e05f9d8';
  const appConfig = new AppConfig();
  const userSession = new UserSession({ appConfig });
  const session = userSession.store.getSessionData();
  session.userData = <any> {
    appPrivateKey: privateKey,
  };
  userSession.store.setSessionData(session);
  const storage = new Storage({ userSession });

  const files = ['aa.json', 'bb.json', 'cc.json', 'dd.json', 'ee.json'];

  for (let i = 0; i < files.length; i++) {
    const myData = JSON.stringify({
      // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
      hello: 'hello: ' + i,
      num: i,
    });
    await storage.putFile(files[i], myData, { encrypt: false });
  }
  const promises = [];
  for (let i = 0; i < files.length; i++) {
    promises.push(storage.deleteFile(files[i]));
  }
  Promise.all(promises).then(() => {
    const se = userSession.store.getSessionData();
    console.log('Final session', se);
    console.log('localStorage: ', localStorage.getItem(LOCALSTORAGE_SESSION_KEY));
  });
})();


```

## Checklist
- [X] Code is commented where needed
- [X] Unit test coverage for new or modified code paths
- [X] `npm run test` passes
- [ ] Changelog is updated
- [X] Tag 1 of @yknl or @zone117x for review
