### PR TITLE
fix: sponsored spending condition has an empty signature

### DIFF
--- a/packages/transactions/src/builders.ts
+++ b/packages/transactions/src/builders.ts
@@ -1326,5 +1326,5 @@ export async function sponsorTransaction(
   );
   signer.signSponsor(privKey);
 
-  return options.transaction;
+  return signer.transaction;
 }

--- a/packages/transactions/tests/builder.test.ts
+++ b/packages/transactions/tests/builder.test.ts
@@ -33,6 +33,7 @@ import { createAssetInfo } from '../src/types';
 import {
   createMessageSignature,
   createTransactionAuthField,
+  emptyMessageSignature,
   isSingleSig,
   MultiSigSpendingCondition,
   nextSignature,
@@ -894,6 +895,10 @@ test('Make sponsored STX token transfer', async () => {
   expect(deserializedSponsorSpendingCondition.hashMode).toBe(addressHashMode);
   expect(deserializedSponsorSpendingCondition.nonce!.toString()).toBe(sponsorNonce.toString());
   expect(deserializedSponsorSpendingCondition.fee!.toString()).toBe(sponsorFee.toString());
+
+  const spendingCondition = deserializedSponsorSpendingCondition as SingleSigSpendingCondition;
+  const emptySignature = emptyMessageSignature();
+  expect(spendingCondition.signature.data.toString()).not.toBe(emptySignature.data.toString());
 
   const deserializedPayload = deserializedSponsorTx.payload as TokenTransferPayload;
   expect(deserializedPayload.amount.toString()).toBe(amount.toString());


### PR DESCRIPTION
## Description

The code calculated the correct signature for sponsored transactions, but did not return it.  It's a one-line fix.

See [this discord thread](https://discord.com/channels/621759717756370964/889793249676505118/889795860949508097) for details.

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?

This shouldn't break anything.

## Are documentation updates required?

No.

## Testing information

I've added a check for empty signatures in `packages/transactions/tests/builder.test.ts` (_Make sponsored STX token transfer_) but more tests can be added.

## Checklist
- [X] Code is commented where needed
- [X] Unit test coverage for new or modified code paths
- [X] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @yknl or @zone117x for review

Tagging: @yknl 
