### PR TITLE
fix: a few Clarity value construction functions were not being exported

### DIFF
--- a/packages/transactions/src/clarity/index.ts
+++ b/packages/transactions/src/clarity/index.ts
@@ -27,7 +27,13 @@ import {
 
 import { ListCV, listCV } from './types/listCV';
 import { TupleCV, tupleCV } from './types/tupleCV';
-import { StringAsciiCV, StringUtf8CV, stringUtf8CV, stringAsciiCV, stringCV } from './types/stringCV';
+import {
+  StringAsciiCV,
+  StringUtf8CV,
+  stringUtf8CV,
+  stringAsciiCV,
+  stringCV,
+} from './types/stringCV';
 import { serializeCV } from './serialize';
 import deserializeCV from './deserialize';
 

--- a/packages/transactions/src/clarity/index.ts
+++ b/packages/transactions/src/clarity/index.ts
@@ -1,9 +1,9 @@
 import { ClarityValue, getCVTypeString, cvToString, cvToJSON, cvToValue } from './clarityValue';
 import { ClarityType } from './constants';
-import { BooleanCV, TrueCV, FalseCV, trueCV, falseCV } from './types/booleanCV';
+import { BooleanCV, TrueCV, FalseCV, trueCV, falseCV, boolCV } from './types/booleanCV';
 import { IntCV, UIntCV, intCV, uintCV } from './types/intCV';
 import { BufferCV, bufferCV, bufferCVFromString } from './types/bufferCV';
-import { OptionalCV, NoneCV, SomeCV, noneCV, someCV } from './types/optionalCV';
+import { OptionalCV, NoneCV, SomeCV, noneCV, someCV, optionalCVOf } from './types/optionalCV';
 
 import {
   ResponseCV,
@@ -22,11 +22,12 @@ import {
   contractPrincipalCVFromAddress,
   PrincipalCV,
   contractPrincipalCVFromStandard,
+  principalCV,
 } from './types/principalCV';
 
 import { ListCV, listCV } from './types/listCV';
 import { TupleCV, tupleCV } from './types/tupleCV';
-import { StringAsciiCV, StringUtf8CV, stringUtf8CV, stringAsciiCV } from './types/stringCV';
+import { StringAsciiCV, StringUtf8CV, stringUtf8CV, stringAsciiCV, stringCV } from './types/stringCV';
 import { serializeCV } from './serialize';
 import deserializeCV from './deserialize';
 
@@ -57,6 +58,7 @@ export {
 
 // Value construction functions
 export {
+  boolCV,
   trueCV,
   falseCV,
   intCV,
@@ -65,8 +67,10 @@ export {
   bufferCVFromString,
   noneCV,
   someCV,
+  optionalCVOf,
   responseOkCV,
   responseErrorCV,
+  principalCV,
   standardPrincipalCV,
   standardPrincipalCVFromAddress,
   contractPrincipalCV,
@@ -74,6 +78,7 @@ export {
   contractPrincipalCVFromStandard,
   listCV,
   tupleCV,
+  stringCV,
   stringAsciiCV,
   stringUtf8CV,
   getCVTypeString,

--- a/packages/transactions/src/clarity/types/booleanCV.ts
+++ b/packages/transactions/src/clarity/types/booleanCV.ts
@@ -46,4 +46,22 @@ const trueCV = (): BooleanCV => ({ type: ClarityType.BoolTrue });
  */
 const falseCV = (): BooleanCV => ({ type: ClarityType.BoolFalse });
 
-export { BooleanCV, TrueCV, FalseCV, trueCV, falseCV };
+/**
+ * Converts a boolean to BooleanCV clarity type
+ *
+ * @returns {BooleanCV} returns instance of type BooleanCV
+ *
+ * @example
+ * ```
+ *  import { boolCV } from '@stacks/transactions';
+ *
+ *  const boolCV = boolCV(false);
+ *  // { type: 4 }
+ * ```
+ *
+ * @visit
+ * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts clarity test cases for more examples}
+ */
+const boolCV = (bool: boolean) => (bool ? trueCV() : falseCV());
+
+export { BooleanCV, TrueCV, FalseCV, boolCV, trueCV, falseCV };


### PR DESCRIPTION
> This PR was published to npm with the version `6.1.1-pr.1822dae.0`
> e.g. `npm install @stacks/common@6.1.1-pr.1822dae.0 --save-exact`<!-- Sticky Header Marker -->

