### PR TITLE
refactor(wallet-sdk): remove bitcoinjs-lib, unused

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23897,7 +23897,6 @@
         "@stacks/profile": "^6.0.0",
         "@stacks/storage": "^6.0.0",
         "@stacks/transactions": "^6.0.0",
-        "bitcoinjs-lib": "^5.2.0",
         "buffer": "^6.0.3",
         "c32check": "^2.0.0",
         "jsontokens": "^4.0.1",
@@ -24623,7 +24622,7 @@
       "integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
       "dev": true,
       "requires": {
-        "ajv": "6.12.3",
+        "ajv": "^6.12.4",
         "debug": "^4.3.2",
         "espree": "^9.4.0",
         "globals": "^13.15.0",
@@ -27609,7 +27608,7 @@
         "cross-fetch": "^3.0.6",
         "eventemitter3": "^4.0.4",
         "jsonrpc-lite": "^2.2.0",
-        "socket.io-client": "4.5.3",
+        "socket.io-client": "^4.0.1",
         "ws": "^7.4.0"
       }
     },
@@ -27954,7 +27953,7 @@
           "requires": {
             "@eslint/eslintrc": "^1.0.4",
             "@humanwhocodes/config-array": "^0.6.0",
-            "ajv": "6.12.3",
+            "ajv": "^6.10.0",
             "chalk": "^4.0.0",
             "cross-spawn": "^7.0.2",
             "debug": "^4.3.2",
@@ -28282,7 +28281,6 @@
         "@stacks/transactions": "^6.0.0",
         "@types/node": "^18.0.4",
         "assert": "^2.0.0",
-        "bitcoinjs-lib": "^5.2.0",
         "buffer": "^6.0.3",
         "c32check": "^2.0.0",
         "crypto-browserify": "^3.12.0",
@@ -29915,7 +29913,7 @@
       "requires": {
         "@types/bn.js": "^4.11.5",
         "@types/elliptic": "^6.4.9",
-        "ajv": "6.12.3",
+        "ajv": "^4.11.5",
         "bip39": "^3.0.2",
         "bitcoinjs-lib": "^5.1.2",
         "bn.js": "^4.11.8",
@@ -29927,7 +29925,7 @@
         "query-string": "^6.3.0",
         "request": "^2.88.0",
         "ripemd160": "^2.0.2",
-        "schema-inspector": "2.0.1",
+        "schema-inspector": "^1.6.8",
         "triplesec": "^3.0.26",
         "uuid": "^3.3.2",
         "zone-file": "^1.0.0"
@@ -31220,7 +31218,7 @@
         "boolbase": "~1.0.0",
         "css-what": "2.1",
         "domutils": "1.5.1",
-        "nth-check": "2.0.1"
+        "nth-check": "~1.0.1"
       }
     },
     "css-what": {
@@ -32499,7 +32497,7 @@
         "@humanwhocodes/config-array": "^0.11.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
-        "ajv": "6.12.3",
+        "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
         "debug": "^4.3.2",
@@ -33981,7 +33979,7 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
       "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
       "requires": {
-        "ajv": "6.12.3",
+        "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
       }
     },
@@ -38044,8 +38042,7 @@
       }
     },
     "nth-check": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
+      "version": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
       "integrity": "sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==",
       "requires": {
         "boolbase": "^1.0.0"
@@ -39929,7 +39926,7 @@
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.8",
-        "ajv": "6.12.3",
+        "ajv": "^6.12.5",
         "ajv-keywords": "^3.5.2"
       }
     },

--- a/packages/wallet-sdk/package.json
+++ b/packages/wallet-sdk/package.json
@@ -37,7 +37,6 @@
     "@stacks/profile": "^6.0.0",
     "@stacks/storage": "^6.0.0",
     "@stacks/transactions": "^6.0.0",
-    "bitcoinjs-lib": "^5.2.0",
     "buffer": "^6.0.3",
     "c32check": "^2.0.0",
     "jsontokens": "^4.0.1",


### PR DESCRIPTION
> This PR was published to npm with the version `6.0.3-pr.44cc5b5.0`
> e.g. `npm install @stacks/common@6.0.3-pr.44cc5b5.0 --save-exact`<!-- Sticky Header Marker -->

Doesn't seem like package is used. An inner dep, `tiny-secp256k1` causes build issues in desktop wallet.