### PR TITLE
[Bundle Size][Wallet-Sdk] Offload randomBytes dependency

### DIFF
--- a/packages/wallet-sdk/package.json
+++ b/packages/wallet-sdk/package.json
@@ -57,7 +57,6 @@
     "bn.js": "^5.2.0",
     "c32check": "^1.1.3",
     "jsontokens": "^3.0.0",
-    "randombytes": "^2.1.0",
     "triplesec": "^4.0.3",
     "zone-file": "^2.0.0-beta.3"
   },


### PR DESCRIPTION
## Description

Wallet-Sdk is using ramdombytes export from `@stacks/encryption`. Due to which `ramdombytes` dependency is redundant and not used within wallet-sdk. 

It's safe to remove ramdombytes dependency from package.json

For details refer to issue #1193

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Testing information

1. `npm run test`

## Checklist
- [X] Code is commented where needed
- [X] Unit test coverage for new or modified code paths
- [X] `npm run test` passes
- [ ] Changelog is updated
- [X] Tag @janniks and @zone117x for review
