### PR TITLE
feat: support `versioned-smart-contract` tx types

### DIFF
--- a/packages/transactions/src/constants.ts
+++ b/packages/transactions/src/constants.ts
@@ -35,9 +35,15 @@ enum StacksMessageType {
 enum PayloadType {
   TokenTransfer = 0x00,
   SmartContract = 0x01,
+  VersionedSmartContract = 0x06,
   ContractCall = 0x02,
   PoisonMicroblock = 0x03,
   Coinbase = 0x04,
+}
+
+enum ClarityVersion {
+  Clarity1 = 1,
+  Clarity2 = 2,
 }
 
 /**
@@ -172,6 +178,7 @@ export {
   ChainID,
   StacksMessageType,
   PayloadType,
+  ClarityVersion,
   AnchorMode,
   TransactionVersion,
   PostConditionMode,

--- a/packages/transactions/src/index.ts
+++ b/packages/transactions/src/index.ts
@@ -15,6 +15,7 @@ export {
   TokenTransferPayload,
   ContractCallPayload,
   SmartContractPayload,
+  VersionedSmartContractPayload,
   PoisonPayload,
   CoinbasePayload,
   serializePayload,

--- a/packages/transactions/src/transaction.ts
+++ b/packages/transactions/src/transaction.ts
@@ -82,6 +82,7 @@ export class StacksTransaction {
         }
         case PayloadType.ContractCall:
         case PayloadType.SmartContract:
+        case PayloadType.VersionedSmartContract:
         case PayloadType.TokenTransfer: {
           this.anchorMode = AnchorMode.Any;
           break;

--- a/packages/transactions/tests/builder.test.ts
+++ b/packages/transactions/tests/builder.test.ts
@@ -48,6 +48,7 @@ import {
   AddressHashMode,
   AnchorMode,
   AuthType,
+  ClarityVersion,
   DEFAULT_CORE_NODE_API_URL,
   FungibleConditionCode,
   NonFungibleConditionCode,
@@ -653,6 +654,32 @@ test('addSignature to an unsigned transaction', async () => {
     sig
   );
   expect(unsignedTx).not.toBe(signedTx);
+});
+
+test('Make versioned smart contract deploy', async () => {
+  const contractName = 'kv-store';
+  const codeBody = fs.readFileSync('./tests/contracts/kv-store.clar').toString();
+  const senderKey = 'e494f188c2d35887531ba474c433b1e41fadd8eb824aca983447fd4bb8b277a801';
+  const fee = 0;
+  const nonce = 0;
+
+  const transaction = await makeContractDeploy({
+    contractName,
+    codeBody,
+    senderKey,
+    fee,
+    nonce,
+    network: new StacksTestnet(),
+    anchorMode: AnchorMode.Any,
+    clarityVersion: ClarityVersion.Clarity2,
+  });
+
+  const serialized = transaction.serialize().toString('hex');
+
+  const tx =
+    '80800000000400e6c05355e0c990ffad19a5e9bda394a9c50034290000000000000000000000000000000000009172c9841e763c32e827c177491f5228956e6ef1071043be898bfdd694bf3e680309b0666e8fec013a8a453573a8bd707152c9f21aa6f2d5e57c407af672b6f00302000000000602086b762d73746f72650000015628646566696e652d6d61702073746f72652028286b657920286275666620333229292920282876616c7565202862756666203332292929290a0a28646566696e652d7075626c696320286765742d76616c756520286b65792028627566662033322929290a20202020286d6174636820286d61702d6765743f2073746f72652028286b6579206b65792929290a2020202020202020656e74727920286f6b20286765742076616c756520656e74727929290a20202020202020202865727220302929290a0a28646566696e652d7075626c696320287365742d76616c756520286b65792028627566662033322929202876616c75652028627566662033322929290a2020202028626567696e0a2020202020202020286d61702d7365742073746f72652028286b6579206b6579292920282876616c75652076616c75652929290a2020202020202020286f6b2027747275652929290a';
+
+  expect(serialized).toBe(tx);
 });
 
 test('Make smart contract deploy', async () => {

--- a/packages/transactions/tests/payload.test.ts
+++ b/packages/transactions/tests/payload.test.ts
@@ -7,13 +7,14 @@ import {
   createCoinbasePayload,
   createContractCallPayload,
   createTokenTransferPayload,
+  VersionedSmartContractPayload,
 } from '../src/payload';
 
 import { serializeDeserialize } from './macros';
 
 import { trueCV, falseCV, standardPrincipalCV, contractPrincipalCV } from '../src/clarity';
 
-import { COINBASE_BUFFER_LENGTH_BYTES, StacksMessageType } from '../src/constants';
+import { ClarityVersion, COINBASE_BUFFER_LENGTH_BYTES, StacksMessageType } from '../src/constants';
 import { principalToString } from '../src/clarity/types/principalCV';
 
 test('STX token transfer payload serialization and deserialization', () => {
@@ -113,6 +114,30 @@ test('Smart contract payload serialization and deserialization', () => {
     payload,
     StacksMessageType.Payload
   ) as SmartContractPayload;
+  expect(deserialized.contractName.content).toBe(contractName);
+  expect(deserialized.codeBody.content).toBe(codeBody);
+});
+
+test('Versioned smart contract payload serialization and deserialization', () => {
+  const contractName = 'contract_name';
+  const codeBody =
+    '(define-map store ((key (buff 32))) ((value (buff 32))))' +
+    '(define-public (get-value (key (buff 32)))' +
+    '   (match (map-get? store ((key key)))' +
+    '       entry (ok (get value entry))' +
+    '       (err 0)))' +
+    '(define-public (set-value (key (buff 32)) (value (buff 32)))' +
+    '   (begin' +
+    '       (map-set store ((key key)) ((value value)))' +
+    "       (ok 'true)))";
+
+  const payload = createSmartContractPayload(contractName, codeBody, ClarityVersion.Clarity2);
+
+  const deserialized = serializeDeserialize(
+    payload,
+    StacksMessageType.Payload
+  ) as VersionedSmartContractPayload;
+  expect(deserialized.clarityVersion).toBe(2);
   expect(deserialized.contractName.content).toBe(contractName);
   expect(deserialized.codeBody.content).toBe(codeBody);
 });


### PR DESCRIPTION
> This PR was published as an *alpha* to npm with the version `4.3.6-pr.e86b982.0` — e.g. `npm install @stacks/common@4.3.6-pr.e86b982.0`<!-- Sticky Header Marker -->

Closes https://github.com/hirosystems/stacks.js/issues/1339

I need this change for some API testing & development for Stacks 2.1. 

This adds an optional arg `clarityVersion` to the smart contract builder functions. If specified, a `versioned-smart-contract` type will be created. If not specified, it will default to the regular `smart-contract`.

Example:
```ts
const transaction = await makeContractDeploy({
  contractName,
  codeBody,
  senderKey,
  clarityVersion: ClarityVersion.Clarity2,
});
```

I have no strong feelings on how these function signatures look. An alternative approach could be using entirely new builder functions for this tx type, rather than an optional arg to the existing functions.

I verified that the serialized payload generated in this PR is valid with the Rust deserialization code at https://github.com/hirosystems/stacks-encoding-native-js/pull/5/files

@janniks feel free to take over this PR and make any changes