### PR TITLE
feat: add additional data to auth resp

### DIFF
--- a/packages/wallet-sdk/src/models/account.ts
+++ b/packages/wallet-sdk/src/models/account.ts
@@ -70,6 +70,7 @@ export const makeAuthResponse = async ({
   scopes = [],
   gaiaHubUrl,
   appPrivateKeyFromWalletSalt = null,
+  additionalData = {},
   fetchFn = createFetchFn(),
 }: {
   account: Account;
@@ -78,6 +79,7 @@ export const makeAuthResponse = async ({
   scopes?: string[];
   gaiaHubUrl: string;
   appPrivateKeyFromWalletSalt?: string | null;
+  additionalData?: Record<string, any>;
   fetchFn?: FetchFn;
 }) => {
   const appPrivateKey = getAppPrivateKey({ account, appDomain });
@@ -121,6 +123,7 @@ export const makeAuthResponse = async ({
         testnet: getStxAddress({ account, transactionVersion: TransactionVersion.Testnet }),
         mainnet: getStxAddress({ account, transactionVersion: TransactionVersion.Mainnet }),
       },
+      ...additionalData,
     },
     {
       profileUrl,


### PR DESCRIPTION
> This PR was published to npm with the version `6.1.2-pr.4e0feae.0`
> e.g. `npm install @stacks/common@6.1.2-pr.4e0feae.0 --save-exact`<!-- Sticky Header Marker -->

Required to add btc addresses to auth response data