### PR TITLE
fix: update version buffer size for pox addresses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,7 @@
 			"devDependencies": {
 				"@changesets/cli": "^2.23.0",
 				"@janniks/typedoc-plugin-monorepo": "^0.4.2-1",
-				"@janniks/typedoc-theme-stacks": "^1.0.1",
+				"@janniks/typedoc-theme-stacks": "^1.0.3",
 				"@rollup/plugin-alias": "^3.1.9",
 				"@rollup/plugin-babel": "^5.3.0",
 				"@rollup/plugin-commonjs": "^22.0.0",
@@ -1488,9 +1488,9 @@
 			}
 		},
 		"node_modules/@janniks/typedoc-theme-stacks": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@janniks/typedoc-theme-stacks/-/typedoc-theme-stacks-1.0.1.tgz",
-			"integrity": "sha512-40WdNBNyBe1oxcJyw8DuPGRr1kIjxxzZk3NQ675L2SzW9F0A+0k4/9eBfeni84zLDnPEmt2eXTtzRp+00Tg+GA==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@janniks/typedoc-theme-stacks/-/typedoc-theme-stacks-1.0.3.tgz",
+			"integrity": "sha512-fMTHvC1j0t+7Ytxa4AnWz16SLpgOQ4f/XbSULBs0VZ8m1ol0SRmluIJKFhabpdufz481Apns498jO9f1dpF4nw==",
 			"dev": true,
 			"peerDependencies": {
 				"typedoc": "^0.22.11"
@@ -23181,6 +23181,7 @@
 			},
 			"devDependencies": {
 				"@types/jest": "^26.0.22",
+				"bitcoinjs-lib": "^5.2.0",
 				"jest": "^26.6.3",
 				"jest-fetch-mock": "^3.0.3",
 				"jest-module-name-mapper": "^0.1.5",
@@ -24271,7 +24272,7 @@
 			"integrity": "sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==",
 			"dev": true,
 			"requires": {
-				"ajv": "^6.12.4",
+				"ajv": "6.12.3",
 				"debug": "^4.3.2",
 				"espree": "^9.3.2",
 				"globals": "^13.15.0",
@@ -24412,9 +24413,9 @@
 			}
 		},
 		"@janniks/typedoc-theme-stacks": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@janniks/typedoc-theme-stacks/-/typedoc-theme-stacks-1.0.1.tgz",
-			"integrity": "sha512-40WdNBNyBe1oxcJyw8DuPGRr1kIjxxzZk3NQ675L2SzW9F0A+0k4/9eBfeni84zLDnPEmt2eXTtzRp+00Tg+GA==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@janniks/typedoc-theme-stacks/-/typedoc-theme-stacks-1.0.3.tgz",
+			"integrity": "sha512-fMTHvC1j0t+7Ytxa4AnWz16SLpgOQ4f/XbSULBs0VZ8m1ol0SRmluIJKFhabpdufz481Apns498jO9f1dpF4nw==",
 			"dev": true,
 			"requires": {}
 		},
@@ -27236,6 +27237,7 @@
 				"@stacks/stacks-blockchain-api-types": "^0.61.0",
 				"@stacks/transactions": "^4.3.0",
 				"@types/jest": "^26.0.22",
+				"bitcoinjs-lib": "^5.2.0",
 				"bs58": "^5.0.0",
 				"jest": "^26.6.3",
 				"jest-fetch-mock": "^3.0.3",
@@ -32544,7 +32546,7 @@
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
 			"integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
 			"requires": {
-				"ajv": "^6.12.3",
+				"ajv": "6.12.3",
 				"har-schema": "^2.0.0"
 			}
 		},
@@ -38427,7 +38429,7 @@
 			"integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
 			"requires": {
 				"@types/json-schema": "^7.0.8",
-				"ajv": "^6.12.5",
+				"ajv": "6.12.3",
 				"ajv-keywords": "^3.5.2"
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@changesets/cli": "^2.23.0",
     "@janniks/typedoc-plugin-monorepo": "^0.4.2-1",
-    "@janniks/typedoc-theme-stacks": "^1.0.1",
+    "@janniks/typedoc-theme-stacks": "^1.0.3",
     "@rollup/plugin-alias": "^3.1.9",
     "@rollup/plugin-babel": "^5.3.0",
     "@rollup/plugin-commonjs": "^22.0.0",

--- a/packages/stacking/package.json
+++ b/packages/stacking/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.22",
+    "bitcoinjs-lib": "^5.2.0",
     "jest": "^26.6.3",
     "jest-fetch-mock": "^3.0.3",
     "jest-module-name-mapper": "^0.1.5",

--- a/packages/stacking/src/index.ts
+++ b/packages/stacking/src/index.ts
@@ -527,7 +527,7 @@ export class StackingClient {
     burnBlockHeight: number;
   }) {
     const { hashMode, data } = decodeBtcAddress(poxAddress);
-    const hashModeBuffer = bufferCV(toBuffer(BigInt(hashMode)));
+    const hashModeBuffer = bufferCV(toBuffer(BigInt(hashMode), 1));
     const hashbytes = bufferCV(data);
     const address = tupleCV({
       hashbytes,
@@ -565,7 +565,7 @@ export class StackingClient {
 
     if (poxAddress) {
       const { hashMode, data } = decodeBtcAddress(poxAddress);
-      const hashModeBuffer = bufferCV(toBuffer(BigInt(hashMode)));
+      const hashModeBuffer = bufferCV(toBuffer(BigInt(hashMode), 1));
       const hashbytes = bufferCV(data);
       address = someCV(
         tupleCV({
@@ -612,7 +612,7 @@ export class StackingClient {
     nonce?: IntegerType;
   }) {
     const { hashMode, data } = decodeBtcAddress(poxAddress);
-    const hashModeBuffer = bufferCV(toBuffer(BigInt(hashMode)));
+    const hashModeBuffer = bufferCV(toBuffer(BigInt(hashMode), 1));
     const hashbytes = bufferCV(data);
     const address = tupleCV({
       hashbytes,
@@ -654,7 +654,7 @@ export class StackingClient {
     rewardCycle: number;
   }) {
     const { hashMode, data } = decodeBtcAddress(poxAddress);
-    const hashModeBuffer = bufferCV(toBuffer(BigInt(hashMode)));
+    const hashModeBuffer = bufferCV(toBuffer(BigInt(hashMode), 1));
     const hashbytes = bufferCV(data);
     const address = tupleCV({
       hashbytes,

--- a/packages/stacking/tests/poxAbi.json
+++ b/packages/stacking/tests/poxAbi.json
@@ -1,0 +1,678 @@
+{
+  "functions": [
+    {
+      "name": "add-pox-addr-to-ith-reward-cycle",
+      "access": "private",
+      "args": [
+        { "name": "cycle-index", "type": "uint128" },
+        {
+          "name": "params",
+          "type": {
+            "tuple": [
+              { "name": "amount-ustx", "type": "uint128" },
+              { "name": "first-reward-cycle", "type": "uint128" },
+              { "name": "i", "type": "uint128" },
+              { "name": "num-cycles", "type": "uint128" },
+              {
+                "name": "pox-addr",
+                "type": {
+                  "tuple": [
+                    { "name": "hashbytes", "type": { "buffer": { "length": 20 } } },
+                    { "name": "version", "type": { "buffer": { "length": 1 } } }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "outputs": {
+        "type": {
+          "tuple": [
+            { "name": "amount-ustx", "type": "uint128" },
+            { "name": "first-reward-cycle", "type": "uint128" },
+            { "name": "i", "type": "uint128" },
+            { "name": "num-cycles", "type": "uint128" },
+            {
+              "name": "pox-addr",
+              "type": {
+                "tuple": [
+                  { "name": "hashbytes", "type": { "buffer": { "length": 20 } } },
+                  { "name": "version", "type": { "buffer": { "length": 1 } } }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "add-pox-addr-to-reward-cycles",
+      "access": "private",
+      "args": [
+        {
+          "name": "pox-addr",
+          "type": {
+            "tuple": [
+              { "name": "hashbytes", "type": { "buffer": { "length": 20 } } },
+              { "name": "version", "type": { "buffer": { "length": 1 } } }
+            ]
+          }
+        },
+        { "name": "first-reward-cycle", "type": "uint128" },
+        { "name": "num-cycles", "type": "uint128" },
+        { "name": "amount-ustx", "type": "uint128" }
+      ],
+      "outputs": { "type": { "response": { "ok": "bool", "error": "int128" } } }
+    },
+    {
+      "name": "add-pox-partial-stacked",
+      "access": "private",
+      "args": [
+        {
+          "name": "pox-addr",
+          "type": {
+            "tuple": [
+              { "name": "hashbytes", "type": { "buffer": { "length": 20 } } },
+              { "name": "version", "type": { "buffer": { "length": 1 } } }
+            ]
+          }
+        },
+        { "name": "first-reward-cycle", "type": "uint128" },
+        { "name": "num-cycles", "type": "uint128" },
+        { "name": "amount-ustx", "type": "uint128" }
+      ],
+      "outputs": { "type": "bool" }
+    },
+    {
+      "name": "add-pox-partial-stacked-to-ith-cycle",
+      "access": "private",
+      "args": [
+        { "name": "cycle-index", "type": "uint128" },
+        {
+          "name": "params",
+          "type": {
+            "tuple": [
+              { "name": "amount-ustx", "type": "uint128" },
+              { "name": "num-cycles", "type": "uint128" },
+              {
+                "name": "pox-addr",
+                "type": {
+                  "tuple": [
+                    { "name": "hashbytes", "type": { "buffer": { "length": 20 } } },
+                    { "name": "version", "type": { "buffer": { "length": 1 } } }
+                  ]
+                }
+              },
+              { "name": "reward-cycle", "type": "uint128" }
+            ]
+          }
+        }
+      ],
+      "outputs": {
+        "type": {
+          "tuple": [
+            { "name": "amount-ustx", "type": "uint128" },
+            { "name": "num-cycles", "type": "uint128" },
+            {
+              "name": "pox-addr",
+              "type": {
+                "tuple": [
+                  { "name": "hashbytes", "type": { "buffer": { "length": 20 } } },
+                  { "name": "version", "type": { "buffer": { "length": 1 } } }
+                ]
+              }
+            },
+            { "name": "reward-cycle", "type": "uint128" }
+          ]
+        }
+      }
+    },
+    {
+      "name": "append-reward-cycle-pox-addr",
+      "access": "private",
+      "args": [
+        {
+          "name": "pox-addr",
+          "type": {
+            "tuple": [
+              { "name": "hashbytes", "type": { "buffer": { "length": 20 } } },
+              { "name": "version", "type": { "buffer": { "length": 1 } } }
+            ]
+          }
+        },
+        { "name": "reward-cycle", "type": "uint128" },
+        { "name": "amount-ustx", "type": "uint128" }
+      ],
+      "outputs": { "type": "uint128" }
+    },
+    {
+      "name": "burn-height-to-reward-cycle",
+      "access": "private",
+      "args": [{ "name": "height", "type": "uint128" }],
+      "outputs": { "type": "uint128" }
+    },
+    {
+      "name": "check-caller-allowed",
+      "access": "private",
+      "args": [],
+      "outputs": { "type": "bool" }
+    },
+    {
+      "name": "check-pox-addr-version",
+      "access": "private",
+      "args": [{ "name": "version", "type": { "buffer": { "length": 1 } } }],
+      "outputs": { "type": "bool" }
+    },
+    {
+      "name": "check-pox-lock-period",
+      "access": "private",
+      "args": [{ "name": "lock-period", "type": "uint128" }],
+      "outputs": { "type": "bool" }
+    },
+    {
+      "name": "current-pox-reward-cycle",
+      "access": "private",
+      "args": [],
+      "outputs": { "type": "uint128" }
+    },
+    {
+      "name": "get-check-delegation",
+      "access": "private",
+      "args": [{ "name": "stacker", "type": "principal" }],
+      "outputs": {
+        "type": {
+          "optional": {
+            "tuple": [
+              { "name": "amount-ustx", "type": "uint128" },
+              { "name": "delegated-to", "type": "principal" },
+              {
+                "name": "pox-addr",
+                "type": {
+                  "optional": {
+                    "tuple": [
+                      { "name": "hashbytes", "type": { "buffer": { "length": 20 } } },
+                      { "name": "version", "type": { "buffer": { "length": 1 } } }
+                    ]
+                  }
+                }
+              },
+              { "name": "until-burn-ht", "type": { "optional": "uint128" } }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "next-cycle-rejection-votes",
+      "access": "private",
+      "args": [],
+      "outputs": { "type": "uint128" }
+    },
+    {
+      "name": "reward-cycle-to-burn-height",
+      "access": "private",
+      "args": [{ "name": "cycle", "type": "uint128" }],
+      "outputs": { "type": "uint128" }
+    },
+    {
+      "name": "allow-contract-caller",
+      "access": "public",
+      "args": [
+        { "name": "caller", "type": "principal" },
+        { "name": "until-burn-ht", "type": { "optional": "uint128" } }
+      ],
+      "outputs": { "type": { "response": { "ok": "bool", "error": "int128" } } }
+    },
+    {
+      "name": "delegate-stack-stx",
+      "access": "public",
+      "args": [
+        { "name": "stacker", "type": "principal" },
+        { "name": "amount-ustx", "type": "uint128" },
+        {
+          "name": "pox-addr",
+          "type": {
+            "tuple": [
+              { "name": "hashbytes", "type": { "buffer": { "length": 20 } } },
+              { "name": "version", "type": { "buffer": { "length": 1 } } }
+            ]
+          }
+        },
+        { "name": "start-burn-ht", "type": "uint128" },
+        { "name": "lock-period", "type": "uint128" }
+      ],
+      "outputs": {
+        "type": {
+          "response": {
+            "ok": {
+              "tuple": [
+                { "name": "lock-amount", "type": "uint128" },
+                { "name": "stacker", "type": "principal" },
+                { "name": "unlock-burn-height", "type": "uint128" }
+              ]
+            },
+            "error": "int128"
+          }
+        }
+      }
+    },
+    {
+      "name": "delegate-stx",
+      "access": "public",
+      "args": [
+        { "name": "amount-ustx", "type": "uint128" },
+        { "name": "delegate-to", "type": "principal" },
+        { "name": "until-burn-ht", "type": { "optional": "uint128" } },
+        {
+          "name": "pox-addr",
+          "type": {
+            "optional": {
+              "tuple": [
+                { "name": "hashbytes", "type": { "buffer": { "length": 20 } } },
+                { "name": "version", "type": { "buffer": { "length": 1 } } }
+              ]
+            }
+          }
+        }
+      ],
+      "outputs": { "type": { "response": { "ok": "bool", "error": "int128" } } }
+    },
+    {
+      "name": "disallow-contract-caller",
+      "access": "public",
+      "args": [{ "name": "caller", "type": "principal" }],
+      "outputs": { "type": { "response": { "ok": "bool", "error": "int128" } } }
+    },
+    {
+      "name": "reject-pox",
+      "access": "public",
+      "args": [],
+      "outputs": { "type": { "response": { "ok": "bool", "error": "int128" } } }
+    },
+    {
+      "name": "revoke-delegate-stx",
+      "access": "public",
+      "args": [],
+      "outputs": { "type": { "response": { "ok": "bool", "error": "int128" } } }
+    },
+    {
+      "name": "set-burnchain-parameters",
+      "access": "public",
+      "args": [
+        { "name": "first-burn-height", "type": "uint128" },
+        { "name": "prepare-cycle-length", "type": "uint128" },
+        { "name": "reward-cycle-length", "type": "uint128" },
+        { "name": "rejection-fraction", "type": "uint128" }
+      ],
+      "outputs": { "type": { "response": { "ok": "bool", "error": "int128" } } }
+    },
+    {
+      "name": "stack-aggregation-commit",
+      "access": "public",
+      "args": [
+        {
+          "name": "pox-addr",
+          "type": {
+            "tuple": [
+              { "name": "hashbytes", "type": { "buffer": { "length": 20 } } },
+              { "name": "version", "type": { "buffer": { "length": 1 } } }
+            ]
+          }
+        },
+        { "name": "reward-cycle", "type": "uint128" }
+      ],
+      "outputs": { "type": { "response": { "ok": "bool", "error": "int128" } } }
+    },
+    {
+      "name": "stack-stx",
+      "access": "public",
+      "args": [
+        { "name": "amount-ustx", "type": "uint128" },
+        {
+          "name": "pox-addr",
+          "type": {
+            "tuple": [
+              { "name": "hashbytes", "type": { "buffer": { "length": 20 } } },
+              { "name": "version", "type": { "buffer": { "length": 1 } } }
+            ]
+          }
+        },
+        { "name": "start-burn-ht", "type": "uint128" },
+        { "name": "lock-period", "type": "uint128" }
+      ],
+      "outputs": {
+        "type": {
+          "response": {
+            "ok": {
+              "tuple": [
+                { "name": "lock-amount", "type": "uint128" },
+                { "name": "stacker", "type": "principal" },
+                { "name": "unlock-burn-height", "type": "uint128" }
+              ]
+            },
+            "error": "int128"
+          }
+        }
+      }
+    },
+    {
+      "name": "can-stack-stx",
+      "access": "read_only",
+      "args": [
+        {
+          "name": "pox-addr",
+          "type": {
+            "tuple": [
+              { "name": "hashbytes", "type": { "buffer": { "length": 20 } } },
+              { "name": "version", "type": { "buffer": { "length": 1 } } }
+            ]
+          }
+        },
+        { "name": "amount-ustx", "type": "uint128" },
+        { "name": "first-reward-cycle", "type": "uint128" },
+        { "name": "num-cycles", "type": "uint128" }
+      ],
+      "outputs": { "type": { "response": { "ok": "bool", "error": "int128" } } }
+    },
+    {
+      "name": "get-pox-info",
+      "access": "read_only",
+      "args": [],
+      "outputs": {
+        "type": {
+          "response": {
+            "ok": {
+              "tuple": [
+                { "name": "current-rejection-votes", "type": "uint128" },
+                { "name": "first-burnchain-block-height", "type": "uint128" },
+                { "name": "min-amount-ustx", "type": "uint128" },
+                { "name": "prepare-cycle-length", "type": "uint128" },
+                { "name": "rejection-fraction", "type": "uint128" },
+                { "name": "reward-cycle-id", "type": "uint128" },
+                { "name": "reward-cycle-length", "type": "uint128" },
+                { "name": "total-liquid-supply-ustx", "type": "uint128" }
+              ]
+            },
+            "error": "none"
+          }
+        }
+      }
+    },
+    {
+      "name": "get-pox-rejection",
+      "access": "read_only",
+      "args": [
+        { "name": "stacker", "type": "principal" },
+        { "name": "reward-cycle", "type": "uint128" }
+      ],
+      "outputs": { "type": { "optional": { "tuple": [{ "name": "amount", "type": "uint128" }] } } }
+    },
+    {
+      "name": "get-reward-set-pox-address",
+      "access": "read_only",
+      "args": [
+        { "name": "reward-cycle", "type": "uint128" },
+        { "name": "index", "type": "uint128" }
+      ],
+      "outputs": {
+        "type": {
+          "optional": {
+            "tuple": [
+              {
+                "name": "pox-addr",
+                "type": {
+                  "tuple": [
+                    { "name": "hashbytes", "type": { "buffer": { "length": 20 } } },
+                    { "name": "version", "type": { "buffer": { "length": 1 } } }
+                  ]
+                }
+              },
+              { "name": "total-ustx", "type": "uint128" }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "get-reward-set-size",
+      "access": "read_only",
+      "args": [{ "name": "reward-cycle", "type": "uint128" }],
+      "outputs": { "type": "uint128" }
+    },
+    {
+      "name": "get-stacker-info",
+      "access": "read_only",
+      "args": [{ "name": "stacker", "type": "principal" }],
+      "outputs": {
+        "type": {
+          "optional": {
+            "tuple": [
+              { "name": "amount-ustx", "type": "uint128" },
+              { "name": "first-reward-cycle", "type": "uint128" },
+              { "name": "lock-period", "type": "uint128" },
+              {
+                "name": "pox-addr",
+                "type": {
+                  "tuple": [
+                    { "name": "hashbytes", "type": { "buffer": { "length": 20 } } },
+                    { "name": "version", "type": { "buffer": { "length": 1 } } }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "get-stacking-minimum",
+      "access": "read_only",
+      "args": [],
+      "outputs": { "type": "uint128" }
+    },
+    {
+      "name": "get-total-ustx-stacked",
+      "access": "read_only",
+      "args": [{ "name": "reward-cycle", "type": "uint128" }],
+      "outputs": { "type": "uint128" }
+    },
+    {
+      "name": "is-pox-active",
+      "access": "read_only",
+      "args": [{ "name": "reward-cycle", "type": "uint128" }],
+      "outputs": { "type": "bool" }
+    },
+    {
+      "name": "minimal-can-stack-stx",
+      "access": "read_only",
+      "args": [
+        {
+          "name": "pox-addr",
+          "type": {
+            "tuple": [
+              { "name": "hashbytes", "type": { "buffer": { "length": 20 } } },
+              { "name": "version", "type": { "buffer": { "length": 1 } } }
+            ]
+          }
+        },
+        { "name": "amount-ustx", "type": "uint128" },
+        { "name": "first-reward-cycle", "type": "uint128" },
+        { "name": "num-cycles", "type": "uint128" }
+      ],
+      "outputs": { "type": { "response": { "ok": "bool", "error": "int128" } } }
+    }
+  ],
+  "variables": [
+    {
+      "name": "ADDRESS_VERSION_P2PKH",
+      "type": { "buffer": { "length": 1 } },
+      "access": "constant"
+    },
+    { "name": "ADDRESS_VERSION_P2SH", "type": { "buffer": { "length": 1 } }, "access": "constant" },
+    {
+      "name": "ADDRESS_VERSION_P2WPKH",
+      "type": { "buffer": { "length": 1 } },
+      "access": "constant"
+    },
+    {
+      "name": "ADDRESS_VERSION_P2WSH",
+      "type": { "buffer": { "length": 1 } },
+      "access": "constant"
+    },
+    { "name": "ERR_DELEGATION_EXPIRES_DURING_LOCK", "type": "int128", "access": "constant" },
+    { "name": "ERR_DELEGATION_POX_ADDR_REQUIRED", "type": "int128", "access": "constant" },
+    { "name": "ERR_DELEGATION_TOO_MUCH_LOCKED", "type": "int128", "access": "constant" },
+    { "name": "ERR_INVALID_START_BURN_HEIGHT", "type": "int128", "access": "constant" },
+    { "name": "ERR_NOT_ALLOWED", "type": "int128", "access": "constant" },
+    { "name": "ERR_STACKING_ALREADY_DELEGATED", "type": "int128", "access": "constant" },
+    { "name": "ERR_STACKING_ALREADY_REJECTED", "type": "int128", "access": "constant" },
+    { "name": "ERR_STACKING_ALREADY_STACKED", "type": "int128", "access": "constant" },
+    { "name": "ERR_STACKING_EXPIRED", "type": "int128", "access": "constant" },
+    { "name": "ERR_STACKING_INSUFFICIENT_FUNDS", "type": "int128", "access": "constant" },
+    { "name": "ERR_STACKING_INVALID_AMOUNT", "type": "int128", "access": "constant" },
+    { "name": "ERR_STACKING_INVALID_LOCK_PERIOD", "type": "int128", "access": "constant" },
+    { "name": "ERR_STACKING_INVALID_POX_ADDRESS", "type": "int128", "access": "constant" },
+    { "name": "ERR_STACKING_NO_SUCH_PRINCIPAL", "type": "int128", "access": "constant" },
+    { "name": "ERR_STACKING_PERMISSION_DENIED", "type": "int128", "access": "constant" },
+    { "name": "ERR_STACKING_POX_ADDRESS_IN_USE", "type": "int128", "access": "constant" },
+    { "name": "ERR_STACKING_STX_LOCKED", "type": "int128", "access": "constant" },
+    { "name": "ERR_STACKING_THRESHOLD_NOT_MET", "type": "int128", "access": "constant" },
+    { "name": "ERR_STACKING_UNREACHABLE", "type": "int128", "access": "constant" },
+    { "name": "MAX_POX_REWARD_CYCLES", "type": "uint128", "access": "constant" },
+    { "name": "MIN_POX_REWARD_CYCLES", "type": "uint128", "access": "constant" },
+    { "name": "POX_REJECTION_FRACTION", "type": "uint128", "access": "constant" },
+    { "name": "PREPARE_CYCLE_LENGTH", "type": "uint128", "access": "constant" },
+    { "name": "REWARD_CYCLE_LENGTH", "type": "uint128", "access": "constant" },
+    { "name": "STACKING_THRESHOLD_100", "type": "uint128", "access": "constant" },
+    { "name": "STACKING_THRESHOLD_25", "type": "uint128", "access": "constant" },
+    { "name": "configured", "type": "bool", "access": "variable" },
+    { "name": "first-burnchain-block-height", "type": "uint128", "access": "variable" },
+    { "name": "pox-prepare-cycle-length", "type": "uint128", "access": "variable" },
+    { "name": "pox-rejection-fraction", "type": "uint128", "access": "variable" },
+    { "name": "pox-reward-cycle-length", "type": "uint128", "access": "variable" }
+  ],
+  "maps": [
+    {
+      "name": "allowance-contract-callers",
+      "key": {
+        "tuple": [
+          { "name": "contract-caller", "type": "principal" },
+          { "name": "sender", "type": "principal" }
+        ]
+      },
+      "value": { "tuple": [{ "name": "until-burn-ht", "type": { "optional": "uint128" } }] }
+    },
+    {
+      "name": "delegation-state",
+      "key": { "tuple": [{ "name": "stacker", "type": "principal" }] },
+      "value": {
+        "tuple": [
+          { "name": "amount-ustx", "type": "uint128" },
+          { "name": "delegated-to", "type": "principal" },
+          {
+            "name": "pox-addr",
+            "type": {
+              "optional": {
+                "tuple": [
+                  { "name": "hashbytes", "type": { "buffer": { "length": 20 } } },
+                  { "name": "version", "type": { "buffer": { "length": 1 } } }
+                ]
+              }
+            }
+          },
+          { "name": "until-burn-ht", "type": { "optional": "uint128" } }
+        ]
+      }
+    },
+    {
+      "name": "partial-stacked-by-cycle",
+      "key": {
+        "tuple": [
+          {
+            "name": "pox-addr",
+            "type": {
+              "tuple": [
+                { "name": "hashbytes", "type": { "buffer": { "length": 20 } } },
+                { "name": "version", "type": { "buffer": { "length": 1 } } }
+              ]
+            }
+          },
+          { "name": "reward-cycle", "type": "uint128" },
+          { "name": "sender", "type": "principal" }
+        ]
+      },
+      "value": { "tuple": [{ "name": "stacked-amount", "type": "uint128" }] }
+    },
+    {
+      "name": "reward-cycle-pox-address-list",
+      "key": {
+        "tuple": [
+          { "name": "index", "type": "uint128" },
+          { "name": "reward-cycle", "type": "uint128" }
+        ]
+      },
+      "value": {
+        "tuple": [
+          {
+            "name": "pox-addr",
+            "type": {
+              "tuple": [
+                { "name": "hashbytes", "type": { "buffer": { "length": 20 } } },
+                { "name": "version", "type": { "buffer": { "length": 1 } } }
+              ]
+            }
+          },
+          { "name": "total-ustx", "type": "uint128" }
+        ]
+      }
+    },
+    {
+      "name": "reward-cycle-pox-address-list-len",
+      "key": { "tuple": [{ "name": "reward-cycle", "type": "uint128" }] },
+      "value": { "tuple": [{ "name": "len", "type": "uint128" }] }
+    },
+    {
+      "name": "reward-cycle-total-stacked",
+      "key": { "tuple": [{ "name": "reward-cycle", "type": "uint128" }] },
+      "value": { "tuple": [{ "name": "total-ustx", "type": "uint128" }] }
+    },
+    {
+      "name": "stacking-rejection",
+      "key": { "tuple": [{ "name": "reward-cycle", "type": "uint128" }] },
+      "value": { "tuple": [{ "name": "amount", "type": "uint128" }] }
+    },
+    {
+      "name": "stacking-rejectors",
+      "key": {
+        "tuple": [
+          { "name": "reward-cycle", "type": "uint128" },
+          { "name": "stacker", "type": "principal" }
+        ]
+      },
+      "value": { "tuple": [{ "name": "amount", "type": "uint128" }] }
+    },
+    {
+      "name": "stacking-state",
+      "key": { "tuple": [{ "name": "stacker", "type": "principal" }] },
+      "value": {
+        "tuple": [
+          { "name": "amount-ustx", "type": "uint128" },
+          { "name": "first-reward-cycle", "type": "uint128" },
+          { "name": "lock-period", "type": "uint128" },
+          {
+            "name": "pox-addr",
+            "type": {
+              "tuple": [
+                { "name": "hashbytes", "type": { "buffer": { "length": 20 } } },
+                { "name": "version", "type": { "buffer": { "length": 1 } } }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "fungible_tokens": [],
+  "non_fungible_tokens": []
+}

--- a/packages/stacking/tests/stacking.test.ts
+++ b/packages/stacking/tests/stacking.test.ts
@@ -7,14 +7,17 @@ import {
   ClarityType,
   intCV,
   noneCV,
+  ReadOnlyFunctionOptions,
   responseErrorCV,
   responseOkCV,
+  SignedContractCallOptions,
   someCV,
   standardPrincipalCV,
   trueCV,
   tupleCV,
   TupleCV,
   uintCV,
+  validateContractCall,
 } from '@stacks/transactions';
 import { address as btcAddress } from 'bitcoinjs-lib';
 import fetchMock from 'jest-fetch-mock';
@@ -25,11 +28,6 @@ import {
   InvalidAddressError,
   poxAddressToBtcAddress,
 } from '../src/utils';
-
-beforeEach(() => {
-  fetchMock.resetMocks();
-  jest.resetModules();
-});
 
 const poxInfo = {
   contract_id: 'ST000000000000000000002AMW42H.pox',
@@ -127,6 +125,29 @@ const blocktimeInfo = {
     target_block_time: 600,
   },
 };
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const poxAbi = require('./poxAbi.json');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { createContractCallPayload } = require('../../transactions/src/payload.ts'); // not exported currently
+
+// testing helper method
+function isPoxAbiValid(opts: SignedContractCallOptions | ReadOnlyFunctionOptions): boolean {
+  return validateContractCall(
+    createContractCallPayload(
+      opts.contractAddress,
+      opts.contractName,
+      opts.functionName,
+      opts.functionArgs
+    ),
+    poxAbi
+  );
+}
+
+beforeEach(() => {
+  fetchMock.resetMocks();
+  jest.resetModules();
+});
 
 test('check stacking eligibility true', async () => {
   const address = 'ST3XKKN4RPV69NN1PHFDNX3TYKXT7XPC4N8KC1ARH';
@@ -287,6 +308,7 @@ test('stack stx', async () => {
   expect(broadcastTransaction).toHaveBeenCalledTimes(1);
   expect(broadcastTransaction).toHaveBeenCalledWith(transaction, network);
   expect(stackingResults).toEqual(broadcastResponse);
+  expect(isPoxAbiValid(expectedContractCallOptions)).toBe(true);
 });
 
 test('delegate stx', async () => {
@@ -358,6 +380,7 @@ test('delegate stx', async () => {
   expect(broadcastTransaction).toHaveBeenCalledTimes(1);
   expect(broadcastTransaction).toHaveBeenCalledWith(transaction, network);
   expect(delegateResults).toEqual(broadcastResponse);
+  expect(isPoxAbiValid(expectedContractCallOptions)).toBe(true);
 });
 
 test('delegate stx with empty optional parameters', async () => {
@@ -421,6 +444,7 @@ test('delegate stx with empty optional parameters', async () => {
   expect(broadcastTransaction).toHaveBeenCalledTimes(1);
   expect(broadcastTransaction).toHaveBeenCalledWith(transaction, network);
   expect(delegateResults).toEqual(broadcastResponse);
+  expect(isPoxAbiValid(expectedContractCallOptions)).toBe(true);
 });
 
 test('delegate stack stx with one delegator', async () => {
@@ -504,6 +528,7 @@ test('delegate stack stx with one delegator', async () => {
   expect(broadcastTransaction).toHaveBeenCalledTimes(1);
   expect(broadcastTransaction).toHaveBeenCalledWith(transaction, network);
   expect(delegateResults).toEqual(broadcastResponse);
+  expect(isPoxAbiValid(expectedContractCallOptions)).toBe(true);
 });
 
 test('delegate stack stx with set nonce', async () => {
@@ -589,6 +614,7 @@ test('delegate stack stx with set nonce', async () => {
   expect(broadcastTransaction).toHaveBeenCalledTimes(1);
   expect(broadcastTransaction).toHaveBeenCalledWith(transaction, network);
   expect(delegateResults).toEqual(broadcastResponse);
+  expect(isPoxAbiValid(expectedContractCallOptions)).toBe(true);
 });
 
 test('delegator commit', async () => {
@@ -651,6 +677,7 @@ test('delegator commit', async () => {
   expect(broadcastTransaction).toHaveBeenCalledTimes(1);
   expect(broadcastTransaction).toHaveBeenCalledWith(transaction, network);
   expect(delegateResults).toEqual(broadcastResponse);
+  expect(isPoxAbiValid(expectedContractCallOptions)).toBe(true);
 });
 
 test('revoke delegate stx', async () => {
@@ -699,6 +726,7 @@ test('revoke delegate stx', async () => {
   expect(broadcastTransaction).toHaveBeenCalledTimes(1);
   expect(broadcastTransaction).toHaveBeenCalledWith(transaction, network);
   expect(revokeDelegateResults).toEqual(broadcastResponse);
+  expect(isPoxAbiValid(expectedContractCallOptions)).toBe(true);
 });
 
 test('get stacking status', async () => {
@@ -768,6 +796,7 @@ test('get stacking status', async () => {
   expect(stackingStatus.details.lock_period).toEqual(lockPeriod);
   expect(stackingStatus.details.pox_address.version.toString()).toEqual(version);
   expect(stackingStatus.details.pox_address.hashbytes.toString()).toEqual(hashbytes);
+  expect(isPoxAbiValid(expectedReadOnlyFunctionCallOptions)).toBe(true);
 });
 
 test('get core info', async () => {

--- a/packages/stacking/tests/stacking.test.ts
+++ b/packages/stacking/tests/stacking.test.ts
@@ -1,25 +1,30 @@
-import { StacksTestnet } from '@stacks/network';
 import { Buffer, toBuffer } from '@stacks/common';
+import { StacksTestnet } from '@stacks/network';
+import {
+  AddressHashMode,
+  AnchorMode,
+  bufferCV,
+  ClarityType,
+  intCV,
+  noneCV,
+  responseErrorCV,
+  responseOkCV,
+  someCV,
+  standardPrincipalCV,
+  trueCV,
+  tupleCV,
+  TupleCV,
+  uintCV,
+} from '@stacks/transactions';
+import { address as btcAddress } from 'bitcoinjs-lib';
 import fetchMock from 'jest-fetch-mock';
 import { StackingErrors } from '../src/constants';
 import {
-  uintCV,
-  bufferCV,
-  tupleCV,
-  standardPrincipalCV,
-  someCV,
-  AddressHashMode,
-  noneCV,
-  responseOkCV,
-  trueCV,
-  responseErrorCV,
-  intCV,
-  TupleCV,
-  ClarityType,
-  AnchorMode,
-} from '@stacks/transactions';
-import { address as btcAddress } from 'bitcoinjs-lib';
-import { decodeBtcAddress, getAddressHashMode, InvalidAddressError, poxAddressToBtcAddress } from '../src/utils';
+  decodeBtcAddress,
+  getAddressHashMode,
+  InvalidAddressError,
+  poxAddressToBtcAddress,
+} from '../src/utils';
 
 beforeEach(() => {
   fetchMock.resetMocks();
@@ -35,35 +40,36 @@ const poxInfo = {
   reward_cycle_id: 8,
   reward_cycle_length: 120,
   rejection_votes_left_required: 12,
-  total_liquid_supply_ustx: 40000291500000000
+  total_liquid_supply_ustx: 40000291500000000,
 };
 
 const balanceInfo = {
-  balance: "0x0000000000000000000052c396acadf8",
-  locked: "0x0000000000000000000050f1ed629000",
+  balance: '0x0000000000000000000052c396acadf8',
+  locked: '0x0000000000000000000050f1ed629000',
   unlock_height: 3960,
-  nonce: 0
-}
+  nonce: 0,
+};
 
 const coreInfo = {
-  "peer_version": 385875968,
-  "pox_consensus": "926fada0bc9b6a249e297a3f8e18795eb515d635",
-  "burn_block_height": 1790,
-  "stable_pox_consensus": "24f2108867fa2fad93e9961140bbfc4c582d56b9",
-  "stable_burn_block_height": 1789,
-  "server_version": "blockstack-core 0.0.1 => 23.0.0.0 (HEAD:a4deb7a+, release build, linux [x86_64])",
-  "network_id": 2147483648,
-  "parent_network_id": 3669344250,
-  "stacks_tip_height": 1478,
-  "stacks_tip": "5cec0c6375921031ebcde873280a511e221e1e62df2410cfb48c46b16353d2d3",
-  "stacks_tip_consensus_hash": "926fada0bc9b6a249e297a3f8e18795eb515d635",
-  "unanchored_tip": "d9f92fb58cb598da1d37b2d147b91847e10c1723b4fd9dc545698d68cfdf3f7c",
-  "exit_at_block_height": null
-}
+  peer_version: 385875968,
+  pox_consensus: '926fada0bc9b6a249e297a3f8e18795eb515d635',
+  burn_block_height: 1790,
+  stable_pox_consensus: '24f2108867fa2fad93e9961140bbfc4c582d56b9',
+  stable_burn_block_height: 1789,
+  server_version:
+    'blockstack-core 0.0.1 => 23.0.0.0 (HEAD:a4deb7a+, release build, linux [x86_64])',
+  network_id: 2147483648,
+  parent_network_id: 3669344250,
+  stacks_tip_height: 1478,
+  stacks_tip: '5cec0c6375921031ebcde873280a511e221e1e62df2410cfb48c46b16353d2d3',
+  stacks_tip_consensus_hash: '926fada0bc9b6a249e297a3f8e18795eb515d635',
+  unanchored_tip: 'd9f92fb58cb598da1d37b2d147b91847e10c1723b4fd9dc545698d68cfdf3f7c',
+  exit_at_block_height: null,
+};
 
 const rewardsTotalInfo = {
   reward_recipient: 'myfTfju9XSMRusaY2qTitSEMSchsWRA441',
-  reward_amount: '450000'
+  reward_amount: '450000',
 };
 
 const rewardsInfo = {
@@ -77,7 +83,7 @@ const rewardsInfo = {
       burn_amount: '0',
       reward_recipient: 'myfTfju9XSMRusaY2qTitSEMSchsWRA441',
       reward_amount: '20000',
-      reward_index: 0
+      reward_index: 0,
     },
     {
       canonical: true,
@@ -86,9 +92,9 @@ const rewardsInfo = {
       burn_amount: '0',
       reward_recipient: 'myfTfju9XSMRusaY2qTitSEMSchsWRA441',
       reward_amount: '20000',
-      reward_index: 0
-    }
-  ]
+      reward_index: 0,
+    },
+  ],
 };
 
 const rewardHoldersInfo = {
@@ -101,26 +107,26 @@ const rewardHoldersInfo = {
       burn_block_hash: '0x000000000000002083ca8303a2262d09a824cecb34b78f13a04787e4f05441d3',
       burn_block_height: 2004622,
       address: 'myfTfju9XSMRusaY2qTitSEMSchsWRA441',
-      slot_index: 1
+      slot_index: 1,
     },
     {
       canonical: true,
       burn_block_hash: '0x000000000000002083ca8303a2262d09a824cecb34b78f13a04787e4f05441d3',
       burn_block_height: 2004622,
       address: 'myfTfju9XSMRusaY2qTitSEMSchsWRA441',
-      slot_index: 0
-    }
-  ]
+      slot_index: 0,
+    },
+  ],
 };
 
 const blocktimeInfo = {
   testnet: {
-    target_block_time: 120
+    target_block_time: 120,
   },
   mainnet: {
-    target_block_time: 600
-  }
-}
+    target_block_time: 600,
+  },
+};
 
 test('check stacking eligibility true', async () => {
   const address = 'ST3XKKN4RPV69NN1PHFDNX3TYKXT7XPC4N8KC1ARH';
@@ -131,6 +137,7 @@ test('check stacking eligibility true', async () => {
   const callReadOnlyFunction = jest.fn().mockResolvedValue(functionCallResponse);
 
   jest.mock('@stacks/transactions', () => ({
+    ...jest.requireActual('@stacks/transactions'),
     callReadOnlyFunction,
     bufferCV: jest.requireActual('@stacks/transactions').bufferCV,
     tupleCV: jest.requireActual('@stacks/transactions').tupleCV,
@@ -140,9 +147,9 @@ test('check stacking eligibility true', async () => {
     ClarityType: jest.requireActual('@stacks/transactions').ClarityType,
     AddressHashMode: jest.requireActual('@stacks/transactions').AddressHashMode,
     validateStacksAddress: jest.requireActual('@stacks/transactions').validateStacksAddress,
-  }))
-
-  const { StackingClient } = require('../src');
+  }));
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { StackingClient } = require('../src'); // needed for jest.mock module
   const client = new StackingClient(address, network);
 
   fetchMock.mockResponse(request => {
@@ -150,15 +157,15 @@ test('check stacking eligibility true', async () => {
     if (url.endsWith('pox')) {
       return Promise.resolve({
         body: JSON.stringify(poxInfo),
-        status: 200
-      })
+        status: 200,
+      });
     } else {
       return Promise.resolve({
         body: JSON.stringify(balanceInfo),
-        status: 200
-      })
+        status: 200,
+      });
     }
-  })
+  });
 
   const cycles = 3;
   const stackingEligibility = await client.canStack({ poxAddress, cycles });
@@ -167,7 +174,7 @@ test('check stacking eligibility true', async () => {
   expect(fetchMock.mock.calls[0][0]).toEqual(network.getAccountApiUrl(address));
   expect(fetchMock.mock.calls[1][0]).toEqual(network.getPoxInfoUrl());
   expect(stackingEligibility.eligible).toBe(true);
-})
+});
 
 test('check stacking eligibility false bad cycles', async () => {
   const address = 'ST3XKKN4RPV69NN1PHFDNX3TYKXT7XPC4N8KC1ARH';
@@ -179,19 +186,11 @@ test('check stacking eligibility false bad cycles', async () => {
   const callReadOnlyFunction = jest.fn().mockResolvedValue(functionCallResponse);
 
   jest.mock('@stacks/transactions', () => ({
+    ...jest.requireActual('@stacks/transactions'),
     callReadOnlyFunction,
-    bufferCV: jest.requireActual('@stacks/transactions').bufferCV,
-    tupleCV: jest.requireActual('@stacks/transactions').tupleCV,
-    uintCV: jest.requireActual('@stacks/transactions').uintCV,
-    intCV: jest.requireActual('@stacks/transactions').intCV,
-    responseErrorCV: jest.requireActual('@stacks/transactions').responseErrorCV,
-    ClarityType: jest.requireActual('@stacks/transactions').ClarityType,
-    cvToString: jest.requireActual('@stacks/transactions').cvToString,
-    AddressHashMode: jest.requireActual('@stacks/transactions').AddressHashMode,
-    validateStacksAddress: jest.requireActual('@stacks/transactions').validateStacksAddress,
-  }))
-
-  const { StackingClient } = require('../src');
+  }));
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { StackingClient } = require('../src'); // needed for jest.mock module
   const client = new StackingClient(address, network);
 
   fetchMock.mockResponse(request => {
@@ -199,15 +198,15 @@ test('check stacking eligibility false bad cycles', async () => {
     if (url.endsWith('pox')) {
       return Promise.resolve({
         body: JSON.stringify(poxInfo),
-        status: 200
-      })
+        status: 200,
+      });
     } else {
       return Promise.resolve({
         body: JSON.stringify(balanceInfo),
-        status: 200
-      })
+        status: 200,
+      });
     }
-  })
+  });
 
   const invalidCycles = 150;
   const stackingEligibility = await client.canStack({ poxAddress, cycles: invalidCycles });
@@ -217,7 +216,7 @@ test('check stacking eligibility false bad cycles', async () => {
   expect(fetchMock.mock.calls[1][0]).toEqual(network.getPoxInfoUrl());
   expect(stackingEligibility.eligible).toBe(false);
   expect(stackingEligibility.reason).toBe(expectedErrorString);
-})
+});
 
 test('stack stx', async () => {
   const address = 'ST3XKKN4RPV69NN1PHFDNX3TYKXT7XPC4N8KC1ARH';
@@ -228,30 +227,26 @@ test('stack stx', async () => {
   const privateKey = 'd48f215481c16cbe6426f8e557df9b78895661971d71735126545abddcd5377001';
   const burnBlockHeight = 2000;
 
-  const transaction = { serialize: () => 'mocktxhex' }
+  const transaction = { serialize: () => 'mocktxhex' };
   const makeContractCall = jest.fn().mockResolvedValue(transaction);
   const broadcastResponse = JSON.stringify({ txid: 'mocktxid' });
   const broadcastTransaction = jest.fn().mockResolvedValue(broadcastResponse);
 
   jest.mock('@stacks/transactions', () => ({
+    ...jest.requireActual('@stacks/transactions'),
     makeContractCall,
     broadcastTransaction,
-    bufferCV: jest.requireActual('@stacks/transactions').bufferCV,
-    tupleCV: jest.requireActual('@stacks/transactions').tupleCV,
-    uintCV: jest.requireActual('@stacks/transactions').uintCV,
-    AddressHashMode: jest.requireActual('@stacks/transactions').AddressHashMode,
-    AnchorMode: jest.requireActual('@stacks/transactions').AnchorMode,
-    validateStacksAddress: jest.requireActual('@stacks/transactions').validateStacksAddress,
-  }))
+  }));
 
   fetchMock.mockResponse(() => {
     return Promise.resolve({
       body: JSON.stringify(poxInfo),
-      status: 200
-    })
-  })
+      status: 200,
+    });
+  });
 
-  const { StackingClient } = require('../src');
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { StackingClient } = require('../src'); // needed for jest.mock module
   const client = new StackingClient(address, network);
 
   const stackingResults = await client.stack({
@@ -259,11 +254,11 @@ test('stack stx', async () => {
     poxAddress,
     cycles,
     privateKey,
-    burnBlockHeight
+    burnBlockHeight,
   });
 
   const { version, hash } = btcAddress.fromBase58Check(poxAddress);
-  const versionBuffer = bufferCV(toBuffer(BigInt(version)));
+  const versionBuffer = bufferCV(toBuffer(BigInt(version), 1));
   const hashbytes = bufferCV(hash);
   const poxAddressCV = tupleCV({
     hashbytes,
@@ -292,7 +287,7 @@ test('stack stx', async () => {
   expect(broadcastTransaction).toHaveBeenCalledTimes(1);
   expect(broadcastTransaction).toHaveBeenCalledWith(transaction, network);
   expect(stackingResults).toEqual(broadcastResponse);
-})
+});
 
 test('delegate stx', async () => {
   const address = 'ST3XKKN4RPV69NN1PHFDNX3TYKXT7XPC4N8KC1ARH';
@@ -303,32 +298,26 @@ test('delegate stx', async () => {
   const untilBurnBlockHeight = 2000;
   const privateKey = 'd48f215481c16cbe6426f8e557df9b78895661971d71735126545abddcd5377001';
 
-  const transaction = { serialize: () => 'mocktxhex' }
+  const transaction = { serialize: () => 'mocktxhex' };
   const makeContractCall = jest.fn().mockResolvedValue(transaction);
   const broadcastResponse = JSON.stringify({ txid: 'mocktxid' });
   const broadcastTransaction = jest.fn().mockResolvedValue(broadcastResponse);
 
   jest.mock('@stacks/transactions', () => ({
+    ...jest.requireActual('@stacks/transactions'),
     makeContractCall,
     broadcastTransaction,
-    bufferCV: jest.requireActual('@stacks/transactions').bufferCV,
-    tupleCV: jest.requireActual('@stacks/transactions').tupleCV,
-    uintCV: jest.requireActual('@stacks/transactions').uintCV,
-    someCV: jest.requireActual('@stacks/transactions').someCV,
-    AddressHashMode: jest.requireActual('@stacks/transactions').AddressHashMode,
-    AnchorMode: jest.requireActual('@stacks/transactions').AnchorMode,
-    standardPrincipalCV: jest.requireActual('@stacks/transactions').standardPrincipalCV,
-    validateStacksAddress: jest.requireActual('@stacks/transactions').validateStacksAddress,
   }));
 
   fetchMock.mockResponse(() => {
     return Promise.resolve({
       body: JSON.stringify(poxInfo),
-      status: 200
-    })
-  })
+      status: 200,
+    });
+  });
 
-  const { StackingClient } = require('../src');
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { StackingClient } = require('../src'); // needed for jest.mock module
   const client = new StackingClient(address, network);
 
   const delegateResults = await client.delegateStx({
@@ -340,7 +329,7 @@ test('delegate stx', async () => {
   });
 
   const { version, hash } = btcAddress.fromBase58Check(poxAddress);
-  const versionBuffer = bufferCV(toBuffer(BigInt(version)));
+  const versionBuffer = bufferCV(toBuffer(BigInt(version), 1));
   const hashbytes = bufferCV(hash);
   const poxAddressCV = tupleCV({
     hashbytes,
@@ -369,7 +358,7 @@ test('delegate stx', async () => {
   expect(broadcastTransaction).toHaveBeenCalledTimes(1);
   expect(broadcastTransaction).toHaveBeenCalledWith(transaction, network);
   expect(delegateResults).toEqual(broadcastResponse);
-})
+});
 
 test('delegate stx with empty optional parameters', async () => {
   const address = 'ST3XKKN4RPV69NN1PHFDNX3TYKXT7XPC4N8KC1ARH';
@@ -378,32 +367,26 @@ test('delegate stx with empty optional parameters', async () => {
   const amountMicroStx = BigInt(100000000000);
   const privateKey = 'd48f215481c16cbe6426f8e557df9b78895661971d71735126545abddcd5377001';
 
-  const transaction = { serialize: () => 'mocktxhex' }
+  const transaction = { serialize: () => 'mocktxhex' };
   const makeContractCall = jest.fn().mockResolvedValue(transaction);
   const broadcastResponse = JSON.stringify({ txid: 'mocktxid' });
   const broadcastTransaction = jest.fn().mockResolvedValue(broadcastResponse);
 
   jest.mock('@stacks/transactions', () => ({
+    ...jest.requireActual('@stacks/transactions'),
     makeContractCall,
     broadcastTransaction,
-    bufferCV: jest.requireActual('@stacks/transactions').bufferCV,
-    tupleCV: jest.requireActual('@stacks/transactions').tupleCV,
-    uintCV: jest.requireActual('@stacks/transactions').uintCV,
-    AddressHashMode: jest.requireActual('@stacks/transactions').AddressHashMode,
-    AnchorMode: jest.requireActual('@stacks/transactions').AnchorMode,
-    standardPrincipalCV: jest.requireActual('@stacks/transactions').standardPrincipalCV,
-    noneCV: jest.requireActual('@stacks/transactions').noneCV,
-    validateStacksAddress: jest.requireActual('@stacks/transactions').validateStacksAddress,
   }));
 
   fetchMock.mockResponse(() => {
     return Promise.resolve({
       body: JSON.stringify(poxInfo),
-      status: 200
-    })
-  })
+      status: 200,
+    });
+  });
 
-  const { StackingClient } = require('../src');
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { StackingClient } = require('../src'); // needed for jest.mock module
   const client = new StackingClient(address, network);
 
   const delegateResults = await client.delegateStx({
@@ -438,7 +421,7 @@ test('delegate stx with empty optional parameters', async () => {
   expect(broadcastTransaction).toHaveBeenCalledTimes(1);
   expect(broadcastTransaction).toHaveBeenCalledWith(transaction, network);
   expect(delegateResults).toEqual(broadcastResponse);
-})
+});
 
 test('delegate stack stx with one delegator', async () => {
   const stacker = 'ST3XKKN4RPV69NN1PHFDNX3TYKXT7XPC4N8KC1ARH';
@@ -450,23 +433,15 @@ test('delegate stack stx with one delegator', async () => {
   const cycles = 10;
   const privateKey = 'd48f215481c16cbe6426f8e557df9b78895661971d71735126545abddcd5377001';
 
-  const transaction = { serialize: () => 'mocktxhex' }
+  const transaction = { serialize: () => 'mocktxhex' };
   const makeContractCall = jest.fn().mockResolvedValue(transaction);
   const broadcastResponse = JSON.stringify({ txid: 'mocktxid' });
   const broadcastTransaction = jest.fn().mockResolvedValue(broadcastResponse);
 
   jest.mock('@stacks/transactions', () => ({
+    ...jest.requireActual('@stacks/transactions'),
     makeContractCall,
     broadcastTransaction,
-    bufferCV: jest.requireActual('@stacks/transactions').bufferCV,
-    tupleCV: jest.requireActual('@stacks/transactions').tupleCV,
-    uintCV: jest.requireActual('@stacks/transactions').uintCV,
-    getNonce: jest.requireActual('@stacks/transactions').getNonce,
-    AddressHashMode: jest.requireActual('@stacks/transactions').AddressHashMode,
-    AnchorMode: jest.requireActual('@stacks/transactions').AnchorMode,
-    standardPrincipalCV: jest.requireActual('@stacks/transactions').standardPrincipalCV,
-    getAddressFromPrivateKey: jest.requireActual('@stacks/transactions').getAddressFromPrivateKey,
-    validateStacksAddress: jest.requireActual('@stacks/transactions').validateStacksAddress,
   }));
 
   fetchMock.mockResponse(request => {
@@ -474,17 +449,19 @@ test('delegate stack stx with one delegator', async () => {
     if (url.endsWith('pox')) {
       return Promise.resolve({
         body: JSON.stringify(poxInfo),
-        status: 200
-      })
+        status: 200,
+      });
     } else {
       return Promise.resolve({
         body: JSON.stringify(balanceInfo),
-        status: 200
-      })
+        status: 200,
+      });
     }
-  })
+  });
 
-  const { StackingClient } = require('../src');
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { StackingClient } = require('../src'); // needed for jest.mock module // needed for jest.mock module
   const client = new StackingClient(address, network);
 
   const delegateResults = await client.delegateStackStx({
@@ -497,7 +474,7 @@ test('delegate stack stx with one delegator', async () => {
   });
 
   const { version, hash } = btcAddress.fromBase58Check(poxAddress);
-  const versionBuffer = bufferCV(toBuffer(BigInt(version)));
+  const versionBuffer = bufferCV(toBuffer(BigInt(version), 1));
   const hashbytes = bufferCV(hash);
   const poxAddressCV = tupleCV({
     hashbytes,
@@ -527,7 +504,7 @@ test('delegate stack stx with one delegator', async () => {
   expect(broadcastTransaction).toHaveBeenCalledTimes(1);
   expect(broadcastTransaction).toHaveBeenCalledWith(transaction, network);
   expect(delegateResults).toEqual(broadcastResponse);
-})
+});
 
 test('delegate stack stx with set nonce', async () => {
   const stacker = 'ST3XKKN4RPV69NN1PHFDNX3TYKXT7XPC4N8KC1ARH';
@@ -540,23 +517,15 @@ test('delegate stack stx with set nonce', async () => {
   const privateKey = 'd48f215481c16cbe6426f8e557df9b78895661971d71735126545abddcd5377001';
   const nonce = BigInt(1);
 
-  const transaction = { serialize: () => 'mocktxhex' }
+  const transaction = { serialize: () => 'mocktxhex' };
   const makeContractCall = jest.fn().mockResolvedValue(transaction);
   const broadcastResponse = JSON.stringify({ txid: 'mocktxid' });
   const broadcastTransaction = jest.fn().mockResolvedValue(broadcastResponse);
 
   jest.mock('@stacks/transactions', () => ({
+    ...jest.requireActual('@stacks/transactions'),
     makeContractCall,
     broadcastTransaction,
-    bufferCV: jest.requireActual('@stacks/transactions').bufferCV,
-    tupleCV: jest.requireActual('@stacks/transactions').tupleCV,
-    uintCV: jest.requireActual('@stacks/transactions').uintCV,
-    getNonce: jest.requireActual('@stacks/transactions').getNonce,
-    AddressHashMode: jest.requireActual('@stacks/transactions').AddressHashMode,
-    AnchorMode: jest.requireActual('@stacks/transactions').AnchorMode,
-    standardPrincipalCV: jest.requireActual('@stacks/transactions').standardPrincipalCV,
-    getAddressFromPrivateKey: jest.requireActual('@stacks/transactions').getAddressFromPrivateKey,
-    validateStacksAddress: jest.requireActual('@stacks/transactions').validateStacksAddress,
   }));
 
   fetchMock.mockResponse(request => {
@@ -564,17 +533,18 @@ test('delegate stack stx with set nonce', async () => {
     if (url.endsWith('pox')) {
       return Promise.resolve({
         body: JSON.stringify(poxInfo),
-        status: 200
-      })
+        status: 200,
+      });
     } else {
       return Promise.resolve({
         body: JSON.stringify(balanceInfo),
-        status: 200
-      })
+        status: 200,
+      });
     }
-  })
+  });
 
-  const { StackingClient } = require('../src');
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { StackingClient } = require('../src'); // needed for jest.mock module
   const client = new StackingClient(address, network);
 
   const delegateResults = await client.delegateStackStx({
@@ -588,7 +558,7 @@ test('delegate stack stx with set nonce', async () => {
   });
 
   const { version, hash } = btcAddress.fromBase58Check(poxAddress);
-  const versionBuffer = bufferCV(toBuffer(BigInt(version)));
+  const versionBuffer = bufferCV(toBuffer(BigInt(version), 1));
   const hashbytes = bufferCV(hash);
   const poxAddressCV = tupleCV({
     hashbytes,
@@ -619,7 +589,7 @@ test('delegate stack stx with set nonce', async () => {
   expect(broadcastTransaction).toHaveBeenCalledTimes(1);
   expect(broadcastTransaction).toHaveBeenCalledWith(transaction, network);
   expect(delegateResults).toEqual(broadcastResponse);
-})
+});
 
 test('delegator commit', async () => {
   const address = 'ST3XKKN4RPV69NN1PHFDNX3TYKXT7XPC4N8KC1ARH';
@@ -628,31 +598,26 @@ test('delegator commit', async () => {
   const rewardCycle = 10;
   const privateKey = 'd48f215481c16cbe6426f8e557df9b78895661971d71735126545abddcd5377001';
 
-  const transaction = { serialize: () => 'mocktxhex' }
+  const transaction = { serialize: () => 'mocktxhex' };
   const makeContractCall = jest.fn().mockResolvedValue(transaction);
   const broadcastResponse = JSON.stringify({ txid: 'mocktxid' });
   const broadcastTransaction = jest.fn().mockResolvedValue(broadcastResponse);
 
   jest.mock('@stacks/transactions', () => ({
+    ...jest.requireActual('@stacks/transactions'),
     makeContractCall,
     broadcastTransaction,
-    bufferCV: jest.requireActual('@stacks/transactions').bufferCV,
-    tupleCV: jest.requireActual('@stacks/transactions').tupleCV,
-    uintCV: jest.requireActual('@stacks/transactions').uintCV,
-    AddressHashMode: jest.requireActual('@stacks/transactions').AddressHashMode,
-    AnchorMode: jest.requireActual('@stacks/transactions').AnchorMode,
-    standardPrincipalCV: jest.requireActual('@stacks/transactions').standardPrincipalCV,
-    validateStacksAddress: jest.requireActual('@stacks/transactions').validateStacksAddress,
   }));
 
   fetchMock.mockResponse(() => {
     return Promise.resolve({
       body: JSON.stringify(poxInfo),
-      status: 200
-    })
-  })
+      status: 200,
+    });
+  });
 
-  const { StackingClient } = require('../src');
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { StackingClient } = require('../src'); // needed for jest.mock module
   const client = new StackingClient(address, network);
 
   const delegateResults = await client.stackAggregationCommit({
@@ -662,7 +627,7 @@ test('delegator commit', async () => {
   });
 
   const { version, hash } = btcAddress.fromBase58Check(poxAddress);
-  const versionBuffer = bufferCV(toBuffer(BigInt(version)));
+  const versionBuffer = bufferCV(toBuffer(BigInt(version), 1));
   const hashbytes = bufferCV(hash);
   const poxAddressCV = tupleCV({
     hashbytes,
@@ -673,10 +638,7 @@ test('delegator commit', async () => {
     contractAddress: poxInfo.contract_id.split('.')[0],
     contractName: poxInfo.contract_id.split('.')[1],
     functionName: 'stack-aggregation-commit',
-    functionArgs: [
-      poxAddressCV,
-      uintCV(rewardCycle),
-    ],
+    functionArgs: [poxAddressCV, uintCV(rewardCycle)],
     validateWithAbi: true,
     network,
     senderKey: privateKey,
@@ -689,42 +651,36 @@ test('delegator commit', async () => {
   expect(broadcastTransaction).toHaveBeenCalledTimes(1);
   expect(broadcastTransaction).toHaveBeenCalledWith(transaction, network);
   expect(delegateResults).toEqual(broadcastResponse);
-})
+});
 
 test('revoke delegate stx', async () => {
   const address = 'ST3XKKN4RPV69NN1PHFDNX3TYKXT7XPC4N8KC1ARH';
   const network = new StacksTestnet();
   const privateKey = 'd48f215481c16cbe6426f8e557df9b78895661971d71735126545abddcd5377001';
 
-  const transaction = { serialize: () => 'mocktxhex' }
+  const transaction = { serialize: () => 'mocktxhex' };
   const makeContractCall = jest.fn().mockResolvedValue(transaction);
   const broadcastResponse = JSON.stringify({ txid: 'mocktxid' });
   const broadcastTransaction = jest.fn().mockResolvedValue(broadcastResponse);
 
   jest.mock('@stacks/transactions', () => ({
+    ...jest.requireActual('@stacks/transactions'),
     makeContractCall,
     broadcastTransaction,
-    bufferCV: jest.requireActual('@stacks/transactions').bufferCV,
-    tupleCV: jest.requireActual('@stacks/transactions').tupleCV,
-    uintCV: jest.requireActual('@stacks/transactions').uintCV,
-    AddressHashMode: jest.requireActual('@stacks/transactions').AddressHashMode,
-    AnchorMode: jest.requireActual('@stacks/transactions').AnchorMode,
-    standardPrincipalCV: jest.requireActual('@stacks/transactions').standardPrincipalCV,
-    validateStacksAddress: jest.requireActual('@stacks/transactions').validateStacksAddress,
   }));
 
   fetchMock.mockResponse(() => {
     return Promise.resolve({
       body: JSON.stringify(poxInfo),
-      status: 200
-    })
-  })
+      status: 200,
+    });
+  });
 
-  const { StackingClient } = require('../src');
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { StackingClient } = require('../src'); // needed for jest.mock module
   const client = new StackingClient(address, network);
 
   const revokeDelegateResults = await client.revokeDelegateStx(privateKey);
-
 
   const expectedContractCallOptions = {
     contractAddress: poxInfo.contract_id.split('.')[0],
@@ -734,7 +690,7 @@ test('revoke delegate stx', async () => {
     validateWithAbi: true,
     network,
     senderKey: privateKey,
-    anchorMode: AnchorMode.Any
+    anchorMode: AnchorMode.Any,
   };
 
   expect(fetchMock.mock.calls[0][0]).toEqual(network.getPoxInfoUrl());
@@ -743,8 +699,7 @@ test('revoke delegate stx', async () => {
   expect(broadcastTransaction).toHaveBeenCalledTimes(1);
   expect(broadcastTransaction).toHaveBeenCalledWith(transaction, network);
   expect(revokeDelegateResults).toEqual(broadcastResponse);
-})
-
+});
 
 test('get stacking status', async () => {
   const address = 'ST3XKKN4RPV69NN1PHFDNX3TYKXT7XPC4N8KC1ARH';
@@ -755,42 +710,42 @@ test('get stacking status', async () => {
   const version = '00';
   const hashbytes = '05cf52a44bf3e6829b4f8c221cc675355bf83b7d';
 
-  const functionCallResponse = someCV(tupleCV({
-    "amount-ustx": uintCV(amountMicrostx),
-    "first-reward-cycle": uintCV(firstRewardCycle),
-    "lock-period": uintCV(lockPeriod),
-    "pox-addr": tupleCV({
-      "version": bufferCV(Buffer.from(version)),
-      "hashbytes": bufferCV(Buffer.from(hashbytes))
+  const functionCallResponse = someCV(
+    tupleCV({
+      'amount-ustx': uintCV(amountMicrostx),
+      'first-reward-cycle': uintCV(firstRewardCycle),
+      'lock-period': uintCV(lockPeriod),
+      'pox-addr': tupleCV({
+        version: bufferCV(Buffer.from(version)),
+        hashbytes: bufferCV(Buffer.from(hashbytes)),
+      }),
     })
-  }));
+  );
 
   const callReadOnlyFunction = jest.fn().mockResolvedValue(functionCallResponse);
 
   jest.mock('@stacks/transactions', () => ({
+    ...jest.requireActual('@stacks/transactions'),
     callReadOnlyFunction,
-    cvToString: jest.requireActual('@stacks/transactions').cvToString,
-    standardPrincipalCV: jest.requireActual('@stacks/transactions').standardPrincipalCV,
-    ClarityType: jest.requireActual('@stacks/transactions').ClarityType,
-    validateStacksAddress: jest.requireActual('@stacks/transactions').validateStacksAddress,
-  }))
+  }));
 
   fetchMock.mockResponse(request => {
     const url = request.url;
     if (url.endsWith('pox')) {
       return Promise.resolve({
         body: JSON.stringify(poxInfo),
-        status: 200
-      })
+        status: 200,
+      });
     } else {
       return Promise.resolve({
         body: JSON.stringify(balanceInfo),
-        status: 200
-      })
+        status: 200,
+      });
     }
-  })
+  });
 
-  const { StackingClient } = require('../src');
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { StackingClient } = require('../src'); // needed for jest.mock module
   const client = new StackingClient(address, network);
 
   const stackingStatus = await client.getStatus();
@@ -799,22 +754,21 @@ test('get stacking status', async () => {
     contractAddress: poxInfo.contract_id.split('.')[0],
     contractName: poxInfo.contract_id.split('.')[1],
     functionName: 'get-stacker-info',
-    functionArgs: [
-      standardPrincipalCV(address)
-    ],
+    functionArgs: [standardPrincipalCV(address)],
     senderAddress: address,
-    network
+    network,
   };
 
   expect(callReadOnlyFunction).toHaveBeenCalledTimes(1);
   expect(callReadOnlyFunction).toHaveBeenCalledWith(expectedReadOnlyFunctionCallOptions);
+
   expect(stackingStatus.stacked).toEqual(true);
   expect(stackingStatus.details.amount_microstx).toEqual(amountMicrostx.toString());
   expect(stackingStatus.details.first_reward_cycle).toEqual(firstRewardCycle);
   expect(stackingStatus.details.lock_period).toEqual(lockPeriod);
   expect(stackingStatus.details.pox_address.version.toString()).toEqual(version);
   expect(stackingStatus.details.pox_address.hashbytes.toString()).toEqual(hashbytes);
-})
+});
 
 test('get core info', async () => {
   const address = 'ST3XKKN4RPV69NN1PHFDNX3TYKXT7XPC4N8KC1ARH';
@@ -823,18 +777,19 @@ test('get core info', async () => {
   fetchMock.mockResponse(() => {
     return Promise.resolve({
       body: JSON.stringify(coreInfo),
-      status: 200
-    })
-  })
+      status: 200,
+    });
+  });
 
-  const { StackingClient } = require('../src');
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { StackingClient } = require('../src'); // needed for jest.mock module
   const client = new StackingClient(address, network);
 
   const responseCoreInfo = await client.getCoreInfo();
 
   expect(fetchMock.mock.calls[0][0]).toEqual(network.getInfoUrl());
   expect(responseCoreInfo).toEqual(coreInfo);
-})
+});
 
 test('get pox info', async () => {
   const address = 'ST3XKKN4RPV69NN1PHFDNX3TYKXT7XPC4N8KC1ARH';
@@ -843,18 +798,19 @@ test('get pox info', async () => {
   fetchMock.mockResponse(() => {
     return Promise.resolve({
       body: JSON.stringify(poxInfo),
-      status: 200
-    })
-  })
+      status: 200,
+    });
+  });
 
-  const { StackingClient } = require('../src');
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { StackingClient } = require('../src'); // needed for jest.mock module
   const client = new StackingClient(address, network);
 
   const responsePoxInfo = await client.getPoxInfo();
 
   expect(fetchMock.mock.calls[0][0]).toEqual(network.getPoxInfoUrl());
   expect(responsePoxInfo).toEqual(poxInfo);
-})
+});
 
 test('get a list of burnchain rewards for the set address', async () => {
   const address = 'myfTfju9XSMRusaY2qTitSEMSchsWRA441';
@@ -863,13 +819,14 @@ test('get a list of burnchain rewards for the set address', async () => {
   fetchMock.mockResponse(() => {
     return Promise.resolve({
       body: JSON.stringify(rewardsInfo),
-      status: 200
-    })
-  })
+      status: 200,
+    });
+  });
 
-  const { StackingClient } = require('../src');
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { StackingClient } = require('../src'); // needed for jest.mock module
   const client = new StackingClient(address, network);
-  const options = {limit: 2, offset: 0};
+  const options = { limit: 2, offset: 0 };
   const response = await client.getRewardsForBtcAddress(options);
 
   expect(fetchMock.mock.calls[0][0]).toEqual(network.getRewardsUrl(address, options));
@@ -883,11 +840,12 @@ test('get the burnchain rewards total for the set address', async () => {
   fetchMock.mockResponse(() => {
     return Promise.resolve({
       body: JSON.stringify(rewardsTotalInfo),
-      status: 200
-    })
+      status: 200,
+    });
   });
 
-  const { StackingClient } = require('../src');
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { StackingClient } = require('../src'); // needed for jest.mock module
   const client = new StackingClient(address, network);
   const response = await client.getRewardsTotalForBtcAddress();
 
@@ -902,19 +860,19 @@ test('get a list of burnchain reward holders for the set address ', async () => 
   fetchMock.mockResponse(() => {
     return Promise.resolve({
       body: JSON.stringify(rewardHoldersInfo),
-      status: 200
-    })
-  })
+      status: 200,
+    });
+  });
 
-  const { StackingClient } = require('../src');
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { StackingClient } = require('../src'); // needed for jest.mock module
   const client = new StackingClient(address, network);
-  const options = {limit: 2, offset: 0};
+  const options = { limit: 2, offset: 0 };
   const response = await client.getRewardHoldersForBtcAddress(options);
 
   expect(fetchMock.mock.calls[0][0]).toEqual(network.getRewardHoldersUrl(address, options));
   expect(response).toEqual(rewardHoldersInfo);
 });
-
 
 test('get target block time info', async () => {
   const address = 'ST3XKKN4RPV69NN1PHFDNX3TYKXT7XPC4N8KC1ARH';
@@ -923,18 +881,19 @@ test('get target block time info', async () => {
   fetchMock.mockResponse(() => {
     return Promise.resolve({
       body: JSON.stringify(blocktimeInfo),
-      status: 200
-    })
-  })
+      status: 200,
+    });
+  });
 
-  const { StackingClient } = require('../src');
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { StackingClient } = require('../src'); // needed for jest.mock module
   const client = new StackingClient(address, network);
 
   const responseBlockTimeInfo = await client.getTargetBlockTime();
 
   expect(fetchMock.mock.calls[0][0]).toEqual(network.getBlockTimeInfoUrl());
   expect(responseBlockTimeInfo).toEqual(blocktimeInfo.testnet.target_block_time);
-})
+});
 
 test('get account balance', async () => {
   const address = 'ST3XKKN4RPV69NN1PHFDNX3TYKXT7XPC4N8KC1ARH';
@@ -943,18 +902,19 @@ test('get account balance', async () => {
   fetchMock.mockResponse(() => {
     return Promise.resolve({
       body: JSON.stringify(balanceInfo),
-      status: 200
-    })
-  })
+      status: 200,
+    });
+  });
 
-  const { StackingClient } = require('../src');
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { StackingClient } = require('../src'); // needed for jest.mock module
   const client = new StackingClient(address, network);
 
   const responseBalanceInfo = await client.getAccountBalance();
 
   expect(fetchMock.mock.calls[0][0]).toEqual(network.getAccountApiUrl(address));
   expect(responseBalanceInfo.toString()).toEqual(BigInt(balanceInfo.balance).toString());
-})
+});
 
 test('get seconds until next cycle', async () => {
   const address = 'ST3XKKN4RPV69NN1PHFDNX3TYKXT7XPC4N8KC1ARH';
@@ -980,7 +940,8 @@ test('get seconds until next cycle', async () => {
       });
     });
 
-  const { StackingClient } = require('../src');
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { StackingClient } = require('../src'); // needed for jest.mock module
   const client = new StackingClient(address, network);
 
   const responseSecondsUntilNextCycle = await client.getSecondsUntilNextCycle();
@@ -1012,7 +973,7 @@ test('pox address hash mode', async () => {
   const p2wpkhTestnet = 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx';
   const p2wsh = 'bc1qup6umurcl7s6zw42gcxfzl346psazws74x72ty6gmlvkaxz6kv4sqsth99';
   const p2wshTestnet = 'tb1qup6umurcl7s6zw42gcxfzl346psazws74x72ty6gmlvkaxz6kv4shcacl2';
-  
+
   expect(() => getAddressHashMode(p2wpkh)).toThrowError(InvalidAddressError);
   expect(() => getAddressHashMode(p2wpkhTestnet)).toThrowError(InvalidAddressError);
   expect(() => getAddressHashMode(p2wsh)).toThrowError(InvalidAddressError);
@@ -1022,8 +983,7 @@ test('pox address hash mode', async () => {
   expect(() => decodeBtcAddress(p2wpkhTestnet)).toThrowError(InvalidAddressError);
   expect(() => decodeBtcAddress(p2wsh)).toThrowError(InvalidAddressError);
   expect(() => decodeBtcAddress(p2wshTestnet)).toThrowError(InvalidAddressError);
-})
-
+});
 
 test('pox address to btc address', () => {
   const vectors: {
@@ -1036,7 +996,7 @@ test('pox address to btc address', () => {
       version: Buffer.from([0x01]),
       hashBytes: Buffer.from('07366658d1e5f0f75c585a17b618b776f4f10a6b', 'hex'),
       network: 'mainnet',
-      expectedBtcAddr: '32M9pegJxqXBoxXSKBN1s7HJUR2YMkMaFg'
+      expectedBtcAddr: '32M9pegJxqXBoxXSKBN1s7HJUR2YMkMaFg',
     },
     {
       version: Buffer.from([0x01]),
@@ -1061,7 +1021,7 @@ test('pox address to btc address', () => {
       hashBytes: Buffer.from('3149c3eba2d21cfdeea56894866b8f4cd11b72ad', 'hex'),
       network: 'testnet',
       expectedBtcAddr: '2MwjqTzEJodSaoehcxRSqfWrvJMGZHq4tdC',
-    }
+    },
   ];
 
   vectors.forEach(item => {
@@ -1090,6 +1050,6 @@ test('pox address to btc address', () => {
     expect(btcAddress).toBe(item.expectedBtcAddr);
     const decodedAddress = decodeBtcAddress(btcAddress);
     expect(decodedAddress.hashMode).toBe(item.version[0]);
-    expect(decodedAddress.data.toString('hex')).toBe(item.hashBytes.toString('hex')); 
+    expect(decodedAddress.data.toString('hex')).toBe(item.hashBytes.toString('hex'));
   });
 });


### PR DESCRIPTION
bug reported on [discord#documentation](https://discord.com/channels/621759717756370964/750467085720617031/992103351334469685)

using the example stacking function with this version fails with the following (pre-4.0.0 version works as expected):
```
 ➭ cat package.json && node index.js 
{
  "name": "t",
  "version": "1.0.0",
  "description": "",
  "keywords": [],
  "author": "",
  "license": "GPLv3",
  "type": "module",
  "dependencies": {
    "@stacks/network": "^4.3.0",
    "@stacks/stacking": "^4.3.0"

  }
}
(node:66903) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
/Users/wileyj/Downloads/test/node_modules/@stacks/transactions/dist/contract-abi.js:265
                throw new Error(`Clarity function \`${payload.functionName.content}\` expects argument ${argNum} to be of type ${getTypeString(abiArg.type)}, not ${(0, clarity_1.getCVTypeString)(payloadArg)}`);
                      ^

Error: Clarity function `stack-stx` expects argument 2 to be of type (tuple (hashbytes (buff 20)) (version (buff 1))), not (tuple (hashbytes (buff 20)) (version (buff 16)))
    at validateContractCall (/Users/wileyj/Downloads/test/node_modules/@stacks/transactions/dist/contract-abi.js:265:23)
    at makeUnsignedContractCall (/Users/wileyj/Downloads/test/node_modules/@stacks/transactions/dist/builders.js:350:49)
    at async makeContractCall (/Users/wileyj/Downloads/test/node_modules/@stacks/transactions/dist/builders.js:395:29)
    at async StackingClient.stack (/Users/wileyj/Downloads/test/node_modules/@stacks/stacking/dist/index.js:145:20)
    at async file:///Users/wileyj/Downloads/test/index.js:14:25

Node.js v18.4.0
```
---

The bug was introduced when switching away from bn.js. Buffers from BigInt were the wrong size after the switch.