### PR TITLE
fix: convert checksum to buffer

### DIFF
--- a/packages/encryption/src/keys.ts
+++ b/packages/encryption/src/keys.ts
@@ -62,7 +62,7 @@ export function base58CheckDecode(btcAddress: string): {
  * @ignore
  */
 export function base58Encode(hash: Buffer) {
-  const checksum = sha256(sha256(hash));
+  const checksum = Buffer.from(sha256(sha256(hash)));
   return base58.encode(Buffer.concat([hash, checksum], hash.length + 4));
 }
 

--- a/packages/encryption/tests/keys.test.ts
+++ b/packages/encryption/tests/keys.test.ts
@@ -4,13 +4,13 @@ import { address, ECPair, networks } from 'bitcoinjs-lib';
 import bs58check from 'bs58check';
 import { SECP256K1Client } from 'jsontokens';
 import {
+  base58Encode,
+  compressPrivateKey,
+  ecSign,
   getPublicKeyFromPrivate,
   hashSha256Sync,
   makeECPrivateKey,
   publicKeyToAddress,
-  ecSign,
-  base58Encode,
-  compressPrivateKey,
 } from '../src';
 import { hashRipemd160 } from '../src/hashRipemd160';
 


### PR DESCRIPTION
- convert a Uint8Array to Buffer

some build environments apparently failed on this, others didn't