### PR TITLE
docs: fix example for `get_stacks_wallet_key`

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -389,7 +389,7 @@ Get the payment private key from a 24-word backup phrase used by the Stacks wall
 
 Example
     // Specify -t for testnet
-    stx get_stacks_payment_key "toast canal educate tissue express melody produce later gospel victory meadow outdoor hollow catch liberty annual gasp hat hello april equip thank neck cruise"
+    stx get_stacks_wallet_key "toast canal educate tissue express melody produce later gospel victory meadow outdoor hollow catch liberty annual gasp hat hello april equip thank neck cruise"
     [
       {
         "privateKey": "a25cea8d310ce656c6d427068c77bad58327334f73e39c296508b06589bc4fa201",

--- a/packages/cli/src/argparse.ts
+++ b/packages/cli/src/argparse.ts
@@ -1366,7 +1366,7 @@ export const CLI_ARGS = {
         '\n' +
         'Example\n' +
         '\n' +
-        '    $ stx get_stacks_payment_key "toast canal educate tissue express melody produce later gospel victory meadow outdoor hollow catch liberty annual gasp hat hello april equip thank neck cruise"\n' +
+        '    $ stx get_stacks_wallet_key "toast canal educate tissue express melody produce later gospel victory meadow outdoor hollow catch liberty annual gasp hat hello april equip thank neck cruise"\n' +
         '    [\n' +
         '      {\n' +
         '        "privateKey": "a25cea8d310ce656c6d427068c77bad58327334f73e39c296508b06589bc4fa201",\n' +


### PR DESCRIPTION
This is just a simple doc fix to update the example for `get_stacks_wallet_key`.