### PR TITLE
nit: match code example with bigint literal in @stacks/transactions

### DIFF
--- a/packages/transactions/README.md
+++ b/packages/transactions/README.md
@@ -50,8 +50,8 @@ const txOptions = {
   senderKey: 'b244296d5907de9864c0b0d51f98a13c52890be0404e83f273144cd5b9960eed01',
   network,
   memo: 'test memo',
-  nonce: new BigNum(0), // set a nonce manually if you don't want builder to fetch from a Stacks node
-  fee: new BigNum(200), // set a tx fee if you don't want the builder to estimate
+  nonce: 0n, // set a nonce manually if you don't want builder to fetch from a Stacks node
+  fee: 200n, // set a tx fee if you don't want the builder to estimate
   anchorMode: AnchorMode.Any,
 };
 


### PR DESCRIPTION
Use the following template to create your pull request

## Description
```typescript


const txOptions = {
  //....
  nonce: new BigNum(0), // set a nonce manually if you don't want builder to fetch from a Stacks node
  fee: new BigNum(200), // set a tx fee if you don't want the builder to estimate
 //...
};



```
I was testing around a few snippets from the examples and found this: - [`@stacks/transactions`](https://github.com/blockstack/stacks.js/tree/master/packages/transactions#stx-token-transfer-transaction)
BigNum is undefined, I looked around the code base and there's little to no mention of BigNum, so I changed it to a bigint literal as the typescript param of the function that receives those values accepts 'bigint'.





## Type of Change
- [ ] New feature
- [ ] Bug fix
- [x] API reference/documentation update
- [ ] Other



## Checklist
- [x] Tag 1 of @yknl or @zone117x for review
