### PR TITLE
[FIX] verify in verifyECDSA is missing strict param

### DIFF
--- a/packages/encryption/src/ec.ts
+++ b/packages/encryption/src/ec.ts
@@ -512,7 +512,10 @@ export function verifyECDSA(
 ): boolean {
   const contentBuffer = getBuffer(content);
   const contentHash = hashSha256Sync(contentBuffer);
-  return verify(signature, contentHash, publicKey);
+  // verify() is strict: true by default. High-s signatures are rejected, which mirrors libsecp behavior
+  // Set verify options to strict: false, to support the legacy stacks implementations
+  // Reference: https://github.com/paulmillr/noble-secp256k1/releases/tag/1.4.0
+  return verify(signature, contentHash, publicKey, { strict: false });
 }
 
 interface VerifyMessageSignatureArgs {
@@ -534,7 +537,10 @@ export function verifyMessageSignature({
   const { r, s } = parseRecoverableSignatureVrs(signature);
   const sig = new Signature(hexToBigInt(r), hexToBigInt(s));
   const hashedMsg = typeof message === 'string' ? hashMessage(message) : message;
-  return verify(sig, hashedMsg, publicKey);
+  // verify() is strict: true by default. High-s signatures are rejected, which mirrors libsecp behavior
+  // Set verify options to strict: false, to support the legacy stacks implementations
+  // Reference: https://github.com/paulmillr/noble-secp256k1/releases/tag/1.4.0
+  return verify(sig, hashedMsg, publicKey, { strict: false });
 }
 
 /**


### PR DESCRIPTION
## Description
- By default `@noble/secp256k1` signature verification rejects High-s signatures.
- Support stacks legacy implementation like `verify(sig, hashedMsg, publicKey, { strict: false });` by setting strict: false
- Reference: `https://github.com/paulmillr/noble-secp256k1/releases/tag/1.4.0`

For details refer to issue #1278

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Testing information

Provide context on how tests should be performed.
`npm run test`
Existing tests are robust enough so no new test is added

## Checklist
- [X] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [X] `npm run test` passes
- [ ] Changelog is updated
- [X] Tag reviewers