### PR TITLE
Fix/1109

### DIFF
--- a/packages/common/src/errors.ts
+++ b/packages/common/src/errors.ts
@@ -51,7 +51,7 @@ export class BlockstackError extends Error {
     if (!stack) {
       try {
         throw new Error();
-      } catch (e) {
+      } catch (e: any) {
         stack = e.stack;
       }
     } else {

--- a/packages/encryption/tests/encryption.test.ts
+++ b/packages/encryption/tests/encryption.test.ts
@@ -311,7 +311,7 @@ test('encrypt-to-decrypt fails on bad mac', async () => {
   try {
     await decryptECIES(privateKey, cipherObj)
     expect(false).toEqual(true)
-  } catch (e) {
+  } catch (e: any) {
 
     expect(e.code).toEqual(ERROR_CODES.FAILED_DECRYPTION_ERROR)
     expect(e.message.indexOf('failure in MAC check')).not.toEqual(-1)
@@ -331,7 +331,7 @@ test('Should be able to prevent a public key twist attack for secp256k1', async 
     const testString = 'all work and no play makes jack a dull boy';
     await encryptECIES(badPublicKey, Buffer.from(testString), true);
     expect(false).toEqual(true);
-  } catch (error) {
+  } catch (error: any) {
     expect(error.reason).toEqual('IsNotPoint');
   }
 })
@@ -349,7 +349,7 @@ test('Should be able to accept public key with valid point on secp256k', async (
     // encryptECIES should not throw invalid point exception
     await encryptECIES(goodPublicKey, Buffer.from(testString), true);
     expect(true).toEqual(true);
-  } catch (error) {
+  } catch (error: any) {
     expect(error.reason).toEqual('IsNotPoint');
   }
 })
@@ -361,7 +361,7 @@ test('Should reject public key having invalid length', async () => {
     await encryptECIES(invalidPublicKey, Buffer.from(testString), true);
     //Should throw invalid format exception
     expect(false).toEqual(true);
-  } catch (error) {
+  } catch (error: any) {
     expect(error.reason).toEqual('InvalidFormat');
   }
 })
@@ -373,7 +373,7 @@ test('Should accept public key having valid length', async () => {
     await encryptECIES(publicKey, Buffer.from(testString), true);
     // Should not throw invalid format exception
     expect(true).toEqual(true);
-  } catch (error) {
+  } catch (error: any) {
     expect(error.reason).toEqual('InvalidFormat');
   }
 })
@@ -385,7 +385,7 @@ test('Should reject invalid uncompressed public key', async () => {
     await encryptECIES(invalidPublicKey, Buffer.from(testString), true);
     // Should throw invalid format exception
     expect(false).toEqual(true);
-  } catch (error) {
+  } catch (error: any) {
     expect(error.reason).toEqual('InvalidFormat');
   }
 })
@@ -397,7 +397,7 @@ test('Should accept valid uncompressed public key', async () => {
     await encryptECIES(publicKey, Buffer.from(testString), true);
     // Should not throw invalid format exception
     expect(true).toEqual(true);
-  } catch (error) {
+  } catch (error: any) {
     expect(error.reason).toEqual('InvalidFormat');
   }
 })
@@ -409,7 +409,7 @@ test('Should reject invalid compressed public key', async () => {
     await encryptECIES(invalidPublicKey, Buffer.from(testString), true);
     // Should throw invalid format exception
     expect(false).toEqual(true);
-  } catch (error) {
+  } catch (error: any) {
     expect(error.reason).toEqual('InvalidFormat');
   }
 })
@@ -421,7 +421,7 @@ test('Should accept valid compressed public key', async () => {
     await encryptECIES(publicKey, Buffer.from(testString), true);
     // Should not throw invalid format exception
     expect(true).toEqual(true);
-  } catch (error) {
+  } catch (error: any) {
     expect(error.reason).toEqual('InvalidFormat');
   }
 })

--- a/packages/profile/src/profile.ts
+++ b/packages/profile/src/profile.ts
@@ -302,12 +302,21 @@ export function getTokenFileUrl(zoneFileJson: any): string | null {
   if (zoneFileJson.uri.length < 1) {
     return null;
   }
-  const firstUriRecord = zoneFileJson.uri[0];
 
-  if (!firstUriRecord.hasOwnProperty('target')) {
+  const validRecords = zoneFileJson.uri.filter(
+    (record: any) => record.hasOwnProperty('target') && record.name === '_http._tcp'
+  );
+
+  if (validRecords.length < 1) {
     return null;
   }
-  let tokenFileUrl = firstUriRecord.target;
+
+  const firstValidRecord = validRecords[0];
+
+  if (!firstValidRecord.hasOwnProperty('target')) {
+    return null;
+  }
+  let tokenFileUrl = firstValidRecord.target;
 
   if (tokenFileUrl.startsWith('https')) {
     // pass

--- a/packages/profile/tests/profiles.test.ts
+++ b/packages/profile/tests/profiles.test.ts
@@ -1,9 +1,11 @@
+import { parseZoneFile } from 'zone-file'
 import {
   signProfileToken,
   wrapProfileToken,
   verifyProfileToken,
   extractProfile,
   makeProfileZoneFile,
+  getTokenFileUrl,
 } from '../src'
 
 import { sampleProfiles } from './sampleData'
@@ -54,6 +56,20 @@ profiles.forEach(profile => {
     const expectedZoneFile = '$ORIGIN satoshi.id\n$TTL 3600\n_http._tcp	IN	URI	10	1	"https://example.com/satoshi.json"\n\n'
     const actualZoneFile = makeProfileZoneFile(origin, tokenFileUrl)
     expect(actualZoneFile).toEqual(expectedZoneFile)
+  })
+
+  test('getTokenFileUrl', () => {
+    const zoneFile = '$ORIGIN satoshi.id\n$TTL 3600\n_http._tcp	IN	URI	10	1	"https://example.com/satoshi.json"\n\n'
+    const expectedTokenFileUrl = "https://example.com/satoshi.json"
+    const actualTokenFileUrl = getTokenFileUrl(parseZoneFile(zoneFile))
+    expect(actualTokenFileUrl).toEqual(expectedTokenFileUrl)
+  })
+
+  test('getTokenFileUrl from zonefile with redirect', () => {
+    const zoneFile = '$ORIGIN satoshi.id\n$TTL 3600\n_redirect	IN	URI	10	1	"https://example.com/"\n_http._tcp	IN	URI	10	1	"https://example.com/satoshi.json"\n\n'
+    const expectedTokenFileUrl = "https://example.com/satoshi.json"
+    const actualTokenFileUrl = getTokenFileUrl(parseZoneFile(zoneFile))
+    expect(actualTokenFileUrl).toEqual(expectedTokenFileUrl)
   })
 
 });

--- a/packages/storage/src/storage.ts
+++ b/packages/storage/src/storage.ts
@@ -606,7 +606,7 @@ export class Storage {
 
     try {
       return await uploadFn(gaiaHubConfig);
-    } catch (error) {
+    } catch (error: any) {
       // If the upload fails on first attempt, it could be due to a recoverable
       // error which may succeed by refreshing the config and retrying.
       if (isRecoverableGaiaError(error)) {

--- a/packages/storage/tests/storage.test.ts
+++ b/packages/storage/tests/storage.test.ts
@@ -1044,7 +1044,7 @@ test('putFile throws correct error when server rejects etag', async () => {
     const options = { encrypt: false };
 
     await storage.putFile(path, content, options);
-  } catch (err) {
+  } catch (err: any) {
     expect(err.code).toEqual('precondition_failed_error');
   }
 });
@@ -1472,21 +1472,21 @@ test('putFile & getFile unencrypted, signed', async () => {
   try {
     await storage.getFile(badSigPath, decryptOptions);
     fail('Should have failed to read file.');
-  } catch (err) {
+  } catch (err: any) {
     expect(err.message.indexOf('do not match ECDSA')).toBeGreaterThanOrEqual(0);
   }
 
   try {
     await storage.getFile(noSigPath, decryptOptions);
     fail('Should have failed to read file.');
-  } catch (err) {
+  } catch (err: any) {
     expect(err.message.indexOf('obtain signature for file')).toBeGreaterThanOrEqual(0);
   }
 
   try {
     await storage.getFile(badPKPath, decryptOptions);
     fail('Should have failed to read file.');
-  } catch (err) {
+  } catch (err: any) {
     expect(err.message.indexOf('match gaia address')).toBeGreaterThanOrEqual(0);
   }
 
@@ -1496,21 +1496,21 @@ test('putFile & getFile unencrypted, signed', async () => {
   try {
     await storage.getFile(badSigPath, multiplayerDecryptOptions);
     fail('Should have failed to read file.');
-  } catch (err) {
+  } catch (err: any) {
     expect(err.message.indexOf('do not match ECDSA')).toBeGreaterThanOrEqual(0);
   }
 
   try {
     await storage.getFile(noSigPath, multiplayerDecryptOptions);
     fail('Should have failed to read file.');
-  } catch (err) {
+  } catch (err: any) {
     expect(err.message.indexOf('obtain signature for file')).toBeGreaterThanOrEqual(0);
   }
 
   try {
     await storage.getFile(badPKPath, multiplayerDecryptOptions);
     fail('Should have failed to read file.');
-  } catch (err) {
+  } catch (err: any) {
     expect(err.message.indexOf('match gaia address')).toBeGreaterThanOrEqual(0);
   }
 });
@@ -1561,7 +1561,7 @@ test('putFile oversized -- unencrypted, signed', async () => {
   try {
     await storage.putFile('file.bin', fileContent, encryptOptions);
     fail('should have thrown error with oversized content -- unencrypted, signed');
-  } catch (error) {
+  } catch (error: any) {
     expect(error.name).toEqual('PayloadTooLargeError');
   }
 });
@@ -1612,7 +1612,7 @@ test('putFile oversized -- encrypted, signed', async () => {
   try {
     await storage.putFile('file.bin', fileContent, encryptOptions);
     fail('should have thrown error with oversized content -- encrypted, signed');
-  } catch (error) {
+  } catch (error: any) {
     expect(error.name).toEqual('PayloadTooLargeError');
   }
 });
@@ -1663,7 +1663,7 @@ test('putFile oversized -- unencrypted', async () => {
   try {
     await storage.putFile('file.bin', fileContent, encryptOptions);
     fail('should have thrown error with oversized content -- unencrypted');
-  } catch (error) {
+  } catch (error: any) {
     expect(error.name).toEqual('PayloadTooLargeError');
   }
 });
@@ -1714,7 +1714,7 @@ test('putFile oversized -- encrypted', async () => {
   try {
     await storage.putFile('file.bin', fileContent, encryptOptions);
     fail('should have thrown error with oversized content -- encrypted');
-  } catch (error) {
+  } catch (error: any) {
     expect(error.name).toEqual('PayloadTooLargeError');
   }
 });
@@ -2199,7 +2199,7 @@ test('getUserAppFileUrl without user session', async () => {
   const fileUrl = 'https://gaia.blockstack.org/hub/1DDUqfKtQgYNt722wuB4Z2fPC7aiNGQa5R/file.json';
   const zoneFileLookupURL = 'https://potato/v1/names';
   const path = 'file.json';
-  const username = 'yukan.id';
+  const username = 'yukan.btc';
   const appOrigin = 'http://localhost:8080';
   const nameRecord = {
     status: 'registered',


### PR DESCRIPTION
## Description
This PR improves the handling of zone file content. btc.us allows to add redirect records into the users' zonefiles. This PR ignores these entries when finding the profile url.
For details refer to issue #1109 

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?

no

## Testing information

Unit test added

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [x] Changelog is updated
- [x] Tag 1 of @yknl or @zone117x for review
