### PR TITLE
feat: implement `getContractMapEntry` function

### DIFF
--- a/packages/network/src/network.ts
+++ b/packages/network/src/network.ts
@@ -102,6 +102,8 @@ export class StacksNetwork {
     ${contractAddress}/${contractName}/get-stacker-info`;
   getDataVarUrl = (contractAddress: string, contractName: string, dataVarName: string) =>
     `${this.coreApiUrl}/v2/data_var/${contractAddress}/${contractName}/${dataVarName}?proof=0`;
+  getMapEntryUrl = (contractAddress: string, contractName: string, mapName: string) =>
+    `${this.coreApiUrl}/v2/map_entry/${contractAddress}/${contractName}/${mapName}?proof=0`;
   getNameInfo(fullyQualifiedName: string) {
     /*
       TODO: Update to v2 API URL for name lookups


### PR DESCRIPTION
> This PR was published to npm with the version `6.2.2-pr.3c85dab.0`
> e.g. `npm install @stacks/common@6.2.2-pr.3c85dab.0 --save-exact`<!-- Sticky Header Marker -->

Implement `getContractMapEntry` function for the [`POST /v2/map_entry/[Stacks Address]/[Contract Name]/[Map Name]` RPC endpoint](https://github.com/stacks-network/stacks-blockchain/blob/master/docs/rpc-endpoints.md#post-v2map_entrystacks-addresscontract-namemap-name)

This makes the endpoint less cumbersome to use by handling the POST body clarity serialization. 

Example usage (untyped):
```ts
import { getContractMapEntry, principalCV } from '@stacks/transactions';

const result = await getContractMapEntry({
  contractAddress: 'SPSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1F4DYQ11',
  contractName: 'newyorkcitycoin-core-v2',
  mapName: 'UserIds',
  mapKey: principalCV('SP25V8V2QQ2K8N3JAS15Z14W4YW7ABFDZHK5ZPGW7'),
});

console.log(result);
// > {type: 1, value: 60n}
```

Example usage (typed):
```ts
import { getContractMapEntry, principalCV, UIntCV, ClarityType } from '@stacks/transactions';

const result = await getContractMapEntry<UIntCV>({
  contractAddress: 'SPSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1F4DYQ11',
  contractName: 'newyorkcitycoin-core-v2',
  mapName: 'UserIds',
  mapKey: principalCV('SP25V8V2QQ2K8N3JAS15Z14W4YW7ABFDZHK5ZPGW7'),
});

if (result.type === ClarityType.OptionalNone) {
  throw new Error('Not found!');
}

// Type is narrowed to `UIntCV`
console.log(result.value);
// > 60n
```

This function can be improved later on with a flag to enable more checking. For example, it could validate the contract principal and map name are valid with an ABI fetch, then validate that the map Clarity value type matches the type from the ABI. Right now, the RPC endpoint returns `none` for most of these conditions.