### PR TITLE
fix: remove username matching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21494,7 +21494,6 @@
 				"@stacks/encryption": "^3.3.0",
 				"@stacks/network": "^3.3.0",
 				"@stacks/profile": "^3.3.0",
-				"c32check": "^1.1.3",
 				"cross-fetch": "^3.1.4",
 				"jsontokens": "^3.0.0",
 				"query-string": "^6.13.1"
@@ -24526,7 +24525,6 @@
 				"@stacks/network": "^3.3.0",
 				"@stacks/profile": "^3.3.0",
 				"@types/jest": "^26.0.22",
-				"c32check": "^1.1.3",
 				"cross-fetch": "^3.1.4",
 				"jest": "^26.6.3",
 				"jest-fetch-mock": "^3.0.3",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -44,7 +44,6 @@
     "@stacks/encryption": "^3.3.0",
     "@stacks/network": "^3.3.0",
     "@stacks/profile": "^3.3.0",
-    "c32check": "^1.1.3",
     "cross-fetch": "^3.1.4",
     "jsontokens": "^3.0.0",
     "query-string": "^6.13.1"

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -6,7 +6,6 @@ export {
   verifyAuthResponse,
   isExpirationDateValid,
   isIssuanceDateValid,
-  doPublicKeysMatchUsername,
   doPublicKeysMatchIssuer,
   doSignaturesMatchPublicKeys,
   isManifestUriValid,

--- a/packages/auth/src/messages.ts
+++ b/packages/auth/src/messages.ts
@@ -12,7 +12,7 @@ import {
 } from '@stacks/encryption';
 import { DEFAULT_SCOPE, AuthScope } from './constants';
 
-const VERSION = '1.3.1';
+const VERSION = '1.4.0';
 
 type AuthMetadata = {
   email?: string;

--- a/packages/auth/src/messages.ts
+++ b/packages/auth/src/messages.ts
@@ -159,7 +159,6 @@ export async function decryptPrivateKey(
  * @param  {String} privateKey the identity key of the Blockstack ID generating
  * the authentication response
  * @param  {Object} profile the profile object for the Blockstack ID
- * @param  {String} username the username of the Blockstack ID if any, otherwise `null`
  * @param  {AuthMetadata} metadata an object containing metadata sent as part of the authentication
  * response including `email` if requested and available and a URL to the profile
  * @param  {String} coreToken core session token when responding to a legacy auth request
@@ -181,7 +180,6 @@ export async function makeAuthResponse(
   privateKey: string,
   // eslint-disable-next-line @typescript-eslint/ban-types
   profile: {} = {},
-  username: string | null = null,
   metadata: AuthMetadata | null,
   coreToken: string | null = null,
   appPrivateKey: string | null = null,
@@ -232,7 +230,6 @@ export async function makeAuthResponse(
       public_keys: [publicKey],
       appPrivateKeyFromWalletSalt,
       profile,
-      username,
       core_token: coreTokenPayload,
     },
     additionalProperties

--- a/packages/auth/src/userData.ts
+++ b/packages/auth/src/userData.ts
@@ -2,8 +2,6 @@
  *  Returned from the [[UserSession.loadUserData]] function.
  */
 export interface UserData {
-  // public: the blockstack ID (for example: stackerson.id or alice.blockstack.id)
-  username: string;
   // public: the email address for the user. only available if the `email`
   // scope is requested, and if the user has entered a valid email into
   // their profile.

--- a/packages/auth/src/userSession.ts
+++ b/packages/auth/src/userSession.ts
@@ -25,7 +25,7 @@ import {
   nextHour,
 } from '@stacks/common';
 import { extractProfile } from '@stacks/profile';
-import { AuthScope, DEFAULT_PROFILE, NAME_LOOKUP_PATH } from './constants';
+import { AuthScope, DEFAULT_PROFILE } from './constants';
 import * as queryString from 'query-string';
 import { UserData } from './userData';
 import { StacksMainnet } from '@stacks/network';
@@ -237,27 +237,7 @@ export class UserSession {
       throw new Error('Unexpected token payload type of string');
     }
 
-    // Section below is removed since the config was never persisted and therefore useless
-
-    // if (isLaterVersion(tokenPayload.version as string, '1.3.0')
-    //    && tokenPayload.blockstackAPIUrl !== null && tokenPayload.blockstackAPIUrl !== undefined) {
-    //   // override globally
-    //   Logger.info(`Overriding ${config.network.blockstackAPIUrl} `
-    //     + `with ${tokenPayload.blockstackAPIUrl}`)
-    //   // TODO: this config is never saved so the user node preference
-    //   // is not respected in later sessions..
-    //   config.network.blockstackAPIUrl = tokenPayload.blockstackAPIUrl as string
-    //   coreNode = tokenPayload.blockstackAPIUrl as string
-    // }
-
-    const nameLookupURL = `${coreNode}${NAME_LOOKUP_PATH}`;
-
-    const fallbackLookupURLs = [
-      `https://stacks-node-api.stacks.co${NAME_LOOKUP_PATH}`,
-      `https://registrar.stacks.co${NAME_LOOKUP_PATH}`,
-    ].filter(url => url !== nameLookupURL);
-
-    const isValid = await verifyAuthResponse(authResponseToken, nameLookupURL, fallbackLookupURLs);
+    const isValid = await verifyAuthResponse(authResponseToken);
     if (!isValid) {
       throw new LoginFailedError('Invalid authentication response.');
     }

--- a/packages/auth/src/userSession.ts
+++ b/packages/auth/src/userSession.ts
@@ -297,7 +297,6 @@ export class UserSession {
     }
 
     const userData: UserData = {
-      username: tokenPayload.username as string,
       profile: tokenPayload.profile,
       email: tokenPayload.email as string,
       decentralizedID: tokenPayload.iss,

--- a/packages/auth/src/verification.ts
+++ b/packages/auth/src/verification.ts
@@ -275,22 +275,12 @@ export async function verifyAuthRequestAndLoadManifest(token: string): Promise<a
  * @private
  * @ignore
  */
-export async function verifyAuthResponse(
-  token: string,
-  nameLookupURL: string,
-  fallbackLookupURLs?: string[]
-): Promise<boolean> {
-  const values = await Promise.all([
+export async function verifyAuthResponse(token: string): Promise<boolean> {
+  const conditions = await Promise.all([
     isExpirationDateValid(token),
     isIssuanceDateValid(token),
     doSignaturesMatchPublicKeys(token),
     doPublicKeysMatchIssuer(token),
   ]);
-  const usernameMatchings = await Promise.all(
-    [nameLookupURL]
-      .concat(fallbackLookupURLs || [])
-      .map(url => doPublicKeysMatchUsername(token, url))
-  );
-  const someUsernameMatches = usernameMatchings.includes(true);
-  return !!someUsernameMatches && values.every(val => val);
+  return conditions.every(val => val);
 }

--- a/packages/auth/src/verification.ts
+++ b/packages/auth/src/verification.ts
@@ -203,8 +203,6 @@ export async function verifyAuthRequestAndLoadManifest(token: string): Promise<a
 /**
  * Verify the authentication response is valid.
  * @param {String} token the authentication response token
- * @param {String} nameLookupURL the url use to verify owner of a username
- * @param fallbackLookupURLs an optional array of name lookup URLs to check usernames for
  * @return {Promise} that resolves to true if auth response
  * is valid and false if it does not
  * @private

--- a/packages/auth/tests/auth.test.ts
+++ b/packages/auth/tests/auth.test.ts
@@ -183,7 +183,7 @@ test('makeAuthResponse && verifyAuthResponse', async () => {
   );
   expect((decodedToken.payload as any).username).toBe(null);
 
-  await verifyAuthResponse(authResponse, nameLookupURL).then(verifiedResult => {
+  await verifyAuthResponse(authResponse).then(verifiedResult => {
     expect(verifiedResult).toBe(true);
   });
 
@@ -257,11 +257,11 @@ test('auth response with username', async () => {
     expect(verified).toBe(true);
   });
 
-  await verifyAuthResponse(authResponse, nameLookupURL).then(verifiedResult => {
+  await verifyAuthResponse(authResponse).then(verifiedResult => {
     expect(verifiedResult).toBe(true);
   });
 
-  expect(fetchMock.mock.calls.length).toEqual(2);
+  expect(fetchMock.mock.calls.length).toEqual(1);
 });
 
 test('auth response with invalid private key', async () => {
@@ -308,8 +308,6 @@ test('auth response with invalid private key', async () => {
 });
 
 test('handlePendingSignIn with authResponseToken', async () => {
-  const url = `${nameLookupURL}ryan.id`;
-
   fetchMock.mockResponse(JSON.stringify(sampleNameRecords.ryan));
 
   const appPrivateKey = makeECPrivateKey();
@@ -338,12 +336,10 @@ test('handlePendingSignIn with authResponseToken', async () => {
 
   expect(fail).toBeCalledTimes(0);
   expect(pass).toBeCalledTimes(1);
-  expect(fetchMock.mock.calls.length).toEqual(3);
-  expect(fetchMock.mock.calls[0][0]).toEqual(url);
+  expect(fetchMock.mock.calls.length).toEqual(0);
 });
 
 test('handlePendingSignIn 2', async () => {
-  const url = `${nameLookupURL}ryan.id`;
   fetchMock.mockResponse(JSON.stringify(sampleNameRecords.ryan));
 
   const appPrivateKey = makeECPrivateKey();
@@ -371,8 +367,7 @@ test('handlePendingSignIn 2', async () => {
   await blockstack.handlePendingSignIn(authResponse).then(pass).catch(fail);
   expect(fail).toBeCalledTimes(0);
   expect(pass).toBeCalledTimes(1);
-  expect(fetchMock.mock.calls.length).toEqual(3);
-  expect(fetchMock.mock.calls[0][0]).toEqual(url);
+  expect(fetchMock.mock.calls.length).toEqual(0);
 });
 
 test('handlePendingSignIn with existing user session', async () => {

--- a/packages/auth/tests/auth.test.ts
+++ b/packages/auth/tests/auth.test.ts
@@ -165,7 +165,7 @@ test('invalid auth request - invalid manifest uri', async () => {
 });
 
 test('makeAuthResponse && verifyAuthResponse', async () => {
-  const authResponse = await makeAuthResponse(privateKey, sampleProfiles.ryan, null, null);
+  const authResponse = await makeAuthResponse(privateKey, sampleProfiles.ryan, null);
   expect(authResponse).toBeTruthy();
 
   const decodedToken = decodeToken(authResponse);
@@ -179,7 +179,9 @@ test('makeAuthResponse && verifyAuthResponse', async () => {
   expect(JSON.stringify((decodedToken.payload as any).profile)).toEqual(
     JSON.stringify(sampleProfiles.ryan)
   );
-  expect((decodedToken.payload as any).username).toBe(null);
+
+  // username was removed from payload
+  expect('username' in (decodedToken.payload as any)).toBeFalsy();
 
   await verifyAuthResponse(authResponse).then(verifiedResult => {
     expect(verifiedResult).toBe(true);
@@ -196,7 +198,6 @@ test('auth response with invalid or empty appPrivateKeyFromWalletSalt', async ()
   const authResponse = await makeAuthResponse(
     privateKey,
     sampleProfiles.ryan,
-    null,
     null,
     null,
     null,
@@ -223,7 +224,6 @@ test('auth response with valid appPrivateKeyFromWalletSalt', async () => {
     null,
     null,
     null,
-    null,
     undefined,
     null,
     null,
@@ -245,7 +245,7 @@ test('auth response with valid appPrivateKeyFromWalletSalt', async () => {
 test('auth response with username', async () => {
   fetchMock.mockResponse(JSON.stringify(sampleNameRecords.ryan));
 
-  const authResponse = await makeAuthResponse(privateKey, sampleProfiles.ryan, 'ryan.id', null);
+  const authResponse = await makeAuthResponse(privateKey, sampleProfiles.ryan, null);
 
   await verifyAuthResponse(authResponse).then(verifiedResult => {
     expect(verifiedResult).toBe(true);
@@ -270,7 +270,6 @@ test('auth response with invalid private key', async () => {
   const authResponse = await makeAuthResponse(
     privateKey,
     sampleProfiles.ryan,
-    'ryan.id',
     metadata,
     undefined,
     appPrivateKey,
@@ -312,7 +311,6 @@ test('handlePendingSignIn with authResponseToken', async () => {
   const authResponse = await makeAuthResponse(
     privateKey,
     sampleProfiles.ryan,
-    'ryan.id',
     metadata,
     undefined,
     appPrivateKey,
@@ -340,7 +338,6 @@ test('handlePendingSignIn 2', async () => {
   const authResponse = await makeAuthResponse(
     privateKey,
     sampleProfiles.ryan,
-    'ryan.id',
     metadata,
     undefined,
     appPrivateKey,
@@ -387,7 +384,6 @@ test('handlePendingSignIn with existing user session', async () => {
   const authResponse = await makeAuthResponse(
     privateKey,
     sampleProfiles.ryan,
-    'ryan.id',
     metadata,
     undefined,
     appPrivateKey,
@@ -453,7 +449,6 @@ test('handlePendingSignIn with authResponseToken, transit key and custom Blockst
   const authResponse = await makeAuthResponse(
     privateKey,
     sampleProfiles.ryan,
-    'ryan.id',
     metadata,
     undefined,
     appPrivateKey,
@@ -503,7 +498,6 @@ test(
     const authResponse = await makeAuthResponse(
       privateKey,
       sampleProfiles.ryan,
-      'ryan.id',
       metadata,
       undefined,
       appPrivateKey,

--- a/packages/auth/tests/auth.test.ts
+++ b/packages/auth/tests/auth.test.ts
@@ -8,7 +8,6 @@ import {
   isIssuanceDateValid,
   doSignaturesMatchPublicKeys,
   doPublicKeysMatchIssuer,
-  doPublicKeysMatchUsername,
   isManifestUriValid,
   isRedirectUriValid,
   verifyAuthRequestAndLoadManifest,
@@ -30,7 +29,6 @@ beforeEach(() => {
 
 const privateKey = 'a5c61c6ca7b3e7e55edee68566aeab22e4da26baa285c7bd10e8d2218aa3b229';
 const publicKey = '027d28f9951ce46538951e3697c62588a87f1f1f295de4a14fdd4c780fc52cfe69';
-const nameLookupURL = 'https://stacks-node-api.mainnet.stacks.co/v1/names/';
 
 test('makeAuthRequest && verifyAuthRequest', async () => {
   const appConfig = new AppConfig(['store_write'], 'http://localhost:3000');
@@ -191,10 +189,6 @@ test('makeAuthResponse && verifyAuthResponse', async () => {
   expect(isIssuanceDateValid(authResponse)).toBe(true);
   expect(doSignaturesMatchPublicKeys(authResponse)).toBe(true);
   expect(doPublicKeysMatchIssuer(authResponse)).toBe(true);
-
-  await doPublicKeysMatchUsername(authResponse, nameLookupURL).then(verifiedResult => {
-    expect(verifiedResult).toBe(true);
-  });
 });
 
 test('auth response with invalid or empty appPrivateKeyFromWalletSalt', async () => {
@@ -253,15 +247,11 @@ test('auth response with username', async () => {
 
   const authResponse = await makeAuthResponse(privateKey, sampleProfiles.ryan, 'ryan.id', null);
 
-  await doPublicKeysMatchUsername(authResponse, nameLookupURL).then(verified => {
-    expect(verified).toBe(true);
-  });
-
   await verifyAuthResponse(authResponse).then(verifiedResult => {
     expect(verifiedResult).toBe(true);
   });
 
-  expect(fetchMock.mock.calls.length).toEqual(1);
+  expect(fetchMock.mock.calls.length).toEqual(0);
 });
 
 test('auth response with invalid private key', async () => {

--- a/packages/keychain/src/identity.ts
+++ b/packages/keychain/src/identity.ts
@@ -96,7 +96,6 @@ export class Identity implements IdentifyInterface {
         ...(this.profile || {}),
         stxAddress,
       },
-      this.defaultUsername || '',
       {
         profileUrl,
       },

--- a/packages/wallet-sdk/src/models/account.ts
+++ b/packages/wallet-sdk/src/models/account.ts
@@ -118,7 +118,6 @@ export const makeAuthResponse = async ({
         mainnet: getStxAddress({ account, transactionVersion: TransactionVersion.Mainnet }),
       },
     },
-    account.username || '',
     {
       profileUrl,
     },


### PR DESCRIPTION
## scope
**EDIT:** now removes the `username` field completely from `auth`

~removes username matching from auth package (application-side)
currently — in applications using @stacks/connect — the @stacks/auth package will "validate" usernames which the wallet returned in the authResponse. as "validation" these usernames are matched to the response of the API's `/names` endpoint.~

~the matching is removed from [`verifyAuthResponse`](https://github.com/hirosystems/stacks.js/pull/1230/files#diff-916fca8273bf9c9b085f7a99720e76d1d5a974da0b1b237b4d9ff2d9686b48fe). in addition, the previously used `doPublicKeysMatchUsername` [seems incorrect](https://github.com/hirosystems/stacks-wallet-web/issues/2354#issuecomment-1093026523) and is removed completely (only used in `verifyAuthResponse` previously).~

## comments
~a second PR could investigate removing the `username` field from auth responses in general, as brought up [here](https://github.com/hirosystems/stacks.js/issues/1144#issuecomment-1099968763) (should be coordinated w/ wallet-web).~