### PR TITLE
refactor: remove query-string dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25002,8 +25002,7 @@
         "@stacks/network": "^6.1.1",
         "@stacks/profile": "^6.1.1",
         "cross-fetch": "^3.1.5",
-        "jsontokens": "^4.0.1",
-        "query-string": "^6.13.1"
+        "jsontokens": "^4.0.1"
       },
       "devDependencies": {
         "process": "^0.11.10",
@@ -29952,7 +29951,6 @@
         "cross-fetch": "^3.1.5",
         "jsontokens": "^4.0.1",
         "process": "^0.11.10",
-        "query-string": "^6.13.1",
         "rimraf": "^3.0.2"
       }
     },

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -25,8 +25,7 @@
     "@stacks/network": "^6.1.1",
     "@stacks/profile": "^6.1.1",
     "cross-fetch": "^3.1.5",
-    "jsontokens": "^4.0.1",
-    "query-string": "^6.13.1"
+    "jsontokens": "^4.0.1"
   },
   "devDependencies": {
     "process": "^0.11.10",

--- a/packages/auth/src/provider.ts
+++ b/packages/auth/src/provider.ts
@@ -1,4 +1,3 @@
-import * as queryString from 'query-string';
 import { decodeToken } from 'jsontokens';
 import { BLOCKSTACK_HANDLER, getGlobalObject } from '@stacks/common';
 import { createFetchFn, FetchFn } from '@stacks/network';
@@ -10,21 +9,14 @@ import { createFetchFn, FetchFn } from '@stacks/network';
  * @private
  * @ignore
  */
-export function getAuthRequestFromURL() {
+export function getAuthRequestFromURL(): string | null {
   const location = getGlobalObject('location', {
     throwIfUnavailable: true,
     usageDesc: 'getAuthRequestFromURL',
   });
-  if (location?.search) {
-    const queryDict = queryString.parse(location?.search);
-    if (queryDict.authRequest) {
-      return (queryDict.authRequest as string).split(`${BLOCKSTACK_HANDLER}:`).join('');
-    } else {
-      return null;
-    }
-  } else {
-    return null;
-  }
+
+  const params = new URLSearchParams(location?.search);
+  return params.get('authRequest')?.replaceAll(`${BLOCKSTACK_HANDLER}:`, '') ?? null;
 }
 
 /**

--- a/packages/auth/src/userSession.ts
+++ b/packages/auth/src/userSession.ts
@@ -23,7 +23,7 @@ import {
 } from '@stacks/common';
 import { extractProfile } from '@stacks/profile';
 import { AuthScope, DEFAULT_PROFILE } from './constants';
-import * as queryString from 'query-string';
+
 import { UserData } from './userData';
 import { createFetchFn, FetchFn, StacksMainnet } from '@stacks/network';
 import { protocolEchoReplyDetection } from './protocolEchoDetection';
@@ -162,11 +162,9 @@ export class UserSession {
       throwIfUnavailable: true,
       usageDesc: 'getAuthResponseToken',
     })?.search;
-    if (search) {
-      const queryDict = queryString.parse(search);
-      return queryDict.authResponse ? (queryDict.authResponse as string) : '';
-    }
-    return '';
+
+    const params = new URLSearchParams(search);
+    return params.get('authResponse') ?? '';
   }
 
   /**


### PR DESCRIPTION
> This PR was published to npm with the version `6.1.2-pr.70d913b.0`
> e.g. `npm install @stacks/common@6.1.2-pr.70d913b.0 --save-exact`<!-- Sticky Header Marker -->



- removes `query-string` dependency, replaces with native js `URLSearchParams`

![Screenshot 2023-01-31 at 10 49 34](https://user-images.githubusercontent.com/6362150/215726430-e0679005-b676-4d06-9037-4ba5b6744e01.png)

