### PR TITLE
chore: upgrade noble/scure packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4562,22 +4562,6 @@
         }
       ]
     },
-    "node_modules/@scure/bip32": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.1.1.tgz",
-      "integrity": "sha512-UmI+liY7np2XakaW+6lMB6HZnpczWk1yXZTxvg8TM8MdOcKHCGL1YkraGj8eAjPfMwFNiAyek2hXmS/XFbab8g==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ],
-      "dependencies": {
-        "@noble/hashes": "~1.1.3",
-        "@noble/secp256k1": "~1.7.0",
-        "@scure/base": "~1.1.0"
-      }
-    },
     "node_modules/@scure/bip39": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.1.0.tgz",
@@ -23462,8 +23446,8 @@
       "version": "6.1.0",
       "license": "MIT",
       "dependencies": {
-        "@scure/bip32": "^1.1.1",
-        "@scure/bip39": "^1.1.0",
+        "@scure/bip32": "1.1.3",
+        "@scure/bip39": "1.1.0",
         "@stacks/auth": "^6.1.0",
         "@stacks/blockchain-api-client": "4.0.1",
         "@stacks/bns": "^6.1.0",
@@ -23506,6 +23490,22 @@
         "@types/ripemd160": "^2.0.0",
         "@types/wif": "^2.0.2",
         "rimraf": "^3.0.2"
+      }
+    },
+    "packages/cli/node_modules/@scure/bip32": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.1.3.tgz",
+      "integrity": "sha512-dSH3+LCWONlSNQuF34xZrG6Xas7tp2jSSqHb/pMfXWM0vKE4JZOtK3uJfoWouUVW5IGlls75HkXmYLldZ8ySgQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "dependencies": {
+        "@noble/hashes": "~1.1.3",
+        "@noble/secp256k1": "~1.7.0",
+        "@scure/base": "~1.1.0"
       }
     },
     "packages/cli/node_modules/@types/node": {
@@ -23630,9 +23630,9 @@
       "version": "6.1.0",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "^1.1.3",
-        "@noble/secp256k1": "^1.6.3",
-        "@scure/bip39": "^1.1.0",
+        "@noble/hashes": "1.1.5",
+        "@noble/secp256k1": "1.7.1",
+        "@scure/bip39": "1.1.0",
         "@stacks/common": "^6.0.0",
         "@types/node": "^18.0.4",
         "base64-js": "^1.5.1",
@@ -23657,6 +23657,28 @@
         "stream-browserify": "^3.0.0",
         "triplesec": "^4.0.3"
       }
+    },
+    "packages/encryption/node_modules/@noble/hashes": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.5.tgz",
+      "integrity": "sha512-LTMZiiLc+V4v1Yi16TD6aX2gmtKszNye0pQgbaLqkvhIqP7nVsSaJsWloGQjJfJ8offaoP5GtX3yY5swbcJxxQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
+    "packages/encryption/node_modules/@noble/secp256k1": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
+      "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
     },
     "packages/encryption/node_modules/@types/node": {
       "version": "18.7.23",
@@ -23728,7 +23750,7 @@
       "version": "6.1.0",
       "license": "MIT",
       "dependencies": {
-        "@scure/base": "^1.1.1",
+        "@scure/base": "1.1.1",
         "@stacks/common": "^6.0.0",
         "@stacks/encryption": "^6.1.0",
         "@stacks/network": "^6.1.0",
@@ -23865,8 +23887,8 @@
       "version": "6.1.0",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "^1.1.3",
-        "@noble/secp256k1": "^1.6.3",
+        "@noble/hashes": "1.1.5",
+        "@noble/secp256k1": "1.7.1",
         "@stacks/common": "^6.0.0",
         "@stacks/network": "^6.1.0",
         "c32check": "^2.0.0",
@@ -23883,13 +23905,35 @@
         "rimraf": "^3.0.2"
       }
     },
+    "packages/transactions/node_modules/@noble/hashes": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.5.tgz",
+      "integrity": "sha512-LTMZiiLc+V4v1Yi16TD6aX2gmtKszNye0pQgbaLqkvhIqP7nVsSaJsWloGQjJfJ8offaoP5GtX3yY5swbcJxxQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
+    "packages/transactions/node_modules/@noble/secp256k1": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
+      "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
     "packages/wallet-sdk": {
       "name": "@stacks/wallet-sdk",
       "version": "6.1.0",
       "license": "MIT",
       "dependencies": {
-        "@scure/bip32": "^1.1.1",
-        "@scure/bip39": "^1.1.0",
+        "@scure/bip32": "1.1.3",
+        "@scure/bip39": "1.1.0",
         "@stacks/auth": "^6.1.0",
         "@stacks/common": "^6.0.0",
         "@stacks/encryption": "^6.1.0",
@@ -23909,6 +23953,22 @@
         "crypto-browserify": "^3.12.0",
         "process": "^0.11.10",
         "yalc": "1.0.0-pre.49"
+      }
+    },
+    "packages/wallet-sdk/node_modules/@scure/bip32": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.1.3.tgz",
+      "integrity": "sha512-dSH3+LCWONlSNQuF34xZrG6Xas7tp2jSSqHb/pMfXWM0vKE4JZOtK3uJfoWouUVW5IGlls75HkXmYLldZ8ySgQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "dependencies": {
+        "@noble/hashes": "~1.1.3",
+        "@noble/secp256k1": "~1.7.0",
+        "@scure/base": "~1.1.0"
       }
     },
     "packages/wallet-sdk/node_modules/@types/node": {
@@ -27536,16 +27596,6 @@
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
       "integrity": "sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA=="
     },
-    "@scure/bip32": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.1.1.tgz",
-      "integrity": "sha512-UmI+liY7np2XakaW+6lMB6HZnpczWk1yXZTxvg8TM8MdOcKHCGL1YkraGj8eAjPfMwFNiAyek2hXmS/XFbab8g==",
-      "requires": {
-        "@noble/hashes": "~1.1.3",
-        "@noble/secp256k1": "~1.7.0",
-        "@scure/base": "~1.1.0"
-      }
-    },
     "@scure/bip39": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.1.0.tgz",
@@ -27625,8 +27675,8 @@
     "@stacks/cli": {
       "version": "file:packages/cli",
       "requires": {
-        "@scure/bip32": "^1.1.1",
-        "@scure/bip39": "^1.1.0",
+        "@scure/bip32": "1.1.3",
+        "@scure/bip39": "1.1.0",
         "@stacks/auth": "^6.1.0",
         "@stacks/blockchain-api-client": "4.0.1",
         "@stacks/bns": "^6.1.0",
@@ -27665,6 +27715,16 @@
         "zone-file": "^2.0.0-beta.3"
       },
       "dependencies": {
+        "@scure/bip32": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.1.3.tgz",
+          "integrity": "sha512-dSH3+LCWONlSNQuF34xZrG6Xas7tp2jSSqHb/pMfXWM0vKE4JZOtK3uJfoWouUVW5IGlls75HkXmYLldZ8ySgQ==",
+          "requires": {
+            "@noble/hashes": "~1.1.3",
+            "@noble/secp256k1": "~1.7.0",
+            "@scure/base": "~1.1.0"
+          }
+        },
         "@types/node": {
           "version": "18.7.23",
           "dev": true
@@ -27747,10 +27807,10 @@
     "@stacks/encryption": {
       "version": "file:packages/encryption",
       "requires": {
-        "@noble/hashes": "^1.1.3",
-        "@noble/secp256k1": "^1.6.3",
+        "@noble/hashes": "1.1.5",
+        "@noble/secp256k1": "1.7.1",
         "@peculiar/webcrypto": "^1.1.6",
-        "@scure/bip39": "^1.1.0",
+        "@scure/bip39": "1.1.0",
         "@stacks/common": "^6.0.0",
         "@stacks/transactions": "^6.1.0",
         "@types/bs58check": "^2.1.0",
@@ -27773,6 +27833,16 @@
         "varuint-bitcoin": "^1.1.2"
       },
       "dependencies": {
+        "@noble/hashes": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.5.tgz",
+          "integrity": "sha512-LTMZiiLc+V4v1Yi16TD6aX2gmtKszNye0pQgbaLqkvhIqP7nVsSaJsWloGQjJfJ8offaoP5GtX3yY5swbcJxxQ=="
+        },
+        "@noble/secp256k1": {
+          "version": "1.7.1",
+          "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
+          "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw=="
+        },
         "@types/node": {
           "version": "18.7.23"
         },
@@ -28149,7 +28219,7 @@
     "@stacks/stacking": {
       "version": "file:packages/stacking",
       "requires": {
-        "@scure/base": "^1.1.1",
+        "@scure/base": "1.1.1",
         "@stacks/blockchain-api-client": "^6.2.1",
         "@stacks/common": "^6.0.0",
         "@stacks/encryption": "^6.1.0",
@@ -28251,8 +28321,8 @@
     "@stacks/transactions": {
       "version": "file:packages/transactions",
       "requires": {
-        "@noble/hashes": "^1.1.3",
-        "@noble/secp256k1": "^1.6.3",
+        "@noble/hashes": "1.1.5",
+        "@noble/secp256k1": "1.7.1",
         "@stacks/common": "^6.0.0",
         "@stacks/encryption": "^6.1.0",
         "@stacks/network": "^6.1.0",
@@ -28265,13 +28335,25 @@
         "lodash.clonedeep": "^4.5.0",
         "process": "^0.11.10",
         "rimraf": "^3.0.2"
+      },
+      "dependencies": {
+        "@noble/hashes": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.5.tgz",
+          "integrity": "sha512-LTMZiiLc+V4v1Yi16TD6aX2gmtKszNye0pQgbaLqkvhIqP7nVsSaJsWloGQjJfJ8offaoP5GtX3yY5swbcJxxQ=="
+        },
+        "@noble/secp256k1": {
+          "version": "1.7.1",
+          "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
+          "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw=="
+        }
       }
     },
     "@stacks/wallet-sdk": {
       "version": "file:packages/wallet-sdk",
       "requires": {
-        "@scure/bip32": "^1.1.1",
-        "@scure/bip39": "^1.1.0",
+        "@scure/bip32": "1.1.3",
+        "@scure/bip39": "1.1.0",
         "@stacks/auth": "^6.1.0",
         "@stacks/common": "^6.0.0",
         "@stacks/encryption": "^6.1.0",
@@ -28291,6 +28373,16 @@
         "zone-file": "^2.0.0-beta.3"
       },
       "dependencies": {
+        "@scure/bip32": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.1.3.tgz",
+          "integrity": "sha512-dSH3+LCWONlSNQuF34xZrG6Xas7tp2jSSqHb/pMfXWM0vKE4JZOtK3uJfoWouUVW5IGlls75HkXmYLldZ8ySgQ==",
+          "requires": {
+            "@noble/hashes": "~1.1.3",
+            "@noble/secp256k1": "~1.7.0",
+            "@scure/base": "~1.1.0"
+          }
+        },
         "@types/node": {
           "version": "18.7.23",
           "dev": true

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,8 +18,8 @@
     "test:watch": "jest --watch --coverage=false"
   },
   "dependencies": {
-    "@scure/bip32": "^1.1.1",
-    "@scure/bip39": "^1.1.0",
+    "@scure/bip32": "1.1.3",
+    "@scure/bip39": "1.1.0",
     "@stacks/auth": "^6.1.0",
     "@stacks/blockchain-api-client": "4.0.1",
     "@stacks/bns": "^6.1.0",

--- a/packages/encryption/package.json
+++ b/packages/encryption/package.json
@@ -20,9 +20,9 @@
     "typecheck:watch": "npm run typecheck -- --watch"
   },
   "dependencies": {
-    "@noble/hashes": "^1.1.3",
-    "@noble/secp256k1": "^1.6.3",
-    "@scure/bip39": "^1.1.0",
+    "@noble/hashes": "1.1.5",
+    "@noble/secp256k1": "1.7.1",
+    "@scure/bip39": "1.1.0",
     "@stacks/common": "^6.0.0",
     "@types/node": "^18.0.4",
     "base64-js": "^1.5.1",

--- a/packages/stacking/package.json
+++ b/packages/stacking/package.json
@@ -20,7 +20,7 @@
     "typecheck:watch": "npm run typecheck -- --watch"
   },
   "dependencies": {
-    "@scure/base": "^1.1.1",
+    "@scure/base": "1.1.1",
     "@stacks/common": "^6.0.0",
     "@stacks/encryption": "^6.1.0",
     "@stacks/network": "^6.1.0",

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -25,8 +25,8 @@
     "typecheck:watch": "npm run typecheck -- --watch"
   },
   "dependencies": {
-    "@noble/hashes": "^1.1.3",
-    "@noble/secp256k1": "^1.6.3",
+    "@noble/hashes": "1.1.5",
+    "@noble/secp256k1": "1.7.1",
     "@stacks/common": "^6.0.0",
     "@stacks/network": "^6.1.0",
     "c32check": "^2.0.0",

--- a/packages/wallet-sdk/package.json
+++ b/packages/wallet-sdk/package.json
@@ -28,8 +28,8 @@
     "typecheck:watch": "npm run typecheck -- --watch"
   },
   "dependencies": {
-    "@scure/bip32": "^1.1.1",
-    "@scure/bip39": "^1.1.0",
+    "@scure/bip32": "1.1.3",
+    "@scure/bip39": "1.1.0",
     "@stacks/auth": "^6.1.0",
     "@stacks/common": "^6.0.0",
     "@stacks/encryption": "^6.1.0",


### PR DESCRIPTION
> This PR was published to npm with the version `6.1.1-pr.66881c4.0`
> e.g. `npm install @stacks/common@6.1.1-pr.66881c4.0 --save-exact`<!-- Sticky Header Marker -->

Ran into some type mismatches in these packages. 