### PR TITLE
[Bundle Size] Offload lodash dependency

### DIFF
--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@types/common-tags": "^1.8.0",
     "@types/jest": "^26.0.22",
-    "@types/lodash": "^4.14.160",
+    "@types/lodash.clonedeep": "^4.5.6",
     "common-tags": "^1.8.0",
     "jest": "^26.6.3",
     "jest-fetch-mock": "^3.0.3",
@@ -51,7 +51,7 @@
     "c32check": "^1.1.3",
     "cross-fetch": "^3.1.4",
     "elliptic": "^6.5.4",
-    "lodash": "^4.17.20",
+    "lodash.clonedeep": "^4.5.0",
     "randombytes": "^2.1.0",
     "ripemd160-min": "^0.0.6",
     "sha.js": "^2.4.11",

--- a/packages/transactions/src/utils.ts
+++ b/packages/transactions/src/utils.ts
@@ -6,7 +6,7 @@ import randombytes from 'randombytes';
 import { deserializeCV } from './clarity';
 import fetch from 'cross-fetch';
 import { c32addressDecode } from 'c32check';
-import lodashCloneDeep from 'lodash/cloneDeep';
+import lodashCloneDeep from 'lodash.clonedeep';
 import { with0x } from '@stacks/common';
 
 export { randombytes as randomBytes };


### PR DESCRIPTION
## Description
This PR removes `lodash` dependency from stacks.js packages.  
`lodash` minified size is around `69KB` out of which stacks.js is using around `10KB` of its modules. This will help to reduce the bundle size. In the subsequent pr, further dependencies can be removed to reduce the bundle size further. 

For details refer to issue #1120

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Testing information

1. `npm run test`

## Checklist
- [X] Code is commented where needed
- [X] Unit test coverage for new or modified code paths
- [X] `npm run test` passes
- [ ] Changelog is updated
- [X] Tag 1 of @yknl or @zone117x for review
