### PR TITLE
Github action to report circular dependency

### DIFF
--- a/.github/workflows/circular.dep.check.yml
+++ b/.github/workflows/circular.dep.check.yml
@@ -34,5 +34,4 @@ jobs:
         run: npm run bootstrap
 
       - name: List circular dependencies
-        continue-on-error: true
         run: npm run madge


### PR DESCRIPTION
## Description
Currently there are `✔ No circular dependencies in stacks.`. As i solved all these in #795. So modifying the github action to treat as error if found any circular dependency.  

For details refer to issue #795

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No
## Testing information
- `npm run test`
- `npm run madge`  will give `✔ No circular dependency found!` 

## Checklist
- [X] Code is commented where needed
- [X] Unit test coverage for new or modified code paths
- [X] `npm run test` passes
- [ ] Changelog is updated
- [X] Tag 1 of @yknl or @zone117x for review
