### PR TITLE
Add clarification to callReadOnlyFunction doc

### DIFF
--- a/packages/transactions/src/builders.ts
+++ b/packages/transactions/src/builders.ts
@@ -1278,7 +1278,8 @@ export interface ReadOnlyFunctionOptions {
 }
 
 /**
- * Calls a read only function from a contract interface
+ * Calls a function as read-only from a contract interface
+ * It is not necessary that the function is defined as read-only in the contract
  *
  * @param  {ReadOnlyFunctionOptions} readOnlyFunctionOptions - the options object
  *


### PR DESCRIPTION
## Description

It is possible to call any public function using `callReadOnlyFunction`, not only those defined with `(define-read-only)`

This commit updates the docstring to make this more clear

Discord discussion that prompted this: https://discord.com/channels/621759717756370964/713087894260023377/966642415945519104

## Type of Change
- [x] API reference/documentation update

## Does this introduce a breaking change?

Nope

## Are documentation updates required?

It's just a documentation update :) 

## Testing information

N/A

## Checklist
- [x] Code is commented where needed
~~- [ ] Unit test coverage for new or modified code paths~~ (N/A)
- [x] `npm run test` passes
~~- [ ] Changelog is updated~~ (N/A)
- [x] Tag 1 of @yknl or @zone117x for review

@yknl 