### PR TITLE
feat: Add encode / decode messages to support

### DIFF
--- a/packages/encryption/package.json
+++ b/packages/encryption/package.json
@@ -41,7 +41,8 @@
     "bn.js": "^5.2.0",
     "bs58": "^5.0.0",
     "ripemd160-min": "^0.0.6",
-    "sha.js": "^2.4.11"
+    "sha.js": "^2.4.11",
+    "varuint-bitcoin": "^1.1.2"
   },
   "devDependencies": {
     "@peculiar/webcrypto": "^1.1.6",

--- a/packages/encryption/src/index.ts
+++ b/packages/encryption/src/index.ts
@@ -11,3 +11,5 @@ export * from './sha2Hash';
 export * from './encryption';
 
 export * from './utils';
+
+export * from './messageSignature';

--- a/packages/encryption/src/messageSignature.ts
+++ b/packages/encryption/src/messageSignature.ts
@@ -1,0 +1,26 @@
+import { sha256 } from 'sha.js';
+import { encode, decode, encodingLength } from 'varuint-bitcoin';
+import { Buffer } from '@stacks/common';
+
+// 'Stacks Message Signing:\n'.length //  = 24
+// 'Stacks Message Signing:\n'.length.toString(16) //  = 18
+const chainPrefix = '\x18Stacks Message Signing:\n';
+
+export function hashMessage(message: string) {
+  return new sha256().update(encodeMessage(message)).digest();
+}
+
+export function encodeMessage(message: string | Buffer): Buffer {
+  const encoded = encode(Buffer.from(message).length);
+  return Buffer.concat([Buffer.from(chainPrefix), encoded, Buffer.from(message)]);
+}
+
+export function decodeMessage(encodedMessage: Buffer): Buffer {
+  // Remove the chain prefix: 1 for the varint and 24 for the length of the string
+  // 'Stacks Message Signing:\n'
+  const messageWithoutChainPrefix = encodedMessage.subarray(1 + 24);
+  const decoded = decode(messageWithoutChainPrefix);
+  const varIntLength = encodingLength(decoded);
+  // Remove the varint prefix
+  return messageWithoutChainPrefix.slice(varIntLength);
+}

--- a/packages/encryption/tests/messageSignature.test.ts
+++ b/packages/encryption/tests/messageSignature.test.ts
@@ -1,0 +1,38 @@
+import { decodeMessage, encodeMessage, hashMessage } from '../src/messageSignature';
+
+test('encodeMessage / decodeMessage', () => {
+  // array of messages and their expected encoded message
+  const messages = [
+    ['hello world', '\x18Stacks Message Signing:\n\x0bhello world'],
+    ['', '\x18Stacks Message Signing:\n\x00'],
+    // Longer message (to test a different length for the var_int prefix)
+    ['This is a really long message to test the var_int prefix This is a really long message to test the var_int prefix This is a really long message to test the var_int prefix This is a really long message to test the var_int prefix This is a really long message to test the var_int prefix',
+      Buffer.concat([
+        Buffer.from('\x18Stacks Message Signing:\n'),
+        // message length = 284 (decimal) = 011c (hex) <=> \x1c\x01 (little endian encoding)
+        // Since length = 284 is < 0xFFFF, prefix the int with 0xFD followed by 2 bytes for a total of 3 bytes (see https://en.bitcoin.it/wiki/Protocol_documentation#Variable_length_integer)
+        Buffer.from(new Uint8Array([253, 28, 1])),
+        Buffer.from('This is a really long message to test the var_int prefix This is a really long message to test the var_int prefix This is a really long message to test the var_int prefix This is a really long message to test the var_int prefix This is a really long message to test the var_int prefix')
+      ])],
+  ]
+  for (let messageArr of messages) {
+    const [message, expectedEncodedMessage] = messageArr;
+    const encodedMessage = encodeMessage(message);
+    expect(encodedMessage.equals(Buffer.from(expectedEncodedMessage))).toBeTruthy();
+    const decodedMessage = decodeMessage(encodedMessage);
+    expect(decodedMessage.toString()).toEqual(message);
+  }
+
+
+});
+
+test('hash message vs hash of manually constructed message', () => {
+  // echo -n '\x18Stacks Message Signing:\n\x0bhello world' | openssl dgst -sha256
+  // 664d1478d36935361c1a8eda75fce73c49a93b58e55ed7cb45c3860317814991
+
+  const message1 = 'hello world';
+  const hash1 = hashMessage(message1);
+  const expectedHash = '664d1478d36935361c1a8eda75fce73c49a93b58e55ed7cb45c3860317814991';
+  expect(hash1.length).toEqual(32); // 32 bytes of sha256
+  expect(hash1.toString('hex')).toEqual(expectedHash);
+});


### PR DESCRIPTION
This adds an `encodeMessage`, `decodeMessage` and `hashMessage` functions to support arbitrary message signing
more details in #1231

cc: @janniks 

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @yknl or @zone117x for review
