### PR TITLE
[CLI] bns register name

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -90,6 +90,7 @@
   "dependencies": {
     "@stacks/auth": "^3.1.0",
     "@stacks/blockchain-api-client": "^0.34.1",
+    "@stacks/bns": "^3.1.0",
     "@stacks/common": "^3.0.0",
     "@stacks/network": "^3.0.0",
     "@stacks/stacking": "^3.1.0",

--- a/packages/cli/src/argparse.ts
+++ b/packages/cli/src/argparse.ts
@@ -1981,9 +1981,9 @@ export const CLI_ARGS = {
       type: 'array',
       items: [
         {
-          name: 'blockstack_id',
+          name: 'fully-qualified-name',
           type: 'string',
-          realtype: 'on-chain-blockstack_id',
+          realtype: 'on-chain-fully-qualified-name',
           pattern: NAME_PATTERN,
         },
         {
@@ -1993,15 +1993,9 @@ export const CLI_ARGS = {
           pattern: PRIVATE_KEY_PATTERN,
         },
         {
-          name: 'payment_key',
+          name: 'salt',
           type: 'string',
-          realtype: 'private_key',
-          pattern: `${PRIVATE_KEY_PATTERN_ANY}`,
-        },
-        {
-          name: 'gaia_hub',
-          type: 'string',
-          realtype: 'url',
+          realtype: 'text',
         },
         {
           name: 'zonefile',
@@ -2010,7 +2004,7 @@ export const CLI_ARGS = {
         },
       ],
       minItems: 4,
-      maxItems: 5,
+      maxItems: 4,
       help:
         'If you are trying to register a name for a *private key*, use this command.\n' +
         '\n' +
@@ -2039,9 +2033,7 @@ export const CLI_ARGS = {
         'Example:\n' +
         '\n' +
         '    $ export OWNER="136ff26efa5db6f06b28f9c8c7a0216a1a52598045162abfe435d13036154a1b01"\n' +
-        '    $ export PAYMENT="bfeffdf57f29b0cc1fab9ea197bb1413da2561fe4b83e962c7f02fbbe2b1cd5401"\n' +
-        '    $ stx register example.id "$OWNER" "$PAYMENT" https://hub.blockstack.org\n' +
-        '    9bb908bfd4ab221f0829167a461229172184fc825a012c4e551533aa283207b1\n' +
+        '    $ stx register example.id "$OWNER" salt zonfile' +
         '\n',
       group: 'Blockstack ID Management',
     },


### PR DESCRIPTION
## Description
- This is first PR to fix the broken commands in cli. There will be separate pr's for other commands.
- This PR brings back 'bns' `register-name` command in cli. 

For details refer to issue #922 

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Testing information

1. `npm run test`

## Checklist
- [X] Code is commented where needed
- [X] Unit test coverage for new or modified code paths
- [X] `npm run test` passes
- [ ] Changelog is updated
- [X] Tag 1 of @yknl or @zone117x for review
