### PR TITLE
fix: export structuredDataSignature

### DIFF
--- a/packages/transactions/src/index.ts
+++ b/packages/transactions/src/index.ts
@@ -37,4 +37,5 @@ export * from './authorization';
 export * from './utils';
 export * from './common';
 export * from './signature';
+export * from './structuredDataSignature';
 export * from './postcondition-types';


### PR DESCRIPTION
We recently added structuredDataSignature following SIP-018 https://github.com/hirosystems/stacks.js/pull/1284
but the functions and types were not exported 🤦 , so nobody can use it yet. 
This PR fixes that.

cc: @janniks 