### PR TITLE
[Bundle Size][Transactions] Offload randomBytes dependency

### DIFF
--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -46,13 +46,11 @@
     "@stacks/network": "^3.3.0",
     "@types/bn.js": "^4.11.6",
     "@types/node": "^14.14.43",
-    "@types/randombytes": "^2.0.0",
     "@types/sha.js": "^2.4.0",
     "bn.js": "^5.2.0",
     "c32check": "^1.1.3",
     "cross-fetch": "^3.1.4",
     "lodash.clonedeep": "^4.5.0",
-    "randombytes": "^2.1.0",
     "ripemd160-min": "^0.0.6",
     "sha.js": "^2.4.11",
     "smart-buffer": "^4.1.0"

--- a/packages/transactions/src/utils.ts
+++ b/packages/transactions/src/utils.ts
@@ -2,14 +2,20 @@ import { Buffer } from '@stacks/common';
 import { sha256, sha512 } from 'sha.js';
 import { ClarityValue, serializeCV } from './clarity';
 import RIPEMD160 from 'ripemd160-min';
-import randombytes from 'randombytes';
+import { utils } from '@noble/secp256k1';
 import { deserializeCV } from './clarity';
 import fetch from 'cross-fetch';
 import { c32addressDecode } from 'c32check';
 import lodashCloneDeep from 'lodash.clonedeep';
 import { with0x } from '@stacks/common';
 
-export { randombytes as randomBytes };
+/**
+ * Use utils.randomBytes to replace randombytes dependency
+ * Generates a buffer with random bytes of given length
+ * @param {bytesLength} an optional bytes length, default is 32 bytes
+ * @return {Buffer} For return type compatibility converting utils.randomBytes return value to buffer
+ */
+export const randomBytes = (bytesLength?: number) => Buffer.from(utils.randomBytes(bytesLength));
 
 export class BufferArray {
   _value: Buffer[] = [];


### PR DESCRIPTION
## Description

Use `ramdomBytes` exported by `noble/secp256k1` intstead of extra ramdombytes dependency in transactions package.

For details refer to issue #1193

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Testing information

1. `npm run test`

## Checklist
- [X] Code is commented where needed
- [X] Unit test coverage for new or modified code paths
- [X] `npm run test` passes
- [ ] Changelog is updated
- [X] Tag @janniks and @zone117x for review
