### PR TITLE
[Browser support] Fix type error can't convert BigInt to number

### DIFF
--- a/packages/transactions/src/clarity/types/intCV.ts
+++ b/packages/transactions/src/clarity/types/intCV.ts
@@ -1,10 +1,11 @@
 import { IntegerType, intToBigInt } from '@stacks/common';
 import { ClarityType } from '../clarityValue';
 
-const MAX_U128 = BigInt(2) ** BigInt(128) - BigInt(1);
+const MAX_U128 = BigInt('0xffffffffffffffffffffffffffffffff'); // (2 ** 128 - 1)
 const MIN_U128 = BigInt(0);
-const MAX_I128 = BigInt(2) ** BigInt(127) - BigInt(1);
-const MIN_I128 = BigInt(-2) ** BigInt(127);
+const MAX_I128 = BigInt('0x7fffffffffffffffffffffffffffffff'); // (2 ** 127 - 1)
+// no signed (negative) hex support in bigint constructor
+const MIN_I128 = BigInt('-170141183460469231731687303715884105728'); // (-2 ** 127)
 
 interface IntCV {
   readonly type: ClarityType.Int;


### PR DESCRIPTION
## Description
The `transpilers` coverts the lines like `const MAX_U128 = BigInt(2) ** BigInt(128) - BigInt(1);` to `Math.pow(BigInt(2), BigInt(128)) - BigInt(1);`.

Definitely `Math.pow` will throw exception `can't convert BigInt to number`.

A lot of users are facing this issue and merging this pr will unblock them.

This PR closes the issue #1119 and #1096




## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No
## Testing information
Provide context on how tests should be performed.
* `npm run test`
* Merging this pr will fix `can't convert BigInt to number` exception


## Checklist
- [X] Code is commented where needed
- [X] Unit test coverage for new or modified code paths
- [X] `npm run test` passes
- [ ] Changelog is updated
- [X] Tag 1 of @yknl or @zone117x for review
