### PR TITLE
feat: allow string name for AnchorMode

### DIFF
--- a/packages/transactions/src/builders.ts
+++ b/packages/transactions/src/builders.ts
@@ -32,6 +32,7 @@ import {
   RECOVERABLE_ECDSA_SIG_LENGTH_BYTES,
   StacksMessageType,
   ClarityVersion,
+  AnchorModeName,
 } from './constants';
 import { ClarityAbi, validateContractCall } from './contract-abi';
 import { NoEstimateAvailableError } from './errors';
@@ -528,7 +529,7 @@ export interface TokenTransferOptions {
   network?: StacksNetworkName | StacksNetwork;
   /** the transaction anchorMode, which specifies whether it should be
    * included in an anchor block or a microblock */
-  anchorMode: AnchorMode;
+  anchorMode: AnchorModeName | AnchorMode;
   /** an arbitrary string to include in the transaction, must be less than 34 bytes */
   memo?: string;
   /** the post condition mode, specifying whether or not post-conditions must fully cover all
@@ -710,7 +711,7 @@ export interface BaseContractDeployOptions {
   network?: StacksNetworkName | StacksNetwork;
   /** the transaction anchorMode, which specifies whether it should be
    * included in an anchor block or a microblock */
-  anchorMode: AnchorMode;
+  anchorMode: AnchorModeName | AnchorMode;
   /** the post condition mode, specifying whether or not post-conditions must fully cover all
    * transfered assets */
   postConditionMode?: PostConditionMode;
@@ -901,7 +902,7 @@ export interface ContractCallOptions {
   network?: StacksNetworkName | StacksNetwork;
   /** the transaction anchorMode, which specifies whether it should be
    * included in an anchor block or a microblock */
-  anchorMode: AnchorMode;
+  anchorMode: AnchorModeName | AnchorMode;
   /** the post condition mode, specifying whether or not post-conditions must fully cover all
    * transfered assets */
   postConditionMode?: PostConditionMode;

--- a/packages/transactions/src/constants.ts
+++ b/packages/transactions/src/constants.ts
@@ -74,6 +74,25 @@ enum AnchorMode {
   Any = 0x03,
 }
 
+const AnchorModeNames = ['onChainOnly', 'offChainOnly', 'any'] as const;
+type AnchorModeName = typeof AnchorModeNames[number];
+
+const AnchorModeMap = {
+  [AnchorModeNames[0]]: AnchorMode.OnChainOnly,
+  [AnchorModeNames[1]]: AnchorMode.OffChainOnly,
+  [AnchorModeNames[2]]: AnchorMode.Any,
+  [AnchorMode.OnChainOnly]: AnchorMode.OnChainOnly,
+  [AnchorMode.OffChainOnly]: AnchorMode.OffChainOnly,
+  [AnchorMode.Any]: AnchorMode.Any,
+};
+
+function anchorModeFromNameOrValue(mode: AnchorModeName | AnchorMode): AnchorMode {
+  if (mode in AnchorModeMap) {
+    return AnchorModeMap[mode];
+  }
+  throw new Error(`Invalid anchor mode "${mode}", must be one of: ${AnchorModeNames.join(', ')}`);
+}
+
 enum TransactionVersion {
   Mainnet = 0x00,
   Testnet = 0x80,
@@ -188,6 +207,9 @@ export {
   PayloadType,
   ClarityVersion,
   AnchorMode,
+  AnchorModeName,
+  AnchorModeNames,
+  anchorModeFromNameOrValue,
   TransactionVersion,
   PostConditionMode,
   PostConditionType,

--- a/packages/transactions/src/transaction.ts
+++ b/packages/transactions/src/transaction.ts
@@ -8,6 +8,8 @@ import {
 } from '@stacks/common';
 import {
   AnchorMode,
+  anchorModeFromNameOrValue,
+  AnchorModeName,
   AuthType,
   ChainID,
   DEFAULT_CHAIN_ID,
@@ -61,7 +63,7 @@ export class StacksTransaction {
     payload: PayloadInput,
     postConditions?: LengthPrefixedList,
     postConditionMode?: PostConditionMode,
-    anchorMode?: AnchorMode,
+    anchorMode?: AnchorModeName | AnchorMode,
     chainId?: ChainID
   ) {
     this.version = version;
@@ -79,7 +81,7 @@ export class StacksTransaction {
     this.postConditions = postConditions ?? createLPList([]);
 
     if (anchorMode) {
-      this.anchorMode = anchorMode;
+      this.anchorMode = anchorModeFromNameOrValue(anchorMode);
     } else {
       switch (payload.payloadType) {
         case PayloadType.Coinbase:


### PR DESCRIPTION
> This PR was published to npm with the version `6.1.1-pr.35dd959.0`
> e.g. `npm install @stacks/common@6.1.1-pr.35dd959.0 --save-exact`<!-- Sticky Header Marker -->

Small DX improvement by allowing `anchorMode` to be specified as a string value. `AnchorMode` is commonly the only enum import required when building txs. This PR makes it possible to specify the value as a string, similar to the `network: 'mainnet' | 'testnet'` option.

Example
```ts
import { AnchorMode, makeSTXTokenTransfer } from '@stacks/transactions';

const transaction = await makeSTXTokenTransfer({
  recipient: 'SP3FGQ8Z7JY9BWYZ5WM53E0M9NK7WHJF0691NZ159',
  amount: 12345n,
  senderKey: 'b244296d5907de9864c0b0d51f98a13c52890be0404e83f273144cd5b9960eed01',
  network: 'mainnet',
  memo: 'test',
  nonce: 0n,
  fee: 200n,
  anchorMode: AnchorMode.Any, // can now be 'any'
});
```