### PR TITLE
[poc] add missing rsv functions

### DIFF
--- a/packages/common/src/signatures.ts
+++ b/packages/common/src/signatures.ts
@@ -1,16 +1,28 @@
 import { hexToInt } from './utils';
 
-export function parseRecoverableSignature(signature: string) {
-  const coordinateValueBytes = 32;
-  if (signature.length < coordinateValueBytes * 2 * 2 + 1) {
+const COORDINATE_BYTES = 32;
+
+/** @ignore */
+export function parseRecoverableSignatureVrs(signature: string) {
+  if (signature.length < COORDINATE_BYTES * 2 * 2 + 1) {
     throw new Error('Invalid signature');
   }
-  const recoveryParamHex = signature.substr(0, 2);
-  const r = signature.substr(2, coordinateValueBytes * 2);
-  const s = signature.substr(2 + coordinateValueBytes * 2, coordinateValueBytes * 2);
+  const recoveryIdHex = signature.slice(0, 2);
+  const r = signature.slice(2, 2 + COORDINATE_BYTES * 2);
+  const s = signature.slice(2 + COORDINATE_BYTES * 2);
   return {
-    recoveryParam: hexToInt(recoveryParamHex),
+    recoveryId: hexToInt(recoveryIdHex),
     r,
     s,
   };
+}
+
+/** @ignore */
+export function signatureVrsToRsv(signature: string) {
+  return signature.slice(2) + signature.slice(0, 2);
+}
+
+/** @ignore */
+export function signatureRsvToVrs(signature: string) {
+  return signature.slice(-2) + signature.slice(0, -2);
 }

--- a/packages/common/tests/signature.test.ts
+++ b/packages/common/tests/signature.test.ts
@@ -1,0 +1,18 @@
+import { parseRecoverableSignatureVrs, signatureRsvToVrs, signatureVrsToRsv } from '../src';
+
+test('parseRecoverableSignatureVrs', () => {
+  const signatureHex = `01${'r'.repeat(64)}${'s'.repeat(64)}`;
+
+  const parsed = parseRecoverableSignatureVrs(signatureHex);
+
+  expect(parsed.recoveryId).toBe(1);
+  expect(parsed.r).toBe('r'.repeat(64));
+  expect(parsed.s).toBe('s'.repeat(64));
+
+  expect(() => parseRecoverableSignatureVrs('short')).toThrow('Invalid signature');
+});
+
+test('signatureVrsToRsv <> signatureRsvToVrs', () => {
+  expect(signatureVrsToRsv('VVRRRSSS')).toBe('RRRSSSVV');
+  expect(signatureRsvToVrs('RRRSSSVV')).toBe('VVRRRSSS');
+});

--- a/packages/encryption/tests/ec.test.ts
+++ b/packages/encryption/tests/ec.test.ts
@@ -1,0 +1,40 @@
+import { sha256 } from '@noble/hashes/sha256';
+import { Buffer } from '@stacks/common';
+import { verifyMessageSignature, verifyMessageSignatureRsv } from '../src/ec';
+
+test('verifyMessageSignature', () => {
+  // $ clarinet console
+  // > (secp256k1-verify
+  //     0xa591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e
+  //     0xf540e429fc6e8a4c27f2782479e739cae99aa21e8cb25d4436f333577bc791cd1d9672055dd1604dd5194b88076e4f859dd93c834785ed589ec38291698d414200
+  //     0x0290255f88fa311f5dee9425ce33d7d516c24157e2aae8e25a6c631dd6f7322aef
+  //   )
+  // >> true
+
+  const publicKey = '0290255f88fa311f5dee9425ce33d7d516c24157e2aae8e25a6c631dd6f7322aef';
+  const signatureVrs =
+    '00f540e429fc6e8a4c27f2782479e739cae99aa21e8cb25d4436f333577bc791cd1d9672055dd1604dd5194b88076e4f859dd93c834785ed589ec38291698d4142';
+  const message = Buffer.from(sha256('Hello World'));
+
+  expect(verifyMessageSignature({ signature: signatureVrs, publicKey, message })).toBe(true);
+});
+
+test('verifyMessageSignatureRsv', () => {
+  // $ clarinet console
+  // > (secp256k1-verify
+  //     0xa591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e
+  //     0xf540e429fc6e8a4c27f2782479e739cae99aa21e8cb25d4436f333577bc791cd1d9672055dd1604dd5194b88076e4f859dd93c834785ed589ec38291698d414200
+  //     0x0290255f88fa311f5dee9425ce33d7d516c24157e2aae8e25a6c631dd6f7322aef
+  //   )
+  // >> true
+
+  const publicKey = '0290255f88fa311f5dee9425ce33d7d516c24157e2aae8e25a6c631dd6f7322aef';
+  const signatureRsv =
+    'f540e429fc6e8a4c27f2782479e739cae99aa21e8cb25d4436f333577bc791cd1d9672055dd1604dd5194b88076e4f859dd93c834785ed589ec38291698d414200';
+  const message = Buffer.from(sha256('Hello World'));
+
+  expect(message.toString('hex')).toBe(
+    'a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e'
+  );
+  expect(verifyMessageSignatureRsv({ signature: signatureRsv, publicKey, message })).toBe(true);
+});

--- a/packages/transactions/tests/keys.test.ts
+++ b/packages/transactions/tests/keys.test.ts
@@ -1,10 +1,18 @@
+import { sha256 } from '@noble/hashes/sha256';
 import {
   getPublicKey as nobleGetPublicKey,
   signSync as nobleSecp256k1Sign,
   utils,
   verify as nobleSecp256k1Verify,
 } from '@noble/secp256k1';
-import { Buffer, bytesToHex, utf8ToBytes } from '@stacks/common';
+import {
+  Buffer,
+  bytesToHex,
+  hexToBigInt,
+  parseRecoverableSignatureVrs,
+  signatureRsvToVrs,
+  utf8ToBytes,
+} from '@stacks/common';
 import { ec as EC } from 'elliptic';
 import {
   compressPublicKey,
@@ -16,8 +24,10 @@ import {
   privateKeyToString,
   PubKeyEncoding,
   pubKeyfromPrivKey,
-  publicKeyFromSignature,
+  publicKeyFromSignatureRsv,
+  publicKeyFromSignatureVrs,
   publicKeyToString,
+  signMessageHashRsv,
   signWithKey,
   StacksMessageType,
   StacksPublicKey,
@@ -77,7 +87,73 @@ test('Stacks public key and private keys', () => {
   );
 });
 
-test('Retrieve public key from signature', () => {
+test('signWithKey', () => {
+  // $ clarinet console
+  // > (secp256k1-verify
+  //     0xa591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e
+  //     0xf540e429fc6e8a4c27f2782479e739cae99aa21e8cb25d4436f333577bc791cd1d9672055dd1604dd5194b88076e4f859dd93c834785ed589ec38291698d414200
+  //     0x0290255f88fa311f5dee9425ce33d7d516c24157e2aae8e25a6c631dd6f7322aef
+  //   )
+  // >> true
+
+  const privateKey = createStacksPrivateKey(
+    'bcf62fdd286f9b30b2c289cce3189dbf3b502dcd955b2dc4f67d18d77f3e73c7'
+  );
+  const expectedMessageHash = 'a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e';
+  const expectedSignatureVrs =
+    '00f540e429fc6e8a4c27f2782479e739cae99aa21e8cb25d4436f333577bc791cd1d9672055dd1604dd5194b88076e4f859dd93c834785ed589ec38291698d4142';
+
+  const messageHash = Buffer.from(sha256('Hello World')).toString('hex');
+  expect(messageHash).toBe(expectedMessageHash);
+
+  const signature = signWithKey(privateKey, messageHash);
+  expect(signature.data).toBe(expectedSignatureVrs);
+});
+
+test('signMessageHashRsv', () => {
+  // $ clarinet console
+  // > (secp256k1-verify
+  //     0xa591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e
+  //     0xf540e429fc6e8a4c27f2782479e739cae99aa21e8cb25d4436f333577bc791cd1d9672055dd1604dd5194b88076e4f859dd93c834785ed589ec38291698d414200
+  //     0x0290255f88fa311f5dee9425ce33d7d516c24157e2aae8e25a6c631dd6f7322aef
+  //   )
+  // >> true
+
+  const privateKey = createStacksPrivateKey(
+    'bcf62fdd286f9b30b2c289cce3189dbf3b502dcd955b2dc4f67d18d77f3e73c7'
+  );
+  const expectedMessageHash = 'a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e';
+  const expectedSignatureRsv =
+    'f540e429fc6e8a4c27f2782479e739cae99aa21e8cb25d4436f333577bc791cd1d9672055dd1604dd5194b88076e4f859dd93c834785ed589ec38291698d414200';
+
+  const messageHash = Buffer.from(sha256('Hello World')).toString('hex');
+  expect(messageHash).toBe(expectedMessageHash);
+
+  const signature = signMessageHashRsv({ privateKey, messageHash });
+  expect(signature.data).toBe(expectedSignatureRsv);
+});
+
+test('noble sign message', () => {
+  // example from https://paulmillr.com/noble/
+  const privateKey = createStacksPrivateKey(
+    '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+  );
+  const expectedMessageHash = '011a775441ecb14943130a16f00cdd41818a83dd04372f3259e3ca7237e3cdaa';
+  const expectedR = 114926983411733245831514739773229123958640458736536797227773647312126690926912n;
+  const expectedS = 3148023981578716756961627923124903910422344826113324160219886779423594190576n;
+
+  const messageHash = Buffer.from(sha256('greetings from noble')).toString('hex');
+  expect(messageHash).toBe(expectedMessageHash);
+
+  const signatureRsv = signMessageHashRsv({ privateKey, messageHash }).data;
+  const signatureVrs = signatureRsvToVrs(signatureRsv);
+
+  const { r: signatureR, s: signatureS } = parseRecoverableSignatureVrs(signatureVrs);
+  expect(hexToBigInt(signatureR)).toBe(expectedR);
+  expect(hexToBigInt(signatureS)).toBe(expectedS);
+});
+
+test('Retrieve public key from rsv signature', () => {
   const privKey = createStacksPrivateKey(
     'edf9aee84d9b7abc145504dde6726c64f369d37ee34ded868fabd876c26570bc'
   );
@@ -89,12 +165,38 @@ test('Retrieve public key from signature', () => {
   const messageHex = bytesToHex(utf8ToBytes(message));
   const sig = signWithKey(privKey, messageHex);
 
-  const uncompressedPubKeyFromSig = publicKeyFromSignature(
+  const uncompressedPubKeyFromSig = publicKeyFromSignatureVrs(
     messageHex,
     sig,
     PubKeyEncoding.Uncompressed
   );
-  const compressedPubKeyFromSig = publicKeyFromSignature(
+  const compressedPubKeyFromSig = publicKeyFromSignatureVrs(
+    messageHex,
+    sig,
+    PubKeyEncoding.Compressed
+  );
+
+  expect(uncompressedPubKeyFromSig).toBe(uncompressedPubKey);
+  expect(compressedPubKeyFromSig).toBe(compressedPubKey);
+});
+
+test('Retrieve public key from vrs signature', () => {
+  const privateKey = createStacksPrivateKey(
+    'edf9aee84d9b7abc145504dde6726c64f369d37ee34ded868fabd876c26570bc'
+  );
+  const uncompressedPubKey =
+    '04ef788b3830c00abe8f64f62dc32fc863bc0b2cafeb073b6c8e1c7657d9c2c3ab5b435d20ea91337cdd8c30dd7427bb098a5355e9c9bfad43797899b8137237cf';
+  const compressedPubKey = '03ef788b3830c00abe8f64f62dc32fc863bc0b2cafeb073b6c8e1c7657d9c2c3ab';
+
+  const messageHex = bytesToHex(utf8ToBytes('hello world'));
+  const sig = signMessageHashRsv({ privateKey, messageHash: messageHex });
+
+  const uncompressedPubKeyFromSig = publicKeyFromSignatureRsv(
+    messageHex,
+    sig,
+    PubKeyEncoding.Uncompressed
+  );
+  const compressedPubKeyFromSig = publicKeyFromSignatureRsv(
     messageHex,
     sig,
     PubKeyEncoding.Compressed


### PR DESCRIPTION
## scope
- adds previously missing signing functions in RSV format (Clarity compatible)

## references (important for history/context)
- https://github.com/hirosystems/stacks-wallet-web/issues/2419
- https://github.com/hirosystems/stacks-wallet-web/pull/2429
- https://github.com/hirosystems/stacks.js/pull/1263

## usage
The original functions are marked as deprecated and the correct format methods introduced use a suffix of `Rsv` e.g. `verifyMessageSignatureRsv(...)`

I would propose this _deprecating_ path forward and let stacks-wallet-web switch to `signMessageHashRsv`. The suffix highlights explicitness. I also added `MessageHash` to the function name to further make it clear that a typical use works on a hash (compared to a message/plain-text) and the sign function does not do any previous message hashing here.

If folks are against the suffix, I'm also not opposed to `signMessageHash` or a consumer-facing `signMessage`, which would internally use more explicit methods.

In a planned overhaul (and major version bump) of the available crypto-helper methods of stacks.js, we will probably refactor this again and remove deprecated functions. Ideally, I would want to see stacks.js only export Clarity-compatible methods (to not confuse developers).

