### PR TITLE
Remove regtest from network list #1107

### DIFF
--- a/packages/cli/src/argparse.ts
+++ b/packages/cli/src/argparse.ts
@@ -88,16 +88,6 @@ const CONFIG_DEFAULTS: CLI_CONFIG_TYPE = {
   logConfig: LOG_CONFIG_DEFAULTS,
 };
 
-const CONFIG_REGTEST_DEFAULTS: CLI_CONFIG_TYPE = {
-  blockstackAPIUrl: 'http://localhost:16268',
-  blockstackNodeUrl: 'http://localhost:16264',
-  broadcastServiceUrl: 'http://localhost:16269',
-  utxoServiceUrl: 'http://localhost:18332',
-  logConfig: LOG_CONFIG_DEFAULTS,
-  bitcoindPassword: 'blockstacksystem',
-  bitcoindUsername: 'blockstack',
-};
-
 const CONFIG_LOCALNET_DEFAULTS = {
   blockstackAPIUrl: `http://localhost:20443`,
   blockstackNodeUrl: `http://localhost:20443`,
@@ -117,7 +107,6 @@ const CONFIG_TESTNET_DEFAULTS = {
 };
 
 export const DEFAULT_CONFIG_PATH = '~/.blockstack-cli.conf';
-export const DEFAULT_CONFIG_REGTEST_PATH = path.join(os.homedir(), '.blockstack-cli-regtest.conf');
 export const DEFAULT_CONFIG_TESTNET_PATH = path.join(os.homedir(), '.blockstack-cli-testnet.conf');
 
 export const DEFAULT_MAX_ID_SEARCH_INDEX = 256;
@@ -3377,15 +3366,10 @@ export function checkArgs(argList: string[]): CheckArgsSuccessType | CheckArgsFa
  * If no config file exists, then return the default config.
  *
  * @configPath (string) the path to the config file.
- * @networkType (sring) 'mainnet', 'regtest', 'localnet', or 'testnet'
+ * @networkType (sring) 'mainnet', 'localnet', or 'testnet'
  */
 export function loadConfig(configFile: string, networkType: string): CLI_CONFIG_TYPE {
-  if (
-    networkType !== 'mainnet' &&
-    networkType !== 'testnet' &&
-    networkType != 'regtest' &&
-    networkType != 'localnet'
-  ) {
+  if (networkType !== 'mainnet' && networkType !== 'testnet' && networkType != 'localnet') {
     throw new Error('Unregognized network');
   }
 
@@ -3393,8 +3377,6 @@ export function loadConfig(configFile: string, networkType: string): CLI_CONFIG_
 
   if (networkType === 'mainnet') {
     configRet = Object.assign({}, CONFIG_DEFAULTS);
-  } else if (networkType === 'regtest') {
-    configRet = Object.assign({}, CONFIG_REGTEST_DEFAULTS);
   } else if (networkType === 'localnet') {
     configRet = Object.assign({}, CONFIG_LOCALNET_DEFAULTS);
   } else {

--- a/packages/cli/src/auth.ts
+++ b/packages/cli/src/auth.ts
@@ -309,7 +309,7 @@ async function getIdentityInfo(
   _appGaiaHub: string,
   _profileGaiaHub: string
 ): Promise<NamedIdentityType[]> {
-  network.setCoerceMainnetAddress(true); // for lookups in regtest
+  network.setCoerceMainnetAddress(false);
   let identities: NamedIdentityType[];
 
   try {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -78,7 +78,6 @@ import {
   makeAllCommandsList,
   USAGE,
   DEFAULT_CONFIG_PATH,
-  DEFAULT_CONFIG_REGTEST_PATH,
   DEFAULT_CONFIG_TESTNET_PATH,
   ID_ADDRESS_PATTERN,
   STACKS_ADDRESS_PATTERN,
@@ -372,7 +371,7 @@ function balance(network: CLINetworkAdapter, args: string[]): Promise<string> {
   let address = args[0];
 
   if (BLOCKSTACK_TEST) {
-    // force testnet address if we're in regtest or testnet mode
+    // force testnet address if we're in testnet mode
     address = network.coerceAddress(address);
   }
 
@@ -1842,8 +1841,6 @@ export function CLIMain() {
 
     const configPath = CLIOptAsString(opts, 'c')
       ? CLIOptAsString(opts, 'c')
-      : integration_test
-      ? DEFAULT_CONFIG_REGTEST_PATH
       : testnet
       ? DEFAULT_CONFIG_TESTNET_PATH
       : DEFAULT_CONFIG_PATH;
@@ -1853,13 +1850,7 @@ export function CLIMain() {
     const priceToPay = CLIOptAsString(opts, 'P') ? CLIOptAsString(opts, 'P') : '0';
     const priceUnits = CLIOptAsString(opts, 'D');
 
-    const networkType = testnet
-      ? 'testnet'
-      : localnet
-      ? 'localnet'
-      : integration_test
-      ? 'regtest'
-      : 'mainnet';
+    const networkType = testnet ? 'testnet' : localnet ? 'localnet' : 'mainnet';
 
     const configData = loadConfig(configPath!, networkType);
 

--- a/packages/cli/src/keys.ts
+++ b/packages/cli/src/keys.ts
@@ -149,7 +149,7 @@ export async function getStacksWalletKeyInfo(
     // btcAddress = const { address } = bitcoin.payments.p2pkh({ pubkey: keyPair.publicKey });
     const { address } = bitcoin.payments.p2pkh({
       pubkey: ecPair.publicKey,
-      network: bitcoin.networks.regtest,
+      network: bitcoin.networks.testnet,
     });
     btcAddress = address!;
   } else {

--- a/packages/cli/src/network.ts
+++ b/packages/cli/src/network.ts
@@ -7,8 +7,6 @@ import { CLI_CONFIG_TYPE } from './argparse';
 
 import { BlockstackNetwork } from 'blockstack/lib/network';
 
-const SATOSHIS_PER_BTC = 1e8;
-
 export interface CLI_NETWORK_OPTS {
   consensusHash: string | null;
   feeRate: number | null;
@@ -121,10 +119,6 @@ export class CLINetworkAdapter {
     if (this.feeRate) {
       // override with CLI option
       return Promise.resolve(this.feeRate);
-    }
-    if (this.isTestnet()) {
-      // in regtest mode
-      return Promise.resolve(Math.floor(0.00001 * SATOSHIS_PER_BTC));
     }
     return this.legacyNetwork.getFeeRate();
   }
@@ -330,8 +324,8 @@ export class CLINetworkAdapter {
 /*
  * Instantiate a network using settings from the config file.
  */
-export function getNetwork(configData: CLI_CONFIG_TYPE, regTest: boolean): BlockstackNetwork {
-  if (regTest) {
+export function getNetwork(configData: CLI_CONFIG_TYPE, testNet: boolean): BlockstackNetwork {
+  if (testNet) {
     const network = new blockstack.network.LocalRegtest(
       configData.blockstackAPIUrl,
       configData.broadcastServiceUrl,

--- a/packages/network/README.md
+++ b/packages/network/README.md
@@ -10,7 +10,7 @@ npm install @stacks/network
 
 ## Usage
 
-Creating a Stacks mainnet, testnet, regtest or mocknet network
+Creating a Stacks mainnet, testnet or mocknet network
 
 ```typescript
 import { StacksMainnet, StacksTestnet, StacksMocknet } from '@stacks/network';
@@ -18,8 +18,6 @@ import { StacksMainnet, StacksTestnet, StacksMocknet } from '@stacks/network';
 const network = new StacksMainnet();
 
 const testnet = new StacksTestnet();
-
-const regtest = new StacksRegtest();
 
 const mocknet = new StacksMocknet();
 ```

--- a/packages/network/src/index.ts
+++ b/packages/network/src/index.ts
@@ -1,7 +1,6 @@
 import { TransactionVersion, ChainID, fetchPrivate } from '@stacks/common';
 
 export const HIRO_MAINNET_DEFAULT = 'https://stacks-node-api.mainnet.stacks.co';
-export const HIRO_REGTEST_DEFAULT = 'https://stacks-node-api.regtest.stacks.co';
 export const HIRO_TESTNET_DEFAULT = 'https://stacks-node-api.testnet.stacks.co';
 export const HIRO_MOCKNET_DEFAULT = 'http://localhost:3999';
 
@@ -143,15 +142,6 @@ export class StacksMocknet extends StacksMainnet implements StacksNetwork {
   chainId = ChainID.Testnet;
 
   constructor(networkUrl: NetworkConfig = { url: HIRO_MOCKNET_DEFAULT }) {
-    super(networkUrl);
-  }
-}
-
-export class StacksRegtest extends StacksMainnet implements StacksNetwork {
-  version = TransactionVersion.Testnet;
-  chainId = ChainID.Testnet;
-
-  constructor(networkUrl: NetworkConfig = { url: HIRO_REGTEST_DEFAULT }) {
     super(networkUrl);
   }
 }


### PR DESCRIPTION
## Description

This PR removes RegTest from the network list. 
For details refer to issue [#1107](https://github.com/blockstack/stacks.js/issues/1107)

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [x] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Testing information
'npm run test' successfully passes 

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] Tag 1 of @yknl or @zone117x for review
