### PR TITLE
feat: strict ECDSA Signatures

### DIFF
--- a/packages/encryption/src/cryptoRandom.ts
+++ b/packages/encryption/src/cryptoRandom.ts
@@ -1,17 +1,17 @@
 import { utils } from '@noble/secp256k1';
 
 /**
- * Reexports @noble/secp256k1's randombytes
+ * Reexports @noble/secp256k1's `randomBytes`.
  * Generates bytes with random bytes of given length
- * @param bytesLength an optional bytes length, default `32` bytes
+ * @param bytesLength an optional bytes length, default `32`
  * @return {Uint8Array} random bytes
  */
 export const randomBytes = (bytesLength: number = 32): Uint8Array => utils.randomBytes(bytesLength);
 
 /**
- * Reexports @noble/secp256k1's randombytes
+ * Reexports @noble/secp256k1's `randomPrivateKey`.
  * Generates a random scalar between 0 and the group prime for secp256k1
- * @returns {Uint8Array}
+ * @returns {Uint8Array} random private key
  */
 export const randomPrivateKey = (): Uint8Array => utils.randomPrivateKey();
 

--- a/packages/encryption/src/cryptoRandom.ts
+++ b/packages/encryption/src/cryptoRandom.ts
@@ -8,5 +8,12 @@ import { utils } from '@noble/secp256k1';
  */
 export const randomBytes = (bytesLength: number = 32): Uint8Array => utils.randomBytes(bytesLength);
 
+/**
+ * Reexports @noble/secp256k1's randombytes
+ * Generates a random scalar between 0 and the group prime for secp256k1
+ * @returns {Uint8Array}
+ */
+export const randomPrivateKey = (): Uint8Array => utils.randomPrivateKey();
+
 /** Optional function to generate cryptographically secure random bytes */
 export type GetRandomBytes = (count: number) => Uint8Array;

--- a/packages/encryption/tests/ec.test.ts
+++ b/packages/encryption/tests/ec.test.ts
@@ -1,14 +1,12 @@
 import { sha256 } from '@noble/hashes/sha256';
-import { bytesToHex, concatBytes, hexToBytes } from '@stacks/common';
+import { bytesToHex, concatBytes } from '@stacks/common';
+import { getPublicKey, makeRandomPrivKey, signMessageHashRsv } from '../../transactions/src';
+import { encodeMessage } from '../src';
 import {
-  signECDSA,
-  signStrictECDSA,
   verifyMessageSignature,
   verifyMessageSignatureRsv,
   verifyStrictMessageSignatureRsv,
 } from '../src/ec';
-import { randomPrivateKey } from '../src/cryptoRandom';
-import { getPublicKeyFromPrivate } from '../src/keys';
 
 test('verifyMessageSignature', () => {
   // $ clarinet console
@@ -48,25 +46,21 @@ test('verifyMessageSignatureRsv', () => {
 });
 
 test('verifyStrictMessageSignatureRsv', () => {
-  const secretKey = bytesToHex(randomPrivateKey());
-  const publicKey = getPublicKeyFromPrivate(secretKey);
-  const message = sha256('Hello World');
-  expect(bytesToHex(message)).toBe(
-    'a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e'
-  );
-  const signature = signStrictECDSA(secretKey, message);
-  const signatureRsv = signature.signature;
-  expect(verifyStrictMessageSignatureRsv({ signature: signatureRsv, publicKey, message })).toBe(
-    true
-  );
+  const privateKey = makeRandomPrivKey();
+  const publicKey = getPublicKey(privateKey);
 
-  const publicKeyAndMessage = sha256(
-    concatBytes(
-      hexToBytes(publicKey),
-      new Uint8Array([0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x57, 0x6f, 0x72, 0x6c, 0x64])
-    )
-  );
+  const message = 'Hello World';
+
+  const strictMessage = concatBytes(publicKey.data, encodeMessage(message));
+  const strictMessageHash = bytesToHex(sha256(strictMessage));
+
+  const signature = signMessageHashRsv({ messageHash: strictMessageHash, privateKey });
+
   expect(
-    verifyMessageSignatureRsv({ signature: signatureRsv, publicKey, message: publicKeyAndMessage })
+    verifyStrictMessageSignatureRsv({
+      signature: signature.data,
+      publicKey: bytesToHex(publicKey.data),
+      message,
+    })
   ).toBe(true);
 });


### PR DESCRIPTION
> This PR was published to npm with the version `6.2.2-pr.4b3d469.0`
> e.g. `npm install @stacks/common@6.2.2-pr.4b3d469.0 --save-exact`<!-- Sticky Header Marker -->

Strict signatures contain the following properties:

1. Signatures encoded as (R,S), S is always smaller than the group order.
2. The signature is calculated over the hash of the public key and the message

This second property satisfies the requirements for Universal Exclusive Ownership, as defined in [this paper](https://www.bolet.org/~pornin/2005-acns-pornin+stern.pdf) (section 3.3).

Strict signatures are more suitable in applications where it's undesirable for `s1 = s2` given `s1 = sign(k1, msg1)` and `s2 = sign(k2, msg2)`. Direct ECDSA permits this condition (even if `msg1 = msg2`).

### Description

#### Breaking change?

No, it's a new feature.

### Example

<!-- If applicable, add an example on how this improves upon the previous usage -->

---

### Checklist

- [x] Unit tested updated code paths
- [x] Tagged 1 of @janniks or @zone117x for review

<!-- Make sure to run `npm run test` locally to find problems faster -->
