### PR TITLE
fix: export unexported methods

### DIFF
--- a/packages/wallet-sdk/src/index.ts
+++ b/packages/wallet-sdk/src/index.ts
@@ -5,5 +5,7 @@ export * from './models/account';
 export * from './models/common';
 export * from './models/profile';
 export * from './models/wallet-config';
+export * from './models/legacy-wallet-config';
 export * from './encryption';
 export * from './triplesec';
+export * from './utils';


### PR DESCRIPTION
> This PR was published to npm with the version `6.1.1-pr.f7b9da8.0`
> e.g. `npm install @stacks/common@6.1.1-pr.f7b9da8.0 --save-exact`<!-- Sticky Header Marker -->

We need exports in these files. See https://github.com/hirosystems/stacks-wallet-web/pull/3026