### PR TITLE
Add Syvita mainnet endpoint

### DIFF
--- a/packages/network/src/index.ts
+++ b/packages/network/src/index.ts
@@ -4,6 +4,8 @@ export const HIRO_MAINNET_DEFAULT = 'https://stacks-node-api.mainnet.stacks.co';
 export const HIRO_TESTNET_DEFAULT = 'https://stacks-node-api.testnet.stacks.co';
 export const HIRO_MOCKNET_DEFAULT = 'http://localhost:3999';
 
+export const SYVIREAN_MAINNET_DEFAULT = 'https://mainnet.syvita.org';
+
 export interface NetworkConfig {
   url: string;
 }
@@ -148,5 +150,13 @@ export class StacksMocknet extends StacksMainnet implements StacksNetwork {
 
   constructor(networkUrl: NetworkConfig = { url: HIRO_MOCKNET_DEFAULT }) {
     super(networkUrl);
+  }
+}
+
+export class SyvireanMainnet extends StacksMainnet implements StacksNetwork {
+  constructor(
+    networkConfig: NetworkConfig = { url: SYVIREAN_MAINNET_DEFAULT }
+  ) {
+    super(networkConfig);
   }
 }

--- a/packages/network/tests/network.test.ts
+++ b/packages/network/tests/network.test.ts
@@ -2,15 +2,21 @@ import {
   HIRO_MAINNET_DEFAULT,
   HIRO_MOCKNET_DEFAULT,
   HIRO_TESTNET_DEFAULT,
+  SYVIREAN_MAINNET_DEFAULT,
   StacksMainnet,
   StacksMocknet,
   StacksTestnet,
+  SyvireanMainnet,
 } from '@stacks/network';
 
 describe('Setting coreApiUrl', () => {
-  test('it sets mainnet default url', () => {
+  test('it sets hiro mainnet default url', () => {
     const mainnet = new StacksMainnet();
     expect(mainnet.coreApiUrl).toEqual(HIRO_MAINNET_DEFAULT);
+  });
+  test('it sets syvirean mainnet default url', () => {
+    const mainnet = new SyvireanMainnet();
+    expect(mainnet.coreApiUrl).toEqual(SYVIREAN_MAINNET_DEFAULT);
   });
   test('it sets testnet url', () => {
     const testnet = new StacksTestnet();


### PR DESCRIPTION
## Description

Adds Syvita's mainnet as an option in Stacks.js

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?

No

## Are documentation updates required?

No

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @yknl or @zone117x for review
