### PR TITLE
ci: test build step

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -38,7 +38,6 @@ jobs:
       - run: npx lerna publish prepatch --preid pr.$SHA --dist-tag pr --no-verify-access --no-push --no-git-tag-version --yes
         env:
           SHA: ${{ steps.git-commit.outputs.sha }}
-          SKIP_TESTS: true
       - id: published-version
         run: echo "::set-output name=version::$(cat lerna.json | jq -r '.version')"
       - uses: kyranjamie/pull-request-fixed-header@v1.0.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,6 +38,12 @@ jobs:
       - name: Check for circular dependencies
         run: npm run madge
 
+      - name: DEBUG test build
+        run: npx lerna run build
+
+      - name: DEBUG test prepublishOnly
+        run: npx lerna run prepublishOnly --scope @stacks/encryption
+
       - name: Run tests
         run: npm run lerna run test --stream --parallel -- -- --coverage
 


### PR DESCRIPTION
> This PR was published as an *alpha* to npm with the version `4.3.8-pr.161cc75.0` — e.g. `npm install @stacks/common@4.3.8-pr.161cc75.0`<!-- Sticky Header Marker -->

 🚧 test failing ci