### PR TITLE
build: add missing dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19793,6 +19793,7 @@
 				"@stacks/auth": "^4.1.0",
 				"@stacks/common": "^4.1.0",
 				"@stacks/encryption": "^4.1.0",
+				"@stacks/network": "^4.1.0",
 				"jsontokens": "^3.0.0"
 			},
 			"devDependencies": {

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -35,6 +35,7 @@
     "@stacks/auth": "^4.1.0",
     "@stacks/common": "^4.1.0",
     "@stacks/encryption": "^4.1.0",
+    "@stacks/network": "^4.1.0",
     "jsontokens": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
- closes https://github.com/hirosystems/stacks.js/issues/1268

network dep was missing for storage package after refactor