### PR TITLE
fix: update make_keychain command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,8 @@
 				"@noble/hashes": "^1.0.0",
 				"@noble/secp256k1": "^1.5.5",
 				"@peculiar/webcrypto": "^1.1.6",
-				"@scure/bip32": "^1.0.1",
-				"@scure/bip39": "^1.0.0",
+				"@scure/bip32": "^1.1.0",
+				"@scure/bip39": "^1.1.0",
 				"@stacks/blockchain-api-client": "^4.0.1",
 				"@stacks/stacks-blockchain-api-types": "^0.61.0",
 				"@types/bn.js": "^5.1.0",
@@ -32,6 +32,7 @@
 				"@types/ripemd160": "^2.0.0",
 				"@types/sha.js": "^2.4.0",
 				"@types/triplesec": "^3.0.0",
+				"@types/wif": "^2.0.2",
 				"ajv": "6.12.3",
 				"bip32": "^2.0.6",
 				"bip39": "^3.0.2",
@@ -74,6 +75,7 @@
 				"webpack": "^5.36.1",
 				"webpack-bundle-analyzer": "^4.5.0",
 				"webpack-cli": "^4.6.0",
+				"wif": "^2.0.6",
 				"winston": "^3.2.1",
 				"yalc": "1.0.0-pre.49",
 				"zone-file": "^2.0.0-beta.3"
@@ -3751,14 +3753,20 @@
 			}
 		},
 		"node_modules/@noble/hashes": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.0.0.tgz",
-			"integrity": "sha512-DZVbtY62kc3kkBtMHqwCOfXrT/hnoORy5BJ4+HU1IR59X0KWAOqsfzQPcUl/lQLlG7qXbe/fZ3r/emxtAl+sqg=="
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
+			"integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://paulmillr.com/funding/"
+				}
+			]
 		},
 		"node_modules/@noble/secp256k1": {
-			"version": "1.5.5",
-			"resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.5.5.tgz",
-			"integrity": "sha512-sZ1W6gQzYnu45wPrWx8D3kwI2/U29VYTx9OjbDAd7jwRItJ0cSTMPRL/C8AWZFn9kWFLQGqEXVEE86w4Z8LpIQ==",
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.6.3.tgz",
+			"integrity": "sha512-T04e4iTurVy7I8Sw4+c5OSN9/RkPlo1uKxAomtxQNLq8j1uPAqnsqG1bqvY3Jv7c13gyr6dui0zmh/I3+f/JaQ==",
 			"funding": [
 				{
 					"type": "individual",
@@ -4317,9 +4325,9 @@
 			"dev": true
 		},
 		"node_modules/@scure/base": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@scure/base/-/base-1.0.0.tgz",
-			"integrity": "sha512-gIVaYhUsy+9s58m/ETjSJVKHhKTBMmcRb9cEV5/5dwvfDlfORjKrFsDeDHWRrm6RjcPvCLZFwGJjAjLj1gg4HA==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
+			"integrity": "sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==",
 			"funding": [
 				{
 					"type": "individual",
@@ -4328,9 +4336,9 @@
 			]
 		},
 		"node_modules/@scure/bip32": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.0.1.tgz",
-			"integrity": "sha512-AU88KKTpQ+YpTLoicZ/qhFhRRIo96/tlb+8YmDDHR9yiKVjSsFZiefJO4wjS2PMTkz5/oIcw84uAq/8pleQURA==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.1.0.tgz",
+			"integrity": "sha512-ftTW3kKX54YXLCxH6BB7oEEoJfoE2pIgw7MINKAs5PsS6nqKPuKk1haTF/EuHmYqG330t5GSrdmtRuHaY1a62Q==",
 			"funding": [
 				{
 					"type": "individual",
@@ -4338,15 +4346,15 @@
 				}
 			],
 			"dependencies": {
-				"@noble/hashes": "~1.0.0",
-				"@noble/secp256k1": "~1.5.2",
-				"@scure/base": "~1.0.0"
+				"@noble/hashes": "~1.1.1",
+				"@noble/secp256k1": "~1.6.0",
+				"@scure/base": "~1.1.0"
 			}
 		},
 		"node_modules/@scure/bip39": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.0.0.tgz",
-			"integrity": "sha512-HrtcikLbd58PWOkl02k9V6nXWQyoa7A0+Ek9VF7z17DDk9XZAFUcIdqfh0jJXLypmizc5/8P6OxoUeKliiWv4w==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.1.0.tgz",
+			"integrity": "sha512-pwrPOS16VeTKg98dYXQyIjJEcWfz7/1YJIwxUEPFfQPtc86Ym/1sVgQ2RLoD43AazMk2l/unK4ITySSpW2+82w==",
 			"funding": [
 				{
 					"type": "individual",
@@ -4354,8 +4362,8 @@
 				}
 			],
 			"dependencies": {
-				"@noble/hashes": "~1.0.0",
-				"@scure/base": "~1.0.0"
+				"@noble/hashes": "~1.1.1",
+				"@scure/base": "~1.1.0"
 			}
 		},
 		"node_modules/@sinonjs/commons": {
@@ -5293,6 +5301,14 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/@types/triplesec/-/triplesec-3.0.1.tgz",
 			"integrity": "sha512-o9E6wYZK2cOSiZR7UxOFYmoGD1k/u+b+i6GmsKyJET+sg/a12vaWnWlp/FqMQ7PFcgLwGyHqkUNppYL8kjmPfg==",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/wif": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@types/wif/-/wif-2.0.2.tgz",
+			"integrity": "sha512-IiIuBeJzlh4LWJ7kVTrX0nwB60OG0vvGTaWC/SgSbVFw7uYUTF6gEuvDZ1goWkeirekJDD58Y8g7NljQh2fNkA==",
 			"dependencies": {
 				"@types/node": "*"
 			}
@@ -22909,13 +22925,13 @@
 		},
 		"packages/auth": {
 			"name": "@stacks/auth",
-			"version": "4.3.0",
+			"version": "4.3.2",
 			"license": "MIT",
 			"dependencies": {
-				"@stacks/common": "^4.3.0",
-				"@stacks/encryption": "^4.3.0",
-				"@stacks/network": "^4.3.0",
-				"@stacks/profile": "^4.3.0",
+				"@stacks/common": "^4.3.2",
+				"@stacks/encryption": "^4.3.2",
+				"@stacks/network": "^4.3.2",
+				"@stacks/profile": "^4.3.2",
 				"cross-fetch": "^3.1.5",
 				"jsontokens": "^3.1.1",
 				"query-string": "^6.13.1"
@@ -22934,12 +22950,12 @@
 		},
 		"packages/bns": {
 			"name": "@stacks/bns",
-			"version": "4.3.0",
+			"version": "4.3.2",
 			"license": "MIT",
 			"dependencies": {
-				"@stacks/common": "^4.3.0",
-				"@stacks/network": "^4.3.0",
-				"@stacks/transactions": "^4.3.0"
+				"@stacks/common": "^4.3.2",
+				"@stacks/network": "^4.3.2",
+				"@stacks/transactions": "^4.3.2"
 			},
 			"devDependencies": {
 				"@types/jest": "^26.0.22",
@@ -22958,18 +22974,21 @@
 		},
 		"packages/cli": {
 			"name": "@stacks/cli",
-			"version": "4.3.0",
+			"version": "4.3.2",
 			"license": "MIT",
 			"dependencies": {
-				"@stacks/auth": "^4.3.0",
+				"@scure/bip32": "^1.1.0",
+				"@scure/bip39": "^1.1.0",
+				"@stacks/auth": "^4.3.2",
 				"@stacks/blockchain-api-client": "^4.0.1",
-				"@stacks/bns": "^4.3.0",
-				"@stacks/common": "^4.3.0",
-				"@stacks/network": "^4.3.0",
-				"@stacks/stacking": "^4.3.0",
-				"@stacks/storage": "^4.3.0",
-				"@stacks/transactions": "^4.3.0",
-				"@stacks/wallet-sdk": "^4.3.0",
+				"@stacks/bns": "^4.3.2",
+				"@stacks/common": "^4.3.2",
+				"@stacks/encryption": "^4.3.2",
+				"@stacks/network": "^4.3.2",
+				"@stacks/stacking": "^4.3.2",
+				"@stacks/storage": "^4.3.2",
+				"@stacks/transactions": "^4.3.2",
+				"@stacks/wallet-sdk": "^4.3.2",
 				"ajv": "6.12.3",
 				"bip32": "^2.0.6",
 				"bip39": "^3.0.2",
@@ -22984,6 +23003,7 @@
 				"jsontokens": "^3.1.1",
 				"node-fetch": "^2.6.0",
 				"ripemd160": "^2.0.1",
+				"wif": "^2.0.6",
 				"winston": "^3.2.1",
 				"zone-file": "^2.0.0-beta.3"
 			},
@@ -22999,6 +23019,7 @@
 				"@types/jest": "^26.0.22",
 				"@types/node-fetch": "^2.5.0",
 				"@types/ripemd160": "^2.0.0",
+				"@types/wif": "^2.0.2",
 				"jest": "^26.6.3",
 				"jest-fetch-mock": "^3.0.3",
 				"jest-module-name-mapper": "^0.1.5",
@@ -23010,7 +23031,7 @@
 		},
 		"packages/common": {
 			"name": "@stacks/common",
-			"version": "4.3.0",
+			"version": "4.3.2",
 			"license": "MIT",
 			"dependencies": {
 				"@types/bn.js": "^5.1.0",
@@ -23035,13 +23056,13 @@
 		},
 		"packages/encryption": {
 			"name": "@stacks/encryption",
-			"version": "4.3.0",
+			"version": "4.3.2",
 			"license": "MIT",
 			"dependencies": {
 				"@noble/hashes": "^1.0.0",
 				"@noble/secp256k1": "^1.5.5",
-				"@scure/bip39": "^1.0.0",
-				"@stacks/common": "^4.3.0",
+				"@scure/bip39": "^1.1.0",
+				"@stacks/common": "^4.3.2",
 				"@types/node": "^14.14.43",
 				"bs58": "^5.0.0",
 				"ripemd160-min": "^0.0.6",
@@ -23076,17 +23097,17 @@
 		},
 		"packages/keychain": {
 			"name": "@stacks/keychain",
-			"version": "4.3.0",
+			"version": "4.3.2",
 			"license": "MIT",
 			"dependencies": {
 				"@blockstack/rpc-client": "^0.3.0-alpha.11",
-				"@stacks/auth": "^4.3.0",
-				"@stacks/common": "^4.3.0",
-				"@stacks/encryption": "^4.3.0",
-				"@stacks/network": "^4.3.0",
-				"@stacks/profile": "^4.3.0",
-				"@stacks/storage": "^4.3.0",
-				"@stacks/transactions": "^4.3.0",
+				"@stacks/auth": "^4.3.2",
+				"@stacks/common": "^4.3.2",
+				"@stacks/encryption": "^4.3.2",
+				"@stacks/network": "^4.3.2",
+				"@stacks/profile": "^4.3.2",
+				"@stacks/storage": "^4.3.2",
+				"@stacks/transactions": "^4.3.2",
 				"@types/node": "^14.14.43",
 				"@types/triplesec": "^3.0.0",
 				"bip32": "^2.0.6",
@@ -23118,10 +23139,10 @@
 		},
 		"packages/network": {
 			"name": "@stacks/network",
-			"version": "4.3.0",
+			"version": "4.3.2",
 			"license": "MIT",
 			"dependencies": {
-				"@stacks/common": "^4.3.0",
+				"@stacks/common": "^4.3.2",
 				"cross-fetch": "^3.1.5"
 			},
 			"devDependencies": {
@@ -23141,12 +23162,12 @@
 		},
 		"packages/profile": {
 			"name": "@stacks/profile",
-			"version": "4.3.0",
+			"version": "4.3.2",
 			"license": "MIT",
 			"dependencies": {
-				"@stacks/common": "^4.3.0",
-				"@stacks/network": "^4.3.0",
-				"@stacks/transactions": "^4.3.0",
+				"@stacks/common": "^4.3.2",
+				"@stacks/network": "^4.3.2",
+				"@stacks/transactions": "^4.3.2",
 				"jsontokens": "^3.1.1",
 				"schema-inspector": "2.0.1",
 				"zone-file": "^2.0.0-beta.3"
@@ -23169,14 +23190,14 @@
 		},
 		"packages/stacking": {
 			"name": "@stacks/stacking",
-			"version": "4.3.0",
+			"version": "4.3.2",
 			"license": "MIT",
 			"dependencies": {
-				"@stacks/common": "^4.3.0",
-				"@stacks/encryption": "^4.3.0",
-				"@stacks/network": "^4.3.0",
+				"@stacks/common": "^4.3.2",
+				"@stacks/encryption": "^4.3.2",
+				"@stacks/network": "^4.3.2",
 				"@stacks/stacks-blockchain-api-types": "^0.61.0",
-				"@stacks/transactions": "^4.3.0",
+				"@stacks/transactions": "^4.3.2",
 				"bs58": "^5.0.0"
 			},
 			"devDependencies": {
@@ -23197,13 +23218,13 @@
 		},
 		"packages/storage": {
 			"name": "@stacks/storage",
-			"version": "4.3.0",
+			"version": "4.3.2",
 			"license": "MIT",
 			"dependencies": {
-				"@stacks/auth": "^4.3.0",
-				"@stacks/common": "^4.3.0",
-				"@stacks/encryption": "^4.3.0",
-				"@stacks/network": "^4.3.0",
+				"@stacks/auth": "^4.3.2",
+				"@stacks/common": "^4.3.2",
+				"@stacks/encryption": "^4.3.2",
+				"@stacks/network": "^4.3.2",
 				"jsontokens": "^3.1.1"
 			},
 			"devDependencies": {
@@ -23227,13 +23248,13 @@
 		},
 		"packages/transactions": {
 			"name": "@stacks/transactions",
-			"version": "4.3.0",
+			"version": "4.3.2",
 			"license": "MIT",
 			"dependencies": {
 				"@noble/hashes": "^1.0.0",
 				"@noble/secp256k1": "^1.5.5",
-				"@stacks/common": "^4.3.0",
-				"@stacks/network": "^4.3.0",
+				"@stacks/common": "^4.3.2",
+				"@stacks/network": "^4.3.2",
 				"@types/node": "^14.14.43",
 				"@types/sha.js": "^2.4.0",
 				"c32check": "^1.1.3",
@@ -23243,7 +23264,7 @@
 				"smart-buffer": "^4.1.0"
 			},
 			"devDependencies": {
-				"@stacks/encryption": "^4.3.0",
+				"@stacks/encryption": "^4.3.2",
 				"@types/common-tags": "^1.8.0",
 				"@types/elliptic": "^6.4.12",
 				"@types/jest": "^26.0.22",
@@ -23265,18 +23286,18 @@
 		},
 		"packages/wallet-sdk": {
 			"name": "@stacks/wallet-sdk",
-			"version": "4.3.0",
+			"version": "4.3.2",
 			"license": "MIT",
 			"dependencies": {
-				"@scure/bip32": "^1.0.1",
-				"@scure/bip39": "^1.0.0",
-				"@stacks/auth": "^4.3.0",
-				"@stacks/common": "^4.3.0",
-				"@stacks/encryption": "^4.3.0",
-				"@stacks/network": "^4.3.0",
-				"@stacks/profile": "^4.3.0",
-				"@stacks/storage": "^4.3.0",
-				"@stacks/transactions": "^4.3.0",
+				"@scure/bip32": "^1.1.0",
+				"@scure/bip39": "^1.1.0",
+				"@stacks/auth": "^4.3.2",
+				"@stacks/common": "^4.3.2",
+				"@stacks/encryption": "^4.3.2",
+				"@stacks/network": "^4.3.2",
+				"@stacks/profile": "^4.3.2",
+				"@stacks/storage": "^4.3.2",
+				"@stacks/transactions": "^4.3.2",
 				"bitcoinjs-lib": "^5.2.0",
 				"c32check": "^1.1.3",
 				"jsontokens": "^3.1.1",
@@ -24271,7 +24292,7 @@
 			"integrity": "sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==",
 			"dev": true,
 			"requires": {
-				"ajv": "^6.12.4",
+				"ajv": "6.12.3",
 				"debug": "^4.3.2",
 				"espree": "^9.3.2",
 				"globals": "^13.15.0",
@@ -26181,14 +26202,14 @@
 			}
 		},
 		"@noble/hashes": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.0.0.tgz",
-			"integrity": "sha512-DZVbtY62kc3kkBtMHqwCOfXrT/hnoORy5BJ4+HU1IR59X0KWAOqsfzQPcUl/lQLlG7qXbe/fZ3r/emxtAl+sqg=="
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
+			"integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA=="
 		},
 		"@noble/secp256k1": {
-			"version": "1.5.5",
-			"resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.5.5.tgz",
-			"integrity": "sha512-sZ1W6gQzYnu45wPrWx8D3kwI2/U29VYTx9OjbDAd7jwRItJ0cSTMPRL/C8AWZFn9kWFLQGqEXVEE86w4Z8LpIQ=="
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.6.3.tgz",
+			"integrity": "sha512-T04e4iTurVy7I8Sw4+c5OSN9/RkPlo1uKxAomtxQNLq8j1uPAqnsqG1bqvY3Jv7c13gyr6dui0zmh/I3+f/JaQ=="
 		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.5",
@@ -26628,27 +26649,27 @@
 			}
 		},
 		"@scure/base": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@scure/base/-/base-1.0.0.tgz",
-			"integrity": "sha512-gIVaYhUsy+9s58m/ETjSJVKHhKTBMmcRb9cEV5/5dwvfDlfORjKrFsDeDHWRrm6RjcPvCLZFwGJjAjLj1gg4HA=="
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
+			"integrity": "sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA=="
 		},
 		"@scure/bip32": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.0.1.tgz",
-			"integrity": "sha512-AU88KKTpQ+YpTLoicZ/qhFhRRIo96/tlb+8YmDDHR9yiKVjSsFZiefJO4wjS2PMTkz5/oIcw84uAq/8pleQURA==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.1.0.tgz",
+			"integrity": "sha512-ftTW3kKX54YXLCxH6BB7oEEoJfoE2pIgw7MINKAs5PsS6nqKPuKk1haTF/EuHmYqG330t5GSrdmtRuHaY1a62Q==",
 			"requires": {
-				"@noble/hashes": "~1.0.0",
-				"@noble/secp256k1": "~1.5.2",
-				"@scure/base": "~1.0.0"
+				"@noble/hashes": "~1.1.1",
+				"@noble/secp256k1": "~1.6.0",
+				"@scure/base": "~1.1.0"
 			}
 		},
 		"@scure/bip39": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.0.0.tgz",
-			"integrity": "sha512-HrtcikLbd58PWOkl02k9V6nXWQyoa7A0+Ek9VF7z17DDk9XZAFUcIdqfh0jJXLypmizc5/8P6OxoUeKliiWv4w==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.1.0.tgz",
+			"integrity": "sha512-pwrPOS16VeTKg98dYXQyIjJEcWfz7/1YJIwxUEPFfQPtc86Ym/1sVgQ2RLoD43AazMk2l/unK4ITySSpW2+82w==",
 			"requires": {
-				"@noble/hashes": "~1.0.0",
-				"@scure/base": "~1.0.0"
+				"@noble/hashes": "~1.1.1",
+				"@scure/base": "~1.1.0"
 			}
 		},
 		"@sinonjs/commons": {
@@ -26675,10 +26696,10 @@
 		"@stacks/auth": {
 			"version": "file:packages/auth",
 			"requires": {
-				"@stacks/common": "^4.3.0",
-				"@stacks/encryption": "^4.3.0",
-				"@stacks/network": "^4.3.0",
-				"@stacks/profile": "^4.3.0",
+				"@stacks/common": "^4.3.2",
+				"@stacks/encryption": "^4.3.2",
+				"@stacks/network": "^4.3.2",
+				"@stacks/profile": "^4.3.2",
 				"@types/jest": "^26.0.22",
 				"cross-fetch": "^3.1.5",
 				"jest": "^26.6.3",
@@ -26710,9 +26731,9 @@
 		"@stacks/bns": {
 			"version": "file:packages/bns",
 			"requires": {
-				"@stacks/common": "^4.3.0",
-				"@stacks/network": "^4.3.0",
-				"@stacks/transactions": "^4.3.0",
+				"@stacks/common": "^4.3.2",
+				"@stacks/network": "^4.3.2",
+				"@stacks/transactions": "^4.3.2",
 				"@types/jest": "^26.0.22",
 				"jest": "^26.6.3",
 				"jest-fetch-mock": "^3.0.3",
@@ -26730,15 +26751,18 @@
 		"@stacks/cli": {
 			"version": "file:packages/cli",
 			"requires": {
-				"@stacks/auth": "^4.3.0",
+				"@scure/bip32": "^1.1.0",
+				"@scure/bip39": "^1.1.0",
+				"@stacks/auth": "^4.3.2",
 				"@stacks/blockchain-api-client": "^4.0.1",
-				"@stacks/bns": "^4.3.0",
-				"@stacks/common": "^4.3.0",
-				"@stacks/network": "^4.3.0",
-				"@stacks/stacking": "^4.3.0",
-				"@stacks/storage": "^4.3.0",
-				"@stacks/transactions": "^4.3.0",
-				"@stacks/wallet-sdk": "^4.3.0",
+				"@stacks/bns": "^4.3.2",
+				"@stacks/common": "^4.3.2",
+				"@stacks/encryption": "^4.3.2",
+				"@stacks/network": "^4.3.2",
+				"@stacks/stacking": "^4.3.2",
+				"@stacks/storage": "^4.3.2",
+				"@stacks/transactions": "^4.3.2",
+				"@stacks/wallet-sdk": "^4.3.2",
 				"@types/cors": "^2.8.5",
 				"@types/express": "^4.16.1",
 				"@types/express-winston": "^3.0.1",
@@ -26746,6 +26770,7 @@
 				"@types/jest": "^26.0.22",
 				"@types/node-fetch": "^2.5.0",
 				"@types/ripemd160": "^2.0.0",
+				"@types/wif": "^2.0.2",
 				"ajv": "6.12.3",
 				"bip32": "^2.0.6",
 				"bip39": "^3.0.2",
@@ -26767,6 +26792,7 @@
 				"ts-jest": "^26.5.5",
 				"typescript": "^4.2.4",
 				"webpack-bundle-analyzer": "^4.5.0",
+				"wif": "^2.0.6",
 				"winston": "^3.2.1",
 				"zone-file": "^2.0.0-beta.3"
 			}
@@ -26798,8 +26824,8 @@
 				"@noble/hashes": "^1.0.0",
 				"@noble/secp256k1": "^1.5.5",
 				"@peculiar/webcrypto": "^1.1.6",
-				"@scure/bip39": "^1.0.0",
-				"@stacks/common": "^4.3.0",
+				"@scure/bip39": "^1.1.0",
+				"@stacks/common": "^4.3.2",
 				"@types/bs58check": "^2.1.0",
 				"@types/elliptic": "^6.4.12",
 				"@types/jest": "^26.0.22",
@@ -27133,13 +27159,13 @@
 			"version": "file:packages/keychain",
 			"requires": {
 				"@blockstack/rpc-client": "^0.3.0-alpha.11",
-				"@stacks/auth": "^4.3.0",
-				"@stacks/common": "^4.3.0",
-				"@stacks/encryption": "^4.3.0",
-				"@stacks/network": "^4.3.0",
-				"@stacks/profile": "^4.3.0",
-				"@stacks/storage": "^4.3.0",
-				"@stacks/transactions": "^4.3.0",
+				"@stacks/auth": "^4.3.2",
+				"@stacks/common": "^4.3.2",
+				"@stacks/encryption": "^4.3.2",
+				"@stacks/network": "^4.3.2",
+				"@stacks/profile": "^4.3.2",
+				"@stacks/storage": "^4.3.2",
+				"@stacks/transactions": "^4.3.2",
 				"@types/jest": "^26.0.22",
 				"@types/node": "^14.14.43",
 				"@types/triplesec": "^3.0.0",
@@ -27170,7 +27196,7 @@
 		"@stacks/network": {
 			"version": "file:packages/network",
 			"requires": {
-				"@stacks/common": "^4.3.0",
+				"@stacks/common": "^4.3.2",
 				"@types/jest": "^26.0.22",
 				"cross-fetch": "^3.1.5",
 				"jest": "^26.6.3",
@@ -27206,9 +27232,9 @@
 		"@stacks/profile": {
 			"version": "file:packages/profile",
 			"requires": {
-				"@stacks/common": "^4.3.0",
-				"@stacks/network": "^4.3.0",
-				"@stacks/transactions": "^4.3.0",
+				"@stacks/common": "^4.3.2",
+				"@stacks/network": "^4.3.2",
+				"@stacks/transactions": "^4.3.2",
 				"@types/jest": "^26.0.22",
 				"bitcoinjs-lib": "^5.2.0",
 				"jest": "^26.6.3",
@@ -27230,11 +27256,11 @@
 		"@stacks/stacking": {
 			"version": "file:packages/stacking",
 			"requires": {
-				"@stacks/common": "^4.3.0",
-				"@stacks/encryption": "^4.3.0",
-				"@stacks/network": "^4.3.0",
+				"@stacks/common": "^4.3.2",
+				"@stacks/encryption": "^4.3.2",
+				"@stacks/network": "^4.3.2",
 				"@stacks/stacks-blockchain-api-types": "^0.61.0",
-				"@stacks/transactions": "^4.3.0",
+				"@stacks/transactions": "^4.3.2",
 				"@types/jest": "^26.0.22",
 				"bs58": "^5.0.0",
 				"jest": "^26.6.3",
@@ -27259,9 +27285,9 @@
 		"@stacks/storage": {
 			"version": "file:packages/storage",
 			"requires": {
-				"@stacks/auth": "^4.3.0",
-				"@stacks/common": "^4.3.0",
-				"@stacks/encryption": "^4.3.0",
+				"@stacks/auth": "^4.3.2",
+				"@stacks/common": "^4.3.2",
+				"@stacks/encryption": "^4.3.2",
 				"@stacks/network": "^4.1.0",
 				"@types/jest": "^26.0.22",
 				"@types/jsdom": "^16.2.10",
@@ -27286,9 +27312,9 @@
 			"requires": {
 				"@noble/hashes": "^1.0.0",
 				"@noble/secp256k1": "^1.5.5",
-				"@stacks/common": "^4.3.0",
-				"@stacks/encryption": "^4.3.0",
-				"@stacks/network": "^4.3.0",
+				"@stacks/common": "^4.3.2",
+				"@stacks/encryption": "^4.3.2",
+				"@stacks/network": "^4.3.2",
 				"@types/common-tags": "^1.8.0",
 				"@types/elliptic": "^6.4.12",
 				"@types/jest": "^26.0.22",
@@ -27318,15 +27344,15 @@
 		"@stacks/wallet-sdk": {
 			"version": "file:packages/wallet-sdk",
 			"requires": {
-				"@scure/bip32": "^1.0.1",
-				"@scure/bip39": "^1.0.0",
-				"@stacks/auth": "^4.3.0",
-				"@stacks/common": "^4.3.0",
-				"@stacks/encryption": "^4.3.0",
-				"@stacks/network": "^4.3.0",
-				"@stacks/profile": "^4.3.0",
-				"@stacks/storage": "^4.3.0",
-				"@stacks/transactions": "^4.3.0",
+				"@scure/bip32": "^1.1.0",
+				"@scure/bip39": "^1.1.0",
+				"@stacks/auth": "^4.3.2",
+				"@stacks/common": "^4.3.2",
+				"@stacks/encryption": "^4.3.2",
+				"@stacks/network": "^4.3.2",
+				"@stacks/profile": "^4.3.2",
+				"@stacks/storage": "^4.3.2",
+				"@stacks/transactions": "^4.3.2",
 				"@types/jest": "^26.0.22",
 				"@types/node": "^14.14.43",
 				"assert": "^2.0.0",
@@ -27729,6 +27755,14 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/@types/triplesec/-/triplesec-3.0.1.tgz",
 			"integrity": "sha512-o9E6wYZK2cOSiZR7UxOFYmoGD1k/u+b+i6GmsKyJET+sg/a12vaWnWlp/FqMQ7PFcgLwGyHqkUNppYL8kjmPfg==",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"@types/wif": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@types/wif/-/wif-2.0.2.tgz",
+			"integrity": "sha512-IiIuBeJzlh4LWJ7kVTrX0nwB60OG0vvGTaWC/SgSbVFw7uYUTF6gEuvDZ1goWkeirekJDD58Y8g7NljQh2fNkA==",
 			"requires": {
 				"@types/node": "*"
 			}
@@ -32544,7 +32578,7 @@
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
 			"integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
 			"requires": {
-				"ajv": "^6.12.3",
+				"ajv": "6.12.3",
 				"har-schema": "^2.0.0"
 			}
 		},
@@ -38427,7 +38461,7 @@
 			"integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
 			"requires": {
 				"@types/json-schema": "^7.0.8",
-				"ajv": "^6.12.5",
+				"ajv": "6.12.3",
 				"ajv-keywords": "^3.5.2"
 			}
 		},

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,10 +18,13 @@
     "test:watch": "jest --watch --coverage=false"
   },
   "dependencies": {
+    "@scure/bip32": "^1.1.0",
+    "@scure/bip39": "^1.1.0",
     "@stacks/auth": "^4.3.2",
     "@stacks/blockchain-api-client": "^4.0.1",
     "@stacks/bns": "^4.3.2",
     "@stacks/common": "^4.3.2",
+    "@stacks/encryption": "^4.3.2",
     "@stacks/network": "^4.3.2",
     "@stacks/stacking": "^4.3.2",
     "@stacks/storage": "^4.3.2",
@@ -41,6 +44,7 @@
     "jsontokens": "^3.1.1",
     "node-fetch": "^2.6.0",
     "ripemd160": "^2.0.1",
+    "wif": "^2.0.6",
     "winston": "^3.2.1",
     "zone-file": "^2.0.0-beta.3"
   },
@@ -52,6 +56,7 @@
     "@types/jest": "^26.0.22",
     "@types/node-fetch": "^2.5.0",
     "@types/ripemd160": "^2.0.0",
+    "@types/wif": "^2.0.2",
     "jest": "^26.6.3",
     "jest-fetch-mock": "^3.0.3",
     "jest-module-name-mapper": "^0.1.5",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -6,8 +6,8 @@ import * as fs from 'fs';
 import * as winston from 'winston';
 import cors from 'cors';
 
-import * as crypto from 'crypto';
-import * as bip39 from 'bip39';
+import * as scureBip39 from '@scure/bip39';
+import { wordlist } from '@scure/bip39/wordlists/english';
 import express from 'express';
 import * as path from 'path';
 import { prompt } from 'inquirer';
@@ -322,21 +322,15 @@ async function getStacksWalletKey(network: CLINetworkAdapter, args: string[]): P
  * @mnemonic (string) OPTIONAL; the 12-word phrase
  */
 async function makeKeychain(network: CLINetworkAdapter, args: string[]): Promise<string> {
-  let mnemonic: string;
-  if (args[0]) {
-    mnemonic = await getBackupPhrase(args[0]);
-  } else {
-    // eslint-disable-next-line @typescript-eslint/await-thenable
-    mnemonic = await bip39.generateMnemonic(
-      STX_WALLET_COMPATIBLE_SEED_STRENGTH,
-      crypto.randomBytes
-    );
-  }
+  const mnemonic: string = args[0]
+    ? await getBackupPhrase(args[0])
+    : scureBip39.generateMnemonic(wordlist, STX_WALLET_COMPATIBLE_SEED_STRENGTH);
 
   const derivationPath: string | undefined = args[1] || undefined;
   const stacksKeyInfo = await getStacksWalletKeyInfo(network, mnemonic, derivationPath);
+
   return JSONStringify({
-    mnemonic: mnemonic,
+    mnemonic,
     keyInfo: stacksKeyInfo,
   });
 }

--- a/packages/cli/src/common.ts
+++ b/packages/cli/src/common.ts
@@ -1,8 +1,9 @@
+import { publicKeyToAddress } from '@stacks/encryption';
+import { pubKeyfromPrivKey } from '@stacks/transactions';
+import * as bitcoinjs from 'bitcoinjs-lib';
+import { TransactionSigner } from 'blockstack';
 import { DEFAULT_MAX_ID_SEARCH_INDEX } from './argparse';
 import { CLINetworkAdapter } from './network';
-import * as blockstack from 'blockstack';
-import { TransactionSigner } from 'blockstack';
-import * as bitcoinjs from 'bitcoinjs-lib';
 
 let maxIDSearchIndex = DEFAULT_MAX_ID_SEARCH_INDEX;
 
@@ -46,13 +47,12 @@ export function getPrivateKeyAddress(
   privateKey: string | CLITransactionSigner
 ): string {
   if (isCLITransactionSigner(privateKey)) {
-    const pkts = privateKey;
-    return pkts.address;
-  } else {
-    const pk = privateKey;
-    const ecKeyPair = blockstack.hexStringToECPair(pk);
-    return network.coerceAddress(blockstack.ecPairToAddress(ecKeyPair));
+    return privateKey.address;
   }
+
+  const pubKey = pubKeyfromPrivKey(privateKey);
+  const btcAddress = publicKeyToAddress(pubKey.data);
+  return network.coerceAddress(btcAddress);
 }
 
 export function isCLITransactionSigner(

--- a/packages/cli/tests/fixtures/keys.fixture.ts
+++ b/packages/cli/tests/fixtures/keys.fixture.ts
@@ -24,12 +24,12 @@ export const getOwnerKeyInfo: Array<[string, number, string, OwnerKeyInfoType]> 
     },
   ],
   [
-    'oppose spider rich leader proud foil dish finger fee pipe ethics bundle', // mnemonic
+    'oppose spider rich leader proud foil dish finger fee pipe ethics cable', // mnemonic
     0, // index
     'v0.10-current', // version
     {
-      privateKey: '7e96519d1202ad990a4d1d14c9e8891d9c53b52ce1fd4aa1b4549e5fbc8bfcda01',
-      idAddress: 'ID-1FwnbMXxFMxiAFxXV7fKcZn5dB4y6hSkxY',
+      privateKey: 'd98c5f09b826f7f7b543055bdd25197ca08a6cbedbb80f8f5060645274a0704201',
+      idAddress: 'ID-1D6kMXjiSDmNt6hwFPUkeHnFtdUgSoPE1e',
       version: 'v0.10-current',
       index: 0,
     },
@@ -48,8 +48,8 @@ export const findIdentityIndex: Array<[string, string, number]> = [
     1, // index
   ],
   [
-    'oppose spider rich leader proud foil dish finger fee pipe ethics bundle', // mnemonic
-    'ID-1FwnbMXxFMxiAFxXV7fKcZn5dB4y6hSkxY',
+    'oppose spider rich leader proud foil dish finger fee pipe ethics cable', // mnemonic
+    'ID-1D6kMXjiSDmNt6hwFPUkeHnFtdUgSoPE1e',
     0, // index
   ],
 ];

--- a/packages/cli/tests/keys.test.ts
+++ b/packages/cli/tests/keys.test.ts
@@ -25,12 +25,15 @@ test('getStacksWalletKeyInfo', async () => {
 });
 
 describe('getStacksWalletKeyInfo custom derivation path', () => {
-  test.each(keyInfoTests)('%#', async (derivationPath: string, keyInfoResult: WalletKeyInfoResult)  => {
-    const mnemonic = 'apart spin rich leader siren foil dish sausage fee pipe ethics bundle';
-    const info = await getStacksWalletKeyInfo(mainnetNetwork, mnemonic, derivationPath);
+  test.each(keyInfoTests)(
+    '%#',
+    async (derivationPath: string, keyInfoResult: WalletKeyInfoResult) => {
+      const mnemonic = 'apart spin rich leader siren foil dish sausage fee pipe ethics bundle';
+      const info = await getStacksWalletKeyInfo(mainnetNetwork, mnemonic, derivationPath);
 
-    expect(info).toEqual(keyInfoResult);
-  });
+      expect(info).toEqual(keyInfoResult);
+    }
+  );
 });
 
 describe('getOwnerKeyInfo', () => {

--- a/packages/encryption/package.json
+++ b/packages/encryption/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@noble/hashes": "^1.0.0",
     "@noble/secp256k1": "^1.5.5",
-    "@scure/bip39": "^1.0.0",
+    "@scure/bip39": "^1.1.0",
     "@stacks/common": "^4.3.2",
     "@types/node": "^14.14.43",
     "bs58": "^5.0.0",

--- a/packages/encryption/src/hashRipemd160.ts
+++ b/packages/encryption/src/hashRipemd160.ts
@@ -1,6 +1,5 @@
 import { Buffer } from '@stacks/common';
 import Ripemd160Polyfill from 'ripemd160-min';
-import { isNodeCryptoAvailable } from './cryptoUtils';
 
 type NodeCryptoCreateHash = typeof import('crypto').createHash;
 
@@ -47,17 +46,17 @@ export class NodeCryptoRipemd160Digest implements Ripemd160Digest {
 }
 
 export function createHashRipemd160() {
-  const nodeCryptoCreateHash = isNodeCryptoAvailable(nodeCrypto => {
-    if (typeof nodeCrypto.createHash === 'function') {
-      return nodeCrypto.createHash;
-    }
-    return false;
-  });
-  if (nodeCryptoCreateHash) {
-    return new NodeCryptoRipemd160Digest(nodeCryptoCreateHash);
-  } else {
-    return new Ripemd160PolyfillDigest();
-  }
+  // // disable node hashRipemd160, because it doesn't work with node 17,18 openSSL
+  // const nodeCryptoCreateHash = isNodeCryptoAvailable(nodeCrypto => {
+  //   if (typeof nodeCrypto.createHash === 'function') {
+  //     return nodeCrypto.createHash;
+  //   }
+  //   return false;
+  // });
+  // if (nodeCryptoCreateHash) {
+  //   return new NodeCryptoRipemd160Digest(nodeCryptoCreateHash);
+  // } else {
+  return new Ripemd160PolyfillDigest();
 }
 
 export function hashRipemd160(data: Buffer) {

--- a/packages/encryption/src/keys.ts
+++ b/packages/encryption/src/keys.ts
@@ -75,11 +75,24 @@ export function base58CheckEncode(version: number, hash: Buffer) {
 
 /**
  * @ignore
+ * @deprecated Use {@link publicKeyToBtcAddress} instead
  */
 export function publicKeyToAddress(publicKey: string | Buffer) {
   const publicKeyBuffer = Buffer.isBuffer(publicKey) ? publicKey : Buffer.from(publicKey, 'hex');
   const publicKeyHash160 = hashRipemd160(hashSha256Sync(publicKeyBuffer));
   return base58CheckEncode(BITCOIN_PUBKEYHASH, publicKeyHash160);
+}
+
+/**
+ * @ignore
+ */
+export function publicKeyToBtcAddress(
+  publicKey: string | Buffer,
+  version: number = BITCOIN_PUBKEYHASH
+) {
+  const publicKeyBuffer = Buffer.isBuffer(publicKey) ? publicKey : Buffer.from(publicKey, 'hex');
+  const publicKeyHash160 = hashRipemd160(hashSha256Sync(publicKeyBuffer));
+  return base58CheckEncode(version, publicKeyHash160);
 }
 
 /**

--- a/packages/encryption/tests/encryption.test.ts
+++ b/packages/encryption/tests/encryption.test.ts
@@ -47,29 +47,30 @@ test('ripemd160 digest tests', async () => {
     ['message digest', '5d0689ef49d2fae572b881b123a85ffa21595f36'],
     ['', '9c1185a5c5e9fc54612808977ee8f548b2258d31'],
   ];
-  const nodeCryptoHasher = await ripemd160.createHashRipemd160();
-  expect(nodeCryptoHasher instanceof ripemd160.NodeCryptoRipemd160Digest).toEqual(true);
+  const nodeCryptoHasher = ripemd160.createHashRipemd160();
+  expect(nodeCryptoHasher instanceof ripemd160.NodeCryptoRipemd160Digest).toEqual(false); // node crpyto hashRipemd160 disabled
 
   for (const [input, expected] of vectors) {
-    const result = await nodeCryptoHasher.digest(Buffer.from(input));
+    const result = nodeCryptoHasher.digest(Buffer.from(input));
     const resultHex = result.toString('hex');
     expect(resultHex).toEqual(expected);
   }
 
   const polyfillHasher = new ripemd160.Ripemd160PolyfillDigest();
   for (const [input, expected] of vectors) {
-    const result = await polyfillHasher.digest(Buffer.from(input));
+    const result = polyfillHasher.digest(Buffer.from(input));
     const resultHex = result.toString('hex');
     expect(resultHex).toEqual(expected);
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
   const nodeCrypto = require('crypto');
   const createHashOrig = nodeCrypto.createHash;
   nodeCrypto.createHash = () => {
     throw new Error('Artificial broken hash');
   };
   try {
-    await ripemd160.hashRipemd160(Buffer.from('acb'));
+    ripemd160.hashRipemd160(Buffer.from('acb'));
   } finally {
     nodeCrypto.createHash = createHashOrig;
   }

--- a/packages/wallet-sdk/package.json
+++ b/packages/wallet-sdk/package.json
@@ -29,8 +29,8 @@
     "typecheck:watch": "npm run typecheck -- --watch"
   },
   "dependencies": {
-    "@scure/bip32": "^1.0.1",
-    "@scure/bip39": "^1.0.0",
+    "@scure/bip32": "^1.1.0",
+    "@scure/bip39": "^1.1.0",
     "@stacks/auth": "^4.3.2",
     "@stacks/common": "^4.3.2",
     "@stacks/encryption": "^4.3.2",

--- a/packages/wallet-sdk/tests/derive-keychain.test.ts
+++ b/packages/wallet-sdk/tests/derive-keychain.test.ts
@@ -244,6 +244,9 @@ test('fetch username defaults to mainnet', async () => {
 });
 
 test('Verify compatibility between @scure/bip32 and bip32 dependency', () => {
+  // !!! Test currently fails for node v18 !!!
+  // todo: remove test and BIP32Interface backwards compatibility in next major release
+
   // Consider a root key in base58 format
   const root =
     'xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi';


### PR DESCRIPTION
- migrate to scure-bip32 where possible
- disable node `hashRipemd160` (broken in current stable node, requires legacy openssl flags)
- fix faulty tests (invalid mnemonic used prior)