### PR TITLE
fix: add publickey to cli

### DIFF
--- a/packages/cli/src/keys.ts
+++ b/packages/cli/src/keys.ts
@@ -14,7 +14,6 @@ import {
   getPublicKeyFromPrivate,
   publicKeyToBtcAddress,
 } from '@stacks/encryption';
-import { createStacksPrivateKey, privateKeyToString } from '@stacks/transactions';
 import { DerivationType, deriveAccount, generateWallet, getRootNode } from '@stacks/wallet-sdk';
 import * as bip32 from 'bip32';
 import * as bip39 from 'bip39';
@@ -155,7 +154,7 @@ export async function getStacksWalletKeyInfo(
   const pubkey = Buffer.from(child.publicKey!);
   const privkeyBuffer = Buffer.from(child.privateKey!);
   const privkey = bytesToHex(compressPrivateKey(privkeyBuffer));
-  const wifVersion = network.isMainnet() ? BITCOIN_WIF : BITCOIN_WIF_TESTNET;
+  const wifVersion = network.isTestnet() ? BITCOIN_WIF_TESTNET : BITCOIN_WIF;
   const walletImportFormat = wif.encode(wifVersion, privkeyBuffer, true);
 
   const addr = getPrivateKeyAddress(network, privkey);

--- a/packages/cli/src/keys.ts
+++ b/packages/cli/src/keys.ts
@@ -165,6 +165,7 @@ export async function getStacksWalletKeyInfo(
 
   return {
     privateKey: privkey,
+    publicKey: pubkey.toString('hex'),
     address: c32check.b58ToC32(addr),
     btcAddress,
     wif: walletImportFormat,

--- a/packages/cli/src/keys.ts
+++ b/packages/cli/src/keys.ts
@@ -7,6 +7,7 @@ const c32check = require('c32check');
 
 import { HDKey } from '@scure/bip32';
 import * as scureBip39 from '@scure/bip39';
+import { bytesToHex } from '@stacks/common';
 
 import {
   compressPrivateKey,
@@ -26,7 +27,6 @@ import { CLINetworkAdapter } from './network';
 const BITCOIN_PUBKEYHASH = 0;
 const BITCOIN_PUBKEYHASH_TESTNET = 111;
 const BITCOIN_WIF = 128;
-// @ts-ignore
 const BITCOIN_WIF_TESTNET = 239;
 
 export const STX_WALLET_COMPATIBLE_SEED_STRENGTH = 256;
@@ -154,8 +154,9 @@ export async function getStacksWalletKeyInfo(
   const child = master.derive(derivationPath);
   const pubkey = Buffer.from(child.publicKey!);
   const privkeyBuffer = Buffer.from(child.privateKey!);
-  const privkey = privateKeyToString(createStacksPrivateKey(compressPrivateKey(privkeyBuffer)));
-  const walletImportFormat = wif.encode(BITCOIN_WIF, privkeyBuffer, true);
+  const privkey = bytesToHex(compressPrivateKey(privkeyBuffer));
+  const wifVersion = network.isMainnet() ? BITCOIN_WIF : BITCOIN_WIF_TESTNET;
+  const walletImportFormat = wif.encode(wifVersion, privkeyBuffer, true);
 
   const addr = getPrivateKeyAddress(network, privkey);
   const btcAddress = publicKeyToBtcAddress(

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -18,7 +18,8 @@ import { SubdomainOp, subdomainOpToZFPieces } from '../src/utils';
 import {
   keyInfoTests,
   MakeKeychainResult,
-  makekeychainTests,
+  makekeychainTestsMainnet,
+  makekeychainTestsTestnet,
   WalletKeyInfoResult,
 } from './derivation-path/keychain';
 import * as fixtures from './fixtures/cli.fixture';
@@ -174,7 +175,27 @@ describe('Contract function call', () => {
 });
 
 describe('Keychain custom derivation path', () => {
-  test.each(makekeychainTests)(
+  test.each(makekeychainTestsMainnet)(
+    'Make keychain using custom derivation path %#',
+    async (derivationPath: string, keyChainResult: MakeKeychainResult) => {
+      const encrypted =
+        'vim+XrRNSm+SqSn0MyWNEi/e+UK5kX8WGCLE/sevT6srZG+quzpp911sWP0CcvsExCH1M4DgOfOldMitLdkq1b6rApDwtAcOWdAqiaBk37M=';
+      const args = [encrypted, derivationPath];
+
+      // Mock TTY
+      process.stdin.isTTY = true;
+      process.env.password = 'supersecret';
+
+      const keyChain = await makeKeychain(mainnetNetwork, args);
+      const result = JSON.parse(keyChain);
+      expect(result).toEqual(keyChainResult);
+      // Unmock TTY
+      process.stdin.isTTY = false;
+      process.env.password = undefined;
+    }
+  );
+
+  test.each(makekeychainTestsTestnet)(
     'Make keychain using custom derivation path %#',
     async (derivationPath: string, keyChainResult: MakeKeychainResult) => {
       const encrypted =

--- a/packages/cli/tests/derivation-path/keychain.ts
+++ b/packages/cli/tests/derivation-path/keychain.ts
@@ -1,7 +1,8 @@
 export type MakeKeychainResult = {
-  mnemonic: string,
+  mnemonic: string;
   keyInfo: {
     privateKey: string;
+    publicKey: string;
     address: string;
     btcAddress: string;
     wif: string;
@@ -11,13 +12,14 @@ export type MakeKeychainResult = {
 
 export type WalletKeyInfoResult = {
   privateKey: string;
+  publicKey: string;
   address: string;
   btcAddress: string;
   wif: string;
   index: number;
 };
 
-export const makekeychainTests: Array<[string, MakeKeychainResult]> = [
+export const makekeychainTestsMainnet: Array<[string, MakeKeychainResult]> = [
   [
     // Derivation Path
     "m/44'/5757'/0'/0/0",
@@ -26,12 +28,13 @@ export const makekeychainTests: Array<[string, MakeKeychainResult]> = [
       mnemonic: 'vivid oxygen neutral wheat find thumb cigar wheel board kiwi portion business',
       keyInfo: {
         privateKey: 'd1124855494c883c5e1df0201be40a835f08ae5fc3a6520224b2239db94a818001',
-        address: 'ST1J28031BYDX19TYXSNDG9Q4HDB2TBDAM921Y7MS',
-        btcAddress: 'mpeSzfUTBba7qzKNcg8ojNm4GAfwmNPX8X',
+        publicKey: '027e7176a9eb25f609b44368967e146c4f96941d23727b87cfe8370b8147e016af',
+        address: 'SP1J28031BYDX19TYXSNDG9Q4HDB2TBDAM8JJR59C',
+        btcAddress: '1A8VhcPUNa8s4sqku7ARuTYjQB5EvPKQoP',
         wif: 'L4E7pXmqdm8C8TakpX7YDDmFopaQw32Ak6V5BpRFNDJmo7wjGVqc',
-        index: 0
-      }
-    }
+        index: 0,
+      },
+    },
   ],
   [
     // Derivation Path
@@ -41,13 +44,49 @@ export const makekeychainTests: Array<[string, MakeKeychainResult]> = [
       mnemonic: 'vivid oxygen neutral wheat find thumb cigar wheel board kiwi portion business',
       keyInfo: {
         privateKey: 'd4d30d4fdaa59e166865b836548015c2780063b82e7b2a364c8a2e32df7139ce01',
+        publicKey: '028b270e6799b6d3fe99c1a6ada647000d797868a610c19b1636a779d1e591cc52',
+        address: 'SP1WT20920NVRQ892MS535R7XEMV6KD6M6W1H7N2X',
+        btcAddress: '1C67dziRk1iJ9eFA2aEqUVZxPkKJhfyibr',
+        wif: 'L4MQx6c6ZmoiwFYUHnmt39THRGeQnPmfA2AFobwWmssZJabi3qXm',
+        index: 0,
+      },
+    },
+  ],
+];
+
+export const makekeychainTestsTestnet: Array<[string, MakeKeychainResult]> = [
+  [
+    // Derivation Path
+    "m/44'/5757'/0'/0/0",
+    // Expected result
+    {
+      mnemonic: 'vivid oxygen neutral wheat find thumb cigar wheel board kiwi portion business',
+      keyInfo: {
+        privateKey: 'd1124855494c883c5e1df0201be40a835f08ae5fc3a6520224b2239db94a818001',
+        publicKey: '027e7176a9eb25f609b44368967e146c4f96941d23727b87cfe8370b8147e016af',
+        address: 'ST1J28031BYDX19TYXSNDG9Q4HDB2TBDAM921Y7MS',
+        btcAddress: 'mpeSzfUTBba7qzKNcg8ojNm4GAfwmNPX8X',
+        wif: 'cUb7HSmh4ppTHu42CvvfaYGKS3spbV7rp8dYJEsksKxn3s4zqRJD',
+        index: 0,
+      },
+    },
+  ],
+  [
+    // Derivation Path
+    "m/888'/0'/0",
+    // Expected result
+    {
+      mnemonic: 'vivid oxygen neutral wheat find thumb cigar wheel board kiwi portion business',
+      keyInfo: {
+        privateKey: 'd4d30d4fdaa59e166865b836548015c2780063b82e7b2a364c8a2e32df7139ce01',
+        publicKey: '028b270e6799b6d3fe99c1a6ada647000d797868a610c19b1636a779d1e591cc52',
         address: 'ST1WT20920NVRQ892MS535R7XEMV6KD6M6X2HQPK3',
         btcAddress: 'mrc4w3oQZ39Yvkimk9DDJQnHFjv1e336mg',
-        wif: 'L4MQx6c6ZmoiwFYUHnmt39THRGeQnPmfA2AFobwWmssZJabi3qXm',
-        index: 0
-      }
-    }
-  ]
+        wif: 'cUiQR1bwzqVz6h1jgCb1QTxM3VwpSqsME4Jiv2Q2GzXZZKjjSNHg',
+        index: 0,
+      },
+    },
+  ],
 ];
 
 export const keyInfoTests: Array<[string, WalletKeyInfoResult]> = [
@@ -57,11 +96,12 @@ export const keyInfoTests: Array<[string, WalletKeyInfoResult]> = [
     // Expected result
     {
       privateKey: 'd1124855494c883c5e1df0201be40a835f08ae5fc3a6520224b2239db94a818001',
+      publicKey: '027e7176a9eb25f609b44368967e146c4f96941d23727b87cfe8370b8147e016af',
       address: 'ST1J28031BYDX19TYXSNDG9Q4HDB2TBDAM921Y7MS',
       btcAddress: 'mpeSzfUTBba7qzKNcg8ojNm4GAfwmNPX8X',
-      wif: 'L4E7pXmqdm8C8TakpX7YDDmFopaQw32Ak6V5BpRFNDJmo7wjGVqc',
-      index: 0
-    }
+      wif: 'cUb7HSmh4ppTHu42CvvfaYGKS3spbV7rp8dYJEsksKxn3s4zqRJD',
+      index: 0,
+    },
   ],
   [
     // Derivation Path
@@ -69,12 +109,11 @@ export const keyInfoTests: Array<[string, WalletKeyInfoResult]> = [
     // Expected result
     {
       privateKey: 'd4d30d4fdaa59e166865b836548015c2780063b82e7b2a364c8a2e32df7139ce01',
+      publicKey: '028b270e6799b6d3fe99c1a6ada647000d797868a610c19b1636a779d1e591cc52',
       address: 'ST1WT20920NVRQ892MS535R7XEMV6KD6M6X2HQPK3',
       btcAddress: 'mrc4w3oQZ39Yvkimk9DDJQnHFjv1e336mg',
-      wif: 'L4MQx6c6ZmoiwFYUHnmt39THRGeQnPmfA2AFobwWmssZJabi3qXm',
-      index: 0
-    }
-  ]
+      wif: 'cUiQR1bwzqVz6h1jgCb1QTxM3VwpSqsME4Jiv2Q2GzXZZKjjSNHg',
+      index: 0,
+    },
+  ],
 ];
-
-

--- a/packages/cli/tests/derivation-path/wallet.key.info.ts
+++ b/packages/cli/tests/derivation-path/wallet.key.info.ts
@@ -7,11 +7,12 @@ export const keyInfoTests: Array<[string, WalletKeyInfoResult]> = [
     // Expected result
     {
       privateKey: '25899fab1b9b95cc2d1692529f00fb788e85664df3d14db1a660f33c5f96d8ab01',
+      publicKey: '02614ab79b4b66595d7fc78590a0bf798a4432c454dc013ceea129d751e0b55220',
       address: 'SP3RBZ4TZ3EK22SZRKGFZYBCKD7WQ5B8FFS0AYVF7',
       btcAddress: '1Nwxfx7VoYAg2mEN35dTRw4H7gte8ajFki',
       wif: 'KxUgLbeVeFZEUUQpc3ncYn5KFB3WH5MVRv3SJ2g5yPwkrXs3QRaP',
-      index: 0
-    }
+      index: 0,
+    },
   ],
   [
     // Derivation path
@@ -19,14 +20,13 @@ export const keyInfoTests: Array<[string, WalletKeyInfoResult]> = [
     // Expected result
     {
       privateKey: '0f0936f59a7d55be6bcd1820f798460ac4b3aa50f26c8fa76beb82a19af5110901',
+      publicKey: '0335b8b24c697988ddfe38a56b41f9fba3b624f133ee21ab0918d920f8ba45a0da',
       address: 'SPGJAPK47Z9XY7E7BCEJFAEX9C7WGB0YB74A54MA',
       btcAddress: '142G3fnfn1WZPtnYLYiVGt8aU55GZYxeVP',
       wif: 'KwiwQgTK2412XSdBfcRWJ4xQFbevUHCwGnRCuvjeHjSqceNwS1wW',
-      index: 0
-    }
-  ]
+      index: 0,
+    },
+  ],
 ];
 
 export { WalletKeyInfoResult };
-
-

--- a/packages/cli/tests/keys.test.ts
+++ b/packages/cli/tests/keys.test.ts
@@ -17,6 +17,7 @@ test('getStacksWalletKeyInfo', async () => {
 
   expect(info).toEqual({
     privateKey: '25899fab1b9b95cc2d1692529f00fb788e85664df3d14db1a660f33c5f96d8ab01',
+    publicKey: '02614ab79b4b66595d7fc78590a0bf798a4432c454dc013ceea129d751e0b55220',
     address: 'SP3RBZ4TZ3EK22SZRKGFZYBCKD7WQ5B8FFS0AYVF7',
     btcAddress: '1Nwxfx7VoYAg2mEN35dTRw4H7gte8ajFki',
     wif: 'KxUgLbeVeFZEUUQpc3ncYn5KFB3WH5MVRv3SJ2g5yPwkrXs3QRaP',


### PR DESCRIPTION
> This PR was published to npm with the version `5.0.3-pr.0e6a8f8.0`
> e.g. `npm install @stacks/common@5.0.3-pr.0e6a8f8.0 --save-exact`<!-- Sticky Header Marker -->

- closes #1327 
- closes https://github.com/hirosystems/stacks.js/issues/1393
- adds `publicKey` to the output of the `make_keychain` command

> Most test vectors generated using learnmeabitcoin