### PR TITLE
Docs: Added troubleshooting.md and starters note

### DIFF
--- a/docs/includes/stacks.js-starters-note.mdx
+++ b/docs/includes/stacks.js-starters-note.mdx
@@ -1,3 +1,5 @@
 >  **_NOTE:_**
 >
 > Use our prebuilt [Stacks.js starter templates](/stacksjs-starters) to kickstart your frontend application development with your preferred JavaScript framework.
+
+

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,9 @@
+---
+title: Troubleshooting
+---
+
+## Common Pitfall: regenerator-runtime
+
+If using @stacks/connect with vite, rollup, svelte, or vue, a package `regenerator-runtime` needs to be manually added to build the project successfully.
+
+`npm install --save-dev regenerator-runtime.`


### PR DESCRIPTION
> This PR was published to npm with the version `6.0.3-pr.cbfbf5b.0`
> e.g. `npm install @stacks/common@6.0.3-pr.cbfbf5b.0 --save-exact`<!-- Sticky Header Marker -->

Added two missing files from the docs repo. 

- Troubleshooting.md.
- Stacks.js starters note in the includes file.