### PR TITLE
fix: encode wif key correctly for testnet

### DIFF
--- a/packages/cli/src/keys.ts
+++ b/packages/cli/src/keys.ts
@@ -26,7 +26,6 @@ import { CLINetworkAdapter } from './network';
 const BITCOIN_PUBKEYHASH = 0;
 const BITCOIN_PUBKEYHASH_TESTNET = 111;
 const BITCOIN_WIF = 128;
-// @ts-ignore
 const BITCOIN_WIF_TESTNET = 239;
 
 export const STX_WALLET_COMPATIBLE_SEED_STRENGTH = 256;
@@ -155,7 +154,11 @@ export async function getStacksWalletKeyInfo(
   const pubkey = Buffer.from(child.publicKey!);
   const privkeyBuffer = Buffer.from(child.privateKey!);
   const privkey = privateKeyToString(createStacksPrivateKey(compressPrivateKey(privkeyBuffer)));
-  const walletImportFormat = wif.encode(BITCOIN_WIF, privkeyBuffer, true);
+  const walletImportFormat = wif.encode(
+    network.isTestnet() ? BITCOIN_WIF_TESTNET : BITCOIN_WIF,
+    privkeyBuffer,
+    true
+  );
 
   const addr = getPrivateKeyAddress(network, privkey);
   const btcAddress = publicKeyToBtcAddress(

--- a/packages/cli/tests/derivation-path/keychain.ts
+++ b/packages/cli/tests/derivation-path/keychain.ts
@@ -28,7 +28,7 @@ export const makekeychainTests: Array<[string, MakeKeychainResult]> = [
         privateKey: 'd1124855494c883c5e1df0201be40a835f08ae5fc3a6520224b2239db94a818001',
         address: 'ST1J28031BYDX19TYXSNDG9Q4HDB2TBDAM921Y7MS',
         btcAddress: 'mpeSzfUTBba7qzKNcg8ojNm4GAfwmNPX8X',
-        wif: 'L4E7pXmqdm8C8TakpX7YDDmFopaQw32Ak6V5BpRFNDJmo7wjGVqc',
+        wif: 'cUb7HSmh4ppTHu42CvvfaYGKS3spbV7rp8dYJEsksKxn3s4zqRJD',
         index: 0
       }
     }
@@ -43,7 +43,7 @@ export const makekeychainTests: Array<[string, MakeKeychainResult]> = [
         privateKey: 'd4d30d4fdaa59e166865b836548015c2780063b82e7b2a364c8a2e32df7139ce01',
         address: 'ST1WT20920NVRQ892MS535R7XEMV6KD6M6X2HQPK3',
         btcAddress: 'mrc4w3oQZ39Yvkimk9DDJQnHFjv1e336mg',
-        wif: 'L4MQx6c6ZmoiwFYUHnmt39THRGeQnPmfA2AFobwWmssZJabi3qXm',
+        wif: 'cUiQR1bwzqVz6h1jgCb1QTxM3VwpSqsME4Jiv2Q2GzXZZKjjSNHg',
         index: 0
       }
     }
@@ -59,7 +59,7 @@ export const keyInfoTests: Array<[string, WalletKeyInfoResult]> = [
       privateKey: 'd1124855494c883c5e1df0201be40a835f08ae5fc3a6520224b2239db94a818001',
       address: 'ST1J28031BYDX19TYXSNDG9Q4HDB2TBDAM921Y7MS',
       btcAddress: 'mpeSzfUTBba7qzKNcg8ojNm4GAfwmNPX8X',
-      wif: 'L4E7pXmqdm8C8TakpX7YDDmFopaQw32Ak6V5BpRFNDJmo7wjGVqc',
+      wif: 'cUb7HSmh4ppTHu42CvvfaYGKS3spbV7rp8dYJEsksKxn3s4zqRJD',
       index: 0
     }
   ],
@@ -71,7 +71,7 @@ export const keyInfoTests: Array<[string, WalletKeyInfoResult]> = [
       privateKey: 'd4d30d4fdaa59e166865b836548015c2780063b82e7b2a364c8a2e32df7139ce01',
       address: 'ST1WT20920NVRQ892MS535R7XEMV6KD6M6X2HQPK3',
       btcAddress: 'mrc4w3oQZ39Yvkimk9DDJQnHFjv1e336mg',
-      wif: 'L4MQx6c6ZmoiwFYUHnmt39THRGeQnPmfA2AFobwWmssZJabi3qXm',
+      wif: 'cUiQR1bwzqVz6h1jgCb1QTxM3VwpSqsME4Jiv2Q2GzXZZKjjSNHg',
       index: 0
     }
   ]


### PR DESCRIPTION
> This PR was published to npm with the version `5.0.3-pr.f2516ca.0`
> e.g. `npm install @stacks/common@5.0.3-pr.f2516ca.0 --save-exact`<!-- Sticky Header Marker -->

