### PR TITLE
[Transactions] Remove circular dependencies

### DIFF
--- a/packages/transactions/src/builders.ts
+++ b/packages/transactions/src/builders.ts
@@ -31,14 +31,16 @@ import {
 import { TransactionSigner } from './signer';
 
 import {
-  PostCondition,
-  STXPostCondition,
-  FungiblePostCondition,
-  NonFungiblePostCondition,
   createSTXPostCondition,
   createFungiblePostCondition,
   createNonFungiblePostCondition,
 } from './postcondition';
+import {
+  PostCondition,
+  STXPostCondition,
+  FungiblePostCondition,
+  NonFungiblePostCondition,
+} from './postcondition-types';
 
 import {
   AddressHashMode,
@@ -53,7 +55,8 @@ import {
   SingleSigHashMode,
 } from './constants';
 
-import { AssetInfo, createLPList, createStandardPrincipal, createContractPrincipal } from './types';
+import { createLPList } from './types';
+import { AssetInfo, createStandardPrincipal, createContractPrincipal } from './postcondition-types';
 
 import { cvToHex, parseReadOnlyResponse, omit, validateTxId } from './utils';
 

--- a/packages/transactions/src/clarity/clarityValue.ts
+++ b/packages/transactions/src/clarity/clarityValue.ts
@@ -17,28 +17,7 @@ import {
 } from '.';
 
 import { principalToString } from './types/principalCV';
-
-/**
- * Type IDs corresponding to each of the Clarity value types as described here:
- * {@link https://github.com/blockstack/blockstack-core/blob/sip/sip-005/sip/sip-005-blocks-and-transactions.md#clarity-value-representation}
- */
-export enum ClarityType {
-  Int = 0x00,
-  UInt = 0x01,
-  Buffer = 0x02,
-  BoolTrue = 0x03,
-  BoolFalse = 0x04,
-  PrincipalStandard = 0x05,
-  PrincipalContract = 0x06,
-  ResponseOk = 0x07,
-  ResponseErr = 0x08,
-  OptionalNone = 0x09,
-  OptionalSome = 0x0a,
-  List = 0x0b,
-  Tuple = 0x0c,
-  StringASCII = 0x0d,
-  StringUTF8 = 0x0e,
-}
+import { ClarityType } from './constants';
 
 export type ClarityValue =
   | BooleanCV

--- a/packages/transactions/src/clarity/constants.ts
+++ b/packages/transactions/src/clarity/constants.ts
@@ -1,0 +1,21 @@
+/**
+ * Type IDs corresponding to each of the Clarity value types as described here:
+ * {@link https://github.com/blockstack/blockstack-core/blob/sip/sip-005/sip/sip-005-blocks-and-transactions.md#clarity-value-representation}
+ */
+export enum ClarityType {
+  Int = 0x00,
+  UInt = 0x01,
+  Buffer = 0x02,
+  BoolTrue = 0x03,
+  BoolFalse = 0x04,
+  PrincipalStandard = 0x05,
+  PrincipalContract = 0x06,
+  ResponseOk = 0x07,
+  ResponseErr = 0x08,
+  OptionalNone = 0x09,
+  OptionalSome = 0x0a,
+  List = 0x0b,
+  Tuple = 0x0c,
+  StringASCII = 0x0d,
+  StringUTF8 = 0x0e,
+}

--- a/packages/transactions/src/clarity/index.ts
+++ b/packages/transactions/src/clarity/index.ts
@@ -1,11 +1,5 @@
-import {
-  ClarityValue,
-  ClarityType,
-  getCVTypeString,
-  cvToString,
-  cvToJSON,
-  cvToValue,
-} from './clarityValue';
+import { ClarityValue, getCVTypeString, cvToString, cvToJSON, cvToValue } from './clarityValue';
+import { ClarityType } from './constants';
 import { BooleanCV, TrueCV, FalseCV, trueCV, falseCV } from './types/booleanCV';
 import { IntCV, UIntCV, intCV, uintCV } from './types/intCV';
 import { BufferCV, bufferCV, bufferCVFromString } from './types/bufferCV';

--- a/packages/transactions/src/clarity/serialize.ts
+++ b/packages/transactions/src/clarity/serialize.ts
@@ -1,5 +1,6 @@
 import { Buffer } from '@stacks/common';
-import { serializeAddress, serializeLPString, createLPString } from '../types';
+import { serializeAddress, serializeLPString } from '../types';
+import { createLPString } from '../postcondition-types';
 import {
   BooleanCV,
   OptionalCV,
@@ -11,9 +12,9 @@ import {
   ResponseCV,
   ListCV,
   TupleCV,
-  ClarityType,
   ClarityValue,
 } from '.';
+import { ClarityType } from './constants';
 import { BufferArray } from '../utils';
 import { SerializationError } from '../errors';
 import { StringAsciiCV, StringUtf8CV } from './types/stringCV';

--- a/packages/transactions/src/clarity/types/booleanCV.ts
+++ b/packages/transactions/src/clarity/types/booleanCV.ts
@@ -1,4 +1,4 @@
-import { ClarityType } from '../clarityValue';
+import { ClarityType } from '../constants';
 
 type BooleanCV = TrueCV | FalseCV;
 

--- a/packages/transactions/src/clarity/types/bufferCV.ts
+++ b/packages/transactions/src/clarity/types/bufferCV.ts
@@ -1,5 +1,5 @@
 import { Buffer } from '@stacks/common';
-import { ClarityType } from '../clarityValue';
+import { ClarityType } from '../constants';
 
 interface BufferCV {
   readonly type: ClarityType.Buffer;

--- a/packages/transactions/src/clarity/types/intCV.ts
+++ b/packages/transactions/src/clarity/types/intCV.ts
@@ -1,5 +1,5 @@
 import { IntegerType, intToBigInt } from '@stacks/common';
-import { ClarityType } from '../clarityValue';
+import { ClarityType } from '../constants';
 
 const MAX_U128 = BigInt(2) ** BigInt(128) - BigInt(1);
 const MIN_U128 = BigInt(0);

--- a/packages/transactions/src/clarity/types/listCV.ts
+++ b/packages/transactions/src/clarity/types/listCV.ts
@@ -1,4 +1,5 @@
-import { ClarityValue, ClarityType } from '../clarityValue';
+import { ClarityValue } from '../clarityValue';
+import { ClarityType } from '../constants';
 
 interface ListCV<T extends ClarityValue = ClarityValue> {
   type: ClarityType.List;

--- a/packages/transactions/src/clarity/types/optionalCV.ts
+++ b/packages/transactions/src/clarity/types/optionalCV.ts
@@ -1,5 +1,5 @@
-import { ClarityType, ClarityValue } from '../clarityValue';
-
+import { ClarityValue } from '../clarityValue';
+import { ClarityType } from '../constants';
 type OptionalCV<T extends ClarityValue = ClarityValue> = NoneCV | SomeCV<T>;
 
 interface NoneCV {

--- a/packages/transactions/src/clarity/types/principalCV.ts
+++ b/packages/transactions/src/clarity/types/principalCV.ts
@@ -1,12 +1,7 @@
 import { Buffer } from '@stacks/common';
-import {
-  Address,
-  LengthPrefixedString,
-  createAddress,
-  createLPString,
-  addressToString,
-} from '../../types';
-import { ClarityType } from '../clarityValue';
+import { LengthPrefixedString, createAddress, createLPString } from '../../postcondition-types';
+import { Address, addressToString } from '../../common';
+import { ClarityType } from '../constants';
 
 type PrincipalCV = StandardPrincipalCV | ContractPrincipalCV;
 

--- a/packages/transactions/src/clarity/types/responseCV.ts
+++ b/packages/transactions/src/clarity/types/responseCV.ts
@@ -1,4 +1,5 @@
-import { ClarityType, ClarityValue } from '../clarityValue';
+import { ClarityValue } from '../clarityValue';
+import { ClarityType } from '../constants';
 
 type ResponseCV = ResponseErrorCV | ResponseOkCV;
 

--- a/packages/transactions/src/clarity/types/stringCV.ts
+++ b/packages/transactions/src/clarity/types/stringCV.ts
@@ -1,4 +1,4 @@
-import { ClarityType } from '../clarityValue';
+import { ClarityType } from '../constants';
 
 interface StringAsciiCV {
   readonly type: ClarityType.StringASCII;

--- a/packages/transactions/src/clarity/types/tupleCV.ts
+++ b/packages/transactions/src/clarity/types/tupleCV.ts
@@ -1,4 +1,5 @@
-import { ClarityType, ClarityValue } from '../clarityValue';
+import { ClarityValue } from '../clarityValue';
+import { ClarityType } from '../constants';
 import { isClarityName } from '../../utils';
 
 type TupleData<T extends ClarityValue = ClarityValue> = { [key: string]: T };

--- a/packages/transactions/src/common.ts
+++ b/packages/transactions/src/common.ts
@@ -1,0 +1,78 @@
+import {
+  AddressHashMode,
+  AddressVersion,
+  RECOVERABLE_ECDSA_SIG_LENGTH_BYTES,
+  StacksMessageType,
+  TransactionVersion,
+} from './constants';
+import { Buffer } from '@stacks/common';
+import { c32address } from 'c32check';
+
+export interface Address {
+  readonly type: StacksMessageType.Address;
+  readonly version: AddressVersion;
+  readonly hash160: string;
+}
+
+export interface MessageSignature {
+  readonly type: StacksMessageType.MessageSignature;
+  data: string;
+}
+
+export function createMessageSignature(signature: string): MessageSignature {
+  const length = Buffer.from(signature, 'hex').byteLength;
+  if (length != RECOVERABLE_ECDSA_SIG_LENGTH_BYTES) {
+    throw Error('Invalid signature');
+  }
+
+  return {
+    type: StacksMessageType.MessageSignature,
+    data: signature,
+  };
+}
+
+/**
+ * Translates the tx auth hash mode to the corresponding address version.
+ * @see https://github.com/blockstack/stacks-blockchain/blob/master/sip/sip-005-blocks-and-transactions.md#transaction-authorization
+ */
+export function addressHashModeToVersion(
+  hashMode: AddressHashMode,
+  txVersion: TransactionVersion
+): AddressVersion {
+  switch (hashMode) {
+    case AddressHashMode.SerializeP2PKH:
+      switch (txVersion) {
+        case TransactionVersion.Mainnet:
+          return AddressVersion.MainnetSingleSig;
+        case TransactionVersion.Testnet:
+          return AddressVersion.TestnetSingleSig;
+        default:
+          throw new Error(
+            `Unexpected txVersion ${JSON.stringify(txVersion)} for hashMode ${hashMode}`
+          );
+      }
+    case AddressHashMode.SerializeP2SH:
+    case AddressHashMode.SerializeP2WPKH:
+    case AddressHashMode.SerializeP2WSH:
+      switch (txVersion) {
+        case TransactionVersion.Mainnet:
+          return AddressVersion.MainnetMultiSig;
+        case TransactionVersion.Testnet:
+          return AddressVersion.TestnetMultiSig;
+        default:
+          throw new Error(
+            `Unexpected txVersion ${JSON.stringify(txVersion)} for hashMode ${hashMode}`
+          );
+      }
+    default:
+      throw new Error(`Unexpected hashMode ${JSON.stringify(hashMode)}`);
+  }
+}
+
+export function addressFromVersionHash(version: AddressVersion, hash: string): Address {
+  return { type: StacksMessageType.Address, version, hash160: hash };
+}
+
+export function addressToString(address: Address): string {
+  return c32address(address.version, address.hash160).toString();
+}

--- a/packages/transactions/src/index.ts
+++ b/packages/transactions/src/index.ts
@@ -7,8 +7,6 @@ export {
   StandardAuthorization,
   SponsoredAuthorization,
   SpendingCondition,
-  MessageSignature,
-  createMessageSignature,
   emptyMessageSignature,
   isSingleSig,
 } from './authorization';
@@ -22,15 +20,9 @@ export {
 } from './payload';
 
 export {
-  PostCondition,
-  STXPostCondition,
-  FungiblePostCondition,
-  NonFungiblePostCondition,
   createFungiblePostCondition,
   createNonFungiblePostCondition,
   createSTXPostCondition,
-  serializePostCondition,
-  deserializePostCondition,
 } from './postcondition';
 
 export * from './clarity';
@@ -42,3 +34,6 @@ export * from './contract-abi';
 export * from './signer';
 export * from './authorization';
 export * from './utils';
+export * from './common';
+export * from './signature';
+export * from './postcondition-types';

--- a/packages/transactions/src/keys.ts
+++ b/packages/transactions/src/keys.ts
@@ -21,10 +21,15 @@ import {
 
 import { ec as EC } from 'elliptic';
 
-import { MessageSignature, createMessageSignature } from './authorization';
+import {
+  MessageSignature,
+  createMessageSignature,
+  addressHashModeToVersion,
+  addressFromVersionHash,
+  addressToString,
+} from './common';
 import { BufferReader } from './bufferReader';
 import { c32address } from 'c32check';
-import { addressHashModeToVersion, addressFromVersionHash, addressToString } from './types';
 
 export interface StacksPublicKey {
   readonly type: StacksMessageType.PublicKey;

--- a/packages/transactions/src/payload.ts
+++ b/packages/transactions/src/payload.ts
@@ -4,19 +4,16 @@ import { COINBASE_BUFFER_LENGTH_BYTES, PayloadType, StacksMessageType } from './
 import { BufferArray } from './utils';
 
 import {
-  Address,
   MemoString,
-  createAddress,
   createMemoString,
-  LengthPrefixedString,
-  createLPString,
   serializeStacksMessage,
   deserializeAddress,
   deserializeLPString,
   deserializeMemoString,
   codeBodyString,
 } from './types';
-
+import { createAddress, LengthPrefixedString, createLPString } from './postcondition-types';
+import { Address } from './common';
 import { ClarityValue, serializeCV, deserializeCV } from './clarity/';
 
 import { BufferReader } from './bufferReader';

--- a/packages/transactions/src/postcondition-types.ts
+++ b/packages/transactions/src/postcondition-types.ts
@@ -1,0 +1,164 @@
+import {
+  FungibleConditionCode,
+  MAX_STRING_LENGTH_BYTES,
+  NonFungibleConditionCode,
+  PostConditionPrincipalID,
+  PostConditionType,
+  StacksMessageType,
+} from './constants';
+import { c32addressDecode } from 'c32check';
+import { Address } from './common';
+import { ClarityValue } from './clarity';
+import { exceedsMaxLengthBytes } from './utils';
+
+export interface StandardPrincipal {
+  readonly type: StacksMessageType.Principal;
+  readonly prefix: PostConditionPrincipalID.Standard;
+  readonly address: Address;
+}
+
+export interface ContractPrincipal {
+  readonly type: StacksMessageType.Principal;
+  readonly prefix: PostConditionPrincipalID.Contract;
+  readonly address: Address;
+  readonly contractName: LengthPrefixedString;
+}
+
+export interface LengthPrefixedString {
+  readonly type: StacksMessageType.LengthPrefixedString;
+  readonly content: string;
+  readonly lengthPrefixBytes: number;
+  readonly maxLengthBytes: number;
+}
+
+export interface AssetInfo {
+  readonly type: StacksMessageType.AssetInfo;
+  readonly address: Address;
+  readonly contractName: LengthPrefixedString;
+  readonly assetName: LengthPrefixedString;
+}
+
+export interface STXPostCondition {
+  readonly type: StacksMessageType.PostCondition;
+  readonly conditionType: PostConditionType.STX;
+  readonly principal: PostConditionPrincipal;
+  readonly conditionCode: FungibleConditionCode;
+  readonly amount: bigint;
+}
+
+export interface FungiblePostCondition {
+  readonly type: StacksMessageType.PostCondition;
+  readonly conditionType: PostConditionType.Fungible;
+  readonly principal: PostConditionPrincipal;
+  readonly conditionCode: FungibleConditionCode;
+  readonly amount: bigint;
+  readonly assetInfo: AssetInfo;
+}
+
+export interface NonFungiblePostCondition {
+  readonly type: StacksMessageType.PostCondition;
+  readonly conditionType: PostConditionType.NonFungible;
+  readonly principal: PostConditionPrincipal;
+  readonly conditionCode: NonFungibleConditionCode;
+  /** Structure that identifies the token type. */
+  readonly assetInfo: AssetInfo;
+  /** The Clarity value that names the token instance. */
+  readonly assetName: ClarityValue;
+}
+
+export function parseAssetInfoString(id: string): AssetInfo {
+  const [assetAddress, assetContractName, assetTokenName] = id.split(/\.|::/);
+  const assetInfo = createAssetInfo(assetAddress, assetContractName, assetTokenName);
+  return assetInfo;
+}
+
+export function createLPString(content: string): LengthPrefixedString;
+export function createLPString(content: string, lengthPrefixBytes: number): LengthPrefixedString;
+export function createLPString(
+  content: string,
+  lengthPrefixBytes: number,
+  maxLengthBytes: number
+): LengthPrefixedString;
+export function createLPString(
+  content: string,
+  lengthPrefixBytes?: number,
+  maxLengthBytes?: number
+): LengthPrefixedString {
+  const prefixLength = lengthPrefixBytes || 1;
+  const maxLength = maxLengthBytes || MAX_STRING_LENGTH_BYTES;
+  if (exceedsMaxLengthBytes(content, maxLength)) {
+    throw new Error(`String length exceeds maximum bytes ${maxLength.toString()}`);
+  }
+  return {
+    type: StacksMessageType.LengthPrefixedString,
+    content,
+    lengthPrefixBytes: prefixLength,
+    maxLengthBytes: maxLength,
+  };
+}
+
+export function createAssetInfo(
+  addressString: string,
+  contractName: string,
+  assetName: string
+): AssetInfo {
+  return {
+    type: StacksMessageType.AssetInfo,
+    address: createAddress(addressString),
+    contractName: createLPString(contractName),
+    assetName: createLPString(assetName),
+  };
+}
+
+export function createAddress(c32AddressString: string): Address {
+  const addressData = c32addressDecode(c32AddressString);
+  return {
+    type: StacksMessageType.Address,
+    version: addressData[0],
+    hash160: addressData[1],
+  };
+}
+
+/**
+ * Parses a principal string for either a standard principal or contract principal.
+ * @param principalString - String in the format `{address}.{contractName}`
+ * @example "SP13N5TE1FBBGRZD1FCM49QDGN32WAXM2E5F8WT2G.example-contract"
+ * @example "SP13N5TE1FBBGRZD1FCM49QDGN32WAXM2E5F8WT2G"
+ */
+export function parsePrincipalString(
+  principalString: string
+): StandardPrincipal | ContractPrincipal {
+  if (principalString.includes('.')) {
+    const [address, contractName] = principalString.split('.');
+    return createContractPrincipal(address, contractName);
+  } else {
+    return createStandardPrincipal(principalString);
+  }
+}
+
+export function createContractPrincipal(
+  addressString: string,
+  contractName: string
+): ContractPrincipal {
+  const addr = createAddress(addressString);
+  const name = createLPString(contractName);
+  return {
+    type: StacksMessageType.Principal,
+    prefix: PostConditionPrincipalID.Contract,
+    address: addr,
+    contractName: name,
+  };
+}
+
+export function createStandardPrincipal(addressString: string): StandardPrincipal {
+  const addr = createAddress(addressString);
+  return {
+    type: StacksMessageType.Principal,
+    prefix: PostConditionPrincipalID.Standard,
+    address: addr,
+  };
+}
+
+export type PostCondition = STXPostCondition | FungiblePostCondition | NonFungiblePostCondition;
+
+export type PostConditionPrincipal = StandardPrincipal | ContractPrincipal;

--- a/packages/transactions/src/postcondition.ts
+++ b/packages/transactions/src/postcondition.ts
@@ -1,6 +1,4 @@
-import { IntegerType, intToBigInt, intToBytes } from '@stacks/common';
-// @ts-expect-error ts(6133): 'Buffer' is declared but its value is never read
-import { Buffer } from '@stacks/common';
+import { IntegerType, intToBigInt } from '@stacks/common';
 import {
   PostConditionType,
   FungibleConditionCode,
@@ -8,32 +6,17 @@ import {
   StacksMessageType,
 } from './constants';
 
-import { BufferArray } from './utils';
-
 import {
   AssetInfo,
-  serializeAssetInfo,
-  deserializeAssetInfo,
   PostConditionPrincipal,
-  serializePrincipal,
-  deserializePrincipal,
   parseAssetInfoString,
   parsePrincipalString,
-} from './types';
+  STXPostCondition,
+  FungiblePostCondition,
+  NonFungiblePostCondition,
+} from './postcondition-types';
 
-import { BufferReader } from './bufferReader';
-import { ClarityValue, serializeCV, deserializeCV } from './clarity';
-import { DeserializationError } from './errors';
-
-export type PostCondition = STXPostCondition | FungiblePostCondition | NonFungiblePostCondition;
-
-export interface STXPostCondition {
-  readonly type: StacksMessageType.PostCondition;
-  readonly conditionType: PostConditionType.STX;
-  readonly principal: PostConditionPrincipal;
-  readonly conditionCode: FungibleConditionCode;
-  readonly amount: bigint;
-}
+import { ClarityValue } from './clarity';
 
 export function createSTXPostCondition(
   principal: string | PostConditionPrincipal,
@@ -51,15 +34,6 @@ export function createSTXPostCondition(
     conditionCode,
     amount: intToBigInt(amount, false),
   };
-}
-
-export interface FungiblePostCondition {
-  readonly type: StacksMessageType.PostCondition;
-  readonly conditionType: PostConditionType.Fungible;
-  readonly principal: PostConditionPrincipal;
-  readonly conditionCode: FungibleConditionCode;
-  readonly amount: bigint;
-  readonly assetInfo: AssetInfo;
 }
 
 export function createFungiblePostCondition(
@@ -85,17 +59,6 @@ export function createFungiblePostCondition(
   };
 }
 
-export interface NonFungiblePostCondition {
-  readonly type: StacksMessageType.PostCondition;
-  readonly conditionType: PostConditionType.NonFungible;
-  readonly principal: PostConditionPrincipal;
-  readonly conditionCode: NonFungibleConditionCode;
-  /** Structure that identifies the token type. */
-  readonly assetInfo: AssetInfo;
-  /** The Clarity value that names the token instance. */
-  readonly assetName: ClarityValue;
-}
-
 export function createNonFungiblePostCondition(
   principal: string | PostConditionPrincipal,
   conditionCode: NonFungibleConditionCode,
@@ -117,86 +80,4 @@ export function createNonFungiblePostCondition(
     assetInfo,
     assetName,
   };
-}
-
-export function serializePostCondition(postCondition: PostCondition): Buffer {
-  const bufferArray: BufferArray = new BufferArray();
-  bufferArray.appendByte(postCondition.conditionType);
-  bufferArray.push(serializePrincipal(postCondition.principal));
-
-  if (
-    postCondition.conditionType === PostConditionType.Fungible ||
-    postCondition.conditionType === PostConditionType.NonFungible
-  ) {
-    bufferArray.push(serializeAssetInfo(postCondition.assetInfo));
-  }
-
-  if (postCondition.conditionType === PostConditionType.NonFungible) {
-    bufferArray.push(serializeCV(postCondition.assetName));
-  }
-
-  bufferArray.appendByte(postCondition.conditionCode);
-
-  if (
-    postCondition.conditionType === PostConditionType.STX ||
-    postCondition.conditionType === PostConditionType.Fungible
-  ) {
-    bufferArray.push(intToBytes(postCondition.amount, false, 8));
-  }
-
-  return bufferArray.concatBuffer();
-}
-
-export function deserializePostCondition(bufferReader: BufferReader): PostCondition {
-  const postConditionType = bufferReader.readUInt8Enum(PostConditionType, n => {
-    throw new DeserializationError(`Could not read ${n} as PostConditionType`);
-  });
-
-  const principal = deserializePrincipal(bufferReader);
-
-  let conditionCode;
-  let assetInfo;
-  let amount: bigint;
-  switch (postConditionType) {
-    case PostConditionType.STX:
-      conditionCode = bufferReader.readUInt8Enum(FungibleConditionCode, n => {
-        throw new DeserializationError(`Could not read ${n} as FungibleConditionCode`);
-      });
-      amount = BigInt('0x' + bufferReader.readBuffer(8).toString('hex'));
-      return {
-        type: StacksMessageType.PostCondition,
-        conditionType: PostConditionType.STX,
-        principal,
-        conditionCode,
-        amount,
-      };
-    case PostConditionType.Fungible:
-      assetInfo = deserializeAssetInfo(bufferReader);
-      conditionCode = bufferReader.readUInt8Enum(FungibleConditionCode, n => {
-        throw new DeserializationError(`Could not read ${n} as FungibleConditionCode`);
-      });
-      amount = BigInt('0x' + bufferReader.readBuffer(8).toString('hex'));
-      return {
-        type: StacksMessageType.PostCondition,
-        conditionType: PostConditionType.Fungible,
-        principal,
-        conditionCode,
-        amount,
-        assetInfo,
-      };
-    case PostConditionType.NonFungible:
-      assetInfo = deserializeAssetInfo(bufferReader);
-      const assetName = deserializeCV(bufferReader);
-      conditionCode = bufferReader.readUInt8Enum(NonFungibleConditionCode, n => {
-        throw new DeserializationError(`Could not read ${n} as FungibleConditionCode`);
-      });
-      return {
-        type: StacksMessageType.PostCondition,
-        conditionType: PostConditionType.NonFungible,
-        principal,
-        conditionCode,
-        assetInfo,
-        assetName,
-      };
-  }
 }

--- a/packages/transactions/src/signature.ts
+++ b/packages/transactions/src/signature.ts
@@ -1,0 +1,116 @@
+import { BufferReader } from './bufferReader';
+import { DeserializationError } from './errors';
+import { PubKeyEncoding, RECOVERABLE_ECDSA_SIG_LENGTH_BYTES, StacksMessageType } from './constants';
+import {
+  compressPublicKey,
+  deserializePublicKey,
+  serializePublicKey,
+  StacksPublicKey,
+} from './keys';
+
+import { createMessageSignature, MessageSignature } from './common';
+
+// @ts-ignore
+import { Buffer } from '@stacks/common';
+import { BufferArray } from './utils';
+
+export enum AuthFieldType {
+  PublicKeyCompressed = 0x00,
+  PublicKeyUncompressed = 0x01,
+  SignatureCompressed = 0x02,
+  SignatureUncompressed = 0x03,
+}
+
+export interface TransactionAuthField {
+  type: StacksMessageType.TransactionAuthField;
+  pubKeyEncoding: PubKeyEncoding;
+  contents: TransactionAuthFieldContents;
+}
+
+export type TransactionAuthFieldContents = StacksPublicKey | MessageSignature;
+
+export function deserializeMessageSignature(bufferReader: BufferReader): MessageSignature {
+  return createMessageSignature(
+    bufferReader.readBuffer(RECOVERABLE_ECDSA_SIG_LENGTH_BYTES).toString('hex')
+  );
+}
+
+export interface TransactionAuthField {
+  type: StacksMessageType.TransactionAuthField;
+  pubKeyEncoding: PubKeyEncoding;
+  contents: TransactionAuthFieldContents;
+}
+
+export function createTransactionAuthField(
+  pubKeyEncoding: PubKeyEncoding,
+  contents: TransactionAuthFieldContents
+): TransactionAuthField {
+  return {
+    pubKeyEncoding,
+    type: StacksMessageType.TransactionAuthField,
+    contents,
+  };
+}
+
+export function deserializeTransactionAuthField(bufferReader: BufferReader): TransactionAuthField {
+  const authFieldType = bufferReader.readUInt8Enum(AuthFieldType, n => {
+    throw new DeserializationError(`Could not read ${n} as AuthFieldType`);
+  });
+
+  switch (authFieldType) {
+    case AuthFieldType.PublicKeyCompressed:
+      return createTransactionAuthField(
+        PubKeyEncoding.Compressed,
+        deserializePublicKey(bufferReader)
+      );
+    case AuthFieldType.PublicKeyUncompressed:
+      return createTransactionAuthField(
+        PubKeyEncoding.Uncompressed,
+        deserializePublicKey(bufferReader)
+      );
+    case AuthFieldType.SignatureCompressed:
+      return createTransactionAuthField(
+        PubKeyEncoding.Compressed,
+        deserializeMessageSignature(bufferReader)
+      );
+    case AuthFieldType.SignatureUncompressed:
+      return createTransactionAuthField(
+        PubKeyEncoding.Uncompressed,
+        deserializeMessageSignature(bufferReader)
+      );
+    default:
+      throw new Error(`Unknown auth field type: ${JSON.stringify(authFieldType)}`);
+  }
+}
+
+export function serializeMessageSignature(messageSignature: MessageSignature): Buffer {
+  const bufferArray: BufferArray = new BufferArray();
+  bufferArray.appendHexString(messageSignature.data);
+  return bufferArray.concatBuffer();
+}
+
+export function serializeTransactionAuthField(field: TransactionAuthField): Buffer {
+  const bufferArray: BufferArray = new BufferArray();
+
+  switch (field.contents.type) {
+    case StacksMessageType.PublicKey:
+      if (field.pubKeyEncoding == PubKeyEncoding.Compressed) {
+        bufferArray.appendByte(AuthFieldType.PublicKeyCompressed);
+        bufferArray.push(serializePublicKey(field.contents));
+      } else {
+        bufferArray.appendByte(AuthFieldType.PublicKeyUncompressed);
+        bufferArray.push(serializePublicKey(compressPublicKey(field.contents.data)));
+      }
+      break;
+    case StacksMessageType.MessageSignature:
+      if (field.pubKeyEncoding == PubKeyEncoding.Compressed) {
+        bufferArray.appendByte(AuthFieldType.SignatureCompressed);
+      } else {
+        bufferArray.appendByte(AuthFieldType.SignatureUncompressed);
+      }
+      bufferArray.push(serializeMessageSignature(field.contents));
+      break;
+  }
+
+  return bufferArray.concatBuffer();
+}

--- a/packages/transactions/src/transaction.ts
+++ b/packages/transactions/src/transaction.ts
@@ -13,7 +13,6 @@ import {
 
 import {
   Authorization,
-  createTransactionAuthField,
   deserializeAuthorization,
   intoInitialSighashAuth,
   isSingleSig,
@@ -26,6 +25,7 @@ import {
   SpendingConditionOpts,
   verifyOrigin,
 } from './authorization';
+import { createTransactionAuthField } from './signature';
 
 import { BufferArray, cloneDeep, txidFromData } from './utils';
 

--- a/packages/transactions/tests/authorization.test.ts
+++ b/packages/transactions/tests/authorization.test.ts
@@ -1,8 +1,6 @@
 import {
-  createMessageSignature,
   createMultiSigSpendingCondition,
   createSingleSigSpendingCondition,
-  createTransactionAuthField,
   deserializeSpendingCondition,
   emptyMessageSignature,
   serializeSpendingCondition,
@@ -11,6 +9,8 @@ import {
   StandardAuthorization,
   serializeAuthorization,
 } from '../src/authorization';
+import { createTransactionAuthField } from '../src/signature';
+import { createMessageSignature } from '../src/common';
 import { BufferArray } from '../src/utils';
 
 import {AddressHashMode, AuthType, PubKeyEncoding} from '../src/constants';

--- a/packages/transactions/tests/builder.test.ts
+++ b/packages/transactions/tests/builder.test.ts
@@ -29,11 +29,11 @@ import { createTokenTransferPayload, serializePayload, TokenTransferPayload } fr
 
 import { BufferReader } from '../src/bufferReader';
 
-import { createAssetInfo } from '../src/types';
+import { createAssetInfo } from '../src/postcondition-types';
 
 import {
-  createMessageSignature, createSingleSigSpendingCondition, createSponsoredAuth,
-  createTransactionAuthField,
+  createSingleSigSpendingCondition,
+  createSponsoredAuth,
   emptyMessageSignature,
   isSingleSig,
   MultiSigSpendingCondition,
@@ -41,7 +41,8 @@ import {
   SingleSigSpendingCondition,
   SponsoredAuthorization, StandardAuthorization
 } from '../src/authorization';
-
+import { createTransactionAuthField } from '../src/signature';
+import { createMessageSignature } from '../src/common';
 import {
   DEFAULT_CORE_NODE_API_URL,
   FungibleConditionCode,

--- a/packages/transactions/tests/clarity.test.ts
+++ b/packages/transactions/tests/clarity.test.ts
@@ -1,5 +1,6 @@
 import { oneLineTrim } from 'common-tags';
-import { addressToString, deserializeAddress } from '../src/types';
+import { deserializeAddress } from '../src/types';
+import { addressToString } from '../src/common';
 import {
   ClarityValue,
   serializeCV,

--- a/packages/transactions/tests/postcondition.test.ts
+++ b/packages/transactions/tests/postcondition.test.ts
@@ -1,19 +1,19 @@
 import {
-  STXPostCondition,
-  FungiblePostCondition,
-  NonFungiblePostCondition,
   createSTXPostCondition,
   createFungiblePostCondition,
   createNonFungiblePostCondition,
 } from '../src/postcondition';
 
 import {
-  addressToString,
+  STXPostCondition,
+  FungiblePostCondition,
+  NonFungiblePostCondition,
   createAssetInfo,
   createStandardPrincipal,
   createContractPrincipal,
   ContractPrincipal,
-} from '../src/types';
+} from '../src/postcondition-types';
+import { addressToString } from '../src/common';
 
 import {
   PostConditionType,

--- a/packages/transactions/tests/transaction.test.ts
+++ b/packages/transactions/tests/transaction.test.ts
@@ -12,12 +12,10 @@ import {
 
 import { TokenTransferPayload, createTokenTransferPayload } from '../src/payload';
 
-import { STXPostCondition, createSTXPostCondition } from '../src/postcondition';
+import { createSTXPostCondition } from '../src/postcondition';
 
-import {
-  createLPList,
-  createStandardPrincipal
-} from '../src/types';
+import { createLPList } from '../src/types';
+import { createStandardPrincipal, STXPostCondition } from '../src/postcondition-types';
 
 import {
   DEFAULT_CHAIN_ID,

--- a/packages/transactions/tests/types.test.ts
+++ b/packages/transactions/tests/types.test.ts
@@ -1,19 +1,19 @@
 import {
-  Address,
+  createLPList,
+  serializeStacksMessage,
+  deserializeLPList,
+  addressFromHashMode,
+  LengthPrefixedList,
+  addressFromPublicKeys,
+} from '../src/types';
+import {
   LengthPrefixedString,
   AssetInfo,
   createLPString,
   createAddress,
-  createLPList,
-  serializeStacksMessage,
-  deserializeLPList,
-  addressToString,
-  addressFromHashMode,
   createAssetInfo,
-  LengthPrefixedList,
-  addressFromPublicKeys,
-} from '../src/types';
-
+} from '../src/postcondition-types';
+import { Address, addressToString } from '../src/common';
 import { TransactionVersion, AddressHashMode, StacksMessageType } from '../src/constants';
 
 import { serializeDeserialize } from './macros';


### PR DESCRIPTION
## Description
This PR fixes the circular dependencies in `transactions` package. 

Merging this PR will solve remaining last 5 circular dependencies listed by the tool in stack.js in `transactions`.

Merging this PR will give : `✔ No circular dependency found!` by tool.

For details refer to issue #795

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No
## Testing information
- `npm run test`
- `npm run madge`  will give `✔ No circular dependency found!` 

## Checklist
- [X] Code is commented where needed
- [X] Unit test coverage for new or modified code paths
- [X] `npm run test` passes
- [ ] Changelog is updated
- [X] Tag 1 of @yknl or @zone117x for review
