### PR TITLE
fix(encryption): change message signing prefix

### DIFF
--- a/.github/MIGRATION.md
+++ b/.github/MIGRATION.md
@@ -3,6 +3,7 @@
 - [Stacks.js (&lt;=4.x.x) → (5.x.x)](#stacksjs-4xx--5xx)
   - [Breaking Changes](#breaking-changes)
     - [Buffer to Uint8Array](#buffer-to-uint8array)
+    - [Message Signing Prefix](#message-signing-prefix)
 - [blockstack.js → Stacks.js (1.x.x)](#blockstackjs--stacksjs-1xx)
   - [Auth](#auth)
   - [Using blockstack.js](#using-blockstackjs)
@@ -18,7 +19,8 @@
 
 ### Breaking Changes
 
-- To reduce the bundle sizes of applications using Stacks.js we are switching from Buffer (a polyfill to match Node.js APIs) to Uint8Arrays (which Buffers use in the background anyway). [Read more...](#buffer-to-uint8array)
+- To reduce the bundle sizes of applications using Stacks.js, we are switching from Buffer (a polyfill to match Node.js APIs) to Uint8Arrays (which Buffers use in the background anyway). [Read more...](#buffer-to-uint8array)
+- To allow message signing on Ledger hardware wallets, we are changing the message signing prefix. [Read more...]
 
 #### Buffer to Uint8Array
 
@@ -54,6 +56,14 @@ hexToBytes('deadbeef'); // Uint8Array(4) [ 222, 173, 190, 239 ]
 Buffer.from([222, 173, 190, 239]).toString('hex'); // 'deadbeef'
 bytesToHex(Uint8Array.from([222, 173, 190, 239])); // 'deadbeef'
 ```
+
+#### Message Signing Prefix
+
+The message signing prefix was changed from `Stacks Message Signing` to `Stacks Signed Message`.
+The change relates to the functions `verifyMessageSignature`, `encodeMessage`, `decodeMessage`, and `hashMessage`.
+The `verifyMessageSignature` functions was updated to verify against both the old and the new prefix (for unhashed message-input).
+This will generate a different hash/signature from the same input compared to previous versions of Stacks.js.
+If you have previously stored messages/signatures and compare to freshly generated ones, the messages/signatures will not match to previously stored.
 
 ---
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - master
     tags-ignore:
-      - "**"
+      - '**'
 
   workflow_call:
   workflow_dispatch:
@@ -18,10 +18,12 @@ jobs:
         with:
           node-version: 16
           cache: npm
+
       - run: npm ci
 
       - name: Bootstrap lerna
         run: npm run bootstrap
+
       - name: Check bootstrap
         run: |
           if [[ -n $(git status -s) ]]; then
@@ -33,8 +35,10 @@ jobs:
 
       - name: Run lint
         run: npm run lint
+
       - name: Run typecheck
         run: npm run typecheck
+
       - name: Check for circular dependencies
         run: npm run madge
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21882,8 +21882,7 @@
     },
     "packages/auth/node_modules/jsontokens": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-      "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
+      "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.1.2",
         "@noble/secp256k1": "^1.6.3",
@@ -22015,8 +22014,7 @@
     },
     "packages/cli/node_modules/c32check": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/c32check/-/c32check-2.0.0.tgz",
-      "integrity": "sha512-rpwfAcS/CMqo0oCqDf3r9eeLgScRE3l/xHDCXhM3UyrfvIn7PrLq63uHh7yYbv8NzaZn5MVsVhIRpQ+5GZ5HyA==",
+      "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.1.2",
         "base-x": "^4.0.0"
@@ -22027,8 +22025,7 @@
     },
     "packages/cli/node_modules/jsontokens": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-      "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
+      "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.1.2",
         "@noble/secp256k1": "^1.6.3",
@@ -22097,17 +22094,13 @@
     },
     "packages/encryption/node_modules/jsontokens": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-      "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.1.2",
         "@noble/secp256k1": "^1.6.3",
         "base64-js": "^1.5.1"
       }
-    },
-    "packages/keychain": {
-      "extraneous": true
     },
     "packages/network": {
       "name": "@stacks/network",
@@ -22168,8 +22161,7 @@
     },
     "packages/profile/node_modules/jsontokens": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-      "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
+      "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.1.2",
         "@noble/secp256k1": "^1.6.3",
@@ -22259,8 +22251,7 @@
     },
     "packages/storage/node_modules/jsontokens": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-      "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
+      "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.1.2",
         "@noble/secp256k1": "^1.6.3",
@@ -22309,8 +22300,7 @@
     },
     "packages/transactions/node_modules/c32check": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/c32check/-/c32check-2.0.0.tgz",
-      "integrity": "sha512-rpwfAcS/CMqo0oCqDf3r9eeLgScRE3l/xHDCXhM3UyrfvIn7PrLq63uHh7yYbv8NzaZn5MVsVhIRpQ+5GZ5HyA==",
+      "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.1.2",
         "base-x": "^4.0.0"
@@ -22381,8 +22371,7 @@
     },
     "packages/wallet-sdk/node_modules/c32check": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/c32check/-/c32check-2.0.0.tgz",
-      "integrity": "sha512-rpwfAcS/CMqo0oCqDf3r9eeLgScRE3l/xHDCXhM3UyrfvIn7PrLq63uHh7yYbv8NzaZn5MVsVhIRpQ+5GZ5HyA==",
+      "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.1.2",
         "base-x": "^4.0.0"
@@ -22393,8 +22382,7 @@
     },
     "packages/wallet-sdk/node_modules/jsontokens": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-      "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
+      "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.1.2",
         "@noble/secp256k1": "^1.6.3",
@@ -25582,8 +25570,6 @@
             },
             "jsontokens": {
               "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-              "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
               "dev": true,
               "requires": {
                 "@noble/hashes": "^1.1.2",
@@ -25778,8 +25764,6 @@
                     },
                     "jsontokens": {
                       "version": "4.0.1",
-                      "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-                      "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
                       "dev": true,
                       "requires": {
                         "@noble/hashes": "^1.1.2",
@@ -25822,8 +25806,6 @@
                 },
                 "c32check": {
                   "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/c32check/-/c32check-2.0.0.tgz",
-                  "integrity": "sha512-rpwfAcS/CMqo0oCqDf3r9eeLgScRE3l/xHDCXhM3UyrfvIn7PrLq63uHh7yYbv8NzaZn5MVsVhIRpQ+5GZ5HyA==",
                   "requires": {
                     "@noble/hashes": "^1.1.2",
                     "base-x": "^4.0.0"
@@ -25833,8 +25815,6 @@
             },
             "jsontokens": {
               "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-              "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
               "requires": {
                 "@noble/hashes": "^1.1.2",
                 "@noble/secp256k1": "^1.6.3",
@@ -25845,8 +25825,6 @@
         },
         "jsontokens": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-          "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
           "requires": {
             "@noble/hashes": "^1.1.2",
             "@noble/secp256k1": "^1.6.3",
@@ -26017,8 +25995,6 @@
                 },
                 "jsontokens": {
                   "version": "4.0.1",
-                  "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-                  "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
                   "dev": true,
                   "requires": {
                     "@noble/hashes": "^1.1.2",
@@ -26061,8 +26037,6 @@
             },
             "c32check": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/c32check/-/c32check-2.0.0.tgz",
-              "integrity": "sha512-rpwfAcS/CMqo0oCqDf3r9eeLgScRE3l/xHDCXhM3UyrfvIn7PrLq63uHh7yYbv8NzaZn5MVsVhIRpQ+5GZ5HyA==",
               "requires": {
                 "@noble/hashes": "^1.1.2",
                 "base-x": "^4.0.0"
@@ -26204,8 +26178,6 @@
                 },
                 "jsontokens": {
                   "version": "4.0.1",
-                  "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-                  "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
                   "dev": true,
                   "requires": {
                     "@noble/hashes": "^1.1.2",
@@ -26400,8 +26372,6 @@
                         },
                         "jsontokens": {
                           "version": "4.0.1",
-                          "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-                          "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
                           "dev": true,
                           "requires": {
                             "@noble/hashes": "^1.1.2",
@@ -26444,8 +26414,6 @@
                     },
                     "c32check": {
                       "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/c32check/-/c32check-2.0.0.tgz",
-                      "integrity": "sha512-rpwfAcS/CMqo0oCqDf3r9eeLgScRE3l/xHDCXhM3UyrfvIn7PrLq63uHh7yYbv8NzaZn5MVsVhIRpQ+5GZ5HyA==",
                       "requires": {
                         "@noble/hashes": "^1.1.2",
                         "base-x": "^4.0.0"
@@ -26455,8 +26423,6 @@
                 },
                 "jsontokens": {
                   "version": "4.0.1",
-                  "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-                  "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
                   "requires": {
                     "@noble/hashes": "^1.1.2",
                     "@noble/secp256k1": "^1.6.3",
@@ -26467,8 +26433,6 @@
             },
             "jsontokens": {
               "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-              "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
               "requires": {
                 "@noble/hashes": "^1.1.2",
                 "@noble/secp256k1": "^1.6.3",
@@ -26627,8 +26591,6 @@
                     },
                     "jsontokens": {
                       "version": "4.0.1",
-                      "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-                      "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
                       "dev": true,
                       "requires": {
                         "@noble/hashes": "^1.1.2",
@@ -26671,8 +26633,6 @@
                 },
                 "c32check": {
                   "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/c32check/-/c32check-2.0.0.tgz",
-                  "integrity": "sha512-rpwfAcS/CMqo0oCqDf3r9eeLgScRE3l/xHDCXhM3UyrfvIn7PrLq63uHh7yYbv8NzaZn5MVsVhIRpQ+5GZ5HyA==",
                   "requires": {
                     "@noble/hashes": "^1.1.2",
                     "base-x": "^4.0.0"
@@ -26747,8 +26707,6 @@
             },
             "jsontokens": {
               "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-              "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
               "dev": true,
               "requires": {
                 "@noble/hashes": "^1.1.2",
@@ -26873,8 +26831,6 @@
                 },
                 "jsontokens": {
                   "version": "4.0.1",
-                  "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-                  "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
                   "dev": true,
                   "requires": {
                     "@noble/hashes": "^1.1.2",
@@ -27004,8 +26960,6 @@
                     },
                     "jsontokens": {
                       "version": "4.0.1",
-                      "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-                      "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
                       "dev": true,
                       "requires": {
                         "@noble/hashes": "^1.1.2",
@@ -27048,8 +27002,6 @@
                 },
                 "c32check": {
                   "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/c32check/-/c32check-2.0.0.tgz",
-                  "integrity": "sha512-rpwfAcS/CMqo0oCqDf3r9eeLgScRE3l/xHDCXhM3UyrfvIn7PrLq63uHh7yYbv8NzaZn5MVsVhIRpQ+5GZ5HyA==",
                   "requires": {
                     "@noble/hashes": "^1.1.2",
                     "base-x": "^4.0.0"
@@ -27164,8 +27116,6 @@
                     },
                     "jsontokens": {
                       "version": "4.0.1",
-                      "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-                      "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
                       "dev": true,
                       "requires": {
                         "@noble/hashes": "^1.1.2",
@@ -27360,8 +27310,6 @@
                             },
                             "jsontokens": {
                               "version": "4.0.1",
-                              "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-                              "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
                               "dev": true,
                               "requires": {
                                 "@noble/hashes": "^1.1.2",
@@ -27404,8 +27352,6 @@
                         },
                         "c32check": {
                           "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/c32check/-/c32check-2.0.0.tgz",
-                          "integrity": "sha512-rpwfAcS/CMqo0oCqDf3r9eeLgScRE3l/xHDCXhM3UyrfvIn7PrLq63uHh7yYbv8NzaZn5MVsVhIRpQ+5GZ5HyA==",
                           "requires": {
                             "@noble/hashes": "^1.1.2",
                             "base-x": "^4.0.0"
@@ -27415,8 +27361,6 @@
                     },
                     "jsontokens": {
                       "version": "4.0.1",
-                      "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-                      "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
                       "requires": {
                         "@noble/hashes": "^1.1.2",
                         "@noble/secp256k1": "^1.6.3",
@@ -27427,8 +27371,6 @@
                 },
                 "jsontokens": {
                   "version": "4.0.1",
-                  "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-                  "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
                   "requires": {
                     "@noble/hashes": "^1.1.2",
                     "@noble/secp256k1": "^1.6.3",
@@ -27502,8 +27444,6 @@
                 },
                 "jsontokens": {
                   "version": "4.0.1",
-                  "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-                  "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
                   "dev": true,
                   "requires": {
                     "@noble/hashes": "^1.1.2",
@@ -27546,8 +27486,6 @@
             },
             "jsontokens": {
               "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-              "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
               "requires": {
                 "@noble/hashes": "^1.1.2",
                 "@noble/secp256k1": "^1.6.3",
@@ -27645,8 +27583,6 @@
                 },
                 "jsontokens": {
                   "version": "4.0.1",
-                  "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-                  "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
                   "dev": true,
                   "requires": {
                     "@noble/hashes": "^1.1.2",
@@ -27689,8 +27625,6 @@
             },
             "c32check": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/c32check/-/c32check-2.0.0.tgz",
-              "integrity": "sha512-rpwfAcS/CMqo0oCqDf3r9eeLgScRE3l/xHDCXhM3UyrfvIn7PrLq63uHh7yYbv8NzaZn5MVsVhIRpQ+5GZ5HyA==",
               "requires": {
                 "@noble/hashes": "^1.1.2",
                 "base-x": "^4.0.0"
@@ -27810,8 +27744,6 @@
                     },
                     "jsontokens": {
                       "version": "4.0.1",
-                      "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-                      "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
                       "dev": true,
                       "requires": {
                         "@noble/hashes": "^1.1.2",
@@ -28006,8 +27938,6 @@
                             },
                             "jsontokens": {
                               "version": "4.0.1",
-                              "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-                              "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
                               "dev": true,
                               "requires": {
                                 "@noble/hashes": "^1.1.2",
@@ -28050,8 +27980,6 @@
                         },
                         "c32check": {
                           "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/c32check/-/c32check-2.0.0.tgz",
-                          "integrity": "sha512-rpwfAcS/CMqo0oCqDf3r9eeLgScRE3l/xHDCXhM3UyrfvIn7PrLq63uHh7yYbv8NzaZn5MVsVhIRpQ+5GZ5HyA==",
                           "requires": {
                             "@noble/hashes": "^1.1.2",
                             "base-x": "^4.0.0"
@@ -28061,8 +27989,6 @@
                     },
                     "jsontokens": {
                       "version": "4.0.1",
-                      "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-                      "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
                       "requires": {
                         "@noble/hashes": "^1.1.2",
                         "@noble/secp256k1": "^1.6.3",
@@ -28073,8 +27999,6 @@
                 },
                 "jsontokens": {
                   "version": "4.0.1",
-                  "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-                  "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
                   "requires": {
                     "@noble/hashes": "^1.1.2",
                     "@noble/secp256k1": "^1.6.3",
@@ -28148,8 +28072,6 @@
                 },
                 "jsontokens": {
                   "version": "4.0.1",
-                  "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-                  "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
                   "dev": true,
                   "requires": {
                     "@noble/hashes": "^1.1.2",
@@ -28344,8 +28266,6 @@
                         },
                         "jsontokens": {
                           "version": "4.0.1",
-                          "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-                          "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
                           "dev": true,
                           "requires": {
                             "@noble/hashes": "^1.1.2",
@@ -28388,8 +28308,6 @@
                     },
                     "c32check": {
                       "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/c32check/-/c32check-2.0.0.tgz",
-                      "integrity": "sha512-rpwfAcS/CMqo0oCqDf3r9eeLgScRE3l/xHDCXhM3UyrfvIn7PrLq63uHh7yYbv8NzaZn5MVsVhIRpQ+5GZ5HyA==",
                       "requires": {
                         "@noble/hashes": "^1.1.2",
                         "base-x": "^4.0.0"
@@ -28399,8 +28317,6 @@
                 },
                 "jsontokens": {
                   "version": "4.0.1",
-                  "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-                  "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
                   "requires": {
                     "@noble/hashes": "^1.1.2",
                     "@noble/secp256k1": "^1.6.3",
@@ -28514,8 +28430,6 @@
                         },
                         "jsontokens": {
                           "version": "4.0.1",
-                          "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-                          "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
                           "dev": true,
                           "requires": {
                             "@noble/hashes": "^1.1.2",
@@ -28710,8 +28624,6 @@
                                 },
                                 "jsontokens": {
                                   "version": "4.0.1",
-                                  "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-                                  "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
                                   "dev": true,
                                   "requires": {
                                     "@noble/hashes": "^1.1.2",
@@ -28754,8 +28666,6 @@
                             },
                             "c32check": {
                               "version": "2.0.0",
-                              "resolved": "https://registry.npmjs.org/c32check/-/c32check-2.0.0.tgz",
-                              "integrity": "sha512-rpwfAcS/CMqo0oCqDf3r9eeLgScRE3l/xHDCXhM3UyrfvIn7PrLq63uHh7yYbv8NzaZn5MVsVhIRpQ+5GZ5HyA==",
                               "requires": {
                                 "@noble/hashes": "^1.1.2",
                                 "base-x": "^4.0.0"
@@ -28765,8 +28675,6 @@
                         },
                         "jsontokens": {
                           "version": "4.0.1",
-                          "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-                          "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
                           "requires": {
                             "@noble/hashes": "^1.1.2",
                             "@noble/secp256k1": "^1.6.3",
@@ -28777,8 +28685,6 @@
                     },
                     "jsontokens": {
                       "version": "4.0.1",
-                      "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-                      "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
                       "requires": {
                         "@noble/hashes": "^1.1.2",
                         "@noble/secp256k1": "^1.6.3",
@@ -28852,8 +28758,6 @@
                     },
                     "jsontokens": {
                       "version": "4.0.1",
-                      "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-                      "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
                       "dev": true,
                       "requires": {
                         "@noble/hashes": "^1.1.2",
@@ -28896,8 +28800,6 @@
                 },
                 "jsontokens": {
                   "version": "4.0.1",
-                  "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-                  "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
                   "requires": {
                     "@noble/hashes": "^1.1.2",
                     "@noble/secp256k1": "^1.6.3",
@@ -28995,8 +28897,6 @@
                     },
                     "jsontokens": {
                       "version": "4.0.1",
-                      "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-                      "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
                       "dev": true,
                       "requires": {
                         "@noble/hashes": "^1.1.2",
@@ -29039,8 +28939,6 @@
                 },
                 "c32check": {
                   "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/c32check/-/c32check-2.0.0.tgz",
-                  "integrity": "sha512-rpwfAcS/CMqo0oCqDf3r9eeLgScRE3l/xHDCXhM3UyrfvIn7PrLq63uHh7yYbv8NzaZn5MVsVhIRpQ+5GZ5HyA==",
                   "requires": {
                     "@noble/hashes": "^1.1.2",
                     "base-x": "^4.0.0"
@@ -29050,8 +28948,6 @@
             },
             "c32check": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/c32check/-/c32check-2.0.0.tgz",
-              "integrity": "sha512-rpwfAcS/CMqo0oCqDf3r9eeLgScRE3l/xHDCXhM3UyrfvIn7PrLq63uHh7yYbv8NzaZn5MVsVhIRpQ+5GZ5HyA==",
               "requires": {
                 "@noble/hashes": "^1.1.2",
                 "base-x": "^4.0.0"
@@ -29059,8 +28955,6 @@
             },
             "jsontokens": {
               "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-              "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
               "requires": {
                 "@noble/hashes": "^1.1.2",
                 "@noble/secp256k1": "^1.6.3",
@@ -29071,8 +28965,6 @@
         },
         "c32check": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/c32check/-/c32check-2.0.0.tgz",
-          "integrity": "sha512-rpwfAcS/CMqo0oCqDf3r9eeLgScRE3l/xHDCXhM3UyrfvIn7PrLq63uHh7yYbv8NzaZn5MVsVhIRpQ+5GZ5HyA==",
           "requires": {
             "@noble/hashes": "^1.1.2",
             "base-x": "^4.0.0"
@@ -29080,8 +28972,6 @@
         },
         "jsontokens": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-          "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
           "requires": {
             "@noble/hashes": "^1.1.2",
             "@noble/secp256k1": "^1.6.3",
@@ -29155,8 +29045,6 @@
         },
         "jsontokens": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-          "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
           "dev": true,
           "requires": {
             "@noble/hashes": "^1.1.2",
@@ -29628,8 +29516,6 @@
                 },
                 "jsontokens": {
                   "version": "4.0.1",
-                  "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-                  "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
                   "dev": true,
                   "requires": {
                     "@noble/hashes": "^1.1.2",
@@ -29672,8 +29558,6 @@
             },
             "c32check": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/c32check/-/c32check-2.0.0.tgz",
-              "integrity": "sha512-rpwfAcS/CMqo0oCqDf3r9eeLgScRE3l/xHDCXhM3UyrfvIn7PrLq63uHh7yYbv8NzaZn5MVsVhIRpQ+5GZ5HyA==",
               "requires": {
                 "@noble/hashes": "^1.1.2",
                 "base-x": "^4.0.0"
@@ -29683,8 +29567,6 @@
         },
         "jsontokens": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-          "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
           "requires": {
             "@noble/hashes": "^1.1.2",
             "@noble/secp256k1": "^1.6.3",
@@ -29777,8 +29659,6 @@
             },
             "jsontokens": {
               "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-              "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
               "dev": true,
               "requires": {
                 "@noble/hashes": "^1.1.2",
@@ -29908,8 +29788,6 @@
                 },
                 "jsontokens": {
                   "version": "4.0.1",
-                  "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-                  "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
                   "dev": true,
                   "requires": {
                     "@noble/hashes": "^1.1.2",
@@ -29952,8 +29830,6 @@
             },
             "c32check": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/c32check/-/c32check-2.0.0.tgz",
-              "integrity": "sha512-rpwfAcS/CMqo0oCqDf3r9eeLgScRE3l/xHDCXhM3UyrfvIn7PrLq63uHh7yYbv8NzaZn5MVsVhIRpQ+5GZ5HyA==",
               "requires": {
                 "@noble/hashes": "^1.1.2",
                 "base-x": "^4.0.0"
@@ -30071,8 +29947,6 @@
                 },
                 "jsontokens": {
                   "version": "4.0.1",
-                  "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-                  "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
                   "dev": true,
                   "requires": {
                     "@noble/hashes": "^1.1.2",
@@ -30267,8 +30141,6 @@
                         },
                         "jsontokens": {
                           "version": "4.0.1",
-                          "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-                          "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
                           "dev": true,
                           "requires": {
                             "@noble/hashes": "^1.1.2",
@@ -30311,8 +30183,6 @@
                     },
                     "c32check": {
                       "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/c32check/-/c32check-2.0.0.tgz",
-                      "integrity": "sha512-rpwfAcS/CMqo0oCqDf3r9eeLgScRE3l/xHDCXhM3UyrfvIn7PrLq63uHh7yYbv8NzaZn5MVsVhIRpQ+5GZ5HyA==",
                       "requires": {
                         "@noble/hashes": "^1.1.2",
                         "base-x": "^4.0.0"
@@ -30322,8 +30192,6 @@
                 },
                 "jsontokens": {
                   "version": "4.0.1",
-                  "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-                  "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
                   "requires": {
                     "@noble/hashes": "^1.1.2",
                     "@noble/secp256k1": "^1.6.3",
@@ -30334,8 +30202,6 @@
             },
             "jsontokens": {
               "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-              "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
               "requires": {
                 "@noble/hashes": "^1.1.2",
                 "@noble/secp256k1": "^1.6.3",
@@ -30409,8 +30275,6 @@
             },
             "jsontokens": {
               "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-              "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
               "dev": true,
               "requires": {
                 "@noble/hashes": "^1.1.2",
@@ -30453,8 +30317,6 @@
         },
         "jsontokens": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-          "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
           "requires": {
             "@noble/hashes": "^1.1.2",
             "@noble/secp256k1": "^1.6.3",
@@ -30552,8 +30414,6 @@
             },
             "jsontokens": {
               "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-              "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
               "dev": true,
               "requires": {
                 "@noble/hashes": "^1.1.2",
@@ -30596,8 +30456,6 @@
         },
         "c32check": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/c32check/-/c32check-2.0.0.tgz",
-          "integrity": "sha512-rpwfAcS/CMqo0oCqDf3r9eeLgScRE3l/xHDCXhM3UyrfvIn7PrLq63uHh7yYbv8NzaZn5MVsVhIRpQ+5GZ5HyA==",
           "requires": {
             "@noble/hashes": "^1.1.2",
             "base-x": "^4.0.0"
@@ -30717,8 +30575,6 @@
                 },
                 "jsontokens": {
                   "version": "4.0.1",
-                  "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-                  "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
                   "dev": true,
                   "requires": {
                     "@noble/hashes": "^1.1.2",
@@ -30913,8 +30769,6 @@
                         },
                         "jsontokens": {
                           "version": "4.0.1",
-                          "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-                          "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
                           "dev": true,
                           "requires": {
                             "@noble/hashes": "^1.1.2",
@@ -30957,8 +30811,6 @@
                     },
                     "c32check": {
                       "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/c32check/-/c32check-2.0.0.tgz",
-                      "integrity": "sha512-rpwfAcS/CMqo0oCqDf3r9eeLgScRE3l/xHDCXhM3UyrfvIn7PrLq63uHh7yYbv8NzaZn5MVsVhIRpQ+5GZ5HyA==",
                       "requires": {
                         "@noble/hashes": "^1.1.2",
                         "base-x": "^4.0.0"
@@ -30968,8 +30820,6 @@
                 },
                 "jsontokens": {
                   "version": "4.0.1",
-                  "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-                  "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
                   "requires": {
                     "@noble/hashes": "^1.1.2",
                     "@noble/secp256k1": "^1.6.3",
@@ -30980,8 +30830,6 @@
             },
             "jsontokens": {
               "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-              "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
               "requires": {
                 "@noble/hashes": "^1.1.2",
                 "@noble/secp256k1": "^1.6.3",
@@ -31055,8 +30903,6 @@
             },
             "jsontokens": {
               "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-              "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
               "dev": true,
               "requires": {
                 "@noble/hashes": "^1.1.2",
@@ -31251,8 +31097,6 @@
                     },
                     "jsontokens": {
                       "version": "4.0.1",
-                      "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-                      "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
                       "dev": true,
                       "requires": {
                         "@noble/hashes": "^1.1.2",
@@ -31295,8 +31139,6 @@
                 },
                 "c32check": {
                   "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/c32check/-/c32check-2.0.0.tgz",
-                  "integrity": "sha512-rpwfAcS/CMqo0oCqDf3r9eeLgScRE3l/xHDCXhM3UyrfvIn7PrLq63uHh7yYbv8NzaZn5MVsVhIRpQ+5GZ5HyA==",
                   "requires": {
                     "@noble/hashes": "^1.1.2",
                     "base-x": "^4.0.0"
@@ -31306,8 +31148,6 @@
             },
             "jsontokens": {
               "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-              "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
               "requires": {
                 "@noble/hashes": "^1.1.2",
                 "@noble/secp256k1": "^1.6.3",
@@ -31421,8 +31261,6 @@
                     },
                     "jsontokens": {
                       "version": "4.0.1",
-                      "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-                      "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
                       "dev": true,
                       "requires": {
                         "@noble/hashes": "^1.1.2",
@@ -31617,8 +31455,6 @@
                             },
                             "jsontokens": {
                               "version": "4.0.1",
-                              "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-                              "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
                               "dev": true,
                               "requires": {
                                 "@noble/hashes": "^1.1.2",
@@ -31661,8 +31497,6 @@
                         },
                         "c32check": {
                           "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/c32check/-/c32check-2.0.0.tgz",
-                          "integrity": "sha512-rpwfAcS/CMqo0oCqDf3r9eeLgScRE3l/xHDCXhM3UyrfvIn7PrLq63uHh7yYbv8NzaZn5MVsVhIRpQ+5GZ5HyA==",
                           "requires": {
                             "@noble/hashes": "^1.1.2",
                             "base-x": "^4.0.0"
@@ -31672,8 +31506,6 @@
                     },
                     "jsontokens": {
                       "version": "4.0.1",
-                      "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-                      "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
                       "requires": {
                         "@noble/hashes": "^1.1.2",
                         "@noble/secp256k1": "^1.6.3",
@@ -31684,8 +31516,6 @@
                 },
                 "jsontokens": {
                   "version": "4.0.1",
-                  "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-                  "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
                   "requires": {
                     "@noble/hashes": "^1.1.2",
                     "@noble/secp256k1": "^1.6.3",
@@ -31759,8 +31589,6 @@
                 },
                 "jsontokens": {
                   "version": "4.0.1",
-                  "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-                  "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
                   "dev": true,
                   "requires": {
                     "@noble/hashes": "^1.1.2",
@@ -31803,8 +31631,6 @@
             },
             "jsontokens": {
               "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-              "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
               "requires": {
                 "@noble/hashes": "^1.1.2",
                 "@noble/secp256k1": "^1.6.3",
@@ -31902,8 +31728,6 @@
                 },
                 "jsontokens": {
                   "version": "4.0.1",
-                  "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-                  "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
                   "dev": true,
                   "requires": {
                     "@noble/hashes": "^1.1.2",
@@ -31946,8 +31770,6 @@
             },
             "c32check": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/c32check/-/c32check-2.0.0.tgz",
-              "integrity": "sha512-rpwfAcS/CMqo0oCqDf3r9eeLgScRE3l/xHDCXhM3UyrfvIn7PrLq63uHh7yYbv8NzaZn5MVsVhIRpQ+5GZ5HyA==",
               "requires": {
                 "@noble/hashes": "^1.1.2",
                 "base-x": "^4.0.0"
@@ -31957,8 +31779,6 @@
         },
         "c32check": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/c32check/-/c32check-2.0.0.tgz",
-          "integrity": "sha512-rpwfAcS/CMqo0oCqDf3r9eeLgScRE3l/xHDCXhM3UyrfvIn7PrLq63uHh7yYbv8NzaZn5MVsVhIRpQ+5GZ5HyA==",
           "requires": {
             "@noble/hashes": "^1.1.2",
             "base-x": "^4.0.0"
@@ -31966,8 +31786,6 @@
         },
         "jsontokens": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-4.0.1.tgz",
-          "integrity": "sha512-+MO415LEN6M+3FGsRz4wU20g7N2JA+2j9d9+pGaNJHviG4L8N0qzavGyENw6fJqsq9CcrHOIL6iWX5yeTZ86+Q==",
           "requires": {
             "@noble/hashes": "^1.1.2",
             "@noble/secp256k1": "^1.6.3",

--- a/packages/encryption/src/ec.ts
+++ b/packages/encryption/src/ec.ts
@@ -528,14 +528,14 @@ export function verifyMessageSignature({
   // verify() is strict: true by default. High-s signatures are rejected, which mirrors libsecp behavior
   // Set verify options to strict: false, to support the legacy stacks implementations
   // Reference: https://github.com/paulmillr/noble-secp256k1/releases/tag/1.4.0
-  const legacyResult = verify(sig, hashedMsg, publicKey, { strict: false });
+  const verificationResult = verify(sig, hashedMsg, publicKey, { strict: false });
 
-  // Temporary Additional Check ++++++++++++++++++++++++++++++++++++++++++++++++
-  if (legacyResult || typeof message !== 'string') return legacyResult;
+  // Additional Check for Legacy Prefix ++++++++++++++++++++++++++++++++++++++++
+  if (verificationResult || typeof message !== 'string') return verificationResult;
 
-  const FUTURE_PREFIX = '\x17Stacks Signed Message:\n';
-  const futureHash = Buffer.from(sha256(encodeMessage(message, FUTURE_PREFIX)));
-  return verify(sig, futureHash, publicKey, { strict: false });
+  const LEGACY_PREFIX = '\x18Stacks Message Signing:\n';
+  const legacyHash = sha256(encodeMessage(message, LEGACY_PREFIX));
+  return verify(sig, legacyHash, publicKey, { strict: false });
   // +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 }
 

--- a/packages/encryption/src/messageSignature.ts
+++ b/packages/encryption/src/messageSignature.ts
@@ -2,9 +2,9 @@ import { sha256 } from '@noble/hashes/sha256';
 import { concatBytes, utf8ToBytes } from '@stacks/common';
 import { decode, encode, encodingLength } from './varuint';
 
-// 'Stacks Message Signing:\n'.length //  = 24
-// 'Stacks Message Signing:\n'.length.toString(16) //  = 18
-const chainPrefix: string = '\x18Stacks Message Signing:\n';
+// 'Stacks Signed Message:\n'.length === 23
+// 'Stacks Signed Message:\n'.length.toString(16) === 17
+const chainPrefix = '\x17Stacks Signed Message:\n';
 
 export function hashMessage(message: string, prefix: string = chainPrefix): Uint8Array {
   return sha256(encodeMessage(message, prefix));
@@ -23,8 +23,7 @@ export function decodeMessage(
   encodedMessage: Uint8Array,
   prefix: string = chainPrefix
 ): Uint8Array {
-  // Remove the chain prefix: 1 for the varint and 24 for the length of the string
-  // 'Stacks Message Signing:\n'
+  // Remove the chain prefix
   const prefixByteLength = utf8ToBytes(prefix).byteLength;
   const messageWithoutChainPrefix = encodedMessage.subarray(prefixByteLength);
   const decoded = decode(messageWithoutChainPrefix);

--- a/packages/encryption/tests/messageSignature.test.ts
+++ b/packages/encryption/tests/messageSignature.test.ts
@@ -3,14 +3,14 @@ import { decodeMessage, encodeMessage, hashMessage } from '../src/messageSignatu
 
 test('encodeMessage / decodeMessage', () => {
   // array of messages and their expected encoded message
-  const testVectors = [
-    ['hello world', '\x18Stacks Message Signing:\n\x0bhello world'],
-    ['', '\x18Stacks Message Signing:\n\x00'],
+  const messages = [
+    ['hello world', '\x17Stacks Signed Message:\n\x0bhello world'],
+    ['', '\x17Stacks Signed Message:\n\x00'],
     // Longer message (to test a different length for the var_int prefix)
     [
       'This is a really long message to test the var_int prefix This is a really long message to test the var_int prefix This is a really long message to test the var_int prefix This is a really long message to test the var_int prefix This is a really long message to test the var_int prefix',
       concatBytes(
-        utf8ToBytes('\x18Stacks Message Signing:\n'),
+        utf8ToBytes('\x17Stacks Signed Message:\n'),
         // message length = 284 (decimal) = 011c (hex) <=> \x1c\x01 (little endian encoding)
         // Since length = 284 is < 0xFFFF, prefix the int with 0xFD followed by 2 bytes for a total of 3 bytes (see https://en.bitcoin.it/wiki/Protocol_documentation#Variable_length_integer)
         new Uint8Array([253, 28, 1]),
@@ -20,7 +20,8 @@ test('encodeMessage / decodeMessage', () => {
       ),
     ],
   ];
-  for (const [message, expected] of testVectors) {
+  for (const messageArr of messages) {
+    const [message, expected] = messageArr;
     const encodedMessage = encodeMessage(message);
     const expectedBytes = typeof expected == 'string' ? utf8ToBytes(expected) : expected;
     expect(equals(encodedMessage, expectedBytes)).toBeTruthy();
@@ -31,12 +32,12 @@ test('encodeMessage / decodeMessage', () => {
 });
 
 test('hash message vs hash of manually constructed message', () => {
-  // echo -n '\x18Stacks Message Signing:\n\x0bhello world' | openssl dgst -sha256
-  // 664d1478d36935361c1a8eda75fce73c49a93b58e55ed7cb45c3860317814991
+  // echo -n '\x17Stacks Signed Message:\n\x0bhello world' | openssl dgst -sha256
+  // 619997693db23de4b92ed152444a578a134143d9ad2c0f4dff2615de9d42ad96
 
   const message1 = 'hello world';
   const hash1 = hashMessage(message1);
-  const expectedHash = '664d1478d36935361c1a8eda75fce73c49a93b58e55ed7cb45c3860317814991';
+  const expectedHash = '619997693db23de4b92ed152444a578a134143d9ad2c0f4dff2615de9d42ad96';
   expect(hash1.length).toEqual(32); // 32 bytes of sha256
   expect(bytesToHex(hash1)).toEqual(expectedHash);
 });

--- a/packages/transactions/src/keys.ts
+++ b/packages/transactions/src/keys.ts
@@ -88,24 +88,24 @@ export function createStacksPublicKey(key: string): StacksPublicKey {
 }
 
 export function publicKeyFromSignatureVrs(
-  message: string,
+  messageHash: string,
   messageSignature: MessageSignature,
   pubKeyEncoding = PubKeyEncoding.Compressed
 ): string {
   const parsedSignature = parseRecoverableSignatureVrs(messageSignature.data);
   const signature = new Signature(hexToBigInt(parsedSignature.r), hexToBigInt(parsedSignature.s));
-  const point = Point.fromSignature(message, signature, parsedSignature.recoveryId);
+  const point = Point.fromSignature(messageHash, signature, parsedSignature.recoveryId);
   const compressed = pubKeyEncoding === PubKeyEncoding.Compressed;
   return point.toHex(compressed);
 }
 
 export function publicKeyFromSignatureRsv(
-  message: string,
+  messageHash: string,
   messageSignature: MessageSignature,
   pubKeyEncoding = PubKeyEncoding.Compressed
 ): string {
   return publicKeyFromSignatureVrs(
-    message,
+    messageHash,
     { ...messageSignature, data: signatureRsvToVrs(messageSignature.data) },
     pubKeyEncoding
   );

--- a/packages/transactions/src/structuredDataSignature.ts
+++ b/packages/transactions/src/structuredDataSignature.ts
@@ -6,7 +6,7 @@ import { StacksMessageType } from './constants';
 import { signMessageHashRsv, StacksPrivateKey } from './keys';
 
 // Refer to SIP018 https://github.com/stacksgov/sips/
-// > Buffer.from('SIP018', 'ascii')
+// > asciiToBytes('SIP018')
 export const STRUCTURED_DATA_PREFIX = new Uint8Array([0x53, 0x49, 0x50, 0x30, 0x31, 0x38]);
 
 export function hashStructuredData(structuredData: ClarityValue): Uint8Array {

--- a/packages/transactions/tests/structuredDataSignature.test.ts
+++ b/packages/transactions/tests/structuredDataSignature.test.ts
@@ -1,5 +1,5 @@
 import { sha256 } from '@noble/hashes/sha256';
-import { bytesToHex, hexToBytes } from '@stacks/common';
+import { asciiToBytes, bytesToHex, hexToBytes } from '@stacks/common';
 import { verifyMessageSignatureRsv } from '@stacks/encryption';
 import { standardPrincipalCV, stringAsciiCV, trueCV, tupleCV, uintCV } from '../src/clarity';
 import { createStacksPrivateKey, publicKeyFromSignatureRsv, signMessageHashRsv } from '../src/keys';
@@ -21,7 +21,8 @@ const principal1 = 'ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5';
 test('prefix buffer', () => {
   // Refer to SIP018 https://github.com/stacksgov/sips/
   // "\x53\x49\x50\x30\x31\x38" is "SIP018" in ASCII
-  expect(new Uint8Array([0x53, 0x49, 0x50, 0x30, 0x31, 0x38])).toEqual(STRUCTURED_DATA_PREFIX);
+  expect(STRUCTURED_DATA_PREFIX).toEqual(new Uint8Array([0x53, 0x49, 0x50, 0x30, 0x31, 0x38]));
+  expect(asciiToBytes('SIP018')).toEqual(STRUCTURED_DATA_PREFIX);
 });
 
 describe('encodeStructuredData / decodeStructuredDataSignature', () => {


### PR DESCRIPTION
> This PR was published to npm with the version `4.3.9-pr.bb49829.0`
> e.g. `npm install @stacks/common@4.3.9-pr.bb49829.0 --save-exact`<!-- Sticky Header Marker -->

Closes #1328 

This is a potentially breaking change for message signing, but brings the stacks implementation of message signing inline with the eth precedent, and stacks ledger app implementation

cc/ @aulneau for microstacks change?