### PR TITLE
[FIX] Update Core API URL

### DIFF
--- a/packages/auth/src/constants.ts
+++ b/packages/auth/src/constants.ts
@@ -53,7 +53,7 @@ export const BLOCKSTACK_APP_PRIVATE_KEY_LABEL = 'blockstack-transit-private-key'
 /**
  * @ignore
  */
-export const DEFAULT_CORE_NODE = 'https://core.blockstack.org';
+export const DEFAULT_CORE_NODE = 'https://stacks-node-api.stacks.co';
 /**
  * @ignore
  */

--- a/packages/cli/src/argparse.ts
+++ b/packages/cli/src/argparse.ts
@@ -1970,9 +1970,9 @@ export const CLI_ARGS = {
         '      "blockHeight": 567890,\n' +
         '      "confirmations": 7,\n' +
         '    }\n' +
-        '    $ stx -H https://core.blockstack.org zonefile_push "$ZONEFILE_PATH"\n' +
+        '    $ stx -H https://stacks-node-api.stacks.co zonefile_push "$ZONEFILE_PATH"\n' +
         '    [\n' +
-        '      "https://core.blockstack.org"\n' +
+        '      "https://stacks-node-api.stacks.co"\n' +
         '    ]\n' +
         '\n',
       group: 'Blockstack ID Management',
@@ -2618,9 +2618,9 @@ export const CLI_ARGS = {
         '    }\n' +
         '    \n' +
         '    $ # send out the new zone file to a Blockstack peer\n' +
-        '    $ stx -H https://core.blockstack.org zonefile_push /tmp/zonefile.txt\n' +
+        '    $ stx -H https://stacks-node-api.stacks.co zonefile_push /tmp/zonefile.txt\n' +
         '    [\n' +
-        '      "https://core.blockstack.org"\n' +
+        '      "https://stacks-node-api.stacks.co"\n' +
         '    ]\n' +
         '\n',
       group: 'Blockstack ID Management',
@@ -2679,9 +2679,9 @@ export const CLI_ARGS = {
         '\n' +
         'Example:\n' +
         '\n' +
-        '    $ stx -H https://core.blockstack.org zonefile_push /path/to/zonefile.txt\n' +
+        '    $ stx -H https://stacks-node-api.stacks.co zonefile_push /path/to/zonefile.txt\n' +
         '    [\n' +
-        '      "https://core.blockstack.org"\n' +
+        '      "https://stacks-node-api.stacks.co"\n' +
         '    ]\n' +
         '\n',
       group: 'Peer Services',

--- a/packages/keychain/src/identity.ts
+++ b/packages/keychain/src/identity.ts
@@ -133,7 +133,7 @@ export class Identity implements IdentifyInterface {
   }
 
   async fetchNames() {
-    const getNamesUrl = `https://core.blockstack.org/v1/addresses/bitcoin/${this.address}`;
+    const getNamesUrl = `https://stacks-node-api.stacks.co/v1/addresses/bitcoin/${this.address}`;
     const res = await fetch(getNamesUrl);
     const data = await res.json();
     const { names }: { names: string[] } = data;

--- a/packages/keychain/src/utils/index.ts
+++ b/packages/keychain/src/utils/index.ts
@@ -248,7 +248,7 @@ interface NameInfoResponse {
 }
 
 export const getProfileURLFromZoneFile = async (name: string) => {
-  const url = `https://core.blockstack.org/v1/names/${name}`;
+  const url = `https://stacks-node-api.stacks.co/v1/names/${name}`;
   const res = await fetch(url);
   if (res.ok) {
     const nameInfo: NameInfoResponse = await res.json();

--- a/packages/wallet-sdk/src/utils.ts
+++ b/packages/wallet-sdk/src/utils.ts
@@ -19,7 +19,7 @@ interface NameInfoResponse {
 }
 
 export const getProfileURLFromZoneFile = async (name: string) => {
-  const url = `https://core.blockstack.org/v1/names/${name}`;
+  const url = `https://stacks-node-api.stacks.co/v1/names/${name}`;
   const res = await fetchPrivate(url);
   if (res.ok) {
     const nameInfo: NameInfoResponse = await res.json();


### PR DESCRIPTION
## Description
The core node url `https://core.blockstack.org` is deprecated and return `301` status code `permanently moved`. 

The existing usages of old url can be seen at: https://github.com/blockstack/stacks.js/search?q=core.blockstack.org

This PR updates the core node url to new one `https://stacks-node-api.stacks.co`

For details refer to issue #1148

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Testing information

1. `npm run test` passed
2. Tested few usernames including `radicle_art.id.blockstack` mentioned in issue. Worked with new url `https://stacks-node-api.stacks.co`
3. Endpoint: `https://stacks-node-api.stacks.co/v1/names/{name here}` is working with old and new names

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [X] `npm run test` passes
- [ ] Changelog is updated
- [X] Tag 1 of @yknl or @zone117x for review
