### PR TITLE
Docusaurus remote content reorg

### DIFF
--- a/docs/includes/stacks.js-starters-note.mdx
+++ b/docs/includes/stacks.js-starters-note.mdx
@@ -1,3 +1,4 @@
 :::note
+
 Use our prebuilt [Stacks.js starter templates](/stacksjs-starters) to kickstart your frontend application development with your preferred JavaScript framework.
 :::

--- a/docs/includes/stacks.js-starters-note.mdx
+++ b/docs/includes/stacks.js-starters-note.mdx
@@ -1,3 +1,3 @@
 :::note
-Use our prebuilt [Stacks.js starter templates](https://github.com/hirosystems/stacks.js-starters) to kickstart your frontend application development with your preferred JavaScript framework.
+Use our prebuilt [Stacks.js starter templates](/stacksjs-starters) to kickstart your frontend application development with your preferred JavaScript framework.
 :::


### PR DESCRIPTION
> This PR was published to npm with the version `6.1.1-pr.ffd4e43.0`
> e.g. `npm install @stacks/common@6.1.1-pr.ffd4e43.0 --save-exact`<!-- Sticky Header Marker -->

Reverted the stacks JS starters link to "/stacksjs-starters".
