### PR TITLE
fix: rename incorrect nft post-condition codes

### DIFF
--- a/.github/MIGRATION.md
+++ b/.github/MIGRATION.md
@@ -21,7 +21,7 @@
 
 - To reduce the bundle sizes of applications using Stacks.js, we are switching from Buffer (a polyfill to match Node.js APIs) to Uint8Arrays (which Buffers use in the background anyway). [Read more...](#buffer-to-uint8array)
 - To allow message signing on Ledger hardware wallets, we are changing the message signing prefix. [Read more...]
-- Post-conditions for NFTs were renamed to be more clear: `Owns` to `Sends`, `DoesNotOwn` to `DoesNotSend`.
+- Post-conditions for NFTs were renamed to be more clear: `Owns` to `DoesNotSend`, `DoesNotOwn` to `Sends`.
 
 #### Buffer to Uint8Array
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### ⚠ BREAKING CHANGES
 
-* Post-conditions for NFTs were renamed to be more clear: `Owns` to `Sends`, `DoesNotOwn` to `DoesNotSend`.
+* Post-conditions for NFTs were renamed to be more clear: `Owns` to `DoesNotSend`, `DoesNotOwn` to `Sends`.
 * **encryption:** The message signing prefix was changed from `Stacks Message Signing` to `Stacks Signed Message`.
 * remove previously deprecated functions
 * Removes compatibility with `bip32` package from @stacks/wallet-sdk. Now all derivation methods only rely on HDKey from @scure/bip32.

--- a/packages/bns/CHANGELOG.md
+++ b/packages/bns/CHANGELOG.md
@@ -8,7 +8,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### ⚠ BREAKING CHANGES
 
-* Post-conditions for NFTs were renamed to be more clear: `Owns` to `Sends`, `DoesNotOwn` to `DoesNotSend`.
+* Post-conditions for NFTs were renamed to be more clear: `Owns` to `DoesNotSend`, `DoesNotOwn` to `Sends`.
 * Removes compatibility with `bip32` package from @stacks/wallet-sdk. Now all derivation methods only rely on HDKey from @scure/bip32.
 * To reduce the bundle sizes of applications using Stacks.js we are moving away from Buffer (a polyfill to match Node.js APIs) to Uint8Arrays (which Buffers use in the background anyway). To make the switch easier we have introduced a variety of methods for converting between strings and Uint8Arrays: `hexToBytes`, `bytesToHex`, `utf8ToBytes`, `bytesToUtf8`, `asciiToBytes`, `bytesToAscii`, and `concatBytes`.
 

--- a/packages/transactions/README.md
+++ b/packages/transactions/README.md
@@ -459,8 +459,8 @@ const contractFungiblePostCondition = makeContractFungiblePostCondition(
 ### Non-fungible token post condition
 
 > **Warning**
-> The post-condition codes for NFTs are currently misleading. The Stacks blockchain's post-condition processor does NOT check ownership.
-> It checks whether or not a principal **sent** or **did not send** an NFT.
+> The Stacks blockchain's post-condition processor can NOT check ownership.
+> It checks whether or not a principal **will send** or **will not send** an NFT.
 > Post-conditions can NOT verify anything about the recipient of an asset.
 > If you want to verify conditions about asset recipients, you will need to use [Clarity](https://docs.stacks.co/docs/write-smart-contracts/).
 

--- a/packages/transactions/src/constants.ts
+++ b/packages/transactions/src/constants.ts
@@ -126,8 +126,8 @@ enum FungibleConditionCode {
 }
 
 enum NonFungibleConditionCode {
-  DoesNotSend = 0x10,
-  Sends = 0x11,
+  Sends = 0x10,
+  DoesNotSend = 0x11,
 }
 
 enum PostConditionPrincipalID {

--- a/packages/transactions/tests/builder.test.ts
+++ b/packages/transactions/tests/builder.test.ts
@@ -870,14 +870,14 @@ test('Make contract-call with post conditions', async () => {
     ),
     makeStandardNonFungiblePostCondition(
       postConditionAddress,
-      NonFungibleConditionCode.Sends,
+      NonFungibleConditionCode.DoesNotSend,
       info,
       bufferCVFromString(tokenAssetName)
     ),
     makeContractNonFungiblePostCondition(
       postConditionAddress,
       contractName,
-      NonFungibleConditionCode.DoesNotSend,
+      NonFungibleConditionCode.Sends,
       info,
       bufferCVFromString(tokenAssetName)
     ),

--- a/packages/transactions/tests/postcondition.test.ts
+++ b/packages/transactions/tests/postcondition.test.ts
@@ -87,7 +87,7 @@ test('Non-fungible post condition serialization and deserialization', () => {
   const contractName = 'contract-name';
   const principal = createContractPrincipal(address, contractName);
 
-  const conditionCode = NonFungibleConditionCode.Sends;
+  const conditionCode = NonFungibleConditionCode.DoesNotSend;
 
   const assetAddress = 'SP2ZP4GJDZJ1FDHTQ963F0292PE9J9752TZJ68F21';
   const assetContractName = 'contract_name';
@@ -124,7 +124,7 @@ test('Non-fungible post condition with string IDs serialization and deserializat
   const address = 'SP2JXKMSH007NPYAQHKJPQMAQYAD90NQGTVJVQ02B';
   const contractName = 'contract-name';
 
-  const conditionCode = NonFungibleConditionCode.Sends;
+  const conditionCode = NonFungibleConditionCode.DoesNotSend;
 
   const assetAddress = 'SP2ZP4GJDZJ1FDHTQ963F0292PE9J9752TZJ68F21';
   const assetContractName = 'contract_name';


### PR DESCRIPTION
> This PR was published to npm with the version `5.0.1-pr.2945a09.0`
> e.g. `npm install @stacks/common@5.0.1-pr.2945a09.0 --save-exact`<!-- Sticky Header Marker -->

reason: post-condition codes were incorrectly renamed

- renames correctly
- also updates CHANGELOG to be less confusing