### PR TITLE
[2.1] Add more Stacking PoX-2 checks

### DIFF
--- a/configs/jestConfig.js
+++ b/configs/jestConfig.js
@@ -7,6 +7,7 @@ if (process.env.SKIP_TESTS) {
 
 module.exports = packageDirname => {
   return {
+    bail: true,
     rootDir: packageDirname,
     preset: 'ts-jest',
     testEnvironment: 'node',

--- a/packages/stacking/src/index.ts
+++ b/packages/stacking/src/index.ts
@@ -211,7 +211,12 @@ export interface LockStxOptions {
   poxAddress: string;
   /** number of microstacks to lock */
   amountMicroStx: IntegerType;
-  /** the burnchain block height to begin lock */
+  /**
+   * the burnchain block height to begin lock
+   * (recommended: `current_block_height`)
+   *
+   * The start burn lock height needs to be in the cycle before the next stackable cycle (it can not be dated into the future/past)
+   */
   burnBlockHeight: number;
 }
 
@@ -634,7 +639,6 @@ export class StackingClient {
       poxInfo,
       poxOperationInfo,
       cycles,
-      burnBlockHeight,
     });
 
     const contract = await this.getStackingContract(poxOperationInfo);
@@ -650,6 +654,7 @@ export class StackingClient {
     const tx = await makeContractCall({
       ...txOptions,
       senderKey: privateKey,
+      // fee: 10000, // todo: remove
     });
 
     return broadcastTransaction(tx, txOptions.network as StacksNetwork);
@@ -769,7 +774,6 @@ export class StackingClient {
       poxInfo,
       poxOperationInfo,
       cycles,
-      burnBlockHeight,
     });
 
     const contract = await this.getStackingContract(poxOperationInfo);
@@ -918,7 +922,7 @@ export class StackingClient {
     const tx = await makeContractCall({
       ...txOptions,
       senderKey: privateKey,
-      fee: 10000, // todo: remove
+      // fee: 10000, // todo: remove
     });
 
     return broadcastTransaction(tx, txOptions.network as StacksNetwork);

--- a/packages/stacking/tests/apiMockingHelpers.ts
+++ b/packages/stacking/tests/apiMockingHelpers.ts
@@ -89,7 +89,7 @@ export async function waitForBlock(burnBlockId: number, client?: StackingClient)
       current = poxInfo?.current_burnchain_block_height as number;
       if (current && current >= burnBlockId) {
         console.log(`→ block ${current} reached`);
-        return;
+        return await sleep(100);
       }
     } catch (e: any) {
       throw e;
@@ -113,7 +113,7 @@ export async function waitForCycle(cycleId: number, client?: StackingClient) {
       current = poxInfo?.reward_cycle_id;
       if (current && current >= cycleId) {
         console.log(`→ cycle ${current} reached`);
-        return;
+        return await sleep(100);
       }
     } catch (e: any) {
       throw e;

--- a/packages/stacking/tests/apiMockingHelpers.ts
+++ b/packages/stacking/tests/apiMockingHelpers.ts
@@ -50,29 +50,28 @@ function isMocking(): boolean {
   return result[0];
 }
 
-const MAX_ITERATIONS = 120;
-const ITERATION_INTERVAL = 1000;
+const ITERATION_INTERVAL = 200; // in milliseconds
 
 export async function waitForTx(txId: string, apiUrl = 'http://localhost:3999') {
   if (isMocking()) return;
 
   const txApi = new TransactionsApi(new Configuration({ basePath: apiUrl }));
 
-  for (let i = 1; i <= MAX_ITERATIONS; i++) {
+  // let i = 0;
+  while (true) {
     try {
       const txInfo = (await txApi.getTransactionById({ txId })) as any;
-      console.log('txInfo', txInfo);
       if (txInfo?.tx_status === 'success') {
         console.log(`✓ ${JSON.stringify(txInfo?.tx_result)}`);
         return txInfo;
       } else if (txInfo?.tx_result) {
-        return console.log(`✕ ${JSON.stringify(txInfo.tx_result)}`);
+        console.log(`✕ ${JSON.stringify(txInfo.tx_result)}`);
+        return txInfo;
       }
     } catch (e: any) {
-      if (e?.ok === false) throw Error(`✕ ${e?.status}: ${txId}`);
-      throw e;
+      if (e?.ok === false) console.log(`✕ ${e?.status}: ${txId}`);
     }
-    console.log(`waiting (${i}x)`);
+    // console.log(`waiting for tx -- ${i++}x`);
     await sleep(ITERATION_INTERVAL);
   }
 }
@@ -83,7 +82,8 @@ export async function waitForBlock(burnBlockId: number, client?: StackingClient)
   client = client ?? new StackingClient('', new StacksTestnet({ url: 'http://localhost:3999' }));
 
   let current: number;
-  for (let i = 1; i <= MAX_ITERATIONS; i++) {
+  // let i = 0;
+  while (true) {
     try {
       const poxInfo = (await client.getPoxInfo()) as PoxInfo;
       current = poxInfo?.current_burnchain_block_height as number;
@@ -94,7 +94,7 @@ export async function waitForBlock(burnBlockId: number, client?: StackingClient)
     } catch (e: any) {
       throw e;
     }
-    console.log(`waiting (${i}x) for block ${burnBlockId} (current block: ${current})`);
+    // console.log(`waiting for block ${burnBlockId} (current block: ${current}) -- ${i++}x`);
     await sleep(ITERATION_INTERVAL);
   }
 }
@@ -106,7 +106,8 @@ export async function waitForCycle(cycleId: number, client?: StackingClient) {
   client = client ?? new StackingClient('', new StacksTestnet({ url: 'http://localhost:3999' }));
 
   let current: number;
-  for (let i = 1; i <= MAX_ITERATIONS; i++) {
+  // let i = 0;
+  while (true) {
     try {
       const poxInfo = (await client.getPoxInfo()) as PoxInfo;
       current = poxInfo?.reward_cycle_id;
@@ -117,7 +118,7 @@ export async function waitForCycle(cycleId: number, client?: StackingClient) {
     } catch (e: any) {
       throw e;
     }
-    console.log(`waiting (${i}x) for cycle ${cycleId} (current cycle: ${current})`);
+    // console.log(`waiting for cycle ${cycleId} (current cycle: ${current}) -- ${i++}x`);
     await sleep(ITERATION_INTERVAL);
   }
 }

--- a/packages/stacking/tests/stacking-2.1.test.ts
+++ b/packages/stacking/tests/stacking-2.1.test.ts
@@ -14,13 +14,13 @@ import {
   waitForCycle,
   waitForTx,
 } from './apiMockingHelpers';
-import { BTC_ADDRESS_CASES } from './utils.test';
-
-const API_URL = 'http://localhost:3999'; // default regtest url
+import { API_URL, BTC_ADDRESS_CASES } from './utils.test';
 
 // HOW-TO: Run tests unmocked (e.g. with a local regtest environment)
 // * Add a root-level `jest.setTimeout(240_000);` with a high value to the file (outside of describe/test/before's)
 // * Add `fetchMock.dontMock();` to any test that should NOT be mocked and will use the regtest
+
+jest.setTimeout(240_000);
 
 beforeEach(() => {
   jest.resetModules();

--- a/packages/stacking/tests/stacking-2.1.test.ts
+++ b/packages/stacking/tests/stacking-2.1.test.ts
@@ -143,6 +143,7 @@ describe('2.1 period detection', () => {
       '/v2/data_var/ST000000000000000000002AMW42H/pox-2/configured?proof=0': `Data var not found`,
     });
     expect((await client.getPoxOperationInfo()).period).toBe(PoxOperationPeriod.Period1);
+    expect((await client.getPoxInfo()).current_burnchain_block_height).toBeLessThan(109);
 
     await waitForBlock(109);
     setApiMocks({
@@ -150,6 +151,7 @@ describe('2.1 period detection', () => {
       '/v2/data_var/ST000000000000000000002AMW42H/pox-2/configured?proof=0': `Data var not found`,
     });
     expect((await client.getPoxOperationInfo()).period).toBe(PoxOperationPeriod.Period1);
+    expect((await client.getPoxInfo()).current_burnchain_block_height).toBe(109);
 
     await waitForBlock(110);
     setApiMocks({
@@ -157,6 +159,7 @@ describe('2.1 period detection', () => {
       '/v2/data_var/ST000000000000000000002AMW42H/pox-2/configured?proof=0': `{"data":"0x03"}`,
     });
     expect((await client.getPoxOperationInfo()).period).toBe(PoxOperationPeriod.Period2a);
+    expect((await client.getPoxInfo()).current_burnchain_block_height).toBe(110);
 
     await waitForBlock(111);
     setApiMocks({
@@ -164,6 +167,7 @@ describe('2.1 period detection', () => {
       '/v2/data_var/ST000000000000000000002AMW42H/pox-2/configured?proof=0': `{"data":"0x03"}`,
     });
     expect((await client.getPoxOperationInfo()).period).toBe(PoxOperationPeriod.Period2a);
+    expect((await client.getPoxInfo()).current_burnchain_block_height).toBe(111);
 
     await waitForBlock(119);
     setApiMocks({
@@ -171,6 +175,7 @@ describe('2.1 period detection', () => {
       '/v2/data_var/ST000000000000000000002AMW42H/pox-2/configured?proof=0': `{"data":"0x03"}`,
     });
     expect((await client.getPoxOperationInfo()).period).toBe(PoxOperationPeriod.Period2a);
+    expect((await client.getPoxInfo()).current_burnchain_block_height).toBe(119);
 
     await waitForBlock(120);
     setApiMocks({
@@ -178,6 +183,7 @@ describe('2.1 period detection', () => {
       '/v2/data_var/ST000000000000000000002AMW42H/pox-2/configured?proof=0': `{"data":"0x03"}`,
     });
     expect((await client.getPoxOperationInfo()).period).toBe(PoxOperationPeriod.Period2a);
+    expect((await client.getPoxInfo()).current_burnchain_block_height).toBe(120);
 
     await waitForBlock(121);
     setApiMocks({
@@ -185,6 +191,7 @@ describe('2.1 period detection', () => {
       '/v2/data_var/ST000000000000000000002AMW42H/pox-2/configured?proof=0': `{"data":"0x03"}`,
     });
     expect((await client.getPoxOperationInfo()).period).toBe(PoxOperationPeriod.Period2b);
+    expect((await client.getPoxInfo()).current_burnchain_block_height).toBe(121);
 
     await waitForBlock(125);
     setApiMocks({
@@ -192,6 +199,7 @@ describe('2.1 period detection', () => {
       '/v2/data_var/ST000000000000000000002AMW42H/pox-2/configured?proof=0': `{"data":"0x03"}`,
     });
     expect((await client.getPoxOperationInfo()).period).toBe(PoxOperationPeriod.Period2b);
+    expect((await client.getPoxInfo()).current_burnchain_block_height).toBe(125);
 
     await waitForBlock(126);
     setApiMocks({
@@ -199,6 +207,7 @@ describe('2.1 period detection', () => {
       '/v2/data_var/ST000000000000000000002AMW42H/pox-2/configured?proof=0': `{"data":"0x03"}`,
     });
     expect((await client.getPoxOperationInfo()).period).toBe(PoxOperationPeriod.Period3);
+    expect((await client.getPoxInfo()).current_burnchain_block_height).toBe(126);
 
     await waitForBlock(135);
     setApiMocks({
@@ -206,6 +215,7 @@ describe('2.1 period detection', () => {
       '/v2/data_var/ST000000000000000000002AMW42H/pox-2/configured?proof=0': `{"data":"0x03"}`,
     });
     expect((await client.getPoxOperationInfo()).period).toBe(PoxOperationPeriod.Period3);
+    expect((await client.getPoxInfo()).current_burnchain_block_height).toBe(135);
   });
 });
 

--- a/packages/stacking/tests/utils.test.ts
+++ b/packages/stacking/tests/utils.test.ts
@@ -354,16 +354,16 @@ test.each(BTC_ADDRESS_CASES_INVALID_POX_ADDRESS)(
 );
 
 const DETECT_ERR_24_MATRIX = [];
-for (let i = 1; i <= 1; i++) {
+for (let i = 1; i <= 3; i++) {
   // todo: run with more cycles
   for (let j = 0; j <= 5; j++) {
-    for (let k = 0; k <= 3; k++) {
+    for (let k = 0; k <= 5; k++) {
       DETECT_ERR_24_MATRIX.push({ cycles: i, height: j, shift: k });
     }
   }
 }
 
-test.skip.each(DETECT_ERR_24_MATRIX)(
+test.each(DETECT_ERR_24_MATRIX)(
   'throw on potential (err 24)',
   async ({ cycles, height, shift }) => {
     fetchMock.dontMock();


### PR DESCRIPTION
> This PR was published to npm with the version `6.0.1-pr.c52f295.0`
> e.g. `npm install @stacks/common@6.0.1-pr.c52f295.0 --save-exact`<!-- Sticky Header Marker -->

- adds some methods for the API
- tests `(err 24)` detection