### PR TITLE
fix: add missing customizable prefixes

### DIFF
--- a/packages/encryption/src/messageSignature.ts
+++ b/packages/encryption/src/messageSignature.ts
@@ -6,8 +6,8 @@ import { decode, encode, encodingLength } from 'varuint-bitcoin';
 // 'Stacks Message Signing:\n'.length.toString(16) //  = 18
 const chainPrefix: string = '\x18Stacks Message Signing:\n';
 
-export function hashMessage(message: string): Buffer {
-  return Buffer.from(sha256(encodeMessage(message)));
+export function hashMessage(message: string, prefix: string = chainPrefix): Buffer {
+  return Buffer.from(sha256(encodeMessage(message, prefix)));
 }
 
 export function encodeMessage(message: string | Buffer, prefix: string = chainPrefix): Buffer {
@@ -15,10 +15,9 @@ export function encodeMessage(message: string | Buffer, prefix: string = chainPr
   return Buffer.concat([Buffer.from(prefix), encoded, Buffer.from(message)]);
 }
 
-export function decodeMessage(encodedMessage: Buffer): Buffer {
-  // Remove the chain prefix: 1 for the varint and 24 for the length of the string
-  // 'Stacks Message Signing:\n'
-  const messageWithoutChainPrefix = encodedMessage.subarray(1 + 24);
+export function decodeMessage(encodedMessage: Buffer, prefix: string = chainPrefix): Buffer {
+  const prefixByteLength = Buffer.from(prefix).byteLength;
+  const messageWithoutChainPrefix = encodedMessage.subarray(prefixByteLength);
   const decoded = decode(messageWithoutChainPrefix);
   const varIntLength = encodingLength(decoded);
   // Remove the varint prefix


### PR DESCRIPTION
> This PR was published as an *alpha* to npm with the version `4.3.8-pr.9f299ef.0` — e.g. `npm install @stacks/common@4.3.8-pr.9f299ef.0`<!-- Sticky Header Marker -->

