### PR TITLE
fix: add future message signing prefix compatibility

### DIFF
--- a/packages/encryption/src/messageSignature.ts
+++ b/packages/encryption/src/messageSignature.ts
@@ -4,15 +4,15 @@ import { decode, encode, encodingLength } from 'varuint-bitcoin';
 
 // 'Stacks Message Signing:\n'.length //  = 24
 // 'Stacks Message Signing:\n'.length.toString(16) //  = 18
-const chainPrefix = '\x18Stacks Message Signing:\n';
+const chainPrefix: string = '\x18Stacks Message Signing:\n';
 
 export function hashMessage(message: string): Buffer {
   return Buffer.from(sha256(encodeMessage(message)));
 }
 
-export function encodeMessage(message: string | Buffer): Buffer {
+export function encodeMessage(message: string | Buffer, prefix: string = chainPrefix): Buffer {
   const encoded = encode(Buffer.from(message).length);
-  return Buffer.concat([Buffer.from(chainPrefix), encoded, Buffer.from(message)]);
+  return Buffer.concat([Buffer.from(prefix), encoded, Buffer.from(message)]);
 }
 
 export function decodeMessage(encodedMessage: Buffer): Buffer {

--- a/packages/encryption/tests/messageSignature.test.ts
+++ b/packages/encryption/tests/messageSignature.test.ts
@@ -6,15 +6,19 @@ test('encodeMessage / decodeMessage', () => {
     ['hello world', '\x18Stacks Message Signing:\n\x0bhello world'],
     ['', '\x18Stacks Message Signing:\n\x00'],
     // Longer message (to test a different length for the var_int prefix)
-    ['This is a really long message to test the var_int prefix This is a really long message to test the var_int prefix This is a really long message to test the var_int prefix This is a really long message to test the var_int prefix This is a really long message to test the var_int prefix',
+    [
+      'This is a really long message to test the var_int prefix This is a really long message to test the var_int prefix This is a really long message to test the var_int prefix This is a really long message to test the var_int prefix This is a really long message to test the var_int prefix',
       Buffer.concat([
         Buffer.from('\x18Stacks Message Signing:\n'),
         // message length = 284 (decimal) = 011c (hex) <=> \x1c\x01 (little endian encoding)
         // Since length = 284 is < 0xFFFF, prefix the int with 0xFD followed by 2 bytes for a total of 3 bytes (see https://en.bitcoin.it/wiki/Protocol_documentation#Variable_length_integer)
         Buffer.from(new Uint8Array([253, 28, 1])),
-        Buffer.from('This is a really long message to test the var_int prefix This is a really long message to test the var_int prefix This is a really long message to test the var_int prefix This is a really long message to test the var_int prefix This is a really long message to test the var_int prefix')
-      ])],
-  ]
+        Buffer.from(
+          'This is a really long message to test the var_int prefix This is a really long message to test the var_int prefix This is a really long message to test the var_int prefix This is a really long message to test the var_int prefix This is a really long message to test the var_int prefix'
+        ),
+      ]),
+    ],
+  ];
   for (let messageArr of messages) {
     const [message, expectedEncodedMessage] = messageArr;
     const encodedMessage = encodeMessage(message);
@@ -22,8 +26,6 @@ test('encodeMessage / decodeMessage', () => {
     const decodedMessage = decodeMessage(encodedMessage);
     expect(decodedMessage.toString()).toEqual(message);
   }
-
-
 });
 
 test('hash message vs hash of manually constructed message', () => {


### PR DESCRIPTION
> This PR was published as an *alpha* to npm with the version `4.3.7-pr.329ef5b.0` — e.g. `npm install @stacks/common@4.3.7-pr.329ef5b.0`<!-- Sticky Header Marker -->

- solution to reduce breakages in live sign-in systems https://github.com/hirosystems/stacks.js/pull/1329
- also returns `true` for `verifyMessageSignature` if the message was encoded with the future (Ledger compatible prefix)