### PR TITLE
Export PostCondition types individually

### DIFF
--- a/packages/transactions/src/index.ts
+++ b/packages/transactions/src/index.ts
@@ -23,6 +23,9 @@ export {
 
 export {
   PostCondition,
+  STXPostCondition,
+  FungiblePostCondition,
+  NonFungiblePostCondition,
   createFungiblePostCondition,
   createNonFungiblePostCondition,
   createSTXPostCondition,


### PR DESCRIPTION
## Description
This PR fixes the issue #1108. 
Please export `STXPostCondition` , `FungiblePostCondition` , and `NonFungiblePostCondition` from `@stacks/transactions`.

This PR closes the issue #1108


## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No
## Testing information

Should be able to import aforementioned types from `@stacks/transactions`

## Checklist
- [X] Code is commented where needed
- [X] Unit test coverage for new or modified code paths
- [X] `npm run test` passes
- [ ] Changelog is updated
- [X] Tag 1 of @yknl or @zone117x for review
