### PR TITLE
chore: add deprecation notice to keychain package methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22389,13 +22389,13 @@
     },
     "packages/auth": {
       "name": "@stacks/auth",
-      "version": "4.3.4",
+      "version": "4.3.5",
       "license": "MIT",
       "dependencies": {
-        "@stacks/common": "^4.3.4",
-        "@stacks/encryption": "^4.3.4",
-        "@stacks/network": "^4.3.4",
-        "@stacks/profile": "^4.3.4",
+        "@stacks/common": "^4.3.5",
+        "@stacks/encryption": "^4.3.5",
+        "@stacks/network": "^4.3.5",
+        "@stacks/profile": "^4.3.5",
         "cross-fetch": "^3.1.5",
         "jsontokens": "^3.1.1",
         "query-string": "^6.13.1"
@@ -22430,12 +22430,12 @@
     },
     "packages/bns": {
       "name": "@stacks/bns",
-      "version": "4.3.4",
+      "version": "4.3.5",
       "license": "MIT",
       "dependencies": {
-        "@stacks/common": "^4.3.4",
-        "@stacks/network": "^4.3.4",
-        "@stacks/transactions": "^4.3.4"
+        "@stacks/common": "^4.3.5",
+        "@stacks/network": "^4.3.5",
+        "@stacks/transactions": "^4.3.5"
       },
       "devDependencies": {
         "@types/jest": "^26.0.22",
@@ -22466,21 +22466,21 @@
     },
     "packages/cli": {
       "name": "@stacks/cli",
-      "version": "4.3.4",
+      "version": "4.3.5",
       "license": "MIT",
       "dependencies": {
         "@scure/bip32": "^1.1.0",
         "@scure/bip39": "^1.1.0",
-        "@stacks/auth": "^4.3.4",
+        "@stacks/auth": "^4.3.5",
         "@stacks/blockchain-api-client": "4.0.1",
-        "@stacks/bns": "^4.3.4",
-        "@stacks/common": "^4.3.4",
-        "@stacks/encryption": "^4.3.4",
-        "@stacks/network": "^4.3.4",
-        "@stacks/stacking": "^4.3.4",
-        "@stacks/storage": "^4.3.4",
-        "@stacks/transactions": "^4.3.4",
-        "@stacks/wallet-sdk": "^4.3.4",
+        "@stacks/bns": "^4.3.5",
+        "@stacks/common": "^4.3.5",
+        "@stacks/encryption": "^4.3.5",
+        "@stacks/network": "^4.3.5",
+        "@stacks/stacking": "^4.3.5",
+        "@stacks/storage": "^4.3.5",
+        "@stacks/transactions": "^4.3.5",
+        "@stacks/wallet-sdk": "^4.3.5",
         "ajv": "6.12.3",
         "bip32": "^2.0.6",
         "bip39": "^3.0.2",
@@ -22560,7 +22560,7 @@
     },
     "packages/common": {
       "name": "@stacks/common",
-      "version": "4.3.4",
+      "version": "4.3.5",
       "license": "MIT",
       "dependencies": {
         "@types/bn.js": "^5.1.0",
@@ -22585,13 +22585,13 @@
     },
     "packages/encryption": {
       "name": "@stacks/encryption",
-      "version": "4.3.4",
+      "version": "4.3.5",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.0.0",
         "@noble/secp256k1": "^1.5.5",
         "@scure/bip39": "^1.1.0",
-        "@stacks/common": "^4.3.4",
+        "@stacks/common": "^4.3.5",
         "@types/node": "^18.0.4",
         "bs58": "^5.0.0",
         "ripemd160-min": "^0.0.6",
@@ -22630,18 +22630,18 @@
     },
     "packages/keychain": {
       "name": "@stacks/keychain",
-      "version": "4.3.4",
+      "version": "4.3.5",
       "license": "MIT",
       "dependencies": {
         "@blockstack/rpc-client": "^0.3.0-alpha.11",
         "@scure/bip39": "^1.1.0",
-        "@stacks/auth": "^4.3.4",
-        "@stacks/common": "^4.3.4",
-        "@stacks/encryption": "^4.3.4",
-        "@stacks/network": "^4.3.4",
-        "@stacks/profile": "^4.3.4",
-        "@stacks/storage": "^4.3.4",
-        "@stacks/transactions": "^4.3.4",
+        "@stacks/auth": "^4.3.5",
+        "@stacks/common": "^4.3.5",
+        "@stacks/encryption": "^4.3.5",
+        "@stacks/network": "^4.3.5",
+        "@stacks/profile": "^4.3.5",
+        "@stacks/storage": "^4.3.5",
+        "@stacks/transactions": "^4.3.5",
         "@types/node": "^18.0.4",
         "@types/triplesec": "^3.0.0",
         "bip32": "^2.0.6",
@@ -22700,10 +22700,10 @@
     },
     "packages/network": {
       "name": "@stacks/network",
-      "version": "4.3.4",
+      "version": "4.3.5",
       "license": "MIT",
       "dependencies": {
-        "@stacks/common": "^4.3.4",
+        "@stacks/common": "^4.3.5",
         "cross-fetch": "^3.1.5"
       },
       "devDependencies": {
@@ -22727,12 +22727,12 @@
     },
     "packages/profile": {
       "name": "@stacks/profile",
-      "version": "4.3.4",
+      "version": "4.3.5",
       "license": "MIT",
       "dependencies": {
-        "@stacks/common": "^4.3.4",
-        "@stacks/network": "^4.3.4",
-        "@stacks/transactions": "^4.3.4",
+        "@stacks/common": "^4.3.5",
+        "@stacks/network": "^4.3.5",
+        "@stacks/transactions": "^4.3.5",
         "jsontokens": "^3.1.1",
         "schema-inspector": "2.0.1",
         "zone-file": "^2.0.0-beta.3"
@@ -22767,14 +22767,14 @@
     },
     "packages/stacking": {
       "name": "@stacks/stacking",
-      "version": "4.3.4",
+      "version": "4.3.5",
       "license": "MIT",
       "dependencies": {
-        "@stacks/common": "^4.3.4",
-        "@stacks/encryption": "^4.3.4",
-        "@stacks/network": "^4.3.4",
+        "@stacks/common": "^4.3.5",
+        "@stacks/encryption": "^4.3.5",
+        "@stacks/network": "^4.3.5",
         "@stacks/stacks-blockchain-api-types": "^0.61.0",
-        "@stacks/transactions": "^4.3.4",
+        "@stacks/transactions": "^4.3.5",
         "bs58": "^5.0.0"
       },
       "devDependencies": {
@@ -22812,13 +22812,13 @@
     },
     "packages/storage": {
       "name": "@stacks/storage",
-      "version": "4.3.4",
+      "version": "4.3.5",
       "license": "MIT",
       "dependencies": {
-        "@stacks/auth": "^4.3.4",
-        "@stacks/common": "^4.3.4",
-        "@stacks/encryption": "^4.3.4",
-        "@stacks/network": "^4.3.4",
+        "@stacks/auth": "^4.3.5",
+        "@stacks/common": "^4.3.5",
+        "@stacks/encryption": "^4.3.5",
+        "@stacks/network": "^4.3.5",
         "jsontokens": "^3.1.1"
       },
       "devDependencies": {
@@ -22858,13 +22858,13 @@
     },
     "packages/transactions": {
       "name": "@stacks/transactions",
-      "version": "4.3.4",
+      "version": "4.3.5",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.0.0",
         "@noble/secp256k1": "^1.5.5",
-        "@stacks/common": "^4.3.4",
-        "@stacks/network": "^4.3.4",
+        "@stacks/common": "^4.3.5",
+        "@stacks/network": "^4.3.5",
         "@types/node": "^18.0.4",
         "@types/sha.js": "^2.4.0",
         "c32check": "^1.1.3",
@@ -22874,7 +22874,7 @@
         "smart-buffer": "^4.1.0"
       },
       "devDependencies": {
-        "@stacks/encryption": "^4.3.4",
+        "@stacks/encryption": "^4.3.5",
         "@types/common-tags": "^1.8.0",
         "@types/elliptic": "^6.4.12",
         "@types/jest": "^26.0.22",
@@ -22908,18 +22908,18 @@
     },
     "packages/wallet-sdk": {
       "name": "@stacks/wallet-sdk",
-      "version": "4.3.4",
+      "version": "4.3.5",
       "license": "MIT",
       "dependencies": {
         "@scure/bip32": "^1.1.0",
         "@scure/bip39": "^1.1.0",
-        "@stacks/auth": "^4.3.4",
-        "@stacks/common": "^4.3.4",
-        "@stacks/encryption": "^4.3.4",
-        "@stacks/network": "^4.3.4",
-        "@stacks/profile": "^4.3.4",
-        "@stacks/storage": "^4.3.4",
-        "@stacks/transactions": "^4.3.4",
+        "@stacks/auth": "^4.3.5",
+        "@stacks/common": "^4.3.5",
+        "@stacks/encryption": "^4.3.5",
+        "@stacks/network": "^4.3.5",
+        "@stacks/profile": "^4.3.5",
+        "@stacks/storage": "^4.3.5",
+        "@stacks/transactions": "^4.3.5",
         "bitcoinjs-lib": "^5.2.0",
         "c32check": "^1.1.3",
         "jsontokens": "^3.1.1",
@@ -26192,10 +26192,10 @@
     "@stacks/auth": {
       "version": "file:packages/auth",
       "requires": {
-        "@stacks/common": "^4.3.4",
-        "@stacks/encryption": "^4.3.4",
-        "@stacks/network": "^4.3.4",
-        "@stacks/profile": "^4.3.4",
+        "@stacks/common": "^4.3.5",
+        "@stacks/encryption": "^4.3.5",
+        "@stacks/network": "^4.3.5",
+        "@stacks/profile": "^4.3.5",
         "@types/jest": "^26.0.22",
         "cross-fetch": "^3.1.5",
         "jest": "^26.6.3",
@@ -26238,7 +26238,7 @@
             "@noble/secp256k1": "^1.5.5",
             "@peculiar/webcrypto": "^1.1.6",
             "@scure/bip39": "^1.1.0",
-            "@stacks/common": "^4.3.4",
+            "@stacks/common": "^4.3.5",
             "@types/bs58check": "^2.1.0",
             "@types/elliptic": "^6.4.12",
             "@types/jest": "^26.0.22",
@@ -26294,7 +26294,7 @@
         "@stacks/network": {
           "version": "file:packages/network",
           "requires": {
-            "@stacks/common": "^4.3.4",
+            "@stacks/common": "^4.3.5",
             "@types/jest": "^26.0.22",
             "cross-fetch": "^3.1.5",
             "jest": "^26.6.3",
@@ -26336,9 +26336,9 @@
         "@stacks/profile": {
           "version": "file:packages/profile",
           "requires": {
-            "@stacks/common": "^4.3.4",
-            "@stacks/network": "^4.3.4",
-            "@stacks/transactions": "^4.3.4",
+            "@stacks/common": "^4.3.5",
+            "@stacks/network": "^4.3.5",
+            "@stacks/transactions": "^4.3.5",
             "@types/jest": "^26.0.22",
             "bitcoinjs-lib": "^5.2.0",
             "jest": "^26.6.3",
@@ -26381,7 +26381,7 @@
             "@stacks/network": {
               "version": "file:packages/network",
               "requires": {
-                "@stacks/common": "^4.3.4",
+                "@stacks/common": "^4.3.5",
                 "@types/jest": "^26.0.22",
                 "cross-fetch": "^3.1.5",
                 "jest": "^26.6.3",
@@ -26425,9 +26425,9 @@
               "requires": {
                 "@noble/hashes": "^1.0.0",
                 "@noble/secp256k1": "^1.5.5",
-                "@stacks/common": "^4.3.4",
-                "@stacks/encryption": "^4.3.4",
-                "@stacks/network": "^4.3.4",
+                "@stacks/common": "^4.3.5",
+                "@stacks/encryption": "^4.3.5",
+                "@stacks/network": "^4.3.5",
                 "@types/common-tags": "^1.8.0",
                 "@types/elliptic": "^6.4.12",
                 "@types/jest": "^26.0.22",
@@ -26482,7 +26482,7 @@
                     "@noble/secp256k1": "^1.5.5",
                     "@peculiar/webcrypto": "^1.1.6",
                     "@scure/bip39": "^1.1.0",
-                    "@stacks/common": "^4.3.4",
+                    "@stacks/common": "^4.3.5",
                     "@types/bs58check": "^2.1.0",
                     "@types/elliptic": "^6.4.12",
                     "@types/jest": "^26.0.22",
@@ -26538,7 +26538,7 @@
                 "@stacks/network": {
                   "version": "file:packages/network",
                   "requires": {
-                    "@stacks/common": "^4.3.4",
+                    "@stacks/common": "^4.3.5",
                     "@types/jest": "^26.0.22",
                     "cross-fetch": "^3.1.5",
                     "jest": "^26.6.3",
@@ -26598,9 +26598,9 @@
     "@stacks/bns": {
       "version": "file:packages/bns",
       "requires": {
-        "@stacks/common": "^4.3.4",
-        "@stacks/network": "^4.3.4",
-        "@stacks/transactions": "^4.3.4",
+        "@stacks/common": "^4.3.5",
+        "@stacks/network": "^4.3.5",
+        "@stacks/transactions": "^4.3.5",
         "@types/jest": "^26.0.22",
         "jest": "^26.6.3",
         "jest-fetch-mock": "^3.0.3",
@@ -26639,7 +26639,7 @@
         "@stacks/network": {
           "version": "file:packages/network",
           "requires": {
-            "@stacks/common": "^4.3.4",
+            "@stacks/common": "^4.3.5",
             "@types/jest": "^26.0.22",
             "cross-fetch": "^3.1.5",
             "jest": "^26.6.3",
@@ -26683,9 +26683,9 @@
           "requires": {
             "@noble/hashes": "^1.0.0",
             "@noble/secp256k1": "^1.5.5",
-            "@stacks/common": "^4.3.4",
-            "@stacks/encryption": "^4.3.4",
-            "@stacks/network": "^4.3.4",
+            "@stacks/common": "^4.3.5",
+            "@stacks/encryption": "^4.3.5",
+            "@stacks/network": "^4.3.5",
             "@types/common-tags": "^1.8.0",
             "@types/elliptic": "^6.4.12",
             "@types/jest": "^26.0.22",
@@ -26740,7 +26740,7 @@
                 "@noble/secp256k1": "^1.5.5",
                 "@peculiar/webcrypto": "^1.1.6",
                 "@scure/bip39": "^1.1.0",
-                "@stacks/common": "^4.3.4",
+                "@stacks/common": "^4.3.5",
                 "@types/bs58check": "^2.1.0",
                 "@types/elliptic": "^6.4.12",
                 "@types/jest": "^26.0.22",
@@ -26796,7 +26796,7 @@
             "@stacks/network": {
               "version": "file:packages/network",
               "requires": {
-                "@stacks/common": "^4.3.4",
+                "@stacks/common": "^4.3.5",
                 "@types/jest": "^26.0.22",
                 "cross-fetch": "^3.1.5",
                 "jest": "^26.6.3",
@@ -26844,16 +26844,16 @@
       "requires": {
         "@scure/bip32": "^1.1.0",
         "@scure/bip39": "^1.1.0",
-        "@stacks/auth": "^4.3.4",
+        "@stacks/auth": "^4.3.5",
         "@stacks/blockchain-api-client": "4.0.1",
-        "@stacks/bns": "^4.3.4",
-        "@stacks/common": "^4.3.4",
-        "@stacks/encryption": "^4.3.4",
-        "@stacks/network": "^4.3.4",
-        "@stacks/stacking": "^4.3.4",
-        "@stacks/storage": "^4.3.4",
-        "@stacks/transactions": "^4.3.4",
-        "@stacks/wallet-sdk": "^4.3.4",
+        "@stacks/bns": "^4.3.5",
+        "@stacks/common": "^4.3.5",
+        "@stacks/encryption": "^4.3.5",
+        "@stacks/network": "^4.3.5",
+        "@stacks/stacking": "^4.3.5",
+        "@stacks/storage": "^4.3.5",
+        "@stacks/transactions": "^4.3.5",
+        "@stacks/wallet-sdk": "^4.3.5",
         "@types/cors": "^2.8.5",
         "@types/express": "^4.16.1",
         "@types/express-winston": "^3.0.1",
@@ -26892,10 +26892,10 @@
         "@stacks/auth": {
           "version": "file:packages/auth",
           "requires": {
-            "@stacks/common": "^4.3.4",
-            "@stacks/encryption": "^4.3.4",
-            "@stacks/network": "^4.3.4",
-            "@stacks/profile": "^4.3.4",
+            "@stacks/common": "^4.3.5",
+            "@stacks/encryption": "^4.3.5",
+            "@stacks/network": "^4.3.5",
+            "@stacks/profile": "^4.3.5",
             "@types/jest": "^26.0.22",
             "cross-fetch": "^3.1.5",
             "jest": "^26.6.3",
@@ -26938,7 +26938,7 @@
                 "@noble/secp256k1": "^1.5.5",
                 "@peculiar/webcrypto": "^1.1.6",
                 "@scure/bip39": "^1.1.0",
-                "@stacks/common": "^4.3.4",
+                "@stacks/common": "^4.3.5",
                 "@types/bs58check": "^2.1.0",
                 "@types/elliptic": "^6.4.12",
                 "@types/jest": "^26.0.22",
@@ -26994,7 +26994,7 @@
             "@stacks/network": {
               "version": "file:packages/network",
               "requires": {
-                "@stacks/common": "^4.3.4",
+                "@stacks/common": "^4.3.5",
                 "@types/jest": "^26.0.22",
                 "cross-fetch": "^3.1.5",
                 "jest": "^26.6.3",
@@ -27036,9 +27036,9 @@
             "@stacks/profile": {
               "version": "file:packages/profile",
               "requires": {
-                "@stacks/common": "^4.3.4",
-                "@stacks/network": "^4.3.4",
-                "@stacks/transactions": "^4.3.4",
+                "@stacks/common": "^4.3.5",
+                "@stacks/network": "^4.3.5",
+                "@stacks/transactions": "^4.3.5",
                 "@types/jest": "^26.0.22",
                 "bitcoinjs-lib": "^5.2.0",
                 "jest": "^26.6.3",
@@ -27081,7 +27081,7 @@
                 "@stacks/network": {
                   "version": "file:packages/network",
                   "requires": {
-                    "@stacks/common": "^4.3.4",
+                    "@stacks/common": "^4.3.5",
                     "@types/jest": "^26.0.22",
                     "cross-fetch": "^3.1.5",
                     "jest": "^26.6.3",
@@ -27125,9 +27125,9 @@
                   "requires": {
                     "@noble/hashes": "^1.0.0",
                     "@noble/secp256k1": "^1.5.5",
-                    "@stacks/common": "^4.3.4",
-                    "@stacks/encryption": "^4.3.4",
-                    "@stacks/network": "^4.3.4",
+                    "@stacks/common": "^4.3.5",
+                    "@stacks/encryption": "^4.3.5",
+                    "@stacks/network": "^4.3.5",
                     "@types/common-tags": "^1.8.0",
                     "@types/elliptic": "^6.4.12",
                     "@types/jest": "^26.0.22",
@@ -27182,7 +27182,7 @@
                         "@noble/secp256k1": "^1.5.5",
                         "@peculiar/webcrypto": "^1.1.6",
                         "@scure/bip39": "^1.1.0",
-                        "@stacks/common": "^4.3.4",
+                        "@stacks/common": "^4.3.5",
                         "@types/bs58check": "^2.1.0",
                         "@types/elliptic": "^6.4.12",
                         "@types/jest": "^26.0.22",
@@ -27238,7 +27238,7 @@
                     "@stacks/network": {
                       "version": "file:packages/network",
                       "requires": {
-                        "@stacks/common": "^4.3.4",
+                        "@stacks/common": "^4.3.5",
                         "@types/jest": "^26.0.22",
                         "cross-fetch": "^3.1.5",
                         "jest": "^26.6.3",
@@ -27286,9 +27286,9 @@
         "@stacks/bns": {
           "version": "file:packages/bns",
           "requires": {
-            "@stacks/common": "^4.3.4",
-            "@stacks/network": "^4.3.4",
-            "@stacks/transactions": "^4.3.4",
+            "@stacks/common": "^4.3.5",
+            "@stacks/network": "^4.3.5",
+            "@stacks/transactions": "^4.3.5",
             "@types/jest": "^26.0.22",
             "jest": "^26.6.3",
             "jest-fetch-mock": "^3.0.3",
@@ -27327,7 +27327,7 @@
             "@stacks/network": {
               "version": "file:packages/network",
               "requires": {
-                "@stacks/common": "^4.3.4",
+                "@stacks/common": "^4.3.5",
                 "@types/jest": "^26.0.22",
                 "cross-fetch": "^3.1.5",
                 "jest": "^26.6.3",
@@ -27371,9 +27371,9 @@
               "requires": {
                 "@noble/hashes": "^1.0.0",
                 "@noble/secp256k1": "^1.5.5",
-                "@stacks/common": "^4.3.4",
-                "@stacks/encryption": "^4.3.4",
-                "@stacks/network": "^4.3.4",
+                "@stacks/common": "^4.3.5",
+                "@stacks/encryption": "^4.3.5",
+                "@stacks/network": "^4.3.5",
                 "@types/common-tags": "^1.8.0",
                 "@types/elliptic": "^6.4.12",
                 "@types/jest": "^26.0.22",
@@ -27428,7 +27428,7 @@
                     "@noble/secp256k1": "^1.5.5",
                     "@peculiar/webcrypto": "^1.1.6",
                     "@scure/bip39": "^1.1.0",
-                    "@stacks/common": "^4.3.4",
+                    "@stacks/common": "^4.3.5",
                     "@types/bs58check": "^2.1.0",
                     "@types/elliptic": "^6.4.12",
                     "@types/jest": "^26.0.22",
@@ -27484,7 +27484,7 @@
                 "@stacks/network": {
                   "version": "file:packages/network",
                   "requires": {
-                    "@stacks/common": "^4.3.4",
+                    "@stacks/common": "^4.3.5",
                     "@types/jest": "^26.0.22",
                     "cross-fetch": "^3.1.5",
                     "jest": "^26.6.3",
@@ -27555,7 +27555,7 @@
             "@noble/secp256k1": "^1.5.5",
             "@peculiar/webcrypto": "^1.1.6",
             "@scure/bip39": "^1.1.0",
-            "@stacks/common": "^4.3.4",
+            "@stacks/common": "^4.3.5",
             "@types/bs58check": "^2.1.0",
             "@types/elliptic": "^6.4.12",
             "@types/jest": "^26.0.22",
@@ -27611,7 +27611,7 @@
         "@stacks/network": {
           "version": "file:packages/network",
           "requires": {
-            "@stacks/common": "^4.3.4",
+            "@stacks/common": "^4.3.5",
             "@types/jest": "^26.0.22",
             "cross-fetch": "^3.1.5",
             "jest": "^26.6.3",
@@ -27653,11 +27653,11 @@
         "@stacks/stacking": {
           "version": "file:packages/stacking",
           "requires": {
-            "@stacks/common": "^4.3.4",
-            "@stacks/encryption": "^4.3.4",
-            "@stacks/network": "^4.3.4",
+            "@stacks/common": "^4.3.5",
+            "@stacks/encryption": "^4.3.5",
+            "@stacks/network": "^4.3.5",
             "@stacks/stacks-blockchain-api-types": "^0.61.0",
-            "@stacks/transactions": "^4.3.4",
+            "@stacks/transactions": "^4.3.5",
             "@types/jest": "^26.0.22",
             "bitcoinjs-lib": "^5.2.0",
             "bs58": "^5.0.0",
@@ -27703,7 +27703,7 @@
                 "@noble/secp256k1": "^1.5.5",
                 "@peculiar/webcrypto": "^1.1.6",
                 "@scure/bip39": "^1.1.0",
-                "@stacks/common": "^4.3.4",
+                "@stacks/common": "^4.3.5",
                 "@types/bs58check": "^2.1.0",
                 "@types/elliptic": "^6.4.12",
                 "@types/jest": "^26.0.22",
@@ -27759,7 +27759,7 @@
             "@stacks/network": {
               "version": "file:packages/network",
               "requires": {
-                "@stacks/common": "^4.3.4",
+                "@stacks/common": "^4.3.5",
                 "@types/jest": "^26.0.22",
                 "cross-fetch": "^3.1.5",
                 "jest": "^26.6.3",
@@ -27803,9 +27803,9 @@
               "requires": {
                 "@noble/hashes": "^1.0.0",
                 "@noble/secp256k1": "^1.5.5",
-                "@stacks/common": "^4.3.4",
-                "@stacks/encryption": "^4.3.4",
-                "@stacks/network": "^4.3.4",
+                "@stacks/common": "^4.3.5",
+                "@stacks/encryption": "^4.3.5",
+                "@stacks/network": "^4.3.5",
                 "@types/common-tags": "^1.8.0",
                 "@types/elliptic": "^6.4.12",
                 "@types/jest": "^26.0.22",
@@ -27860,7 +27860,7 @@
                     "@noble/secp256k1": "^1.5.5",
                     "@peculiar/webcrypto": "^1.1.6",
                     "@scure/bip39": "^1.1.0",
-                    "@stacks/common": "^4.3.4",
+                    "@stacks/common": "^4.3.5",
                     "@types/bs58check": "^2.1.0",
                     "@types/elliptic": "^6.4.12",
                     "@types/jest": "^26.0.22",
@@ -27916,7 +27916,7 @@
                 "@stacks/network": {
                   "version": "file:packages/network",
                   "requires": {
-                    "@stacks/common": "^4.3.4",
+                    "@stacks/common": "^4.3.5",
                     "@types/jest": "^26.0.22",
                     "cross-fetch": "^3.1.5",
                     "jest": "^26.6.3",
@@ -27962,9 +27962,9 @@
         "@stacks/storage": {
           "version": "file:packages/storage",
           "requires": {
-            "@stacks/auth": "^4.3.4",
-            "@stacks/common": "^4.3.4",
-            "@stacks/encryption": "^4.3.4",
+            "@stacks/auth": "^4.3.5",
+            "@stacks/common": "^4.3.5",
+            "@stacks/encryption": "^4.3.5",
             "@stacks/network": "^4.1.0",
             "@types/jest": "^26.0.22",
             "@types/jsdom": "^16.2.10",
@@ -27987,10 +27987,10 @@
             "@stacks/auth": {
               "version": "file:packages/auth",
               "requires": {
-                "@stacks/common": "^4.3.4",
-                "@stacks/encryption": "^4.3.4",
-                "@stacks/network": "^4.3.4",
-                "@stacks/profile": "^4.3.4",
+                "@stacks/common": "^4.3.5",
+                "@stacks/encryption": "^4.3.5",
+                "@stacks/network": "^4.3.5",
+                "@stacks/profile": "^4.3.5",
                 "@types/jest": "^26.0.22",
                 "cross-fetch": "^3.1.5",
                 "jest": "^26.6.3",
@@ -28033,7 +28033,7 @@
                     "@noble/secp256k1": "^1.5.5",
                     "@peculiar/webcrypto": "^1.1.6",
                     "@scure/bip39": "^1.1.0",
-                    "@stacks/common": "^4.3.4",
+                    "@stacks/common": "^4.3.5",
                     "@types/bs58check": "^2.1.0",
                     "@types/elliptic": "^6.4.12",
                     "@types/jest": "^26.0.22",
@@ -28089,7 +28089,7 @@
                 "@stacks/network": {
                   "version": "file:packages/network",
                   "requires": {
-                    "@stacks/common": "^4.3.4",
+                    "@stacks/common": "^4.3.5",
                     "@types/jest": "^26.0.22",
                     "cross-fetch": "^3.1.5",
                     "jest": "^26.6.3",
@@ -28131,9 +28131,9 @@
                 "@stacks/profile": {
                   "version": "file:packages/profile",
                   "requires": {
-                    "@stacks/common": "^4.3.4",
-                    "@stacks/network": "^4.3.4",
-                    "@stacks/transactions": "^4.3.4",
+                    "@stacks/common": "^4.3.5",
+                    "@stacks/network": "^4.3.5",
+                    "@stacks/transactions": "^4.3.5",
                     "@types/jest": "^26.0.22",
                     "bitcoinjs-lib": "^5.2.0",
                     "jest": "^26.6.3",
@@ -28176,7 +28176,7 @@
                     "@stacks/network": {
                       "version": "file:packages/network",
                       "requires": {
-                        "@stacks/common": "^4.3.4",
+                        "@stacks/common": "^4.3.5",
                         "@types/jest": "^26.0.22",
                         "cross-fetch": "^3.1.5",
                         "jest": "^26.6.3",
@@ -28220,9 +28220,9 @@
                       "requires": {
                         "@noble/hashes": "^1.0.0",
                         "@noble/secp256k1": "^1.5.5",
-                        "@stacks/common": "^4.3.4",
-                        "@stacks/encryption": "^4.3.4",
-                        "@stacks/network": "^4.3.4",
+                        "@stacks/common": "^4.3.5",
+                        "@stacks/encryption": "^4.3.5",
+                        "@stacks/network": "^4.3.5",
                         "@types/common-tags": "^1.8.0",
                         "@types/elliptic": "^6.4.12",
                         "@types/jest": "^26.0.22",
@@ -28277,7 +28277,7 @@
                             "@noble/secp256k1": "^1.5.5",
                             "@peculiar/webcrypto": "^1.1.6",
                             "@scure/bip39": "^1.1.0",
-                            "@stacks/common": "^4.3.4",
+                            "@stacks/common": "^4.3.5",
                             "@types/bs58check": "^2.1.0",
                             "@types/elliptic": "^6.4.12",
                             "@types/jest": "^26.0.22",
@@ -28333,7 +28333,7 @@
                         "@stacks/network": {
                           "version": "file:packages/network",
                           "requires": {
-                            "@stacks/common": "^4.3.4",
+                            "@stacks/common": "^4.3.5",
                             "@types/jest": "^26.0.22",
                             "cross-fetch": "^3.1.5",
                             "jest": "^26.6.3",
@@ -28406,7 +28406,7 @@
                 "@noble/secp256k1": "^1.5.5",
                 "@peculiar/webcrypto": "^1.1.6",
                 "@scure/bip39": "^1.1.0",
-                "@stacks/common": "^4.3.4",
+                "@stacks/common": "^4.3.5",
                 "@types/bs58check": "^2.1.0",
                 "@types/elliptic": "^6.4.12",
                 "@types/jest": "^26.0.22",
@@ -28462,7 +28462,7 @@
             "@stacks/network": {
               "version": "file:packages/network",
               "requires": {
-                "@stacks/common": "^4.3.4",
+                "@stacks/common": "^4.3.5",
                 "@types/jest": "^26.0.22",
                 "cross-fetch": "^3.1.5",
                 "jest": "^26.6.3",
@@ -28508,9 +28508,9 @@
           "requires": {
             "@noble/hashes": "^1.0.0",
             "@noble/secp256k1": "^1.5.5",
-            "@stacks/common": "^4.3.4",
-            "@stacks/encryption": "^4.3.4",
-            "@stacks/network": "^4.3.4",
+            "@stacks/common": "^4.3.5",
+            "@stacks/encryption": "^4.3.5",
+            "@stacks/network": "^4.3.5",
             "@types/common-tags": "^1.8.0",
             "@types/elliptic": "^6.4.12",
             "@types/jest": "^26.0.22",
@@ -28565,7 +28565,7 @@
                 "@noble/secp256k1": "^1.5.5",
                 "@peculiar/webcrypto": "^1.1.6",
                 "@scure/bip39": "^1.1.0",
-                "@stacks/common": "^4.3.4",
+                "@stacks/common": "^4.3.5",
                 "@types/bs58check": "^2.1.0",
                 "@types/elliptic": "^6.4.12",
                 "@types/jest": "^26.0.22",
@@ -28621,7 +28621,7 @@
             "@stacks/network": {
               "version": "file:packages/network",
               "requires": {
-                "@stacks/common": "^4.3.4",
+                "@stacks/common": "^4.3.5",
                 "@types/jest": "^26.0.22",
                 "cross-fetch": "^3.1.5",
                 "jest": "^26.6.3",
@@ -28667,13 +28667,13 @@
           "requires": {
             "@scure/bip32": "^1.1.0",
             "@scure/bip39": "^1.1.0",
-            "@stacks/auth": "^4.3.4",
-            "@stacks/common": "^4.3.4",
-            "@stacks/encryption": "^4.3.4",
-            "@stacks/network": "^4.3.4",
-            "@stacks/profile": "^4.3.4",
-            "@stacks/storage": "^4.3.4",
-            "@stacks/transactions": "^4.3.4",
+            "@stacks/auth": "^4.3.5",
+            "@stacks/common": "^4.3.5",
+            "@stacks/encryption": "^4.3.5",
+            "@stacks/network": "^4.3.5",
+            "@stacks/profile": "^4.3.5",
+            "@stacks/storage": "^4.3.5",
+            "@stacks/transactions": "^4.3.5",
             "@types/jest": "^26.0.22",
             "@types/node": "^18.0.4",
             "assert": "^2.0.0",
@@ -28694,10 +28694,10 @@
             "@stacks/auth": {
               "version": "file:packages/auth",
               "requires": {
-                "@stacks/common": "^4.3.4",
-                "@stacks/encryption": "^4.3.4",
-                "@stacks/network": "^4.3.4",
-                "@stacks/profile": "^4.3.4",
+                "@stacks/common": "^4.3.5",
+                "@stacks/encryption": "^4.3.5",
+                "@stacks/network": "^4.3.5",
+                "@stacks/profile": "^4.3.5",
                 "@types/jest": "^26.0.22",
                 "cross-fetch": "^3.1.5",
                 "jest": "^26.6.3",
@@ -28740,7 +28740,7 @@
                     "@noble/secp256k1": "^1.5.5",
                     "@peculiar/webcrypto": "^1.1.6",
                     "@scure/bip39": "^1.1.0",
-                    "@stacks/common": "^4.3.4",
+                    "@stacks/common": "^4.3.5",
                     "@types/bs58check": "^2.1.0",
                     "@types/elliptic": "^6.4.12",
                     "@types/jest": "^26.0.22",
@@ -28796,7 +28796,7 @@
                 "@stacks/network": {
                   "version": "file:packages/network",
                   "requires": {
-                    "@stacks/common": "^4.3.4",
+                    "@stacks/common": "^4.3.5",
                     "@types/jest": "^26.0.22",
                     "cross-fetch": "^3.1.5",
                     "jest": "^26.6.3",
@@ -28838,9 +28838,9 @@
                 "@stacks/profile": {
                   "version": "file:packages/profile",
                   "requires": {
-                    "@stacks/common": "^4.3.4",
-                    "@stacks/network": "^4.3.4",
-                    "@stacks/transactions": "^4.3.4",
+                    "@stacks/common": "^4.3.5",
+                    "@stacks/network": "^4.3.5",
+                    "@stacks/transactions": "^4.3.5",
                     "@types/jest": "^26.0.22",
                     "bitcoinjs-lib": "^5.2.0",
                     "jest": "^26.6.3",
@@ -28883,7 +28883,7 @@
                     "@stacks/network": {
                       "version": "file:packages/network",
                       "requires": {
-                        "@stacks/common": "^4.3.4",
+                        "@stacks/common": "^4.3.5",
                         "@types/jest": "^26.0.22",
                         "cross-fetch": "^3.1.5",
                         "jest": "^26.6.3",
@@ -28927,9 +28927,9 @@
                       "requires": {
                         "@noble/hashes": "^1.0.0",
                         "@noble/secp256k1": "^1.5.5",
-                        "@stacks/common": "^4.3.4",
-                        "@stacks/encryption": "^4.3.4",
-                        "@stacks/network": "^4.3.4",
+                        "@stacks/common": "^4.3.5",
+                        "@stacks/encryption": "^4.3.5",
+                        "@stacks/network": "^4.3.5",
                         "@types/common-tags": "^1.8.0",
                         "@types/elliptic": "^6.4.12",
                         "@types/jest": "^26.0.22",
@@ -28984,7 +28984,7 @@
                             "@noble/secp256k1": "^1.5.5",
                             "@peculiar/webcrypto": "^1.1.6",
                             "@scure/bip39": "^1.1.0",
-                            "@stacks/common": "^4.3.4",
+                            "@stacks/common": "^4.3.5",
                             "@types/bs58check": "^2.1.0",
                             "@types/elliptic": "^6.4.12",
                             "@types/jest": "^26.0.22",
@@ -29040,7 +29040,7 @@
                         "@stacks/network": {
                           "version": "file:packages/network",
                           "requires": {
-                            "@stacks/common": "^4.3.4",
+                            "@stacks/common": "^4.3.5",
                             "@types/jest": "^26.0.22",
                             "cross-fetch": "^3.1.5",
                             "jest": "^26.6.3",
@@ -29113,7 +29113,7 @@
                 "@noble/secp256k1": "^1.5.5",
                 "@peculiar/webcrypto": "^1.1.6",
                 "@scure/bip39": "^1.1.0",
-                "@stacks/common": "^4.3.4",
+                "@stacks/common": "^4.3.5",
                 "@types/bs58check": "^2.1.0",
                 "@types/elliptic": "^6.4.12",
                 "@types/jest": "^26.0.22",
@@ -29169,7 +29169,7 @@
             "@stacks/network": {
               "version": "file:packages/network",
               "requires": {
-                "@stacks/common": "^4.3.4",
+                "@stacks/common": "^4.3.5",
                 "@types/jest": "^26.0.22",
                 "cross-fetch": "^3.1.5",
                 "jest": "^26.6.3",
@@ -29211,9 +29211,9 @@
             "@stacks/profile": {
               "version": "file:packages/profile",
               "requires": {
-                "@stacks/common": "^4.3.4",
-                "@stacks/network": "^4.3.4",
-                "@stacks/transactions": "^4.3.4",
+                "@stacks/common": "^4.3.5",
+                "@stacks/network": "^4.3.5",
+                "@stacks/transactions": "^4.3.5",
                 "@types/jest": "^26.0.22",
                 "bitcoinjs-lib": "^5.2.0",
                 "jest": "^26.6.3",
@@ -29256,7 +29256,7 @@
                 "@stacks/network": {
                   "version": "file:packages/network",
                   "requires": {
-                    "@stacks/common": "^4.3.4",
+                    "@stacks/common": "^4.3.5",
                     "@types/jest": "^26.0.22",
                     "cross-fetch": "^3.1.5",
                     "jest": "^26.6.3",
@@ -29300,9 +29300,9 @@
                   "requires": {
                     "@noble/hashes": "^1.0.0",
                     "@noble/secp256k1": "^1.5.5",
-                    "@stacks/common": "^4.3.4",
-                    "@stacks/encryption": "^4.3.4",
-                    "@stacks/network": "^4.3.4",
+                    "@stacks/common": "^4.3.5",
+                    "@stacks/encryption": "^4.3.5",
+                    "@stacks/network": "^4.3.5",
                     "@types/common-tags": "^1.8.0",
                     "@types/elliptic": "^6.4.12",
                     "@types/jest": "^26.0.22",
@@ -29357,7 +29357,7 @@
                         "@noble/secp256k1": "^1.5.5",
                         "@peculiar/webcrypto": "^1.1.6",
                         "@scure/bip39": "^1.1.0",
-                        "@stacks/common": "^4.3.4",
+                        "@stacks/common": "^4.3.5",
                         "@types/bs58check": "^2.1.0",
                         "@types/elliptic": "^6.4.12",
                         "@types/jest": "^26.0.22",
@@ -29413,7 +29413,7 @@
                     "@stacks/network": {
                       "version": "file:packages/network",
                       "requires": {
-                        "@stacks/common": "^4.3.4",
+                        "@stacks/common": "^4.3.5",
                         "@types/jest": "^26.0.22",
                         "cross-fetch": "^3.1.5",
                         "jest": "^26.6.3",
@@ -29459,9 +29459,9 @@
             "@stacks/storage": {
               "version": "file:packages/storage",
               "requires": {
-                "@stacks/auth": "^4.3.4",
-                "@stacks/common": "^4.3.4",
-                "@stacks/encryption": "^4.3.4",
+                "@stacks/auth": "^4.3.5",
+                "@stacks/common": "^4.3.5",
+                "@stacks/encryption": "^4.3.5",
                 "@stacks/network": "^4.1.0",
                 "@types/jest": "^26.0.22",
                 "@types/jsdom": "^16.2.10",
@@ -29484,10 +29484,10 @@
                 "@stacks/auth": {
                   "version": "file:packages/auth",
                   "requires": {
-                    "@stacks/common": "^4.3.4",
-                    "@stacks/encryption": "^4.3.4",
-                    "@stacks/network": "^4.3.4",
-                    "@stacks/profile": "^4.3.4",
+                    "@stacks/common": "^4.3.5",
+                    "@stacks/encryption": "^4.3.5",
+                    "@stacks/network": "^4.3.5",
+                    "@stacks/profile": "^4.3.5",
                     "@types/jest": "^26.0.22",
                     "cross-fetch": "^3.1.5",
                     "jest": "^26.6.3",
@@ -29530,7 +29530,7 @@
                         "@noble/secp256k1": "^1.5.5",
                         "@peculiar/webcrypto": "^1.1.6",
                         "@scure/bip39": "^1.1.0",
-                        "@stacks/common": "^4.3.4",
+                        "@stacks/common": "^4.3.5",
                         "@types/bs58check": "^2.1.0",
                         "@types/elliptic": "^6.4.12",
                         "@types/jest": "^26.0.22",
@@ -29586,7 +29586,7 @@
                     "@stacks/network": {
                       "version": "file:packages/network",
                       "requires": {
-                        "@stacks/common": "^4.3.4",
+                        "@stacks/common": "^4.3.5",
                         "@types/jest": "^26.0.22",
                         "cross-fetch": "^3.1.5",
                         "jest": "^26.6.3",
@@ -29628,9 +29628,9 @@
                     "@stacks/profile": {
                       "version": "file:packages/profile",
                       "requires": {
-                        "@stacks/common": "^4.3.4",
-                        "@stacks/network": "^4.3.4",
-                        "@stacks/transactions": "^4.3.4",
+                        "@stacks/common": "^4.3.5",
+                        "@stacks/network": "^4.3.5",
+                        "@stacks/transactions": "^4.3.5",
                         "@types/jest": "^26.0.22",
                         "bitcoinjs-lib": "^5.2.0",
                         "jest": "^26.6.3",
@@ -29673,7 +29673,7 @@
                         "@stacks/network": {
                           "version": "file:packages/network",
                           "requires": {
-                            "@stacks/common": "^4.3.4",
+                            "@stacks/common": "^4.3.5",
                             "@types/jest": "^26.0.22",
                             "cross-fetch": "^3.1.5",
                             "jest": "^26.6.3",
@@ -29717,9 +29717,9 @@
                           "requires": {
                             "@noble/hashes": "^1.0.0",
                             "@noble/secp256k1": "^1.5.5",
-                            "@stacks/common": "^4.3.4",
-                            "@stacks/encryption": "^4.3.4",
-                            "@stacks/network": "^4.3.4",
+                            "@stacks/common": "^4.3.5",
+                            "@stacks/encryption": "^4.3.5",
+                            "@stacks/network": "^4.3.5",
                             "@types/common-tags": "^1.8.0",
                             "@types/elliptic": "^6.4.12",
                             "@types/jest": "^26.0.22",
@@ -29774,7 +29774,7 @@
                                 "@noble/secp256k1": "^1.5.5",
                                 "@peculiar/webcrypto": "^1.1.6",
                                 "@scure/bip39": "^1.1.0",
-                                "@stacks/common": "^4.3.4",
+                                "@stacks/common": "^4.3.5",
                                 "@types/bs58check": "^2.1.0",
                                 "@types/elliptic": "^6.4.12",
                                 "@types/jest": "^26.0.22",
@@ -29830,7 +29830,7 @@
                             "@stacks/network": {
                               "version": "file:packages/network",
                               "requires": {
-                                "@stacks/common": "^4.3.4",
+                                "@stacks/common": "^4.3.5",
                                 "@types/jest": "^26.0.22",
                                 "cross-fetch": "^3.1.5",
                                 "jest": "^26.6.3",
@@ -29903,7 +29903,7 @@
                     "@noble/secp256k1": "^1.5.5",
                     "@peculiar/webcrypto": "^1.1.6",
                     "@scure/bip39": "^1.1.0",
-                    "@stacks/common": "^4.3.4",
+                    "@stacks/common": "^4.3.5",
                     "@types/bs58check": "^2.1.0",
                     "@types/elliptic": "^6.4.12",
                     "@types/jest": "^26.0.22",
@@ -29959,7 +29959,7 @@
                 "@stacks/network": {
                   "version": "file:packages/network",
                   "requires": {
-                    "@stacks/common": "^4.3.4",
+                    "@stacks/common": "^4.3.5",
                     "@types/jest": "^26.0.22",
                     "cross-fetch": "^3.1.5",
                     "jest": "^26.6.3",
@@ -30005,9 +30005,9 @@
               "requires": {
                 "@noble/hashes": "^1.0.0",
                 "@noble/secp256k1": "^1.5.5",
-                "@stacks/common": "^4.3.4",
-                "@stacks/encryption": "^4.3.4",
-                "@stacks/network": "^4.3.4",
+                "@stacks/common": "^4.3.5",
+                "@stacks/encryption": "^4.3.5",
+                "@stacks/network": "^4.3.5",
                 "@types/common-tags": "^1.8.0",
                 "@types/elliptic": "^6.4.12",
                 "@types/jest": "^26.0.22",
@@ -30062,7 +30062,7 @@
                     "@noble/secp256k1": "^1.5.5",
                     "@peculiar/webcrypto": "^1.1.6",
                     "@scure/bip39": "^1.1.0",
-                    "@stacks/common": "^4.3.4",
+                    "@stacks/common": "^4.3.5",
                     "@types/bs58check": "^2.1.0",
                     "@types/elliptic": "^6.4.12",
                     "@types/jest": "^26.0.22",
@@ -30118,7 +30118,7 @@
                 "@stacks/network": {
                   "version": "file:packages/network",
                   "requires": {
-                    "@stacks/common": "^4.3.4",
+                    "@stacks/common": "^4.3.5",
                     "@types/jest": "^26.0.22",
                     "cross-fetch": "^3.1.5",
                     "jest": "^26.6.3",
@@ -30191,7 +30191,7 @@
         "@noble/secp256k1": "^1.5.5",
         "@peculiar/webcrypto": "^1.1.6",
         "@scure/bip39": "^1.1.0",
-        "@stacks/common": "^4.3.4",
+        "@stacks/common": "^4.3.5",
         "@types/bs58check": "^2.1.0",
         "@types/elliptic": "^6.4.12",
         "@types/jest": "^26.0.22",
@@ -30513,13 +30513,13 @@
       "requires": {
         "@blockstack/rpc-client": "^0.3.0-alpha.11",
         "@scure/bip39": "^1.1.0",
-        "@stacks/auth": "^4.3.4",
-        "@stacks/common": "^4.3.4",
-        "@stacks/encryption": "^4.3.4",
-        "@stacks/network": "^4.3.4",
-        "@stacks/profile": "^4.3.4",
-        "@stacks/storage": "^4.3.4",
-        "@stacks/transactions": "^4.3.4",
+        "@stacks/auth": "^4.3.5",
+        "@stacks/common": "^4.3.5",
+        "@stacks/encryption": "^4.3.5",
+        "@stacks/network": "^4.3.5",
+        "@stacks/profile": "^4.3.5",
+        "@stacks/storage": "^4.3.5",
+        "@stacks/transactions": "^4.3.5",
         "@types/jest": "^26.0.22",
         "@types/node": "^18.0.4",
         "@types/triplesec": "^3.0.0",
@@ -30549,10 +30549,10 @@
         "@stacks/auth": {
           "version": "file:packages/auth",
           "requires": {
-            "@stacks/common": "^4.3.4",
-            "@stacks/encryption": "^4.3.4",
-            "@stacks/network": "^4.3.4",
-            "@stacks/profile": "^4.3.4",
+            "@stacks/common": "^4.3.5",
+            "@stacks/encryption": "^4.3.5",
+            "@stacks/network": "^4.3.5",
+            "@stacks/profile": "^4.3.5",
             "@types/jest": "^26.0.22",
             "cross-fetch": "^3.1.5",
             "jest": "^26.6.3",
@@ -30595,7 +30595,7 @@
                 "@noble/secp256k1": "^1.5.5",
                 "@peculiar/webcrypto": "^1.1.6",
                 "@scure/bip39": "^1.1.0",
-                "@stacks/common": "^4.3.4",
+                "@stacks/common": "^4.3.5",
                 "@types/bs58check": "^2.1.0",
                 "@types/elliptic": "^6.4.12",
                 "@types/jest": "^26.0.22",
@@ -30651,7 +30651,7 @@
             "@stacks/network": {
               "version": "file:packages/network",
               "requires": {
-                "@stacks/common": "^4.3.4",
+                "@stacks/common": "^4.3.5",
                 "@types/jest": "^26.0.22",
                 "cross-fetch": "^3.1.5",
                 "jest": "^26.6.3",
@@ -30693,9 +30693,9 @@
             "@stacks/profile": {
               "version": "file:packages/profile",
               "requires": {
-                "@stacks/common": "^4.3.4",
-                "@stacks/network": "^4.3.4",
-                "@stacks/transactions": "^4.3.4",
+                "@stacks/common": "^4.3.5",
+                "@stacks/network": "^4.3.5",
+                "@stacks/transactions": "^4.3.5",
                 "@types/jest": "^26.0.22",
                 "bitcoinjs-lib": "^5.2.0",
                 "jest": "^26.6.3",
@@ -30738,7 +30738,7 @@
                 "@stacks/network": {
                   "version": "file:packages/network",
                   "requires": {
-                    "@stacks/common": "^4.3.4",
+                    "@stacks/common": "^4.3.5",
                     "@types/jest": "^26.0.22",
                     "cross-fetch": "^3.1.5",
                     "jest": "^26.6.3",
@@ -30782,9 +30782,9 @@
                   "requires": {
                     "@noble/hashes": "^1.0.0",
                     "@noble/secp256k1": "^1.5.5",
-                    "@stacks/common": "^4.3.4",
-                    "@stacks/encryption": "^4.3.4",
-                    "@stacks/network": "^4.3.4",
+                    "@stacks/common": "^4.3.5",
+                    "@stacks/encryption": "^4.3.5",
+                    "@stacks/network": "^4.3.5",
                     "@types/common-tags": "^1.8.0",
                     "@types/elliptic": "^6.4.12",
                     "@types/jest": "^26.0.22",
@@ -30839,7 +30839,7 @@
                         "@noble/secp256k1": "^1.5.5",
                         "@peculiar/webcrypto": "^1.1.6",
                         "@scure/bip39": "^1.1.0",
-                        "@stacks/common": "^4.3.4",
+                        "@stacks/common": "^4.3.5",
                         "@types/bs58check": "^2.1.0",
                         "@types/elliptic": "^6.4.12",
                         "@types/jest": "^26.0.22",
@@ -30895,7 +30895,7 @@
                     "@stacks/network": {
                       "version": "file:packages/network",
                       "requires": {
-                        "@stacks/common": "^4.3.4",
+                        "@stacks/common": "^4.3.5",
                         "@types/jest": "^26.0.22",
                         "cross-fetch": "^3.1.5",
                         "jest": "^26.6.3",
@@ -30968,7 +30968,7 @@
             "@noble/secp256k1": "^1.5.5",
             "@peculiar/webcrypto": "^1.1.6",
             "@scure/bip39": "^1.1.0",
-            "@stacks/common": "^4.3.4",
+            "@stacks/common": "^4.3.5",
             "@types/bs58check": "^2.1.0",
             "@types/elliptic": "^6.4.12",
             "@types/jest": "^26.0.22",
@@ -31024,7 +31024,7 @@
         "@stacks/network": {
           "version": "file:packages/network",
           "requires": {
-            "@stacks/common": "^4.3.4",
+            "@stacks/common": "^4.3.5",
             "@types/jest": "^26.0.22",
             "cross-fetch": "^3.1.5",
             "jest": "^26.6.3",
@@ -31066,9 +31066,9 @@
         "@stacks/profile": {
           "version": "file:packages/profile",
           "requires": {
-            "@stacks/common": "^4.3.4",
-            "@stacks/network": "^4.3.4",
-            "@stacks/transactions": "^4.3.4",
+            "@stacks/common": "^4.3.5",
+            "@stacks/network": "^4.3.5",
+            "@stacks/transactions": "^4.3.5",
             "@types/jest": "^26.0.22",
             "bitcoinjs-lib": "^5.2.0",
             "jest": "^26.6.3",
@@ -31111,7 +31111,7 @@
             "@stacks/network": {
               "version": "file:packages/network",
               "requires": {
-                "@stacks/common": "^4.3.4",
+                "@stacks/common": "^4.3.5",
                 "@types/jest": "^26.0.22",
                 "cross-fetch": "^3.1.5",
                 "jest": "^26.6.3",
@@ -31155,9 +31155,9 @@
               "requires": {
                 "@noble/hashes": "^1.0.0",
                 "@noble/secp256k1": "^1.5.5",
-                "@stacks/common": "^4.3.4",
-                "@stacks/encryption": "^4.3.4",
-                "@stacks/network": "^4.3.4",
+                "@stacks/common": "^4.3.5",
+                "@stacks/encryption": "^4.3.5",
+                "@stacks/network": "^4.3.5",
                 "@types/common-tags": "^1.8.0",
                 "@types/elliptic": "^6.4.12",
                 "@types/jest": "^26.0.22",
@@ -31212,7 +31212,7 @@
                     "@noble/secp256k1": "^1.5.5",
                     "@peculiar/webcrypto": "^1.1.6",
                     "@scure/bip39": "^1.1.0",
-                    "@stacks/common": "^4.3.4",
+                    "@stacks/common": "^4.3.5",
                     "@types/bs58check": "^2.1.0",
                     "@types/elliptic": "^6.4.12",
                     "@types/jest": "^26.0.22",
@@ -31268,7 +31268,7 @@
                 "@stacks/network": {
                   "version": "file:packages/network",
                   "requires": {
-                    "@stacks/common": "^4.3.4",
+                    "@stacks/common": "^4.3.5",
                     "@types/jest": "^26.0.22",
                     "cross-fetch": "^3.1.5",
                     "jest": "^26.6.3",
@@ -31314,9 +31314,9 @@
         "@stacks/storage": {
           "version": "file:packages/storage",
           "requires": {
-            "@stacks/auth": "^4.3.4",
-            "@stacks/common": "^4.3.4",
-            "@stacks/encryption": "^4.3.4",
+            "@stacks/auth": "^4.3.5",
+            "@stacks/common": "^4.3.5",
+            "@stacks/encryption": "^4.3.5",
             "@stacks/network": "^4.1.0",
             "@types/jest": "^26.0.22",
             "@types/jsdom": "^16.2.10",
@@ -31339,10 +31339,10 @@
             "@stacks/auth": {
               "version": "file:packages/auth",
               "requires": {
-                "@stacks/common": "^4.3.4",
-                "@stacks/encryption": "^4.3.4",
-                "@stacks/network": "^4.3.4",
-                "@stacks/profile": "^4.3.4",
+                "@stacks/common": "^4.3.5",
+                "@stacks/encryption": "^4.3.5",
+                "@stacks/network": "^4.3.5",
+                "@stacks/profile": "^4.3.5",
                 "@types/jest": "^26.0.22",
                 "cross-fetch": "^3.1.5",
                 "jest": "^26.6.3",
@@ -31385,7 +31385,7 @@
                     "@noble/secp256k1": "^1.5.5",
                     "@peculiar/webcrypto": "^1.1.6",
                     "@scure/bip39": "^1.1.0",
-                    "@stacks/common": "^4.3.4",
+                    "@stacks/common": "^4.3.5",
                     "@types/bs58check": "^2.1.0",
                     "@types/elliptic": "^6.4.12",
                     "@types/jest": "^26.0.22",
@@ -31441,7 +31441,7 @@
                 "@stacks/network": {
                   "version": "file:packages/network",
                   "requires": {
-                    "@stacks/common": "^4.3.4",
+                    "@stacks/common": "^4.3.5",
                     "@types/jest": "^26.0.22",
                     "cross-fetch": "^3.1.5",
                     "jest": "^26.6.3",
@@ -31483,9 +31483,9 @@
                 "@stacks/profile": {
                   "version": "file:packages/profile",
                   "requires": {
-                    "@stacks/common": "^4.3.4",
-                    "@stacks/network": "^4.3.4",
-                    "@stacks/transactions": "^4.3.4",
+                    "@stacks/common": "^4.3.5",
+                    "@stacks/network": "^4.3.5",
+                    "@stacks/transactions": "^4.3.5",
                     "@types/jest": "^26.0.22",
                     "bitcoinjs-lib": "^5.2.0",
                     "jest": "^26.6.3",
@@ -31528,7 +31528,7 @@
                     "@stacks/network": {
                       "version": "file:packages/network",
                       "requires": {
-                        "@stacks/common": "^4.3.4",
+                        "@stacks/common": "^4.3.5",
                         "@types/jest": "^26.0.22",
                         "cross-fetch": "^3.1.5",
                         "jest": "^26.6.3",
@@ -31572,9 +31572,9 @@
                       "requires": {
                         "@noble/hashes": "^1.0.0",
                         "@noble/secp256k1": "^1.5.5",
-                        "@stacks/common": "^4.3.4",
-                        "@stacks/encryption": "^4.3.4",
-                        "@stacks/network": "^4.3.4",
+                        "@stacks/common": "^4.3.5",
+                        "@stacks/encryption": "^4.3.5",
+                        "@stacks/network": "^4.3.5",
                         "@types/common-tags": "^1.8.0",
                         "@types/elliptic": "^6.4.12",
                         "@types/jest": "^26.0.22",
@@ -31629,7 +31629,7 @@
                             "@noble/secp256k1": "^1.5.5",
                             "@peculiar/webcrypto": "^1.1.6",
                             "@scure/bip39": "^1.1.0",
-                            "@stacks/common": "^4.3.4",
+                            "@stacks/common": "^4.3.5",
                             "@types/bs58check": "^2.1.0",
                             "@types/elliptic": "^6.4.12",
                             "@types/jest": "^26.0.22",
@@ -31685,7 +31685,7 @@
                         "@stacks/network": {
                           "version": "file:packages/network",
                           "requires": {
-                            "@stacks/common": "^4.3.4",
+                            "@stacks/common": "^4.3.5",
                             "@types/jest": "^26.0.22",
                             "cross-fetch": "^3.1.5",
                             "jest": "^26.6.3",
@@ -31758,7 +31758,7 @@
                 "@noble/secp256k1": "^1.5.5",
                 "@peculiar/webcrypto": "^1.1.6",
                 "@scure/bip39": "^1.1.0",
-                "@stacks/common": "^4.3.4",
+                "@stacks/common": "^4.3.5",
                 "@types/bs58check": "^2.1.0",
                 "@types/elliptic": "^6.4.12",
                 "@types/jest": "^26.0.22",
@@ -31814,7 +31814,7 @@
             "@stacks/network": {
               "version": "file:packages/network",
               "requires": {
-                "@stacks/common": "^4.3.4",
+                "@stacks/common": "^4.3.5",
                 "@types/jest": "^26.0.22",
                 "cross-fetch": "^3.1.5",
                 "jest": "^26.6.3",
@@ -31860,9 +31860,9 @@
           "requires": {
             "@noble/hashes": "^1.0.0",
             "@noble/secp256k1": "^1.5.5",
-            "@stacks/common": "^4.3.4",
-            "@stacks/encryption": "^4.3.4",
-            "@stacks/network": "^4.3.4",
+            "@stacks/common": "^4.3.5",
+            "@stacks/encryption": "^4.3.5",
+            "@stacks/network": "^4.3.5",
             "@types/common-tags": "^1.8.0",
             "@types/elliptic": "^6.4.12",
             "@types/jest": "^26.0.22",
@@ -31917,7 +31917,7 @@
                 "@noble/secp256k1": "^1.5.5",
                 "@peculiar/webcrypto": "^1.1.6",
                 "@scure/bip39": "^1.1.0",
-                "@stacks/common": "^4.3.4",
+                "@stacks/common": "^4.3.5",
                 "@types/bs58check": "^2.1.0",
                 "@types/elliptic": "^6.4.12",
                 "@types/jest": "^26.0.22",
@@ -31973,7 +31973,7 @@
             "@stacks/network": {
               "version": "file:packages/network",
               "requires": {
-                "@stacks/common": "^4.3.4",
+                "@stacks/common": "^4.3.5",
                 "@types/jest": "^26.0.22",
                 "cross-fetch": "^3.1.5",
                 "jest": "^26.6.3",
@@ -32019,7 +32019,7 @@
     "@stacks/network": {
       "version": "file:packages/network",
       "requires": {
-        "@stacks/common": "^4.3.4",
+        "@stacks/common": "^4.3.5",
         "@types/jest": "^26.0.22",
         "cross-fetch": "^3.1.5",
         "jest": "^26.6.3",
@@ -32074,9 +32074,9 @@
     "@stacks/profile": {
       "version": "file:packages/profile",
       "requires": {
-        "@stacks/common": "^4.3.4",
-        "@stacks/network": "^4.3.4",
-        "@stacks/transactions": "^4.3.4",
+        "@stacks/common": "^4.3.5",
+        "@stacks/network": "^4.3.5",
+        "@stacks/transactions": "^4.3.5",
         "@types/jest": "^26.0.22",
         "bitcoinjs-lib": "^5.2.0",
         "jest": "^26.6.3",
@@ -32119,7 +32119,7 @@
         "@stacks/network": {
           "version": "file:packages/network",
           "requires": {
-            "@stacks/common": "^4.3.4",
+            "@stacks/common": "^4.3.5",
             "@types/jest": "^26.0.22",
             "cross-fetch": "^3.1.5",
             "jest": "^26.6.3",
@@ -32163,9 +32163,9 @@
           "requires": {
             "@noble/hashes": "^1.0.0",
             "@noble/secp256k1": "^1.5.5",
-            "@stacks/common": "^4.3.4",
-            "@stacks/encryption": "^4.3.4",
-            "@stacks/network": "^4.3.4",
+            "@stacks/common": "^4.3.5",
+            "@stacks/encryption": "^4.3.5",
+            "@stacks/network": "^4.3.5",
             "@types/common-tags": "^1.8.0",
             "@types/elliptic": "^6.4.12",
             "@types/jest": "^26.0.22",
@@ -32220,7 +32220,7 @@
                 "@noble/secp256k1": "^1.5.5",
                 "@peculiar/webcrypto": "^1.1.6",
                 "@scure/bip39": "^1.1.0",
-                "@stacks/common": "^4.3.4",
+                "@stacks/common": "^4.3.5",
                 "@types/bs58check": "^2.1.0",
                 "@types/elliptic": "^6.4.12",
                 "@types/jest": "^26.0.22",
@@ -32276,7 +32276,7 @@
             "@stacks/network": {
               "version": "file:packages/network",
               "requires": {
-                "@stacks/common": "^4.3.4",
+                "@stacks/common": "^4.3.5",
                 "@types/jest": "^26.0.22",
                 "cross-fetch": "^3.1.5",
                 "jest": "^26.6.3",
@@ -32322,11 +32322,11 @@
     "@stacks/stacking": {
       "version": "file:packages/stacking",
       "requires": {
-        "@stacks/common": "^4.3.4",
-        "@stacks/encryption": "^4.3.4",
-        "@stacks/network": "^4.3.4",
+        "@stacks/common": "^4.3.5",
+        "@stacks/encryption": "^4.3.5",
+        "@stacks/network": "^4.3.5",
         "@stacks/stacks-blockchain-api-types": "^0.61.0",
-        "@stacks/transactions": "^4.3.4",
+        "@stacks/transactions": "^4.3.5",
         "@types/jest": "^26.0.22",
         "bitcoinjs-lib": "^5.2.0",
         "bs58": "^5.0.0",
@@ -32372,7 +32372,7 @@
             "@noble/secp256k1": "^1.5.5",
             "@peculiar/webcrypto": "^1.1.6",
             "@scure/bip39": "^1.1.0",
-            "@stacks/common": "^4.3.4",
+            "@stacks/common": "^4.3.5",
             "@types/bs58check": "^2.1.0",
             "@types/elliptic": "^6.4.12",
             "@types/jest": "^26.0.22",
@@ -32428,7 +32428,7 @@
         "@stacks/network": {
           "version": "file:packages/network",
           "requires": {
-            "@stacks/common": "^4.3.4",
+            "@stacks/common": "^4.3.5",
             "@types/jest": "^26.0.22",
             "cross-fetch": "^3.1.5",
             "jest": "^26.6.3",
@@ -32472,9 +32472,9 @@
           "requires": {
             "@noble/hashes": "^1.0.0",
             "@noble/secp256k1": "^1.5.5",
-            "@stacks/common": "^4.3.4",
-            "@stacks/encryption": "^4.3.4",
-            "@stacks/network": "^4.3.4",
+            "@stacks/common": "^4.3.5",
+            "@stacks/encryption": "^4.3.5",
+            "@stacks/network": "^4.3.5",
             "@types/common-tags": "^1.8.0",
             "@types/elliptic": "^6.4.12",
             "@types/jest": "^26.0.22",
@@ -32529,7 +32529,7 @@
                 "@noble/secp256k1": "^1.5.5",
                 "@peculiar/webcrypto": "^1.1.6",
                 "@scure/bip39": "^1.1.0",
-                "@stacks/common": "^4.3.4",
+                "@stacks/common": "^4.3.5",
                 "@types/bs58check": "^2.1.0",
                 "@types/elliptic": "^6.4.12",
                 "@types/jest": "^26.0.22",
@@ -32585,7 +32585,7 @@
             "@stacks/network": {
               "version": "file:packages/network",
               "requires": {
-                "@stacks/common": "^4.3.4",
+                "@stacks/common": "^4.3.5",
                 "@types/jest": "^26.0.22",
                 "cross-fetch": "^3.1.5",
                 "jest": "^26.6.3",
@@ -32634,9 +32634,9 @@
     "@stacks/storage": {
       "version": "file:packages/storage",
       "requires": {
-        "@stacks/auth": "^4.3.4",
-        "@stacks/common": "^4.3.4",
-        "@stacks/encryption": "^4.3.4",
+        "@stacks/auth": "^4.3.5",
+        "@stacks/common": "^4.3.5",
+        "@stacks/encryption": "^4.3.5",
         "@stacks/network": "^4.1.0",
         "@types/jest": "^26.0.22",
         "@types/jsdom": "^16.2.10",
@@ -32659,10 +32659,10 @@
         "@stacks/auth": {
           "version": "file:packages/auth",
           "requires": {
-            "@stacks/common": "^4.3.4",
-            "@stacks/encryption": "^4.3.4",
-            "@stacks/network": "^4.3.4",
-            "@stacks/profile": "^4.3.4",
+            "@stacks/common": "^4.3.5",
+            "@stacks/encryption": "^4.3.5",
+            "@stacks/network": "^4.3.5",
+            "@stacks/profile": "^4.3.5",
             "@types/jest": "^26.0.22",
             "cross-fetch": "^3.1.5",
             "jest": "^26.6.3",
@@ -32705,7 +32705,7 @@
                 "@noble/secp256k1": "^1.5.5",
                 "@peculiar/webcrypto": "^1.1.6",
                 "@scure/bip39": "^1.1.0",
-                "@stacks/common": "^4.3.4",
+                "@stacks/common": "^4.3.5",
                 "@types/bs58check": "^2.1.0",
                 "@types/elliptic": "^6.4.12",
                 "@types/jest": "^26.0.22",
@@ -32761,7 +32761,7 @@
             "@stacks/network": {
               "version": "file:packages/network",
               "requires": {
-                "@stacks/common": "^4.3.4",
+                "@stacks/common": "^4.3.5",
                 "@types/jest": "^26.0.22",
                 "cross-fetch": "^3.1.5",
                 "jest": "^26.6.3",
@@ -32803,9 +32803,9 @@
             "@stacks/profile": {
               "version": "file:packages/profile",
               "requires": {
-                "@stacks/common": "^4.3.4",
-                "@stacks/network": "^4.3.4",
-                "@stacks/transactions": "^4.3.4",
+                "@stacks/common": "^4.3.5",
+                "@stacks/network": "^4.3.5",
+                "@stacks/transactions": "^4.3.5",
                 "@types/jest": "^26.0.22",
                 "bitcoinjs-lib": "^5.2.0",
                 "jest": "^26.6.3",
@@ -32848,7 +32848,7 @@
                 "@stacks/network": {
                   "version": "file:packages/network",
                   "requires": {
-                    "@stacks/common": "^4.3.4",
+                    "@stacks/common": "^4.3.5",
                     "@types/jest": "^26.0.22",
                     "cross-fetch": "^3.1.5",
                     "jest": "^26.6.3",
@@ -32892,9 +32892,9 @@
                   "requires": {
                     "@noble/hashes": "^1.0.0",
                     "@noble/secp256k1": "^1.5.5",
-                    "@stacks/common": "^4.3.4",
-                    "@stacks/encryption": "^4.3.4",
-                    "@stacks/network": "^4.3.4",
+                    "@stacks/common": "^4.3.5",
+                    "@stacks/encryption": "^4.3.5",
+                    "@stacks/network": "^4.3.5",
                     "@types/common-tags": "^1.8.0",
                     "@types/elliptic": "^6.4.12",
                     "@types/jest": "^26.0.22",
@@ -32949,7 +32949,7 @@
                         "@noble/secp256k1": "^1.5.5",
                         "@peculiar/webcrypto": "^1.1.6",
                         "@scure/bip39": "^1.1.0",
-                        "@stacks/common": "^4.3.4",
+                        "@stacks/common": "^4.3.5",
                         "@types/bs58check": "^2.1.0",
                         "@types/elliptic": "^6.4.12",
                         "@types/jest": "^26.0.22",
@@ -33005,7 +33005,7 @@
                     "@stacks/network": {
                       "version": "file:packages/network",
                       "requires": {
-                        "@stacks/common": "^4.3.4",
+                        "@stacks/common": "^4.3.5",
                         "@types/jest": "^26.0.22",
                         "cross-fetch": "^3.1.5",
                         "jest": "^26.6.3",
@@ -33078,7 +33078,7 @@
             "@noble/secp256k1": "^1.5.5",
             "@peculiar/webcrypto": "^1.1.6",
             "@scure/bip39": "^1.1.0",
-            "@stacks/common": "^4.3.4",
+            "@stacks/common": "^4.3.5",
             "@types/bs58check": "^2.1.0",
             "@types/elliptic": "^6.4.12",
             "@types/jest": "^26.0.22",
@@ -33134,7 +33134,7 @@
         "@stacks/network": {
           "version": "file:packages/network",
           "requires": {
-            "@stacks/common": "^4.3.4",
+            "@stacks/common": "^4.3.5",
             "@types/jest": "^26.0.22",
             "cross-fetch": "^3.1.5",
             "jest": "^26.6.3",
@@ -33180,9 +33180,9 @@
       "requires": {
         "@noble/hashes": "^1.0.0",
         "@noble/secp256k1": "^1.5.5",
-        "@stacks/common": "^4.3.4",
-        "@stacks/encryption": "^4.3.4",
-        "@stacks/network": "^4.3.4",
+        "@stacks/common": "^4.3.5",
+        "@stacks/encryption": "^4.3.5",
+        "@stacks/network": "^4.3.5",
         "@types/common-tags": "^1.8.0",
         "@types/elliptic": "^6.4.12",
         "@types/jest": "^26.0.22",
@@ -33237,7 +33237,7 @@
             "@noble/secp256k1": "^1.5.5",
             "@peculiar/webcrypto": "^1.1.6",
             "@scure/bip39": "^1.1.0",
-            "@stacks/common": "^4.3.4",
+            "@stacks/common": "^4.3.5",
             "@types/bs58check": "^2.1.0",
             "@types/elliptic": "^6.4.12",
             "@types/jest": "^26.0.22",
@@ -33293,7 +33293,7 @@
         "@stacks/network": {
           "version": "file:packages/network",
           "requires": {
-            "@stacks/common": "^4.3.4",
+            "@stacks/common": "^4.3.5",
             "@types/jest": "^26.0.22",
             "cross-fetch": "^3.1.5",
             "jest": "^26.6.3",
@@ -33339,13 +33339,13 @@
       "requires": {
         "@scure/bip32": "^1.1.0",
         "@scure/bip39": "^1.1.0",
-        "@stacks/auth": "^4.3.4",
-        "@stacks/common": "^4.3.4",
-        "@stacks/encryption": "^4.3.4",
-        "@stacks/network": "^4.3.4",
-        "@stacks/profile": "^4.3.4",
-        "@stacks/storage": "^4.3.4",
-        "@stacks/transactions": "^4.3.4",
+        "@stacks/auth": "^4.3.5",
+        "@stacks/common": "^4.3.5",
+        "@stacks/encryption": "^4.3.5",
+        "@stacks/network": "^4.3.5",
+        "@stacks/profile": "^4.3.5",
+        "@stacks/storage": "^4.3.5",
+        "@stacks/transactions": "^4.3.5",
         "@types/jest": "^26.0.22",
         "@types/node": "^18.0.4",
         "assert": "^2.0.0",
@@ -33366,10 +33366,10 @@
         "@stacks/auth": {
           "version": "file:packages/auth",
           "requires": {
-            "@stacks/common": "^4.3.4",
-            "@stacks/encryption": "^4.3.4",
-            "@stacks/network": "^4.3.4",
-            "@stacks/profile": "^4.3.4",
+            "@stacks/common": "^4.3.5",
+            "@stacks/encryption": "^4.3.5",
+            "@stacks/network": "^4.3.5",
+            "@stacks/profile": "^4.3.5",
             "@types/jest": "^26.0.22",
             "cross-fetch": "^3.1.5",
             "jest": "^26.6.3",
@@ -33412,7 +33412,7 @@
                 "@noble/secp256k1": "^1.5.5",
                 "@peculiar/webcrypto": "^1.1.6",
                 "@scure/bip39": "^1.1.0",
-                "@stacks/common": "^4.3.4",
+                "@stacks/common": "^4.3.5",
                 "@types/bs58check": "^2.1.0",
                 "@types/elliptic": "^6.4.12",
                 "@types/jest": "^26.0.22",
@@ -33468,7 +33468,7 @@
             "@stacks/network": {
               "version": "file:packages/network",
               "requires": {
-                "@stacks/common": "^4.3.4",
+                "@stacks/common": "^4.3.5",
                 "@types/jest": "^26.0.22",
                 "cross-fetch": "^3.1.5",
                 "jest": "^26.6.3",
@@ -33510,9 +33510,9 @@
             "@stacks/profile": {
               "version": "file:packages/profile",
               "requires": {
-                "@stacks/common": "^4.3.4",
-                "@stacks/network": "^4.3.4",
-                "@stacks/transactions": "^4.3.4",
+                "@stacks/common": "^4.3.5",
+                "@stacks/network": "^4.3.5",
+                "@stacks/transactions": "^4.3.5",
                 "@types/jest": "^26.0.22",
                 "bitcoinjs-lib": "^5.2.0",
                 "jest": "^26.6.3",
@@ -33555,7 +33555,7 @@
                 "@stacks/network": {
                   "version": "file:packages/network",
                   "requires": {
-                    "@stacks/common": "^4.3.4",
+                    "@stacks/common": "^4.3.5",
                     "@types/jest": "^26.0.22",
                     "cross-fetch": "^3.1.5",
                     "jest": "^26.6.3",
@@ -33599,9 +33599,9 @@
                   "requires": {
                     "@noble/hashes": "^1.0.0",
                     "@noble/secp256k1": "^1.5.5",
-                    "@stacks/common": "^4.3.4",
-                    "@stacks/encryption": "^4.3.4",
-                    "@stacks/network": "^4.3.4",
+                    "@stacks/common": "^4.3.5",
+                    "@stacks/encryption": "^4.3.5",
+                    "@stacks/network": "^4.3.5",
                     "@types/common-tags": "^1.8.0",
                     "@types/elliptic": "^6.4.12",
                     "@types/jest": "^26.0.22",
@@ -33656,7 +33656,7 @@
                         "@noble/secp256k1": "^1.5.5",
                         "@peculiar/webcrypto": "^1.1.6",
                         "@scure/bip39": "^1.1.0",
-                        "@stacks/common": "^4.3.4",
+                        "@stacks/common": "^4.3.5",
                         "@types/bs58check": "^2.1.0",
                         "@types/elliptic": "^6.4.12",
                         "@types/jest": "^26.0.22",
@@ -33712,7 +33712,7 @@
                     "@stacks/network": {
                       "version": "file:packages/network",
                       "requires": {
-                        "@stacks/common": "^4.3.4",
+                        "@stacks/common": "^4.3.5",
                         "@types/jest": "^26.0.22",
                         "cross-fetch": "^3.1.5",
                         "jest": "^26.6.3",
@@ -33785,7 +33785,7 @@
             "@noble/secp256k1": "^1.5.5",
             "@peculiar/webcrypto": "^1.1.6",
             "@scure/bip39": "^1.1.0",
-            "@stacks/common": "^4.3.4",
+            "@stacks/common": "^4.3.5",
             "@types/bs58check": "^2.1.0",
             "@types/elliptic": "^6.4.12",
             "@types/jest": "^26.0.22",
@@ -33841,7 +33841,7 @@
         "@stacks/network": {
           "version": "file:packages/network",
           "requires": {
-            "@stacks/common": "^4.3.4",
+            "@stacks/common": "^4.3.5",
             "@types/jest": "^26.0.22",
             "cross-fetch": "^3.1.5",
             "jest": "^26.6.3",
@@ -33883,9 +33883,9 @@
         "@stacks/profile": {
           "version": "file:packages/profile",
           "requires": {
-            "@stacks/common": "^4.3.4",
-            "@stacks/network": "^4.3.4",
-            "@stacks/transactions": "^4.3.4",
+            "@stacks/common": "^4.3.5",
+            "@stacks/network": "^4.3.5",
+            "@stacks/transactions": "^4.3.5",
             "@types/jest": "^26.0.22",
             "bitcoinjs-lib": "^5.2.0",
             "jest": "^26.6.3",
@@ -33928,7 +33928,7 @@
             "@stacks/network": {
               "version": "file:packages/network",
               "requires": {
-                "@stacks/common": "^4.3.4",
+                "@stacks/common": "^4.3.5",
                 "@types/jest": "^26.0.22",
                 "cross-fetch": "^3.1.5",
                 "jest": "^26.6.3",
@@ -33972,9 +33972,9 @@
               "requires": {
                 "@noble/hashes": "^1.0.0",
                 "@noble/secp256k1": "^1.5.5",
-                "@stacks/common": "^4.3.4",
-                "@stacks/encryption": "^4.3.4",
-                "@stacks/network": "^4.3.4",
+                "@stacks/common": "^4.3.5",
+                "@stacks/encryption": "^4.3.5",
+                "@stacks/network": "^4.3.5",
                 "@types/common-tags": "^1.8.0",
                 "@types/elliptic": "^6.4.12",
                 "@types/jest": "^26.0.22",
@@ -34029,7 +34029,7 @@
                     "@noble/secp256k1": "^1.5.5",
                     "@peculiar/webcrypto": "^1.1.6",
                     "@scure/bip39": "^1.1.0",
-                    "@stacks/common": "^4.3.4",
+                    "@stacks/common": "^4.3.5",
                     "@types/bs58check": "^2.1.0",
                     "@types/elliptic": "^6.4.12",
                     "@types/jest": "^26.0.22",
@@ -34085,7 +34085,7 @@
                 "@stacks/network": {
                   "version": "file:packages/network",
                   "requires": {
-                    "@stacks/common": "^4.3.4",
+                    "@stacks/common": "^4.3.5",
                     "@types/jest": "^26.0.22",
                     "cross-fetch": "^3.1.5",
                     "jest": "^26.6.3",
@@ -34131,9 +34131,9 @@
         "@stacks/storage": {
           "version": "file:packages/storage",
           "requires": {
-            "@stacks/auth": "^4.3.4",
-            "@stacks/common": "^4.3.4",
-            "@stacks/encryption": "^4.3.4",
+            "@stacks/auth": "^4.3.5",
+            "@stacks/common": "^4.3.5",
+            "@stacks/encryption": "^4.3.5",
             "@stacks/network": "^4.1.0",
             "@types/jest": "^26.0.22",
             "@types/jsdom": "^16.2.10",
@@ -34156,10 +34156,10 @@
             "@stacks/auth": {
               "version": "file:packages/auth",
               "requires": {
-                "@stacks/common": "^4.3.4",
-                "@stacks/encryption": "^4.3.4",
-                "@stacks/network": "^4.3.4",
-                "@stacks/profile": "^4.3.4",
+                "@stacks/common": "^4.3.5",
+                "@stacks/encryption": "^4.3.5",
+                "@stacks/network": "^4.3.5",
+                "@stacks/profile": "^4.3.5",
                 "@types/jest": "^26.0.22",
                 "cross-fetch": "^3.1.5",
                 "jest": "^26.6.3",
@@ -34202,7 +34202,7 @@
                     "@noble/secp256k1": "^1.5.5",
                     "@peculiar/webcrypto": "^1.1.6",
                     "@scure/bip39": "^1.1.0",
-                    "@stacks/common": "^4.3.4",
+                    "@stacks/common": "^4.3.5",
                     "@types/bs58check": "^2.1.0",
                     "@types/elliptic": "^6.4.12",
                     "@types/jest": "^26.0.22",
@@ -34258,7 +34258,7 @@
                 "@stacks/network": {
                   "version": "file:packages/network",
                   "requires": {
-                    "@stacks/common": "^4.3.4",
+                    "@stacks/common": "^4.3.5",
                     "@types/jest": "^26.0.22",
                     "cross-fetch": "^3.1.5",
                     "jest": "^26.6.3",
@@ -34300,9 +34300,9 @@
                 "@stacks/profile": {
                   "version": "file:packages/profile",
                   "requires": {
-                    "@stacks/common": "^4.3.4",
-                    "@stacks/network": "^4.3.4",
-                    "@stacks/transactions": "^4.3.4",
+                    "@stacks/common": "^4.3.5",
+                    "@stacks/network": "^4.3.5",
+                    "@stacks/transactions": "^4.3.5",
                     "@types/jest": "^26.0.22",
                     "bitcoinjs-lib": "^5.2.0",
                     "jest": "^26.6.3",
@@ -34345,7 +34345,7 @@
                     "@stacks/network": {
                       "version": "file:packages/network",
                       "requires": {
-                        "@stacks/common": "^4.3.4",
+                        "@stacks/common": "^4.3.5",
                         "@types/jest": "^26.0.22",
                         "cross-fetch": "^3.1.5",
                         "jest": "^26.6.3",
@@ -34389,9 +34389,9 @@
                       "requires": {
                         "@noble/hashes": "^1.0.0",
                         "@noble/secp256k1": "^1.5.5",
-                        "@stacks/common": "^4.3.4",
-                        "@stacks/encryption": "^4.3.4",
-                        "@stacks/network": "^4.3.4",
+                        "@stacks/common": "^4.3.5",
+                        "@stacks/encryption": "^4.3.5",
+                        "@stacks/network": "^4.3.5",
                         "@types/common-tags": "^1.8.0",
                         "@types/elliptic": "^6.4.12",
                         "@types/jest": "^26.0.22",
@@ -34446,7 +34446,7 @@
                             "@noble/secp256k1": "^1.5.5",
                             "@peculiar/webcrypto": "^1.1.6",
                             "@scure/bip39": "^1.1.0",
-                            "@stacks/common": "^4.3.4",
+                            "@stacks/common": "^4.3.5",
                             "@types/bs58check": "^2.1.0",
                             "@types/elliptic": "^6.4.12",
                             "@types/jest": "^26.0.22",
@@ -34502,7 +34502,7 @@
                         "@stacks/network": {
                           "version": "file:packages/network",
                           "requires": {
-                            "@stacks/common": "^4.3.4",
+                            "@stacks/common": "^4.3.5",
                             "@types/jest": "^26.0.22",
                             "cross-fetch": "^3.1.5",
                             "jest": "^26.6.3",
@@ -34575,7 +34575,7 @@
                 "@noble/secp256k1": "^1.5.5",
                 "@peculiar/webcrypto": "^1.1.6",
                 "@scure/bip39": "^1.1.0",
-                "@stacks/common": "^4.3.4",
+                "@stacks/common": "^4.3.5",
                 "@types/bs58check": "^2.1.0",
                 "@types/elliptic": "^6.4.12",
                 "@types/jest": "^26.0.22",
@@ -34631,7 +34631,7 @@
             "@stacks/network": {
               "version": "file:packages/network",
               "requires": {
-                "@stacks/common": "^4.3.4",
+                "@stacks/common": "^4.3.5",
                 "@types/jest": "^26.0.22",
                 "cross-fetch": "^3.1.5",
                 "jest": "^26.6.3",
@@ -34677,9 +34677,9 @@
           "requires": {
             "@noble/hashes": "^1.0.0",
             "@noble/secp256k1": "^1.5.5",
-            "@stacks/common": "^4.3.4",
-            "@stacks/encryption": "^4.3.4",
-            "@stacks/network": "^4.3.4",
+            "@stacks/common": "^4.3.5",
+            "@stacks/encryption": "^4.3.5",
+            "@stacks/network": "^4.3.5",
             "@types/common-tags": "^1.8.0",
             "@types/elliptic": "^6.4.12",
             "@types/jest": "^26.0.22",
@@ -34734,7 +34734,7 @@
                 "@noble/secp256k1": "^1.5.5",
                 "@peculiar/webcrypto": "^1.1.6",
                 "@scure/bip39": "^1.1.0",
-                "@stacks/common": "^4.3.4",
+                "@stacks/common": "^4.3.5",
                 "@types/bs58check": "^2.1.0",
                 "@types/elliptic": "^6.4.12",
                 "@types/jest": "^26.0.22",
@@ -34790,7 +34790,7 @@
             "@stacks/network": {
               "version": "file:packages/network",
               "requires": {
-                "@stacks/common": "^4.3.4",
+                "@stacks/common": "^4.3.5",
                 "@types/jest": "^26.0.22",
                 "cross-fetch": "^3.1.5",
                 "jest": "^26.6.3",

--- a/packages/keychain/src/address-derivation/index.ts
+++ b/packages/keychain/src/address-derivation/index.ts
@@ -9,10 +9,12 @@ export const derivationPaths = {
   [ChainID.Testnet]: networkDerivationPath,
 };
 
+/** @deprecated */
 export function getDerivationPath(chain: ChainID) {
   return derivationPaths[chain];
 }
 
+/** @deprecated */
 export function deriveStxAddressChain(chain: ChainID) {
   return (rootNode: BIP32Interface) => {
     const childKey = rootNode.derivePath(getDerivationPath(chain));

--- a/packages/keychain/src/common.ts
+++ b/packages/keychain/src/common.ts
@@ -3,7 +3,7 @@ import { IdentityKeyPair } from './utils';
 interface RefreshOptions {
   gaiaUrl: string;
 }
-
+/** @deprecated use `@stacks/profile` instead */
 export interface Identity {
   keyPair: IdentityKeyPair;
   address: string;
@@ -27,6 +27,7 @@ const PERSON_TYPE = 'Person';
 const CONTEXT = 'http://schema.org';
 const IMAGE_TYPE = 'ImageObject';
 
+/** @deprecated use `@stacks/profile` instead */
 export interface ProfileImage {
   '@type': typeof IMAGE_TYPE;
   name: string;

--- a/packages/keychain/src/encryption/decrypt.ts
+++ b/packages/keychain/src/encryption/decrypt.ts
@@ -9,6 +9,7 @@ import { decryptMnemonic } from '@stacks/encryption';
  * @param data - Buffer or hex-encoded string of the encrypted mnemonic
  * @param password - Password for data
  * @return the raw mnemonic phrase
+ * @deprecated use `decrypt` from `@stacks/wallet-sdk` instead
  */
 export async function decrypt(dataBuffer: Buffer | string, password: string): Promise<string> {
   const result = await decryptMnemonic(dataBuffer, password, triplesecDecrypt);

--- a/packages/keychain/src/encryption/encrypt.ts
+++ b/packages/keychain/src/encryption/encrypt.ts
@@ -5,6 +5,7 @@ import { encryptMnemonic } from '@stacks/encryption';
  * @param phrase - Raw mnemonic phrase
  * @param password - Password to encrypt mnemonic with
  * @return The encrypted phrase
+ * @deprecated use `encrypt` from `@stacks/wallet-sdk` instead
  * */
 export async function encrypt(phrase: string, password: string) {
   const result = await encryptMnemonic(phrase, password);

--- a/packages/keychain/src/identity.ts
+++ b/packages/keychain/src/identity.ts
@@ -25,6 +25,7 @@ interface RefreshOptions {
   gaiaUrl: string;
 }
 
+/** @deprecated use `@stacks/auth` and `@stacks/profile` instead */
 export class Identity implements IdentifyInterface {
   public keyPair: IdentityKeyPair;
   public address: string;

--- a/packages/keychain/src/mnemonic/index.ts
+++ b/packages/keychain/src/mnemonic/index.ts
@@ -15,6 +15,7 @@ import { encryptMnemonic } from '@stacks/encryption';
 
 export type AllowedKeyEntropyBits = 128 | 256;
 
+/** @deprecated use `generateSecretKey` and `generateWallet` from `@stacks/wallet-sdk` instead */
 export async function generateMnemonicRootKeychain(entropy: AllowedKeyEntropyBits) {
   const plaintextMnemonic = generateBip39Mnemonic(wordlist, entropy);
   const seed = await mnemonicToSeed(plaintextMnemonic);
@@ -25,6 +26,7 @@ export async function generateMnemonicRootKeychain(entropy: AllowedKeyEntropyBit
   };
 }
 
+/** @deprecated use `generateWallet` from `@stacks/wallet-sdk` instead */
 export async function generateEncryptedMnemonicRootKeychain(
   password: string,
   entropy: AllowedKeyEntropyBits
@@ -40,12 +42,14 @@ export async function generateEncryptedMnemonicRootKeychain(
   };
 }
 
+/** @deprecated use `generateWallet` from `@stacks/wallet-sdk` instead */
 export async function deriveRootKeychainFromMnemonic(plaintextMnemonic: string) {
   const seed = await mnemonicToSeed(plaintextMnemonic);
   const rootNode = bip32.fromSeed(Buffer.from(seed));
   return rootNode;
 }
 
+/** @deprecated use `encrypt` from `@stacks/wallet-sdk` instead */
 export async function encryptMnemonicFormatted(plaintextMnemonic: string, password: string) {
   const encryptedMnemonic = await encryptMnemonic(plaintextMnemonic, password);
   const encryptedMnemonicHex = encryptedMnemonic.toString('hex');

--- a/packages/keychain/src/nodes/identity-address-owner-node.ts
+++ b/packages/keychain/src/nodes/identity-address-owner-node.ts
@@ -10,6 +10,7 @@ const SIGNING_NODE_INDEX = 1;
 const ENCRYPTION_NODE_INDEX = 2;
 const STX_NODE_INDEX = 6;
 
+/** @deprecated use `@stacks/wallet-sdk` instead */
 export default class IdentityAddressOwnerNode {
   hdNode: BIP32Interface;
 

--- a/packages/keychain/src/profiles.ts
+++ b/packages/keychain/src/profiles.ts
@@ -28,6 +28,7 @@ export const registrars = {
   },
 };
 
+/** @deprecated use `@stacks/profile` instead */
 export function signProfileForUpload(profile: Profile, keypair: IdentityKeyPair) {
   const privateKey = keypair.key;
   const publicKey = keypair.keyID;
@@ -38,6 +39,7 @@ export function signProfileForUpload(profile: Profile, keypair: IdentityKeyPair)
   return JSON.stringify(tokenRecords, null, 2);
 }
 
+/** @deprecated use `@stacks/profile` instead */
 export async function uploadProfile(
   gaiaHubUrl: string,
   identity: Identity,
@@ -111,6 +113,7 @@ interface RegisterParams {
 
 /**
  * Register a subdomain for a given identity
+ * @deprecated use `@stacks/profile` instead
  */
 export const registerSubdomain = async ({
   identity,
@@ -134,6 +137,7 @@ export const registerSubdomain = async ({
   return identity;
 };
 
+/** @deprecated use `@stacks/profile` instead */
 export const signAndUploadProfile = async ({
   profile,
   gaiaHubUrl,
@@ -149,6 +153,7 @@ export const signAndUploadProfile = async ({
   await uploadProfile(gaiaHubUrl, identity, signedProfileTokenData, gaiaHubConfig);
 };
 
+/** @deprecated use `@stacks/profile` instead */
 export const fetchProfile = async ({
   identity,
   gaiaUrl,

--- a/packages/keychain/src/utils/gaia.ts
+++ b/packages/keychain/src/utils/gaia.ts
@@ -11,12 +11,14 @@ interface HubInfo {
   read_url_prefix: string;
 }
 
+/** @deprecated use `@stacks/storage` instead */
 export const getHubInfo = async (hubUrl: string, fetchFn: FetchFn = createFetchFn()) => {
   const response = await fetchFn(`${hubUrl}/hub_info`);
   const data: HubInfo = await response.json();
   return data;
 };
 
+/** @deprecated use `@stacks/storage` instead */
 export const makeGaiaAssociationToken = (
   secretKeyHex: string,
   childPublicKeyHex: string
@@ -44,6 +46,7 @@ interface ConnectToGaiaOptions {
   gaiaHubUrl: string;
 }
 
+/** @deprecated use `@stacks/storage` instead */
 export const connectToGaiaHubWithConfig = ({
   hubInfo,
   privateKey,
@@ -68,6 +71,7 @@ interface ReadOnlyGaiaConfigOptions {
 
 /**
  * When you already know the Gaia read URL, make a Gaia config that doesn't have to fetch `/hub_info`
+ * @deprecated use `@stacks/storage` instead
  */
 export const makeReadOnlyGaiaConfig = ({
   readURL,
@@ -83,6 +87,7 @@ export const makeReadOnlyGaiaConfig = ({
   };
 };
 
+/** @deprecated use `@stacks/storage` instead */
 interface GaiaAuthPayload {
   gaiaHubUrl: string;
   iss: string;
@@ -107,6 +112,7 @@ const makeGaiaAuthToken = ({ hubInfo, privateKey, gaiaHubUrl }: ConnectToGaiaOpt
   return `v1:${token}`;
 };
 
+/** @deprecated use `@stacks/storage` instead */
 export const uploadToGaiaHub = async (
   filename: string,
   // eslint-disable-next-line node/prefer-global/buffer

--- a/packages/keychain/src/utils/index.ts
+++ b/packages/keychain/src/utils/index.ts
@@ -10,6 +10,7 @@ import { registrars, Subdomains } from '../profiles';
 const IDENTITY_KEYCHAIN = 888;
 const BLOCKSTACK_ON_BITCOIN = 0;
 
+/** @deprecated */
 export function getIdentityPrivateKeychain(rootNode: BIP32Interface) {
   return rootNode.deriveHardened(IDENTITY_KEYCHAIN).deriveHardened(BLOCKSTACK_ON_BITCOIN);
 }
@@ -17,6 +18,7 @@ export function getIdentityPrivateKeychain(rootNode: BIP32Interface) {
 const EXTERNAL_ADDRESS = 'EXTERNAL_ADDRESS';
 const CHANGE_ADDRESS = 'CHANGE_ADDRESS';
 
+/** @deprecated */
 export function getBitcoinPrivateKeychain(rootNode: BIP32Interface) {
   const BIP_44_PURPOSE = 44;
   const BITCOIN_COIN_TYPE = 0;
@@ -28,6 +30,7 @@ export function getBitcoinPrivateKeychain(rootNode: BIP32Interface) {
     .deriveHardened(ACCOUNT_INDEX);
 }
 
+/** @deprecated */
 export function getBitcoinAddressNode(
   bitcoinKeychain: BIP32Interface,
   addressIndex = 0,
@@ -46,6 +49,7 @@ export function getBitcoinAddressNode(
   return bitcoinKeychain.derive(chain).derive(addressIndex);
 }
 
+/** @deprecated */
 export async function getIdentityOwnerAddressNode(
   identityPrivateKeychain: BIP32Interface,
   identityIndex = 0
@@ -76,6 +80,7 @@ export interface IdentityKeyPair {
   salt: string;
 }
 
+/** @deprecated */
 export function deriveIdentityKeyPair(
   identityOwnerAddressNode: IdentityAddressOwnerNode
 ): IdentityKeyPair {
@@ -95,6 +100,7 @@ export function deriveIdentityKeyPair(
   return keyPair;
 }
 
+/** @deprecated */
 export async function getBlockchainIdentities(
   rootNode: BIP32Interface,
   identitiesToGenerate: number
@@ -133,6 +139,7 @@ export async function getBlockchainIdentities(
   };
 }
 
+/** @deprecated */
 export const makeIdentity = async (rootNode: BIP32Interface, index: number) => {
   const identityPrivateKeychainNode = getIdentityPrivateKeychain(rootNode);
   const identityOwnerAddressNode = await getIdentityOwnerAddressNode(
@@ -163,6 +170,7 @@ export enum IdentityNameValidityError {
 
 const containsLegalCharacters = (name: string) => /^[a-z0-9_]+$/.test(name);
 
+/** @deprecated */
 export const validateSubdomainFormat = (identityName: string): IdentityNameValidityError | null => {
   const nameLength = identityName.length;
 
@@ -181,6 +189,7 @@ export const validateSubdomainFormat = (identityName: string): IdentityNameValid
   return null;
 };
 
+/** @deprecated */
 export const validateSubdomainAvailability = async (
   name: string,
   subdomain: Subdomains = Subdomains.BLOCKSTACK,
@@ -202,6 +211,7 @@ interface RecursiveMakeIdentitiesOptions {
  * Restore identities by recursively making a new identity, and checking if it has a username.
  *
  * As soon as a username is not found for an identity, the recursion stops.
+ *  @deprecated
  */
 export const recursiveRestoreIdentities = async ({
   rootNode,

--- a/packages/keychain/src/wallet/index.ts
+++ b/packages/keychain/src/wallet/index.ts
@@ -63,6 +63,7 @@ export interface ConstructorOptions {
   walletConfig?: WalletConfig;
 }
 
+/** @deprecated use `@stacks/wallet-sdk` instead */
 export class Wallet {
   chain: ChainID;
   encryptedBackupPhrase: string;

--- a/packages/keychain/src/wallet/signer.ts
+++ b/packages/keychain/src/wallet/signer.ts
@@ -50,6 +50,7 @@ interface STXTransferOptions {
   anchorMode: AnchorMode;
 }
 
+/** @deprecated use `@stacks/wallet-sdk` and `@stacks/transactions` instead */
 export class WalletSigner {
   privateKey: Buffer;
 


### PR DESCRIPTION
> This PR was published as an *alpha* to npm with the version `4.3.6-pr.e161700.0` — e.g. `npm install @stacks/common@4.3.6-pr.e161700.0`<!-- Sticky Header Marker -->

- add deprecation docstring to methods which will be removed soon
- this should make updating easier (users can update to the latest minor; replace deprecated methods; update major without too many surprises)