### PR TITLE
docs: update readme for post conditions

### DIFF
--- a/packages/transactions/README.md
+++ b/packages/transactions/README.md
@@ -458,6 +458,12 @@ const contractFungiblePostCondition = makeContractFungiblePostCondition(
 
 ### Non-fungible token post condition
 
+> **Warning**
+> The post-condition codes for NFTs are currently misleading. The Stacks blockchain's post-condition processor does NOT check ownership.
+> It checks whether or not a principal **sent** or **did not send** an NFT.
+> Post-conditions can NOT verify anything about the recipient of an asset.
+> If you want to verify conditions about asset recipients, you will need to use [Clarity](https://docs.stacks.co/docs/write-smart-contracts/).
+
 ```typescript
 import {
   NonFungibleConditionCode,


### PR DESCRIPTION
- adds warning on post-conditions

---

I would propose changing these:
- `Owns` → `Sends`
- `DoesNotOwn` → `DoesNotSend`

The enum values stay the same, so I don't think there is anything to worry about. But I would plan this for a major release (as the old keys would disappear and break codebases).