### PR TITLE
[Fix/1144] Populate username field in auth response

### DIFF
--- a/packages/auth/src/userSession.ts
+++ b/packages/auth/src/userSession.ts
@@ -347,6 +347,16 @@ export class UserSession {
       userData.profile = tokenPayload.profile;
     }
 
+    const address = userData.profile?.stxAddress?.mainnet;
+    if (!userData.username && address) {
+      try {
+        const namesResponse = await fetchPrivate(`${coreNode}/v1/addresses/stacks/${address}`);
+        const namesJson = await namesResponse.json();
+        if ((namesJson.names.length || 0) > 0) {
+          userData.username = namesJson.names[0];
+        }
+      } catch (e) {}
+    }
     sessionData.userData = userData;
     this.store.setSessionData(sessionData);
 


### PR DESCRIPTION
## Description
This PR fixes the issue of empty username field in the auth response.

For details refer to issue #1144

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No
## Are documentation updates required?
No

## Testing information
Provide context on how tests should be performed.
1. Test case added
2. `npm run test` passed successfully

## Checklist
- [X] Code is commented where needed
- [X] Unit test coverage for new or modified code paths
- [X] `npm run test` passes
- [ ] Changelog is updated
- [X] Tag 1 of @yknl or @zone117x for review
