### PR TITLE
[FIX] Deserialize partially signed multisig transactions

### DIFF
--- a/packages/transactions/README.md
+++ b/packages/transactions/README.md
@@ -242,6 +242,7 @@ transaction must be appended to the signature.
 ```typescript
 // deserialize and sign transaction
 const bufferReader = new BufferReader(serializedTx);
+// Partially signed or unsigned multi-sig tx can be deserialized to add the required signatures
 const deserializedTx = deserializeTransaction(bufferReader);
 
 const signer = new TransactionSigner(deserializedTx);

--- a/packages/transactions/src/authorization.ts
+++ b/packages/transactions/src/authorization.ts
@@ -235,7 +235,8 @@ export function deserializeMultiSigSpendingCondition(
   }
   const signaturesRequired = bufferReader.readUInt16BE();
 
-  if (numSigs !== signaturesRequired) throw new VerificationError(`Incorrect number of signatures`);
+  // Partially signed multi-sig tx can be serialized and deserialized without exception (Incorrect number of signatures)
+  // No need to check numSigs !== signaturesRequired to throw Incorrect number of signatures error
 
   if (haveUncompressed && hashMode === AddressHashMode.SerializeP2SH)
     throw new VerificationError('Uncompressed keys are not allowed in this hash mode');

--- a/packages/transactions/tests/authorization.test.ts
+++ b/packages/transactions/tests/authorization.test.ts
@@ -526,13 +526,17 @@ test('Invalid spending conditions', () => {
 
   const badPublicKeyCountBuffer = Buffer.from(badPublicKeyCountBytes);
 
+  // Partially signed multi-sig tx can be serialized and deserialized without exception (Incorrect number of signatures)
+  // Should be able to deserialize as number of signatures are less than signatures required
   expect(() => deserializeSpendingCondition(new BufferReader(badPublicKeyCountBuffer)))
-    .toThrow('Incorrect number of signatures');
+    .not.toThrowError();
 
   const badPublicKeyCount2Buffer = Buffer.from(badPublicKeyCountBytes2);
 
+  // Partially signed multi-sig tx can be serialized and deserialized without exception (Incorrect number of signatures)
+  // Should be able to deserialize as number of signatures are less than signatures required
   expect(() => deserializeSpendingCondition(new BufferReader(badPublicKeyCount2Buffer)))
-    .toThrow('Incorrect number of signatures');
+    .not.toThrowError();
 
   // hashing mode doesn't allow uncompressed keys
   const signatureFF = createMessageSignature('ff'.repeat(65));

--- a/packages/transactions/tests/builder.test.ts
+++ b/packages/transactions/tests/builder.test.ts
@@ -331,7 +331,7 @@ test('Make Multi-Sig STX token transfer', async () => {
   expect(serializedSignedTx.toString('hex')).toBe(signedTx);
 });
 
-test('Should not deserilize partially signed multi-Sig STX token transfer', async () => {
+test('Should deserialize partially signed multi-Sig STX token transfer', async () => {
   const recipient = standardPrincipalCV('SP3FGQ8Z7JY9BWYZ5WM53E0M9NK7WHJF0691NZ159');
   const amount = 2500000;
   const fee = 0;
@@ -373,8 +373,9 @@ test('Should not deserilize partially signed multi-Sig STX token transfer', asyn
 
   const bufferReader = new BufferReader(serializedTx);
 
-  // Should not be able to deserializeTransaction due to missing signatures.
-  expect(() => deserializeTransaction(bufferReader)).toThrow('Incorrect number of signatures');
+  // Partially signed or unsigned multi-sig tx can be serialized and deserialized without exception (Incorrect number of signatures)
+  // Should be able to deserializeTransaction with missing signatures.
+  expect(() => deserializeTransaction(bufferReader)).not.toThrowError();
 
   // Now add the required signatures in the original transactions
   const signer = new TransactionSigner(transaction);
@@ -385,7 +386,7 @@ test('Should not deserilize partially signed multi-Sig STX token transfer', asyn
   const fullySignedTransaction = transaction.serialize();
   const bufferReaderSignedTx = new BufferReader(fullySignedTransaction);
 
-  // Should not throw any exception after adding required signatures.
+  // Should deserialize fully signed multi sig transaction
   const deserializedTx = deserializeTransaction(bufferReaderSignedTx);
 
   expect(deserializedTx.auth.authType).toBe(authType);
@@ -514,7 +515,9 @@ test('Make Multi-Sig STX token transfer with two transaction signers', async () 
 
   // deserialize
   const bufferReader2 = new BufferReader(partiallySignedSerialized);
-  expect(() => deserializeTransaction(bufferReader2)).toThrow('Incorrect number of signatures');
+  // Partially signed multi-sig tx can be serialized and deserialized without exception (Incorrect number of signatures)
+  // Should be able to deserialize as number of signatures are less than signatures required
+  expect(() => deserializeTransaction(bufferReader2)).not.toThrowError();
 
   // finish signing with new TransactionSigner
   const signer2 = new TransactionSigner(transaction);


### PR DESCRIPTION
## Description
Partially signed multisig transaction should be able to deserialize based on given scenario in #1228

Scenario: 
1. userA creates a multi-sig tx using its public key as well as userB's public key;
2. userA signs the tx;
3. userA serializes the partially signed multi-sig tx;
4. userA sends the serialized tx to userB;
5. userB deserializes the tx;
6. userB signs the tx;
7. as the tx is now a fully signed multi-sig tx, userB broadcasts it.

This PR fixes the step number 5 in above scenario. As it throws error (Incorrect number of signatures) if try to deserialize partially signed or unsigned multisig tx. 


For details refer to issue #1228

## Type of Change
- [ ] New feature
- [X] Bug fix
- [X] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
List the APIs or describe the functionality that this PR breaks.
Workarounds for or expected timeline for deprecation

## Are documentation updates required?
Yes. Updated readme file.

## Testing information

Provide context on how tests should be performed.
1. `npm run test`
2. Updated existed test cases
3. Existing test seems robust against the changes in the PR

## Checklist
- [X] Code is commented where needed
- [X] Unit test coverage for new or modified code paths
- [X] `npm run test` passes
- [ ] Changelog is updated
- [X] Tag 1 of @janniks  or @zone117x for review
