### PR TITLE
chore: rename makeAuthRequest to makeAuthRequestToken

### DIFF
--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,5 +1,10 @@
 export { AppConfig } from './appConfig';
-export { makeAuthRequest, makeAuthResponse, decryptPrivateKey } from './messages';
+export {
+  makeAuthRequest,
+  makeAuthRequestToken,
+  makeAuthResponse,
+  decryptPrivateKey,
+} from './messages';
 export { getAuthRequestFromURL, fetchAppManifest } from './provider';
 export {
   verifyAuthRequest,

--- a/packages/auth/src/messages.ts
+++ b/packages/auth/src/messages.ts
@@ -37,6 +37,9 @@ export function generateTransitKey() {
   return transitKey;
 }
 
+/** @deprecated {@link makeAuthRequest} was renamed to {@link makeAuthRequestToken} */
+export const makeAuthRequest = makeAuthRequestToken;
+
 /**
  * Generates an authentication request that can be sent to the Blockstack
  * browser for the user to approve sign in. This authentication request can
@@ -58,7 +61,7 @@ export function generateTransitKey() {
  * by special authenticators.
  * @return {String} the authentication request
  */
-export function makeAuthRequest(
+export function makeAuthRequestToken(
   transitPrivateKey: string,
   redirectURI?: string,
   manifestURI?: string,

--- a/packages/auth/src/userSession.ts
+++ b/packages/auth/src/userSession.ts
@@ -106,9 +106,9 @@ export class UserSession {
    * pass options that aren't part of the Blockstack authentication specification,
    * but might be supported by special authenticators.
    *
-   * @returns {String} the authentication request
+   * @returns {String} the authentication request token
    */
-  makeAuthRequest(
+  makeAuthRequestToken(
     transitKey?: string,
     redirectURI?: string,
     manifestURI?: string,
@@ -126,7 +126,7 @@ export class UserSession {
     manifestURI = manifestURI || appConfig.manifestURI();
     scopes = scopes || appConfig.scopes;
     appDomain = appDomain || appConfig.appDomain;
-    return authMessages.makeAuthRequest(
+    return authMessages.makeAuthRequestToken(
       transitKey,
       redirectURI,
       manifestURI,
@@ -403,3 +403,14 @@ export class UserSession {
     }
   }
 }
+
+// Add method aliases for backwards compatibility
+export interface UserSession {
+  /** @deprecated {@link makeAuthRequest} was renamed to {@link makeAuthRequestToken} */
+  makeAuthRequest(
+    ...args: Parameters<typeof UserSession.prototype.makeAuthRequestToken>
+  ): ReturnType<typeof UserSession.prototype.makeAuthRequestToken>;
+}
+
+// eslint-disable-next-line @typescript-eslint/unbound-method
+UserSession.prototype.makeAuthRequest = UserSession.prototype.makeAuthRequestToken;

--- a/packages/auth/tests/auth.test.ts
+++ b/packages/auth/tests/auth.test.ts
@@ -38,7 +38,7 @@ test('makeAuthRequest && verifyAuthRequest', async () => {
   const appConfig = new AppConfig(['store_write'], 'http://localhost:3000');
   const blockstack = new UserSession({ appConfig });
 
-  const authRequest = blockstack.makeAuthRequest(privateKey);
+  const authRequest = blockstack.makeAuthRequestToken(privateKey);
   expect(authRequest).toBeTruthy();
 
   const decodedToken = decodeToken(authRequest);
@@ -92,7 +92,7 @@ test('make and verify auth request with extraParams', async () => {
   const appConfig = new AppConfig(['store_write'], 'http://localhost:3000');
   const blockstack = new UserSession({ appConfig });
 
-  const authRequest = blockstack.makeAuthRequest(
+  const authRequest = blockstack.makeAuthRequestToken(
     privateKey,
     undefined,
     undefined,
@@ -117,7 +117,7 @@ test('invalid auth request - signature not verified', async () => {
   const appConfig = new AppConfig(['store_write'], 'http://localhost:3000');
   const blockstack = new UserSession({ appConfig });
 
-  const authRequest = blockstack.makeAuthRequest(privateKey);
+  const authRequest = blockstack.makeAuthRequestToken(privateKey);
   const invalidAuthRequest = authRequest.substring(0, authRequest.length - 1);
 
   expect(doSignaturesMatchPublicKeys(invalidAuthRequest)).toEqual(false);
@@ -140,7 +140,7 @@ test('invalid auth request - invalid redirect uri', async () => {
   appConfig.redirectURI = () => 'https://example.com'; // monkey patch for test
   const blockstack = new UserSession({ appConfig });
 
-  const invalidAuthRequest = blockstack.makeAuthRequest(privateKey);
+  const invalidAuthRequest = blockstack.makeAuthRequestToken(privateKey);
   expect(isRedirectUriValid(invalidAuthRequest)).toBe(false);
 
   await verifyAuthRequest(invalidAuthRequest).then(verified => {
@@ -159,7 +159,7 @@ test('invalid auth request - invalid manifest uri', async () => {
   const appConfig = new AppConfig(['store_write'], 'http://localhost:3000');
   appConfig.manifestURI = () => 'https://example.com/manifest.json'; // monkey patch for test
   const blockstack = new UserSession({ appConfig });
-  const invalidAuthRequest = blockstack.makeAuthRequest(privateKey);
+  const invalidAuthRequest = blockstack.makeAuthRequestToken(privateKey);
 
   expect(isManifestUriValid(invalidAuthRequest)).toBe(false);
 


### PR DESCRIPTION
> This PR was published to npm with the version `6.1.2-pr.8efd993.0`
> e.g. `npm install @stacks/common@6.1.2-pr.8efd993.0 --save-exact`<!-- Sticky Header Marker -->

### Description

- fixes #1419 

