### PR TITLE
chore: consolidate licenses

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,37 +1,26 @@
 {
-  "name": "root",
   "private": true,
-  "prettier": "@stacks/prettier-config",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/hirosystems/stacks.js.git"
-  },
+  "name": "root",
   "workspaces": [
     "packages/**"
   ],
-  "release": {
-    "branches": [
-      "master"
-    ],
-    "plugins": [
-      "@semantic-release/commit-analyzer",
-      "@semantic-release/release-notes-generator",
-      [
-        "@semantic-release/npm",
-        {
-          "npmPublish": false
-        }
-      ],
-      "@semantic-release/changelog",
-      [
-        "@semantic-release/git",
-        {
-          "assets": [
-            "docs"
-          ]
-        }
-      ]
-    ]
+  "prettier": "@stacks/prettier-config",
+  "scripts": {
+    "bootstrap": "lerna bootstrap",
+    "build": "lerna run build",
+    "build:docs": "rimraf docs && RELEASE_VERSION=$(node -p \"require('./lerna.json').version\") && typedoc --tsconfig tsconfig.typedoc.json packages/**/src/index.ts --release-version $RELEASE_VERSION",
+    "clean": "lerna clean",
+    "lerna": "lerna",
+    "lint": "npm run lint:eslint && npm run lint:prettier",
+    "lint:eslint": "eslint \"packages/**/src/**/*.{ts,tsx|!(d.ts)}\" -f unix",
+    "lint:eslint:fix": "eslint \"packages/**/src/**/*.{ts,tsx}\" -f unix --fix",
+    "lint:fix": "eslint \"packages/**/src/**/*.{ts,tsx}\" -f unix --fix",
+    "lint:prettier": "prettier --check \"packages/**/src/**/*.{ts,tsx|!(d.ts)}\" *.js --ignore-path .gitignore",
+    "lint:prettier:fix": "prettier --write \"packages/**/src/**/*.{ts,tsx|!(d.ts)}\" *.js --ignore-path .gitignore",
+    "madge": "madge --circular --extensions ts --exclude 'd.ts' packages/",
+    "pack": "lerna run pack",
+    "test": "lerna run test",
+    "typecheck": "lerna run typecheck --parallel --no-bail --stream"
   },
   "devDependencies": {
     "@janniks/typedoc-plugin-monorepo": "^0.4.2-1",
@@ -71,21 +60,8 @@
     "typescript": "^4.2.4",
     "vite-compatible-readable-stream": "^3.6.0"
   },
-  "scripts": {
-    "bootstrap": "lerna bootstrap",
-    "build": "lerna run build",
-    "build:docs": "rimraf docs && RELEASE_VERSION=$(node -p \"require('./lerna.json').version\") && typedoc --tsconfig tsconfig.typedoc.json packages/**/src/index.ts --release-version $RELEASE_VERSION",
-    "clean": "lerna clean",
-    "lerna": "lerna",
-    "lint": "npm run lint:eslint && npm run lint:prettier",
-    "lint:eslint": "eslint \"packages/**/src/**/*.{ts,tsx|!(d.ts)}\" -f unix",
-    "lint:fix": "eslint \"packages/**/src/**/*.{ts,tsx}\" -f unix --fix",
-    "pack": "lerna run pack",
-    "lint:eslint:fix": "eslint \"packages/**/src/**/*.{ts,tsx}\" -f unix --fix",
-    "lint:prettier": "prettier --check \"packages/**/src/**/*.{ts,tsx|!(d.ts)}\" *.js --ignore-path .gitignore",
-    "lint:prettier:fix": "prettier --write \"packages/**/src/**/*.{ts,tsx|!(d.ts)}\" *.js --ignore-path .gitignore",
-    "test": "lerna run test",
-    "typecheck": "lerna run typecheck --parallel --no-bail --stream",
-    "madge": "madge --circular --extensions ts --exclude 'd.ts' packages/"
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hirosystems/stacks.js.git"
   }
 }

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -2,42 +2,23 @@
   "name": "@stacks/auth",
   "version": "4.1.0",
   "description": "Authentication for Stacks apps.",
-  "keywords": [
-    "Stacks",
-    "Blockstack",
-    "Blockchain",
-    "Authentication",
-    "Auth",
-    "Dapp"
-  ],
-  "author": "yknl <yukanliao@gmail.com>",
-  "homepage": "https://blockstack.org",
-  "license": "GPL-3.0-or-later",
-  "files": [
-    "dist",
-    "src"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/blockstack/blockstack.js.git"
-  },
+  "license": "MIT",
+  "author": "Hiro Systems PBC (https://hiro.so)",
+  "homepage": "https://www.hiro.so/stacks-js",
   "scripts": {
-    "start": "tsc -b tsconfig.build.json --watch --verbose",
     "build": "npm run clean && npm run build:cjs && npm run build:esm && npm run build:umd && npm run build:polyfill",
     "build:cjs": "tsc -b tsconfig.build.json",
     "build:esm": "tsc -p tsconfig.build.json --module ES6 --outDir ./dist/esm",
-    "build:umd": "NODE_OPTIONS=--max-old-space-size=8192 webpack --config webpack.config.js",
     "build:polyfill": "NODE_OPTIONS=--max-old-space-size=8192 rollup -c ../../configs/rollup.config.js && rimraf dist/polyfill/dist",
+    "build:umd": "NODE_OPTIONS=--max-old-space-size=8192 webpack --config webpack.config.js",
     "clean": "rimraf dist && tsc -b tsconfig.build.json --clean",
-    "typecheck": "tsc --noEmit",
-    "typecheck:watch": "npm run typecheck -- --watch",
     "pack": "npm pack",
     "prepublishOnly": "npm run test && NODE_ENV=production npm run build",
+    "start": "tsc -b tsconfig.build.json --watch --verbose",
     "test": "jest",
-    "test:watch": "jest --watch --coverage=false"
-  },
-  "bugs": {
-    "url": "https://github.com/blockstack/blockstack.js/issues"
+    "test:watch": "jest --watch --coverage=false",
+    "typecheck": "tsc --noEmit",
+    "typecheck:watch": "npm run typecheck -- --watch"
   },
   "dependencies": {
     "@stacks/common": "^4.1.0",
@@ -65,5 +46,24 @@
   "module": "dist/esm/index.js",
   "browser": "dist/polyfill/index.js",
   "umd:main": "dist/umd/index.js",
-  "unpkg": "dist/umd/index.js"
+  "unpkg": "dist/umd/index.js",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "keywords": [
+    "Auth",
+    "Authentication",
+    "Blockchain",
+    "Blockstack",
+    "Dapp",
+    "Stacks"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hirosystems/stacks.js.git"
+  },
+  "bugs": {
+    "url": "https://github.com/blockstack/blockstack.js/issues"
+  }
 }

--- a/packages/bns/package.json
+++ b/packages/bns/package.json
@@ -2,42 +2,23 @@
   "name": "@stacks/bns",
   "version": "4.1.0",
   "description": "Library for working with the Stacks Blockchain Naming System BNS.",
-  "keywords": [
-    "Stacks",
-    "Blockchain",
-    "Naming",
-    "System",
-    "Blockstack",
-    "BNS"
-  ],
-  "author": "yknl <yukanliao@gmail.com>",
-  "homepage": "https://blockstack.org",
-  "license": "GPL-3.0-or-later",
-  "files": [
-    "dist",
-    "src"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/blockstack/stacks.js.git"
-  },
+  "license": "MIT",
+  "author": "Hiro Systems PBC (https://hiro.so)",
+  "homepage": "https://www.hiro.so/stacks-js",
   "scripts": {
-    "start": "tsc -b tsconfig.build.json --watch --verbose",
     "build": "npm run clean && npm run build:cjs && npm run build:esm && npm run build:umd && npm run build:polyfill",
     "build:cjs": "tsc -b tsconfig.build.json",
     "build:esm": "tsc -p tsconfig.build.json --module ES6 --outDir ./dist/esm",
-    "build:umd": "NODE_OPTIONS=--max-old-space-size=8192 webpack --config webpack.config.js",
     "build:polyfill": "NODE_OPTIONS=--max-old-space-size=8192 rollup -c ../../configs/rollup.config.js && rimraf dist/polyfill/dist",
+    "build:umd": "NODE_OPTIONS=--max-old-space-size=8192 webpack --config webpack.config.js",
     "clean": "rimraf dist && tsc -b tsconfig.build.json --clean",
-    "typecheck": "tsc --noEmit",
-    "typecheck:watch": "npm run typecheck -- --watch",
     "pack": "npm pack",
     "prepublishOnly": "npm run test && NODE_ENV=production npm run build",
+    "start": "tsc -b tsconfig.build.json --watch --verbose",
     "test": "jest",
-    "test:watch": "jest --watch --coverage=false"
-  },
-  "bugs": {
-    "url": "https://github.com/blockstack/stacks.js/issues"
+    "test:watch": "jest --watch --coverage=false",
+    "typecheck": "tsc --noEmit",
+    "typecheck:watch": "npm run typecheck -- --watch"
   },
   "dependencies": {
     "@stacks/common": "^4.1.0",
@@ -64,5 +45,24 @@
   "module": "dist/esm/index.js",
   "browser": "dist/polyfill/index.js",
   "umd:main": "dist/umd/index.js",
-  "unpkg": "dist/umd/index.js"
+  "unpkg": "dist/umd/index.js",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "keywords": [
+    "BNS",
+    "Blockchain",
+    "Blockstack",
+    "Naming",
+    "Stacks",
+    "System"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/blockstack/stacks.js.git"
+  },
+  "bugs": {
+    "url": "https://github.com/blockstack/stacks.js/issues"
+  }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,91 +2,20 @@
   "name": "@stacks/cli",
   "version": "4.1.1",
   "description": "Stacks command line tool",
-  "keywords": [
-    "stacks",
-    "command",
-    "blockchain",
-    "id",
-    "auth",
-    "authentication",
-    "bitcoin",
-    "blockchain auth",
-    "blockchain authentication",
-    "blockchainid",
-    "blockchain id",
-    "bitcoin auth",
-    "bitcoin authentication",
-    "bitcoin login",
-    "blockchain login",
-    "authorization",
-    "login",
-    "signin",
-    "sso",
-    "crypto",
-    "cryptography",
-    "token",
-    "blockstack",
-    "blockstack auth",
-    "profile",
-    "identity",
-    "ethereum"
-  ],
-  "author": {
-    "name": "Jude Nelson",
-    "email": "jude@blockstack.com",
-    "url": "https://blockstack.com"
-  },
-  "homepage": "https://blockstack.org",
+  "license": "MIT",
+  "author": "Hiro Systems PBC (https://hiro.so)",
   "contributors": [
-    {
-      "name": "Ken Liao",
-      "email": "yukanliao@gmail.com"
-    }
+    "Ken Liao <yukanliao@gmail.com>"
   ],
-  "license": "GPL-3.0-or-later",
-  "bin": {
-    "stacks": "./bin.js",
-    "stx": "./bin.js"
-  },
-  "main": "dist/index.js",
-  "files": [
-    "dist",
-    "src"
-  ],
-  "publishConfig": {
-    "access": "public"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/blockstack/blockstack.js.git"
-  },
+  "homepage": "https://www.hiro.so/stacks-js",
   "scripts": {
-    "start": "tsc -b tsconfig.build.json --watch --verbose",
     "build": "npm run clean && npm run build:cjs",
     "build:cjs": "tsc -b tsconfig.build.json",
     "clean": "rimraf dist && tsc -b tsconfig.build.json --clean",
+    "prepublishOnly": "npm run test && NODE_ENV=production npm run build",
+    "start": "tsc -b tsconfig.build.json --watch --verbose",
     "test": "jest",
-    "test:watch": "jest --watch --coverage=false",
-    "prepublishOnly": "npm run test && NODE_ENV=production npm run build"
-  },
-  "bugs": {
-    "url": "https://github.com/blockstack/blockstack.js/issues"
-  },
-  "devDependencies": {
-    "@types/cors": "^2.8.5",
-    "@types/express": "^4.16.1",
-    "@types/express-winston": "^3.0.1",
-    "@types/inquirer": "^6.5.0",
-    "@types/jest": "^26.0.22",
-    "@types/node-fetch": "^2.5.0",
-    "@types/ripemd160": "^2.0.0",
-    "jest": "^26.6.3",
-    "jest-fetch-mock": "^3.0.3",
-    "jest-module-name-mapper": "^0.1.5",
-    "rimraf": "^3.0.2",
-    "ts-jest": "^26.5.5",
-    "typescript": "^4.2.4",
-    "webpack-bundle-analyzer": "^4.5.0"
+    "test:watch": "jest --watch --coverage=false"
   },
   "dependencies": {
     "@stacks/auth": "^4.1.0",
@@ -114,6 +43,70 @@
     "ripemd160": "^2.0.1",
     "winston": "^3.2.1",
     "zone-file": "^2.0.0-beta.3"
+  },
+  "devDependencies": {
+    "@types/cors": "^2.8.5",
+    "@types/express": "^4.16.1",
+    "@types/express-winston": "^3.0.1",
+    "@types/inquirer": "^6.5.0",
+    "@types/jest": "^26.0.22",
+    "@types/node-fetch": "^2.5.0",
+    "@types/ripemd160": "^2.0.0",
+    "jest": "^26.6.3",
+    "jest-fetch-mock": "^3.0.3",
+    "jest-module-name-mapper": "^0.1.5",
+    "rimraf": "^3.0.2",
+    "ts-jest": "^26.5.5",
+    "typescript": "^4.2.4",
+    "webpack-bundle-analyzer": "^4.5.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "dist/index.js",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "keywords": [
+    "auth",
+    "authentication",
+    "authorization",
+    "bitcoin",
+    "bitcoin auth",
+    "bitcoin authentication",
+    "bitcoin login",
+    "blockchain",
+    "blockchain auth",
+    "blockchain authentication",
+    "blockchain id",
+    "blockchain login",
+    "blockchainid",
+    "blockstack",
+    "blockstack auth",
+    "command",
+    "crypto",
+    "cryptography",
+    "ethereum",
+    "id",
+    "identity",
+    "login",
+    "profile",
+    "signin",
+    "sso",
+    "stacks",
+    "token"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hirosystems/stacks.js.git"
+  },
+  "bugs": {
+    "url": "https://github.com/blockstack/blockstack.js/issues"
+  },
+  "bin": {
+    "stacks": "./bin.js",
+    "stx": "./bin.js"
   },
   "gitHead": "77b4d6d531b74996e4b7a0cbd1cf5b8358a690ce"
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -2,37 +2,23 @@
   "name": "@stacks/common",
   "version": "4.1.0",
   "description": "Common Stacks utilities",
-  "author": "yknl <yukanliao@gmail.com>",
-  "homepage": "https://blockstack.org",
-  "license": "GPL-3.0-or-later",
-  "files": [
-    "dist",
-    "src"
-  ],
-  "publishConfig": {
-    "access": "public"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/blockstack/blockstack.js.git"
-  },
+  "license": "MIT",
+  "author": "Hiro Systems PBC (https://hiro.so)",
+  "homepage": "https://www.hiro.so/stacks-js",
   "scripts": {
-    "start": "tsc -b tsconfig.build.json --watch --verbose",
     "build": "npm run clean && npm run build:cjs && npm run build:esm && npm run build:umd && npm run build:polyfill",
     "build:cjs": "tsc -b tsconfig.build.json",
     "build:esm": "tsc -p tsconfig.build.json --module ES6 --outDir ./dist/esm",
-    "build:umd": "NODE_OPTIONS=--max-old-space-size=8192 webpack --config webpack.config.js",
     "build:polyfill": "NODE_OPTIONS=--max-old-space-size=8192 rollup -c ../../configs/rollup.config.js && rimraf dist/polyfill/dist",
+    "build:umd": "NODE_OPTIONS=--max-old-space-size=8192 webpack --config webpack.config.js",
     "clean": "rimraf dist && tsc -b tsconfig.build.json --clean",
-    "typecheck": "tsc --noEmit",
-    "typecheck:watch": "npm run typecheck -- --watch",
     "pack": "npm pack",
     "prepublishOnly": "npm run test && NODE_ENV=production npm run build",
+    "start": "tsc -b tsconfig.build.json --watch --verbose",
     "test": "jest",
-    "test:watch": "jest --watch --coverage=false"
-  },
-  "bugs": {
-    "url": "https://github.com/blockstack/blockstack.js/issues"
+    "test:watch": "jest --watch --coverage=false",
+    "typecheck": "tsc --noEmit",
+    "typecheck:watch": "npm run typecheck -- --watch"
   },
   "dependencies": {
     "@types/bn.js": "^5.1.0",
@@ -56,10 +42,24 @@
     "webpack-cli": "^4.6.0"
   },
   "sideEffects": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "typings": "dist/index.d.ts",
   "main": "dist/index.js",
   "module": "dist/esm/index.js",
   "browser": "dist/polyfill/index.js",
   "umd:main": "dist/umd/index.js",
-  "unpkg": "dist/umd/index.js"
+  "unpkg": "dist/umd/index.js",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hirosystems/stacks.js.git"
+  },
+  "bugs": {
+    "url": "https://github.com/blockstack/blockstack.js/issues"
+  }
 }

--- a/packages/encryption/package.json
+++ b/packages/encryption/package.json
@@ -2,34 +2,23 @@
   "name": "@stacks/encryption",
   "version": "4.1.0",
   "description": "Encryption utilities for Stacks",
-  "author": "yknl <yukanliao@gmail.com>",
-  "homepage": "https://blockstack.org",
-  "license": "GPL-3.0-or-later",
-  "files": [
-    "dist",
-    "src"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/blockstack/blockstack.js.git"
-  },
+  "license": "MIT",
+  "author": "Hiro Systems PBC (https://hiro.so)",
+  "homepage": "https://www.hiro.so/stacks-js",
   "scripts": {
-    "start": "tsc -b tsconfig.build.json --watch --verbose",
     "build": "npm run clean && npm run build:cjs && npm run build:esm && npm run build:umd && npm run build:polyfill",
     "build:cjs": "tsc -b tsconfig.build.json",
     "build:esm": "tsc -p tsconfig.build.json --module ES6 --outDir ./dist/esm",
-    "build:umd": "NODE_OPTIONS=--max-old-space-size=8192 webpack --config webpack.config.js",
     "build:polyfill": "NODE_OPTIONS=--max-old-space-size=8192 rollup -c ../../configs/rollup.config.js && rimraf dist/polyfill/dist",
+    "build:umd": "NODE_OPTIONS=--max-old-space-size=8192 webpack --config webpack.config.js",
     "clean": "rimraf dist && tsc -b tsconfig.build.json --clean",
-    "typecheck": "tsc --noEmit",
-    "typecheck:watch": "npm run typecheck -- --watch",
     "pack": "npm pack",
     "prepublishOnly": "npm run test && NODE_ENV=production npm run build",
+    "start": "tsc -b tsconfig.build.json --watch --verbose",
     "test": "jest",
-    "test:watch": "jest --watch --coverage=false"
-  },
-  "bugs": {
-    "url": "https://github.com/blockstack/blockstack.js/issues"
+    "test:watch": "jest --watch --coverage=false",
+    "typecheck": "tsc --noEmit",
+    "typecheck:watch": "npm run typecheck -- --watch"
   },
   "dependencies": {
     "@noble/hashes": "^1.0.0",
@@ -74,5 +63,16 @@
   "module": "dist/esm/index.js",
   "browser": "dist/polyfill/index.js",
   "umd:main": "dist/umd/index.js",
-  "unpkg": "dist/umd/index.js"
+  "unpkg": "dist/umd/index.js",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hirosystems/stacks.js.git"
+  },
+  "bugs": {
+    "url": "https://github.com/blockstack/blockstack.js/issues"
+  }
 }

--- a/packages/keychain/package.json
+++ b/packages/keychain/package.json
@@ -2,64 +2,27 @@
   "name": "@stacks/keychain",
   "version": "4.1.0",
   "description": "A package for managing Stacks keychains",
-  "keywords": [
-    "Stacks",
-    "Blockstack",
-    "Keychain"
-  ],
-  "author": "Hank Stoever",
-  "homepage": "https://blockstack.org",
+  "license": "MIT",
+  "author": "Hiro Systems PBC (https://hiro.so)",
   "contributors": [
-    {
-      "name": "Hank Stoever"
-    },
-    {
-      "name": "Ken Liao"
-    }
+    "Hank Stoever",
+    "Ken Liao"
   ],
-  "license": "GPL-3.0-or-later",
-  "files": [
-    "dist",
-    "src"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/blockstack/blockstack.js.git"
-  },
-  "bugs": {
-    "url": "https://github.com/blockstack/blockstack.js/issues"
-  },
+  "homepage": "https://www.hiro.so/stacks-js",
   "scripts": {
-    "start": "tsc -b tsconfig.build.json --watch --verbose",
     "build": "npm run clean && npm run build:cjs && npm run build:esm && npm run build:umd && npm run build:polyfill",
     "build:cjs": "tsc -b tsconfig.build.json",
     "build:esm": "tsc -p tsconfig.build.json --module ES6 --outDir ./dist/esm",
-    "build:umd": "NODE_OPTIONS=--max-old-space-size=8192 webpack --config webpack.config.js",
     "build:polyfill": "NODE_OPTIONS=--max-old-space-size=8192 rollup -c ../../configs/rollup.config.js && rimraf dist/polyfill/dist",
+    "build:umd": "NODE_OPTIONS=--max-old-space-size=8192 webpack --config webpack.config.js",
     "clean": "rimraf dist && tsc -b tsconfig.build.json --clean",
-    "typecheck": "tsc --noEmit",
-    "typecheck:watch": "npm run typecheck -- --watch",
     "pack": "npm pack",
     "prepublishOnly": "npm run test && NODE_ENV=production npm run build",
+    "start": "tsc -b tsconfig.build.json --watch --verbose",
     "test": "jest",
-    "test:watch": "jest --watch --coverage=false"
-  },
-  "devDependencies": {
-    "@types/jest": "^26.0.22",
-    "crypto-browserify": "^3.12.0",
-    "jest": "^26.6.3",
-    "jest-fetch-mock": "^3.0.3",
-    "jest-module-name-mapper": "^0.1.5",
-    "process": "^0.11.10",
-    "rimraf": "^3.0.2",
-    "stream-browserify": "^3.0.0",
-    "ts-jest": "^26.5.5",
-    "ts-loader": "^9.1.1",
-    "typescript": "^4.2.4",
-    "util": "^0.12.4",
-    "webpack": "^5.36.1",
-    "webpack-bundle-analyzer": "^4.5.0",
-    "webpack-cli": "^4.6.0"
+    "test:watch": "jest --watch --coverage=false",
+    "typecheck": "tsc --noEmit",
+    "typecheck:watch": "npm run typecheck -- --watch"
   },
   "dependencies": {
     "@blockstack/rpc-client": "^0.3.0-alpha.11",
@@ -81,11 +44,44 @@
     "triplesec": "^4.0.3",
     "zone-file": "^2.0.0-beta.3"
   },
+  "devDependencies": {
+    "@types/jest": "^26.0.22",
+    "crypto-browserify": "^3.12.0",
+    "jest": "^26.6.3",
+    "jest-fetch-mock": "^3.0.3",
+    "jest-module-name-mapper": "^0.1.5",
+    "process": "^0.11.10",
+    "rimraf": "^3.0.2",
+    "stream-browserify": "^3.0.0",
+    "ts-jest": "^26.5.5",
+    "ts-loader": "^9.1.1",
+    "typescript": "^4.2.4",
+    "util": "^0.12.4",
+    "webpack": "^5.36.1",
+    "webpack-bundle-analyzer": "^4.5.0",
+    "webpack-cli": "^4.6.0"
+  },
   "sideEffects": false,
   "typings": "dist/index.d.ts",
   "main": "dist/index.js",
   "module": "dist/esm/index.js",
   "browser": "dist/polyfill/index.js",
   "umd:main": "dist/umd/index.js",
-  "unpkg": "dist/umd/index.js"
+  "unpkg": "dist/umd/index.js",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "keywords": [
+    "Blockstack",
+    "Keychain",
+    "Stacks"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hirosystems/stacks.js.git"
+  },
+  "bugs": {
+    "url": "https://github.com/blockstack/blockstack.js/issues"
+  }
 }

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -2,42 +2,23 @@
   "name": "@stacks/network",
   "version": "4.1.0",
   "description": "Library for Stacks network operations",
-  "keywords": [
-    "stacks",
-    "blockstack",
-    "network"
-  ],
-  "author": "yknl <yukanliao@gmail.com>",
-  "homepage": "https://blockstack.org",
-  "license": "GPL-3.0-or-later",
-  "files": [
-    "dist",
-    "src"
-  ],
-  "publishConfig": {
-    "access": "public"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/blockstack/blockstack.js.git"
-  },
+  "license": "MIT",
+  "author": "Hiro Systems PBC (https://hiro.so)",
+  "homepage": "https://www.hiro.so/stacks-js",
   "scripts": {
-    "start": "tsc -b tsconfig.build.json --watch --verbose",
     "build": "npm run clean && npm run build:cjs && npm run build:esm && npm run build:umd && npm run build:polyfill",
     "build:cjs": "tsc -b tsconfig.build.json",
     "build:esm": "tsc -p tsconfig.build.json --module ES6 --outDir ./dist/esm",
-    "build:umd": "NODE_OPTIONS=--max-old-space-size=8192 webpack --config webpack.config.js",
     "build:polyfill": "NODE_OPTIONS=--max-old-space-size=8192 rollup -c ../../configs/rollup.config.js && rimraf dist/polyfill/dist",
+    "build:umd": "NODE_OPTIONS=--max-old-space-size=8192 webpack --config webpack.config.js",
     "clean": "rimraf dist && tsc -b tsconfig.build.json --clean",
-    "typecheck": "tsc --noEmit",
-    "typecheck:watch": "npm run typecheck -- --watch",
     "pack": "npm pack",
     "prepublishOnly": "npm run test && NODE_ENV=production npm run build",
+    "start": "tsc -b tsconfig.build.json --watch --verbose",
     "test": "jest",
-    "test:watch": "jest --watch --coverage=false"
-  },
-  "bugs": {
-    "url": "https://github.com/blockstack/blockstack.js/issues"
+    "test:watch": "jest --watch --coverage=false",
+    "typecheck": "tsc --noEmit",
+    "typecheck:watch": "npm run typecheck -- --watch"
   },
   "dependencies": {
     "@stacks/common": "^4.1.0",
@@ -58,10 +39,29 @@
     "webpack-cli": "^4.6.0"
   },
   "sideEffects": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "typings": "dist/index.d.ts",
   "main": "dist/index.js",
   "module": "dist/esm/index.js",
   "browser": "dist/polyfill/index.js",
   "umd:main": "dist/umd/index.js",
-  "unpkg": "dist/umd/index.js"
+  "unpkg": "dist/umd/index.js",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "keywords": [
+    "blockstack",
+    "network",
+    "stacks"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hirosystems/stacks.js.git"
+  },
+  "bugs": {
+    "url": "https://github.com/blockstack/blockstack.js/issues"
+  }
 }

--- a/packages/profile/package.json
+++ b/packages/profile/package.json
@@ -2,39 +2,23 @@
   "name": "@stacks/profile",
   "version": "4.1.0",
   "description": "Library for Stacks profiles",
-  "keywords": [
-    "stacks",
-    "blockstack",
-    "profiles"
-  ],
-  "author": "yknl <yukanliao@gmail.com>",
-  "homepage": "https://blockstack.org",
-  "license": "GPL-3.0-or-later",
-  "files": [
-    "dist",
-    "src"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/blockstack/blockstack.js.git"
-  },
+  "license": "MIT",
+  "author": "Hiro Systems PBC (https://hiro.so)",
+  "homepage": "https://www.hiro.so/stacks-js",
   "scripts": {
-    "start": "tsc -b tsconfig.build.json --watch --verbose",
     "build": "npm run clean && npm run build:cjs && npm run build:esm && npm run build:umd && npm run build:polyfill",
     "build:cjs": "tsc -b tsconfig.build.json",
     "build:esm": "tsc -p tsconfig.build.json --module ES6 --outDir ./dist/esm",
-    "build:umd": "NODE_OPTIONS=--max-old-space-size=8192 webpack --config webpack.config.js",
     "build:polyfill": "NODE_OPTIONS=--max-old-space-size=8192 rollup -c ../../configs/rollup.config.js && rimraf dist/polyfill/dist",
+    "build:umd": "NODE_OPTIONS=--max-old-space-size=8192 webpack --config webpack.config.js",
     "clean": "rimraf dist && tsc -b tsconfig.build.json --clean",
-    "typecheck": "tsc --noEmit",
-    "typecheck:watch": "npm run typecheck -- --watch",
     "pack": "npm pack",
     "prepublishOnly": "npm run test && NODE_ENV=production npm run build",
+    "start": "tsc -b tsconfig.build.json --watch --verbose",
     "test": "jest",
-    "test:watch": "jest --watch --coverage=false"
-  },
-  "bugs": {
-    "url": "https://github.com/blockstack/blockstack.js/issues"
+    "test:watch": "jest --watch --coverage=false",
+    "typecheck": "tsc --noEmit",
+    "typecheck:watch": "npm run typecheck -- --watch"
   },
   "dependencies": {
     "@stacks/common": "^4.1.0",
@@ -65,5 +49,21 @@
   "module": "dist/esm/index.js",
   "browser": "dist/polyfill/index.js",
   "umd:main": "dist/umd/index.js",
-  "unpkg": "dist/umd/index.js"
+  "unpkg": "dist/umd/index.js",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "keywords": [
+    "blockstack",
+    "profiles",
+    "stacks"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hirosystems/stacks.js.git"
+  },
+  "bugs": {
+    "url": "https://github.com/blockstack/blockstack.js/issues"
+  }
 }

--- a/packages/stacking/package.json
+++ b/packages/stacking/package.json
@@ -2,38 +2,23 @@
   "name": "@stacks/stacking",
   "version": "4.1.0",
   "description": "Library for Stacking.",
-  "keywords": [
-    "Stacks",
-    "Stacking"
-  ],
-  "author": "yknl <yukanliao@gmail.com>",
-  "homepage": "https://blockstack.org",
-  "license": "GPL-3.0-or-later",
-  "files": [
-    "dist",
-    "src"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/blockstack/blockstack.js.git"
-  },
+  "license": "MIT",
+  "author": "Hiro Systems PBC (https://hiro.so)",
+  "homepage": "https://www.hiro.so/stacks-js",
   "scripts": {
-    "start": "tsc -b tsconfig.build.json --watch --verbose",
     "build": "npm run clean && npm run build:cjs && npm run build:esm && npm run build:umd && npm run build:polyfill",
     "build:cjs": "tsc -b tsconfig.build.json",
     "build:esm": "tsc -p tsconfig.build.json --module ES6 --outDir ./dist/esm",
-    "build:umd": "NODE_OPTIONS=--max-old-space-size=8192 webpack --config webpack.config.js",
     "build:polyfill": "NODE_OPTIONS=--max-old-space-size=8192 rollup -c ../../configs/rollup.config.js && rimraf dist/polyfill/dist",
+    "build:umd": "NODE_OPTIONS=--max-old-space-size=8192 webpack --config webpack.config.js",
     "clean": "rimraf dist && tsc -b tsconfig.build.json --clean",
-    "typecheck": "tsc --noEmit",
-    "typecheck:watch": "npm run typecheck -- --watch",
     "pack": "npm pack",
     "prepublishOnly": "npm run test && NODE_ENV=production npm run build",
+    "start": "tsc -b tsconfig.build.json --watch --verbose",
     "test": "jest",
-    "test:watch": "jest --watch --coverage=false"
-  },
-  "bugs": {
-    "url": "https://github.com/blockstack/blockstack.js/issues"
+    "test:watch": "jest --watch --coverage=false",
+    "typecheck": "tsc --noEmit",
+    "typecheck:watch": "npm run typecheck -- --watch"
   },
   "dependencies": {
     "@stacks/common": "^4.1.0",
@@ -63,5 +48,20 @@
   "module": "dist/esm/index.js",
   "browser": "dist/polyfill/index.js",
   "umd:main": "dist/umd/index.js",
-  "unpkg": "dist/umd/index.js"
+  "unpkg": "dist/umd/index.js",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "keywords": [
+    "Stacking",
+    "Stacks"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hirosystems/stacks.js.git"
+  },
+  "bugs": {
+    "url": "https://github.com/blockstack/blockstack.js/issues"
+  }
 }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -2,34 +2,23 @@
   "name": "@stacks/storage",
   "version": "4.1.0",
   "description": "Stacks storage library",
-  "author": "yknl <yukanliao@gmail.com>",
-  "homepage": "https://blockstack.org",
-  "license": "GPL-3.0-or-later",
-  "files": [
-    "dist",
-    "src"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/blockstack/blockstack.js.git"
-  },
+  "license": "MIT",
+  "author": "Hiro Systems PBC (https://hiro.so)",
+  "homepage": "https://www.hiro.so/stacks-js",
   "scripts": {
-    "start": "tsc -b tsconfig.build.json --watch --verbose",
     "build": "npm run clean && npm run build:cjs && npm run build:esm && npm run build:umd && npm run build:polyfill",
     "build:cjs": "tsc -b tsconfig.build.json",
     "build:esm": "tsc -p tsconfig.build.json --module ES6 --outDir ./dist/esm",
-    "build:umd": "NODE_OPTIONS=--max-old-space-size=8192 webpack --config webpack.config.js",
     "build:polyfill": "NODE_OPTIONS=--max-old-space-size=8192 rollup -c ../../configs/rollup.config.js && rimraf dist/polyfill/dist",
+    "build:umd": "NODE_OPTIONS=--max-old-space-size=8192 webpack --config webpack.config.js",
     "clean": "rimraf dist && tsc -b tsconfig.build.json --clean",
-    "typecheck": "tsc --noEmit",
-    "typecheck:watch": "npm run typecheck -- --watch",
     "pack": "npm pack",
     "prepublishOnly": "npm run test && NODE_ENV=production npm run build",
+    "start": "tsc -b tsconfig.build.json --watch --verbose",
     "test": "jest",
-    "test:watch": "jest --watch --coverage=false"
-  },
-  "bugs": {
-    "url": "https://github.com/blockstack/blockstack.js/issues"
+    "test:watch": "jest --watch --coverage=false",
+    "typecheck": "tsc --noEmit",
+    "typecheck:watch": "npm run typecheck -- --watch"
   },
   "dependencies": {
     "@stacks/auth": "^4.1.0",
@@ -61,5 +50,16 @@
   "module": "dist/esm/index.js",
   "browser": "dist/polyfill/index.js",
   "umd:main": "dist/umd/index.js",
-  "unpkg": "dist/umd/index.js"
+  "unpkg": "dist/umd/index.js",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hirosystems/stacks.js.git"
+  },
+  "bugs": {
+    "url": "https://github.com/blockstack/blockstack.js/issues"
+  }
 }

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -2,24 +2,42 @@
   "name": "@stacks/transactions",
   "version": "4.1.0",
   "description": "Javascript library for constructing transactions on the Stacks blockchain.",
-  "homepage": "https://blockstack.org",
-  "license": "GPL-3.0-or-later",
-  "author": {
-    "name": "Blockstack PBC",
-    "email": "admin@blockstack.com",
-    "url": "https://blockstack.com"
-  },
+  "license": "MIT",
+  "author": "Hiro Systems PBC (https://hiro.so)",
   "contributors": [
-    {
-      "name": "Ken Liao"
-    },
-    {
-      "name": "Reed Rosenbluth"
-    },
-    {
-      "name": "Matthew Little"
-    }
+    "Ken Liao",
+    "Matthew Little",
+    "Reed Rosenbluth"
   ],
+  "homepage": "https://www.hiro.so/stacks-js",
+  "scripts": {
+    "build": "npm run clean && npm run build:cjs && npm run build:esm && npm run build:umd && npm run build:polyfill",
+    "build:cjs": "tsc -b tsconfig.build.json",
+    "build:esm": "tsc -p tsconfig.build.json --module ES6 --outDir ./dist/esm",
+    "build:polyfill": "NODE_OPTIONS=--max-old-space-size=8192 rollup -c ../../configs/rollup.config.js && rimraf dist/polyfill/dist",
+    "build:umd": "NODE_OPTIONS=--max-old-space-size=8192 webpack --config webpack.config.js",
+    "clean": "rimraf dist && tsc -b tsconfig.build.json --clean",
+    "pack": "npm pack",
+    "prepublishOnly": "npm run test && NODE_ENV=production npm run build",
+    "start": "tsc -b tsconfig.build.json --watch --verbose",
+    "test": "jest",
+    "test:watch": "jest --watch --coverage=false",
+    "typecheck": "tsc --noEmit",
+    "typecheck:watch": "npm run typecheck -- --watch"
+  },
+  "dependencies": {
+    "@noble/hashes": "^1.0.0",
+    "@noble/secp256k1": "^1.5.5",
+    "@stacks/common": "^4.1.0",
+    "@stacks/network": "^4.1.0",
+    "@types/node": "^14.14.43",
+    "@types/sha.js": "^2.4.0",
+    "c32check": "^1.1.3",
+    "lodash.clonedeep": "^4.5.0",
+    "ripemd160-min": "^0.0.6",
+    "sha.js": "^2.4.11",
+    "smart-buffer": "^4.1.0"
+  },
   "devDependencies": {
     "@types/common-tags": "^1.8.0",
     "@types/elliptic": "^6.4.12",
@@ -39,53 +57,25 @@
     "webpack-bundle-analyzer": "^4.5.0",
     "webpack-cli": "^4.6.0"
   },
-  "dependencies": {
-    "@noble/hashes": "^1.0.0",
-    "@noble/secp256k1": "^1.5.5",
-    "@stacks/common": "^4.1.0",
-    "@stacks/network": "^4.1.0",
-    "@types/node": "^14.14.43",
-    "@types/sha.js": "^2.4.0",
-    "c32check": "^1.1.3",
-    "lodash.clonedeep": "^4.5.0",
-    "ripemd160-min": "^0.0.6",
-    "sha.js": "^2.4.11",
-    "smart-buffer": "^4.1.0"
-  },
+  "sideEffects": false,
   "publishConfig": {
     "access": "public"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/hirosystems/stacks.js.git"
-  },
-  "scripts": {
-    "start": "tsc -b tsconfig.build.json --watch --verbose",
-    "build": "npm run clean && npm run build:cjs && npm run build:esm && npm run build:umd && npm run build:polyfill",
-    "build:cjs": "tsc -b tsconfig.build.json",
-    "build:esm": "tsc -p tsconfig.build.json --module ES6 --outDir ./dist/esm",
-    "build:umd": "NODE_OPTIONS=--max-old-space-size=8192 webpack --config webpack.config.js",
-    "build:polyfill": "NODE_OPTIONS=--max-old-space-size=8192 rollup -c ../../configs/rollup.config.js && rimraf dist/polyfill/dist",
-    "clean": "rimraf dist && tsc -b tsconfig.build.json --clean",
-    "typecheck": "tsc --noEmit",
-    "typecheck:watch": "npm run typecheck -- --watch",
-    "pack": "npm pack",
-    "prepublishOnly": "npm run test && NODE_ENV=production npm run build",
-    "test": "jest",
-    "test:watch": "jest --watch --coverage=false"
-  },
-  "bugs": {
-    "url": "https://github.com/hirosystems/stacks.js/issues"
-  },
-  "files": [
-    "dist",
-    "src"
-  ],
-  "sideEffects": false,
   "typings": "dist/index.d.ts",
   "main": "dist/index.js",
   "module": "dist/esm/index.js",
   "browser": "dist/polyfill/index.js",
   "umd:main": "dist/umd/index.js",
-  "unpkg": "dist/umd/index.js"
+  "unpkg": "dist/umd/index.js",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hirosystems/stacks.js.git"
+  },
+  "bugs": {
+    "url": "https://github.com/hirosystems/stacks.js/issues"
+  }
 }

--- a/packages/wallet-sdk/package.json
+++ b/packages/wallet-sdk/package.json
@@ -2,47 +2,31 @@
   "name": "@stacks/wallet-sdk",
   "version": "4.1.0",
   "description": "A library for generating Stacks blockchain wallets",
-  "author": "Hank Stoever",
+  "license": "MIT",
+  "author": "Hiro Systems PBC (https://hiro.so)",
   "scripts": {
-    "start": "tsc -b tsconfig.build.json --watch --verbose",
     "build": "npm run clean && npm run build:cjs && npm run build:esm && npm run build:umd && npm run build:polyfill",
     "build:cjs": "tsc -b tsconfig.build.json",
-    "build:esm": "tsc -p tsconfig.build.json --module ES6 --outDir ./dist/esm",
-    "build:umd": "NODE_OPTIONS=--max-old-space-size=8192 webpack --config webpack.config.js",
-    "build:polyfill": "NODE_OPTIONS=--max-old-space-size=8192 rollup -c ../../configs/rollup.config.js && rimraf dist/polyfill/dist",
-    "clean": "rimraf dist && tsc -b tsconfig.build.json --clean",
-    "typecheck": "tsc --noEmit",
-    "typecheck:watch": "npm run typecheck -- --watch",
-    "test": "jest --coverage",
-    "dev": "cross-env NODE_ENV=development tsdx watch",
     "build:cjs:watch": "tsc --outDir ./lib -m commonjs -t es2017 --watch",
+    "build:esm": "tsc -p tsconfig.build.json --module ES6 --outDir ./dist/esm",
     "build:esm:watch": "tsc --outDir ./lib-esm -m es6 -t es2017 --watch",
-    "test:watch": "jest --watch --coverage=false",
+    "build:polyfill": "NODE_OPTIONS=--max-old-space-size=8192 rollup -c ../../configs/rollup.config.js && rimraf dist/polyfill/dist",
+    "build:umd": "NODE_OPTIONS=--max-old-space-size=8192 webpack --config webpack.config.js",
+    "clean": "rimraf dist && tsc -b tsconfig.build.json --clean",
+    "depcheck": "depcheck --ignores='@types/*,eslint*,safe-buffer,codecov,@typescript-eslint/*,@blockstack/*'",
+    "dev": "cross-env NODE_ENV=development tsdx watch",
     "lint": "yarn lint:eslint && yarn lint:prettier",
     "lint:eslint": "eslint \"src/**/*.{ts,tsx}\"",
     "lint:fix": "eslint \"src/**/*.{ts,tsx}\" --fix",
     "lint:prettier": "prettier --check \"src/**/*.{ts,tsx}\" *.js",
     "lint:prettier:fix": "prettier --write \"src/**/*.{ts,tsx}\" *.js",
-    "depcheck": "depcheck --ignores='@types/*,eslint*,safe-buffer,codecov,@typescript-eslint/*,@blockstack/*'",
     "pack": "npm pack",
-    "prepublishOnly": "npm run test && NODE_ENV=production npm run build"
-  },
-  "license": "MIT",
-  "files": [
-    "dist",
-    "src"
-  ],
-  "devDependencies": {
-    "@types/jest": "^26.0.22",
-    "@types/node": "^14.14.43",
-    "assert": "^2.0.0",
-    "bip32": "^2.0.6",
-    "crypto-browserify": "^3.12.0",
-    "jest": "^26.6.3",
-    "jest-fetch-mock": "^3.0.3",
-    "process": "^0.11.10",
-    "webpack-bundle-analyzer": "^4.5.0",
-    "yalc": "1.0.0-pre.49"
+    "prepublishOnly": "npm run test && NODE_ENV=production npm run build",
+    "start": "tsc -b tsconfig.build.json --watch --verbose",
+    "test": "jest --coverage",
+    "test:watch": "jest --watch --coverage=false",
+    "typecheck": "tsc --noEmit",
+    "typecheck:watch": "npm run typecheck -- --watch"
   },
   "dependencies": {
     "@scure/bip32": "^1.0.1",
@@ -60,14 +44,30 @@
     "triplesec": "^4.0.3",
     "zone-file": "^2.0.0-beta.3"
   },
+  "devDependencies": {
+    "@types/jest": "^26.0.22",
+    "@types/node": "^14.14.43",
+    "assert": "^2.0.0",
+    "bip32": "^2.0.6",
+    "crypto-browserify": "^3.12.0",
+    "jest": "^26.6.3",
+    "jest-fetch-mock": "^3.0.3",
+    "process": "^0.11.10",
+    "webpack-bundle-analyzer": "^4.5.0",
+    "yalc": "1.0.0-pre.49"
+  },
+  "sideEffects": false,
   "publishConfig": {
     "access": "public"
   },
-  "sideEffects": false,
   "typings": "dist/index.d.ts",
   "main": "dist/index.js",
   "module": "dist/esm/index.js",
   "browser": "dist/polyfill/index.js",
   "umd:main": "dist/umd/index.js",
-  "unpkg": "dist/umd/index.js"
+  "unpkg": "dist/umd/index.js",
+  "files": [
+    "dist",
+    "src"
+  ]
 }


### PR DESCRIPTION
## scope
- corrects license tag in `package.json`s: Licenses were previously partially incorrect, `package.json`s noted GPL but earlier versions were MIT, as well as `LICENSE` file being MIT — we consolidate back to MIT everywhere.

additional changes:
- fixes authors/links, and shortens [people objects](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#people-fields-author-contributors)
- fixes links
- prettifies `package.json`s
- rewrites outdated authors to generic company email, but keeps original contributors array
- doesn't include email until one is decided, e.g. something similar to opensource@blockstack