### PR TITLE
fix(message-signing): add working message verification utility fn

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -4,4 +4,5 @@ export * from './fetchUtil';
 export * from './logger';
 export * from './utils';
 export * from './constants';
+export * from './signatures';
 export * from './keys';

--- a/packages/common/src/signatures.ts
+++ b/packages/common/src/signatures.ts
@@ -1,0 +1,16 @@
+import { hexToInt } from './utils';
+
+export function parseRecoverableSignature(signature: string) {
+  const coordinateValueBytes = 32;
+  if (signature.length < coordinateValueBytes * 2 * 2 + 1) {
+    throw new Error('Invalid signature');
+  }
+  const recoveryParamHex = signature.substr(0, 2);
+  const r = signature.substr(2, coordinateValueBytes * 2);
+  const s = signature.substr(2 + coordinateValueBytes * 2, coordinateValueBytes * 2);
+  return {
+    recoveryParam: hexToInt(recoveryParamHex),
+    r,
+    s,
+  };
+}

--- a/packages/transactions/src/keys.ts
+++ b/packages/transactions/src/keys.ts
@@ -15,6 +15,7 @@ import {
   intToHex,
   privateKeyToBuffer,
   PRIVATE_KEY_COMPRESSED_LENGTH,
+  parseRecoverableSignature as parseRecoverableSignatureFromCommon,
 } from '@stacks/common';
 import { c32address } from 'c32check';
 import { BufferReader } from './bufferReader';
@@ -179,20 +180,11 @@ export function getSignatureRecoveryParam(signature: string) {
   return hexToInt(recoveryParamHex);
 }
 
-export function parseRecoverableSignature(signature: string) {
-  const coordinateValueBytes = 32;
-  if (signature.length < coordinateValueBytes * 2 * 2 + 1) {
-    throw new Error('Invalid signature');
-  }
-  const recoveryParamHex = signature.substr(0, 2);
-  const r = signature.substr(2, coordinateValueBytes * 2);
-  const s = signature.substr(2 + coordinateValueBytes * 2, coordinateValueBytes * 2);
-  return {
-    recoveryParam: hexToInt(recoveryParamHex),
-    r,
-    s,
-  };
-}
+/**
+ * @deprecated
+ * This method is now exported from `@stacks/common` {@link parseRecoverableSignature}
+ */
+export const parseRecoverableSignature = parseRecoverableSignatureFromCommon;
 
 export function getPublicKey(privateKey: StacksPrivateKey): StacksPublicKey {
   return pubKeyfromPrivKey(privateKey.data);


### PR DESCRIPTION
In changing the signature format, the current docs & blog post has broken code examples.

See https://github.com/hirosystems/stacks-wallet-web/issues/2435

I copied `parseRecoverableSignature` from `@stacks/transactions`. What's best solution to reuse the fn? Atm encryption doesn't rely on tx package. Should we move to common?

Open to other solutions. Would be good to come up with a quick fix though, so users don't hit a wall when trying to use msg signing.