### PR TITLE
fix: remove stacking into period3 check

### DIFF
--- a/packages/stacking/src/index.ts
+++ b/packages/stacking/src/index.ts
@@ -35,7 +35,6 @@ import {
 import { PoxOperationPeriod, StackingErrors } from './constants';
 import {
   ensureLegacyBtcAddressForPox1,
-  ensurePox1DoesNotCreateStateIntoPeriod3,
   ensurePox2IsLive,
   poxAddressToTuple,
   unwrap,
@@ -630,13 +629,6 @@ export class StackingClient {
     const poxInfo = await this.getPoxInfo();
     const poxOperationInfo = await this.getPoxOperationInfo(poxInfo);
 
-    ensurePox1DoesNotCreateStateIntoPeriod3({
-      poxInfo,
-      poxOperationInfo,
-      cycles,
-      burnBlockHeight,
-    });
-
     const contract = await this.getStackingContract(poxOperationInfo);
     ensureLegacyBtcAddressForPox1({ contract, poxAddress });
 
@@ -764,13 +756,6 @@ export class StackingClient {
   }: DelegateStackStxOptions): Promise<TxBroadcastResult> {
     const poxInfo = await this.getPoxInfo();
     const poxOperationInfo = await this.getPoxOperationInfo(poxInfo);
-
-    ensurePox1DoesNotCreateStateIntoPeriod3({
-      poxInfo,
-      poxOperationInfo,
-      cycles,
-      burnBlockHeight,
-    });
 
     const contract = await this.getStackingContract(poxOperationInfo);
     ensureLegacyBtcAddressForPox1({ contract, poxAddress });

--- a/packages/stacking/src/utils.ts
+++ b/packages/stacking/src/utils.ts
@@ -10,7 +10,7 @@ import {
   tupleCV,
   TupleCV,
 } from '@stacks/transactions';
-import { PoxInfo, PoxOperationInfo } from '.';
+import { PoxOperationInfo } from '.';
 import {
   B58_ADDR_PREFIXES,
   BitcoinNetworkVersion,
@@ -304,31 +304,6 @@ export function ensurePox2IsLive(operationInfo: PoxOperationInfo) {
     throw new Error(
       `PoX-2 is not live yet (currently in period ${operationInfo.period} of PoX-2 operation)`
     );
-}
-
-export function ensurePox1DoesNotCreateStateIntoPeriod3({
-  poxInfo,
-  poxOperationInfo,
-  cycles,
-  burnBlockHeight: startBurnBlockHeight,
-}: {
-  poxInfo: PoxInfo;
-  poxOperationInfo: PoxOperationInfo;
-  cycles: number;
-  burnBlockHeight: number;
-}) {
-  if (
-    poxOperationInfo.period === PoxOperationPeriod.Period1 ||
-    poxOperationInfo.period === PoxOperationPeriod.Period3
-  ) {
-    return;
-  }
-
-  const blocksLocked = cycles * poxInfo.reward_cycle_length;
-  const unlockBlockHeight = startBurnBlockHeight + blocksLocked;
-
-  if (unlockBlockHeight >= poxOperationInfo.pox2.activation_burnchain_block_height)
-    throw new Error('Transaction would fail, since it creates state into Period 3 (PoX-2)');
 }
 
 export function ensureLegacyBtcAddressForPox1({

--- a/packages/stacking/tests/apiMockingHelpers.ts
+++ b/packages/stacking/tests/apiMockingHelpers.ts
@@ -148,3 +148,18 @@ export const MOCK_FULL_ACCOUNT = {
   '/v2/accounts/STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6?proof=0': `{"balance":"0x0000000000000000002386f26fb76310","locked":"0x00000000000000000000000000000000","unlock_height":0,"nonce":63}`,
   '/v2/contracts/call-read/ST000000000000000000002AMW42H/pox-2/can-stack-stx': `{"okay":true,"result":"0x0703"}`,
 };
+
+// === FETCHMOCK TESTING HELPERS ===============================================
+
+/**
+ * Gets latest fetchMock broadcast to /transactions
+ * @ignore
+ */
+export function getFetchMockBroadcast() {
+  const broadcast = (Array.from(fetchMock.mock.calls) as any)
+    .reverse()
+    .find((m: any) => m[0].endsWith('/transactions'));
+  return {
+    body: broadcast[1].body,
+  };
+}


### PR DESCRIPTION
> This PR was published to npm with the version `6.0.2-pr.da30fce.0`
> e.g. `npm install @stacks/common@6.0.2-pr.da30fce.0 --save-exact`<!-- Sticky Header Marker -->

> This bug was a remnant of not understanding the periods initially.

I believe, the check to see if something overlaps into Period 3 is no longer needed (and was implemented incorrectly before).
It's not needed since Stacks.js will prefer PoX-2 if available, so @stacks/stacking shouldn't be able to generate txs that target PoX-1 after the 2.1 fork.

### fix:
- removes `ensurePox1DoesNotCreateStateIntoPeriod3` check

### test:
- adds more extensive tests for correct contracts usage

> I will deprecate the faulty version on npm after releasing this fix.