### PR TITLE
fix: add appPrivateKeyFromWalletSalt (#1212)

### DIFF
--- a/packages/auth/src/messages.ts
+++ b/packages/auth/src/messages.ts
@@ -189,7 +189,8 @@ export async function makeAuthResponse(
   transitPublicKey: string | null = null,
   hubUrl: string | null = null,
   blockstackAPIUrl: string | null = null,
-  associationToken: string | null = null
+  associationToken: string | null = null,
+  appPrivateKeyFromWalletSalt: string | null = null
 ): Promise<string> {
   /* Convert the private key to a public key to an issuer */
   const publicKey = SECP256K1Client.derivePublicKey(privateKey);
@@ -229,6 +230,7 @@ export async function makeAuthResponse(
       iss: makeDIDFromAddress(address),
       private_key: privateKeyPayload,
       public_keys: [publicKey],
+      appPrivateKeyFromWalletSalt,
       profile,
       username,
       core_token: coreTokenPayload,

--- a/packages/auth/src/userData.ts
+++ b/packages/auth/src/userData.ts
@@ -36,4 +36,6 @@ export interface UserData {
   profile: any;
   // private: does not get sent to webapp at all.
   gaiaHubConfig?: any;
+  // Based on issue with incorrect appPrivateKey derivation see stacks-web-wallet issue #2238
+  appPrivateKeyFromWalletSalt?: string;
 }

--- a/packages/auth/src/userSession.ts
+++ b/packages/auth/src/userSession.ts
@@ -328,6 +328,7 @@ export class UserSession {
       coreSessionToken,
       authResponseToken,
       hubUrl,
+      appPrivateKeyFromWalletSalt: tokenPayload.appPrivateKeyFromWalletSalt as string,
       coreNode: tokenPayload.blockstackAPIUrl as string,
       // @ts-expect-error
       gaiaAssociationToken,

--- a/packages/auth/tests/auth.test.ts
+++ b/packages/auth/tests/auth.test.ts
@@ -171,6 +171,7 @@ test('makeAuthResponse && verifyAuthResponse', async () => {
   expect(authResponse).toBeTruthy();
 
   const decodedToken = decodeToken(authResponse);
+
   expect(decodedToken).toBeTruthy();
 
   const address = publicKeyToAddress(publicKey);
@@ -194,6 +195,57 @@ test('makeAuthResponse && verifyAuthResponse', async () => {
   await doPublicKeysMatchUsername(authResponse, nameLookupURL).then(verifiedResult => {
     expect(verifiedResult).toBe(true);
   });
+});
+
+test('auth response with invalid or empty appPrivateKeyFromWalletSalt', async () => {
+  let appPrivateKeyFromWalletSalt1;
+  const authResponse = await makeAuthResponse(
+    privateKey,
+    sampleProfiles.ryan,
+    null,
+    null,
+    null,
+    null,
+    undefined,
+    null,
+    null,
+    null,
+    null,
+    appPrivateKeyFromWalletSalt1
+  );
+  expect(authResponse).toBeTruthy();
+  const decodedToken = decodeToken(authResponse);
+  console.log('decodedToken', decodedToken);
+  expect(decodedToken).toBeTruthy();
+  expect((decodedToken.payload as any).appPrivateKeyFromWalletSalt).toBeNull();
+});
+
+test('auth response with valid appPrivateKeyFromWalletSalt', async () => {
+  const appPrivateKeyFromWalletSalt =
+    'ab9a2ad092b910902f4a74f7aeaee874497ed9bc3f6408ed8b07e22425471fde';
+  const authResponse = await makeAuthResponse(
+    privateKey,
+    sampleProfiles.ryan,
+    null,
+    null,
+    null,
+    null,
+    undefined,
+    null,
+    null,
+    null,
+    null,
+    appPrivateKeyFromWalletSalt
+  );
+  expect(authResponse).toBeTruthy();
+
+  const decodedToken = decodeToken(authResponse);
+  console.log('decodedToken', decodedToken);
+
+  expect(decodedToken).toBeTruthy();
+  expect((decodedToken.payload as any).appPrivateKeyFromWalletSalt).toEqual(
+    appPrivateKeyFromWalletSalt
+  );
 });
 
 test('auth response with username', async () => {

--- a/packages/wallet-sdk/src/models/account.ts
+++ b/packages/wallet-sdk/src/models/account.ts
@@ -66,12 +66,14 @@ export const makeAuthResponse = async ({
   transitPublicKey,
   scopes = [],
   gaiaHubUrl,
+  appPrivateKeyFromWalletSalt = null,
 }: {
   account: Account;
   appDomain: string;
   transitPublicKey: string;
   scopes?: string[];
   gaiaHubUrl: string;
+  appPrivateKeyFromWalletSalt?: string | null;
 }) => {
   const appPrivateKey = getAppPrivateKey({ account, appDomain });
   const hubInfo = await getHubInfo(gaiaHubUrl);
@@ -124,6 +126,7 @@ export const makeAuthResponse = async ({
     transitPublicKey,
     gaiaHubUrl,
     undefined,
-    associationToken
+    associationToken,
+    appPrivateKeyFromWalletSalt
   );
 };


### PR DESCRIPTION
This fixes issue #1212 by adding a new attribute to makeAuthResponse
See issue [2238](https://github.com/hirosystems/stacks-wallet-web/issues/2238) in stacks-web-wallet repo

## Description
The stacks-web-wallet needs to be able to pass a new value to dapps that have been potentially affected by issue [2238](https://github.com/hirosystems/stacks-wallet-web/issues/2238) 
The solution here is to add a new attribute to UserSession so dapp can access it directly.
For this purpose a new param `appPrivateKeyFromWalletSalt` has been added to `makeAuthResponse` from account.ts in wallet-sdk and `makeAuthResponse` from message.ts in auth
This change is backward compatible as the param is optional. Existing apps or wallets using this makeAuthResponse won't need to change anything.


## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Testing information

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated

