### PR TITLE
[Bundle Size][Encryption] Offload `bip39` dependency

### DIFF
--- a/packages/encryption/package.json
+++ b/packages/encryption/package.json
@@ -37,7 +37,7 @@
     "@stacks/common": "^3.3.0",
     "@types/bn.js": "^4.11.6",
     "@types/node": "^14.14.43",
-    "bip39": "^3.0.2",
+    "@scure/bip39": "^1.0.0",
     "bitcoinjs-lib": "^5.2.0",
     "bn.js": "^5.2.0",
     "ripemd160-min": "^0.0.6",


### PR DESCRIPTION
## Description
This PR removes `bip39` dependency from `encryption` package

Using: https://github.com/paulmillr/scure-bip39
Secure, [audited](https://github.com/paulmillr/scure-bip39#security) & minimal implementation of BIP39 mnemonic phrases.

`scure-bip39` is fast and small in size very similiar to `noble-secp256k1` library.

Visit: https://github.com/paulmillr/scure-bip39

For details refer to issue #1203

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Testing information

1. `npm run test`

## Checklist
- [X] Code is commented where needed
- [X] Unit test coverage for new or modified code paths
- [X] `npm run test` passes
- [ ] Changelog is updated
- [X] Tag @janniks and @zone117x for review
