### PR TITLE
feat: add estimation fallback

### DIFF
--- a/packages/transactions/src/errors.ts
+++ b/packages/transactions/src/errors.ts
@@ -1,4 +1,4 @@
-export class SerializationError extends Error {
+class TransactionError extends Error {
   constructor(message: string) {
     super(message);
     this.message = message;
@@ -9,45 +9,44 @@ export class SerializationError extends Error {
   }
 }
 
-export class DeserializationError extends Error {
+export class SerializationError extends TransactionError {
   constructor(message: string) {
     super(message);
-    this.message = message;
-    this.name = this.constructor.name;
-    if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, this.constructor);
-    }
   }
 }
 
-export class NotImplementedError extends Error {
+export class DeserializationError extends TransactionError {
   constructor(message: string) {
     super(message);
-    this.message = message;
-    this.name = this.constructor.name;
-    if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, this.constructor);
-    }
   }
 }
 
-export class SigningError extends Error {
+/**
+ * Thrown when `NoEstimateAvailable` is received as an error reason from a
+ * Stacks node. The Stacks node has not seen this kind of contract-call before,
+ * and it cannot provide an estimate yet.
+ * @see https://docs.hiro.so/api#tag/Fees/operation/post_fee_transaction
+ */
+export class NoEstimateAvailableError extends TransactionError {
   constructor(message: string) {
     super(message);
-    this.message = message;
-    this.name = this.constructor.name;
-    if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, this.constructor);
-    }
   }
 }
-export class VerificationError extends Error {
+
+export class NotImplementedError extends TransactionError {
   constructor(message: string) {
     super(message);
-    this.message = message;
-    this.name = this.constructor.name;
-    if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, this.constructor);
-    }
+  }
+}
+
+export class SigningError extends TransactionError {
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+export class VerificationError extends TransactionError {
+  constructor(message: string) {
+    super(message);
   }
 }


### PR DESCRIPTION
> This PR was published to npm with the version `6.0.3-pr.5dbcd63.0`
> e.g. `npm install @stacks/common@6.0.3-pr.5dbcd63.0 --save-exact`<!-- Sticky Header Marker -->

- adds a fallback estimation if `NoEstimateAvailable` is received from the stacks node
- this is closer to legacy behavior and once existed in a way (before transaction estimates were a thing and everything was a transfer estimate)