### PR TITLE
ci: add fixed header to prs

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -39,3 +39,9 @@ jobs:
         env:
           SHA: ${{ steps.git-commit.outputs.sha }}
           SKIP_TESTS: true
+      - id: published-version
+        run: echo "::set-output name=version::$(cat lerna.json | jq -r '.version')"
+      - uses: kyranjamie/pull-request-fixed-header@v1.0.1
+        with:
+          header: "> This PR was published as an *alpha* to npm with the version `${{ steps.published-version.outputs.version }}` — e.g. `npm install @stacks/common@${{ steps.published-version.outputs.version }}`"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -4,7 +4,7 @@
   "description": "Authentication for Stacks apps.",
   "license": "MIT",
   "author": "Hiro Systems PBC (https://hiro.so)",
-  "homepage": "https://www.hiro.so/stacks-js",
+  "homepage": "https://hiro.so/stacks-js",
   "scripts": {
     "build": "npm run clean && npm run build:cjs && npm run build:esm && npm run build:umd && npm run build:polyfill",
     "build:cjs": "tsc -b tsconfig.build.json",

--- a/packages/bns/package.json
+++ b/packages/bns/package.json
@@ -4,7 +4,7 @@
   "description": "Library for working with the Stacks Blockchain Naming System BNS.",
   "license": "MIT",
   "author": "Hiro Systems PBC (https://hiro.so)",
-  "homepage": "https://www.hiro.so/stacks-js",
+  "homepage": "https://hiro.so/stacks-js",
   "scripts": {
     "build": "npm run clean && npm run build:cjs && npm run build:esm && npm run build:umd",
     "build:cjs": "tsc -b tsconfig.build.json",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -7,7 +7,7 @@
   "contributors": [
     "Ken Liao <yukanliao@gmail.com>"
   ],
-  "homepage": "https://www.hiro.so/stacks-js",
+  "homepage": "https://hiro.so/stacks-js",
   "scripts": {
     "build": "npm run clean && npm run build:cjs",
     "build:cjs": "tsc -b tsconfig.build.json",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -4,7 +4,7 @@
   "description": "Common Stacks utilities",
   "license": "MIT",
   "author": "Hiro Systems PBC (https://hiro.so)",
-  "homepage": "https://www.hiro.so/stacks-js",
+  "homepage": "https://hiro.so/stacks-js",
   "scripts": {
     "build": "npm run clean && npm run build:cjs && npm run build:esm && npm run build:umd",
     "build:cjs": "tsc -b tsconfig.build.json",

--- a/packages/encryption/package.json
+++ b/packages/encryption/package.json
@@ -4,7 +4,7 @@
   "description": "Encryption utilities for Stacks",
   "license": "MIT",
   "author": "Hiro Systems PBC (https://hiro.so)",
-  "homepage": "https://www.hiro.so/stacks-js",
+  "homepage": "https://hiro.so/stacks-js",
   "scripts": {
     "build": "npm run clean && npm run build:cjs && npm run build:esm && npm run build:umd",
     "build:cjs": "tsc -b tsconfig.build.json",

--- a/packages/keychain/package.json
+++ b/packages/keychain/package.json
@@ -8,7 +8,7 @@
     "Hank Stoever",
     "Ken Liao"
   ],
-  "homepage": "https://www.hiro.so/stacks-js",
+  "homepage": "https://hiro.so/stacks-js",
   "scripts": {
     "build": "npm run clean && npm run build:cjs && npm run build:esm && npm run build:umd && npm run build:polyfill",
     "build:cjs": "tsc -b tsconfig.build.json",

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -4,7 +4,7 @@
   "description": "Library for Stacks network operations",
   "license": "MIT",
   "author": "Hiro Systems PBC (https://hiro.so)",
-  "homepage": "https://www.hiro.so/stacks-js",
+  "homepage": "https://hiro.so/stacks-js",
   "scripts": {
     "build": "npm run clean && npm run build:cjs && npm run build:esm && npm run build:umd",
     "build:cjs": "tsc -b tsconfig.build.json",

--- a/packages/profile/package.json
+++ b/packages/profile/package.json
@@ -4,7 +4,7 @@
   "description": "Library for Stacks profiles",
   "license": "MIT",
   "author": "Hiro Systems PBC (https://hiro.so)",
-  "homepage": "https://www.hiro.so/stacks-js",
+  "homepage": "https://hiro.so/stacks-js",
   "scripts": {
     "build": "npm run clean && npm run build:cjs && npm run build:esm && npm run build:umd && npm run build:polyfill",
     "build:cjs": "tsc -b tsconfig.build.json",

--- a/packages/stacking/package.json
+++ b/packages/stacking/package.json
@@ -4,7 +4,7 @@
   "description": "Library for Stacking.",
   "license": "MIT",
   "author": "Hiro Systems PBC (https://hiro.so)",
-  "homepage": "https://www.hiro.so/stacks-js",
+  "homepage": "https://hiro.so/stacks-js",
   "scripts": {
     "build": "npm run clean && npm run build:cjs && npm run build:esm && npm run build:umd",
     "build:cjs": "tsc -b tsconfig.build.json",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -4,7 +4,7 @@
   "description": "Stacks storage library",
   "license": "MIT",
   "author": "Hiro Systems PBC (https://hiro.so)",
-  "homepage": "https://www.hiro.so/stacks-js",
+  "homepage": "https://hiro.so/stacks-js",
   "scripts": {
     "build": "npm run clean && npm run build:cjs && npm run build:esm && npm run build:umd && npm run build:polyfill",
     "build:cjs": "tsc -b tsconfig.build.json",

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -9,7 +9,7 @@
     "Matthew Little",
     "Reed Rosenbluth"
   ],
-  "homepage": "https://www.hiro.so/stacks-js",
+  "homepage": "https://hiro.so/stacks-js",
   "scripts": {
     "build": "npm run clean && npm run build:cjs && npm run build:esm && npm run build:umd && npm run build:polyfill",
     "build:cjs": "tsc -b tsconfig.build.json",


### PR DESCRIPTION
> This PR was published as an *alpha* to npm with the version `4.3.5-pr.fe70600.0` — e.g. `npm install @stacks/common@4.3.5-pr.fe70600.0`<!-- Sticky Header Marker -->

## changes
- adds fixed header (inspired by wallet-web) to stacks.js pull requests