### PR TITLE
fix: rename incorrect nft post-condition codes

### DIFF
--- a/packages/bns/src/index.ts
+++ b/packages/bns/src/index.ts
@@ -708,7 +708,7 @@ export async function buildTransferNameTx({
   ];
   const postConditionSender = createNonFungiblePostCondition(
     publicKeyToAddress(getAddressVersion(network), createStacksPublicKey(publicKey)),
-    NonFungibleConditionCode.DoesNotSend,
+    NonFungibleConditionCode.Sends,
     parseAssetInfoString(`${getBnsContractAddress(network)}.bns::names`),
     tupleCV({
       name: bufferCVFromString(name),
@@ -717,7 +717,7 @@ export async function buildTransferNameTx({
   );
   const postConditionReceiver = createNonFungiblePostCondition(
     newOwnerAddress,
-    NonFungibleConditionCode.Sends,
+    NonFungibleConditionCode.DoesNotSend,
     parseAssetInfoString(`${getBnsContractAddress(network)}.bns::names`),
     tupleCV({
       name: bufferCVFromString(name),

--- a/packages/bns/tests/bns.test.ts
+++ b/packages/bns/tests/bns.test.ts
@@ -709,7 +709,7 @@ test('transferName', async () => {
   const { namespace, name } = decodeFQN(fullyQualifiedName);
   const nameTransferPostConditionOne = createNonFungiblePostCondition(
     publicKeyToAddress(getAddressVersion(network), createStacksPublicKey(publicKey)),
-    NonFungibleConditionCode.DoesNotSend,
+    NonFungibleConditionCode.Sends,
     parseAssetInfoString(`${getBnsContractAddress(network)}.bns::names`),
     tupleCV({
       name: bufferCVFromString(name),
@@ -718,7 +718,7 @@ test('transferName', async () => {
   );
   const nameTransferPostConditionTwo = createNonFungiblePostCondition(
     newOwnerAddress,
-    NonFungibleConditionCode.Sends,
+    NonFungibleConditionCode.DoesNotSend,
     parseAssetInfoString(`${getBnsContractAddress(network)}.bns::names`),
     tupleCV({
       name: bufferCVFromString(name),
@@ -777,7 +777,7 @@ test('transferName optionalArguments', async () => {
   const { namespace, name } = decodeFQN(fullyQualifiedName);
   const nameTransferPostConditionOne = createNonFungiblePostCondition(
     publicKeyToAddress(getAddressVersion(network), createStacksPublicKey(publicKey)),
-    NonFungibleConditionCode.DoesNotSend,
+    NonFungibleConditionCode.Sends,
     parseAssetInfoString(`${getBnsContractAddress(network)}.bns::names`),
     tupleCV({
       name: bufferCVFromString(name),
@@ -786,7 +786,7 @@ test('transferName optionalArguments', async () => {
   );
   const nameTransferPostConditionTwo = createNonFungiblePostCondition(
     newOwnerAddress,
-    NonFungibleConditionCode.Sends,
+    NonFungibleConditionCode.DoesNotSend,
     parseAssetInfoString(`${getBnsContractAddress(network)}.bns::names`),
     tupleCV({
       name: bufferCVFromString(name),

--- a/packages/transactions/README.md
+++ b/packages/transactions/README.md
@@ -475,7 +475,7 @@ import {
 
 // With a standard principal
 const postConditionAddress = 'SP2ZD731ANQZT6J4K3F5N8A40ZXWXC1XFXHVVQFKE';
-const postConditionCode = NonFungibleConditionCode.Sends;
+const postConditionCode = NonFungibleConditionCode.DoesNotSend;
 const assetAddress = 'SP62M8MEFH32WGSB7XSF9WJZD7TQB48VQB5ANWSJ';
 const assetContractName = 'test-asset-contract';
 const assetName = 'test-asset';


### PR DESCRIPTION
> This PR was published to npm with the version `5.0.2-pr.32227aa.0`
> e.g. `npm install @stacks/common@5.0.2-pr.32227aa.0 --save-exact`<!-- Sticky Header Marker -->

- more post-conditions that were missed in a refactor
- closes https://github.com/hirosystems/stacks.js/issues/1378