### PR TITLE
feat: add pc post condition builder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "ts-jest": "^28.0.8",
         "typedoc": "^0.23.20",
         "typedoc-plugin-replace-text": "^2.1.0",
-        "typescript": "^4.2.4",
+        "typescript": "^4.9.5",
         "webpack": "^5.36.1",
         "webpack-bundle-analyzer": "^4.5.0",
         "webpack-cli": "^4.10.0"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "ts-jest": "^28.0.8",
     "typedoc": "^0.23.20",
     "typedoc-plugin-replace-text": "^2.1.0",
-    "typescript": "^4.2.4",
+    "typescript": "^4.9.5",
     "webpack": "^5.36.1",
     "webpack-bundle-analyzer": "^4.5.0",
     "webpack-cli": "^4.10.0"

--- a/packages/transactions/src/builders.ts
+++ b/packages/transactions/src/builders.ts
@@ -565,7 +565,7 @@ export interface SignedMultiSigTokenTransferOptions extends TokenTransferOptions
  *
  * Returns a Stacks token transfer transaction.
  *
- * @param  {UnsignedTokenTransferOptions | UnsignedMultiSigTokenTransferOptions} txOptions - an options object for the token transfer
+ * @param {UnsignedTokenTransferOptions | UnsignedMultiSigTokenTransferOptions} txOptions - an options object for the token transfer
  *
  * @return {Promise<StacksTransaction>}
  */
@@ -656,7 +656,7 @@ export async function makeUnsignedSTXTokenTransfer(
  *
  * Returns a signed Stacks token transfer transaction.
  *
- * @param  {SignedTokenTransferOptions | SignedMultiSigTokenTransferOptions} txOptions - an options object for the token transfer
+ * @param {SignedTokenTransferOptions | SignedMultiSigTokenTransferOptions} txOptions - an options object for the token transfer
  *
  * @return {StacksTransaction}
  */
@@ -786,7 +786,7 @@ export async function estimateContractDeploy(
 /**
  * Generates a Clarity smart contract deploy transaction
  *
- * @param  {ContractDeployOptions} txOptions - an options object for the contract deploy
+ * @param {ContractDeployOptions} txOptions - an options object for the contract deploy
  *
  * Returns a signed Stacks smart contract deploy transaction.
  *
@@ -1095,7 +1095,7 @@ export async function makeUnsignedContractCall(
 /**
  * Generates a Clarity smart contract function call transaction
  *
- * @param  {SignedContractCallOptions | SignedMultiSigContractCallOptions} txOptions - an options object for the contract function call
+ * @param {SignedContractCallOptions | SignedMultiSigContractCallOptions} txOptions - an options object for the contract function call
  *
  * Returns a signed Stacks smart contract function call transaction.
  *
@@ -1141,7 +1141,7 @@ export async function makeContractCall(
  *
  * @param address - the c32check address
  * @param conditionCode - the condition code
- * @param amount - the amount of STX tokens
+ * @param amount - the amount of STX tokens (denoted in micro-STX)
  */
 export function makeStandardSTXPostCondition(
   address: string,
@@ -1159,7 +1159,7 @@ export function makeStandardSTXPostCondition(
  * @param address - the c32check address of the contract
  * @param contractName - the name of the contract
  * @param conditionCode - the condition code
- * @param amount - the amount of STX tokens
+ * @param amount - the amount of STX tokens (denoted in micro-STX)
  *
  * @return {STXPostCondition}
  */
@@ -1183,7 +1183,7 @@ export function makeContractSTXPostCondition(
  *
  * @param address - the c32check address
  * @param conditionCode - the condition code
- * @param amount - the amount of fungible tokens
+ * @param amount - the amount of fungible tokens (in their respective base unit)
  * @param assetInfo - asset info describing the fungible token
  */
 export function makeStandardFungiblePostCondition(
@@ -1208,7 +1208,7 @@ export function makeStandardFungiblePostCondition(
  * @param address - the c32check address
  * @param contractName - the name of the contract
  * @param conditionCode - the condition code
- * @param amount - the amount of fungible tokens
+ * @param amount - the amount of fungible tokens (in their respective base unit)
  * @param assetInfo - asset info describing the fungible token
  */
 export function makeContractFungiblePostCondition(
@@ -1231,10 +1231,10 @@ export function makeContractFungiblePostCondition(
  *
  * Returns a non-fungible token post condition object
  *
- * @param  {String} address - the c32check address
- * @param  {FungibleConditionCode} conditionCode - the condition code
- * @param  {AssetInfo} assetInfo - asset info describing the non-fungible token
- * @param  {ClarityValue} assetName - asset name describing the non-fungible token
+ * @param {String} address - the c32check address
+ * @param {FungibleConditionCode} conditionCode - the condition code
+ * @param {AssetInfo} assetInfo - asset info describing the non-fungible token
+ * @param {ClarityValue} assetId - asset identifier of the nft instance (typically a uint/buffer/string)
  *
  * @return {NonFungiblePostCondition}
  */
@@ -1242,13 +1242,13 @@ export function makeStandardNonFungiblePostCondition(
   address: string,
   conditionCode: NonFungibleConditionCode,
   assetInfo: string | AssetInfo,
-  assetName: ClarityValue
+  assetId: ClarityValue
 ): NonFungiblePostCondition {
   return createNonFungiblePostCondition(
     createStandardPrincipal(address),
     conditionCode,
     assetInfo,
-    assetName
+    assetId
   );
 }
 
@@ -1257,11 +1257,11 @@ export function makeStandardNonFungiblePostCondition(
  *
  * Returns a non-fungible token post condition object
  *
- * @param  {String} address - the c32check address
- * @param  {String} contractName - the name of the contract
- * @param  {FungibleConditionCode} conditionCode - the condition code
- * @param  {AssetInfo} assetInfo - asset info describing the non-fungible token
- * @param  {ClarityValue} assetName - asset name describing the non-fungible token
+ * @param {String} address - the c32check address
+ * @param {String} contractName - the name of the contract
+ * @param {FungibleConditionCode} conditionCode - the condition code
+ * @param {AssetInfo} assetInfo - asset info describing the non-fungible token
+ * @param {ClarityValue} assetId - asset identifier of the nft instance (typically a uint/buffer/string)
  *
  * @return {NonFungiblePostCondition}
  */
@@ -1270,25 +1270,25 @@ export function makeContractNonFungiblePostCondition(
   contractName: string,
   conditionCode: NonFungibleConditionCode,
   assetInfo: string | AssetInfo,
-  assetName: ClarityValue
+  assetId: ClarityValue
 ): NonFungiblePostCondition {
   return createNonFungiblePostCondition(
     createContractPrincipal(address, contractName),
     conditionCode,
     assetInfo,
-    assetName
+    assetId
   );
 }
 
 /**
  * Read only function options
  *
- * @param  {String} contractAddress - the c32check address of the contract
- * @param  {String} contractName - the contract name
- * @param  {String} functionName - name of the function to be called
- * @param  {[ClarityValue]} functionArgs - an array of Clarity values as arguments to the function call
- * @param  {StacksNetwork} network - the Stacks blockchain network this transaction is destined for
- * @param  {String} senderAddress - the c32check address of the sender
+ * @param {String} contractAddress - the c32check address of the contract
+ * @param {String} contractName - the contract name
+ * @param {String} functionName - name of the function to be called
+ * @param {[ClarityValue]} functionArgs - an array of Clarity values as arguments to the function call
+ * @param {StacksNetwork} network - the Stacks blockchain network this transaction is destined for
+ * @param {String} senderAddress - the c32check address of the sender
  */
 
 export interface ReadOnlyFunctionOptions {
@@ -1306,7 +1306,7 @@ export interface ReadOnlyFunctionOptions {
  * Calls a function as read-only from a contract interface
  * It is not necessary that the function is defined as read-only in the contract
  *
- * @param  {ReadOnlyFunctionOptions} readOnlyFunctionOptions - the options object
+ * @param {ReadOnlyFunctionOptions} readOnlyFunctionOptions - the options object
  *
  * Returns an object with a status bool (okay) and a result string that is a serialized clarity value in hex format.
  *
@@ -1441,7 +1441,7 @@ export interface SponsorOptionsOpts {
 /**
  * Constructs and signs a sponsored transaction as the sponsor
  *
- * @param  {SponsorOptionsOpts} sponsorOptions - the sponsor options object
+ * @param {SponsorOptionsOpts} sponsorOptions - the sponsor options object
  *
  * Returns a signed sponsored transaction.
  *

--- a/packages/transactions/src/index.ts
+++ b/packages/transactions/src/index.ts
@@ -46,3 +46,5 @@ export * from './common';
 export * from './signature';
 export * from './structuredDataSignature';
 export * from './postcondition-types';
+
+export * as Pc from './pc';

--- a/packages/transactions/src/pc.ts
+++ b/packages/transactions/src/pc.ts
@@ -1,0 +1,235 @@
+import { IntegerType } from '@stacks/common';
+import {
+  makeContractFungiblePostCondition,
+  makeContractNonFungiblePostCondition,
+  makeContractSTXPostCondition,
+  makeStandardFungiblePostCondition,
+  makeStandardNonFungiblePostCondition,
+  makeStandardSTXPostCondition,
+} from './builders';
+import { ClarityValue } from './clarity';
+import { FungibleConditionCode, NonFungibleConditionCode } from './constants';
+import { createAssetInfo } from './postcondition-types';
+
+/// `Pc.` Post Condition Builder
+//
+// This is a behavioral helper interface for constructing post conditions.
+//
+// The general pattern is:
+//   PRINCIPAL -> [AMOUNT] -> CODE -> ASSET
+//
+
+/**
+ * An address string encoded as c32check
+ * @internal
+ */
+type AddressString = string;
+
+/**
+ * A contract identifier string given as `<address>.<contract-name>`
+ * @internal
+ */
+type ContractIdString = `${string}.${string}`;
+
+/**
+ * ### `Pc.` Post Condition Builder
+ * @param {AddressString | ContractIdString} principal The principal to check, which should/should-not be sending assets. A string in the format "address" or "address.contractId".
+ * @returns A partial post condition builder, which can be chained into a final post condition.
+ * @example
+ * ```
+ * import { Pc } from '@stacks/transactions';
+ * Pc.principal('STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6').willSendEq(100).stx();
+ * ```
+ */
+export function principal(principal: AddressString | ContractIdString) {
+  if (isContractIdString(principal)) {
+    // `principal` is a ContractIdString here
+    const [address, name] = parseContract(principal);
+    return new PartialPcWithPrincipal(address, name);
+  }
+
+  return new PartialPcWithPrincipal(principal, undefined);
+}
+
+class PartialPcWithPrincipal {
+  constructor(private address: string, private contractName?: string) {}
+
+  // todo: split FT and STX into separate methods? e.g. `willSendSTXEq` and `willSendFtEq`
+
+  /**
+   * ### Fungible Token Post Condition
+   * A post-condition sending `FungibleConditionCode.Equal` uSTX or other fungible tokens.
+   * Finalize with the chained `.ustx()` or `.ft(…)` method.
+   */
+  willSendEq(amount: IntegerType) {
+    return new PartialPcFtWithCode(
+      this.address,
+      amount,
+      FungibleConditionCode.Equal,
+      this.contractName
+    );
+  }
+
+  /**
+   * ### Fungible Token Post Condition
+   * A post-condition sending `FungibleConditionCode.LessEqual` uSTX or other fungible tokens.
+   * Finalize with the chained `.ustx()` or `.ft(…)` method.
+   */
+  willSendLte(amount: IntegerType) {
+    return new PartialPcFtWithCode(
+      this.address,
+      amount,
+      FungibleConditionCode.LessEqual,
+      this.contractName
+    );
+  }
+
+  /**
+   * ### Fungible Token Post Condition
+   * A post-condition sending `FungibleConditionCode.Less` uSTX or other fungible tokens.
+   * Finalize with the chained `.ustx()` or `.ft(…)` method.
+   */
+  willSendLt(amount: IntegerType) {
+    return new PartialPcFtWithCode(
+      this.address,
+      amount,
+      FungibleConditionCode.Less,
+      this.contractName
+    );
+  }
+
+  /**
+   * ### Fungible Token Post Condition
+   * A post-condition sending `FungibleConditionCode.GreaterEqual` uSTX or other fungible tokens.
+   * Finalize with the chained `.ustx()` or `.ft(…)` method.
+   */
+  willSendGte(amount: IntegerType) {
+    return new PartialPcFtWithCode(
+      this.address,
+      amount,
+      FungibleConditionCode.GreaterEqual,
+      this.contractName
+    );
+  }
+
+  /**
+   * ### Fungible Token Post Condition
+   * A post-condition sending `FungibleConditionCode.Greater` uSTX or other fungible tokens.
+   * Finalize with the chained `.ustx()` or `.ft(…)` method.
+   */
+  willSendGt(amount: IntegerType) {
+    return new PartialPcFtWithCode(
+      this.address,
+      amount,
+      FungibleConditionCode.Greater,
+      this.contractName
+    );
+  }
+
+  /**
+   * ### NFT Post Condition
+   * A post-condition which `NonFungibleConditionCode.Sends` an NFT.
+   * Finalize with the chained `.nft(…)` method.
+   */
+  willSendAsset() {
+    return new PartialPcNftWithCode(
+      this.address,
+      NonFungibleConditionCode.Sends,
+      this.contractName
+    );
+  }
+
+  /**
+   * ### NFT Post Condition
+   * A post-condition which `NonFungibleConditionCode.DoesNotSend` an NFT.
+   * Finalize with the chained `.nft(…)` method.
+   */
+  willNotSendAsset() {
+    return new PartialPcNftWithCode(
+      this.address,
+      NonFungibleConditionCode.DoesNotSend,
+      this.contractName
+    );
+  }
+}
+
+class PartialPcFtWithCode {
+  constructor(
+    private address: string,
+    private amount: IntegerType,
+    private code: FungibleConditionCode,
+    private contractName?: string
+  ) {}
+
+  /**
+   * ### STX Post Condition
+   * ⚠ Amount of STX is denoted in uSTX (micro-STX)
+   */
+  ustx() {
+    // todo: rename to `uSTX`?
+    if (this.contractName) {
+      return makeContractSTXPostCondition(this.address, this.contractName, this.code, this.amount);
+    }
+    return makeStandardSTXPostCondition(this.address, this.code, this.amount);
+  }
+
+  /**
+   * ### Fungible Token Post Condition
+   * ⚠ Amount of fungible tokens is denoted in the smallest unit of the token
+   */
+  ft(contractId: ContractIdString, tokenName: string) {
+    const [address, name] = parseContract(contractId);
+    if (this.contractName) {
+      return makeContractFungiblePostCondition(
+        this.address,
+        this.contractName,
+        this.code,
+        this.amount,
+        createAssetInfo(address, name, tokenName)
+      );
+    }
+    return makeStandardFungiblePostCondition(
+      this.address,
+      this.code,
+      this.amount,
+      createAssetInfo(address, name, tokenName)
+    );
+  }
+}
+
+class PartialPcNftWithCode {
+  constructor(
+    private principal: string,
+    private code: NonFungibleConditionCode,
+    private contractName?: string
+  ) {}
+
+  nft(contractId: ContractIdString, assetName: string, assetId: ClarityValue) {
+    const [address, name] = parseContract(contractId);
+    if (this.contractName) {
+      return makeContractNonFungiblePostCondition(
+        this.principal,
+        this.contractName,
+        this.code,
+        createAssetInfo(address, name, assetName),
+        assetId
+      );
+    }
+    return makeStandardNonFungiblePostCondition(
+      this.principal,
+      this.code,
+      createAssetInfo(address, name, assetName),
+      assetId
+    );
+  }
+}
+
+function parseContract(contractId: ContractIdString) {
+  const [address, name] = contractId.split('.');
+  if (!address || !name) throw new Error(`Invalid contract identifier: ${contractId}`);
+  return [address, name];
+}
+
+function isContractIdString(value: AddressString | ContractIdString): value is ContractIdString {
+  return value.includes('.');
+}

--- a/packages/transactions/src/pc.ts
+++ b/packages/transactions/src/pc.ts
@@ -9,7 +9,7 @@ import {
 } from './builders';
 import { ClarityValue } from './clarity';
 import { FungibleConditionCode, NonFungibleConditionCode } from './constants';
-import { createAssetInfo } from './postcondition-types';
+import { createAssetInfo, NonFungiblePostCondition } from './postcondition-types';
 
 /// `Pc.` Post Condition Builder
 //
@@ -32,6 +32,12 @@ type AddressString = string;
 type ContractIdString = `${string}.${string}`;
 
 /**
+ * An asset identifier string given as `<contract-id>::<token-name>` aka `<contract-address>.<contract-name>::<token-name>`
+ * @internal
+ */
+type NftString = `${ContractIdString}::${string}`;
+
+/**
  * ### `Pc.` Post Condition Builder
  * @param {AddressString | ContractIdString} principal The principal to check, which should/should-not be sending assets. A string in the format "address" or "address.contractId".
  * @returns A partial post condition builder, which can be chained into a final post condition.
@@ -44,7 +50,7 @@ type ContractIdString = `${string}.${string}`;
 export function principal(principal: AddressString | ContractIdString) {
   if (isContractIdString(principal)) {
     // `principal` is a ContractIdString here
-    const [address, name] = parseContract(principal);
+    const [address, name] = parseContractId(principal);
     return new PartialPcWithPrincipal(address, name);
   }
 
@@ -178,7 +184,7 @@ class PartialPcFtWithCode {
    * ⚠ Amount of fungible tokens is denoted in the smallest unit of the token
    */
   ft(contractId: ContractIdString, tokenName: string) {
-    const [address, name] = parseContract(contractId);
+    const [address, name] = parseContractId(contractId);
     if (this.contractName) {
       return makeContractFungiblePostCondition(
         this.address,
@@ -204,32 +210,91 @@ class PartialPcNftWithCode {
     private contractName?: string
   ) {}
 
-  nft(contractId: ContractIdString, assetName: string, assetId: ClarityValue) {
-    const [address, name] = parseContract(contractId);
+  /**
+   * ### Non-Fungible Token Post Condition
+   * @param assetName - The name of the NFT asset. Formatted as `<contract-address>.<contract-name>::<token-name>`.
+   * @param assetId - The asset identifier of the NFT. A Clarity value defining the single NFT instance.
+   */
+  nft(assetName: NftString, assetId: ClarityValue): NonFungiblePostCondition;
+  /**
+   * ### Non-Fungible Token Post Condition
+   * @param contractId - The contract identifier of the NFT. Formatted as `<contract-address>.<contract-name>`.
+   * @param tokenName - The name of the NFT asset.
+   * @param assetId - The asset identifier of the NFT. A Clarity value defining the single NFT instance.
+   */
+  nft(
+    contractId: ContractIdString,
+    tokenName: string,
+    assetId: ClarityValue
+  ): NonFungiblePostCondition;
+  nft(...args: [any, any] | [any, any, any]): NonFungiblePostCondition {
+    const { contractAddress, contractName, tokenName, assetId } = getNftArgs(
+      ...(args as [any, any, any])
+    );
+
     if (this.contractName) {
       return makeContractNonFungiblePostCondition(
         this.principal,
         this.contractName,
         this.code,
-        createAssetInfo(address, name, assetName),
+        createAssetInfo(contractAddress, contractName, tokenName),
         assetId
       );
     }
+
     return makeStandardNonFungiblePostCondition(
       this.principal,
       this.code,
-      createAssetInfo(address, name, assetName),
+      createAssetInfo(contractAddress, contractName, tokenName),
       assetId
     );
   }
 }
 
-function parseContract(contractId: ContractIdString) {
+function parseContractId(contractId: ContractIdString) {
   const [address, name] = contractId.split('.');
   if (!address || !name) throw new Error(`Invalid contract identifier: ${contractId}`);
   return [address, name];
 }
 
+function parseNft(nftAssetName: NftString) {
+  const [principal, tokenName] = nftAssetName.split('::') as [ContractIdString, string];
+  if (!principal || !tokenName)
+    throw new Error(`Invalid fully-qualified nft asset name: ${nftAssetName}`);
+  const [address, name] = parseContractId(principal);
+  return { contractAddress: address, contractName: name, tokenName };
+}
+
 function isContractIdString(value: AddressString | ContractIdString): value is ContractIdString {
   return value.includes('.');
+}
+
+/**
+ * Helper method for `PartialPcNftWithCode.nft` to parse the arguments.
+ * @internal
+ */
+function getNftArgs(
+  assetName: NftString,
+  assetId: ClarityValue
+): { contractAddress: string; contractName: string; tokenName: string; assetId: ClarityValue };
+function getNftArgs(
+  contractId: ContractIdString,
+  tokenName: string,
+  assetId: ClarityValue
+): { contractAddress: string; contractName: string; tokenName: string; assetId: ClarityValue };
+function getNftArgs(...args: [any, any] | [any, any, any]): {
+  contractAddress: string;
+  contractName: string;
+  tokenName: string;
+  assetId: ClarityValue;
+} {
+  if (args.length === 2) {
+    const [assetName, assetId] = args;
+    return { ...parseNft(assetName), assetId };
+  }
+
+  // args.length === 3
+  const [contractId, tokenName, assetId] = args;
+  const [address, name] = parseContractId(contractId);
+  return { contractAddress: address, contractName: name, tokenName, assetId };
 }

--- a/packages/transactions/src/pc.ts
+++ b/packages/transactions/src/pc.ts
@@ -39,6 +39,7 @@ type NftString = `${ContractIdString}::${string}`;
 
 /**
  * ### `Pc.` Post Condition Builder
+ * @beta Interface may be subject to change in future releases.
  * @param {AddressString | ContractIdString} principal The principal to check, which should/should-not be sending assets. A string in the format "address" or "address.contractId".
  * @returns A partial post condition builder, which can be chained into a final post condition.
  * @example
@@ -64,8 +65,13 @@ class PartialPcWithPrincipal {
 
   /**
    * ### Fungible Token Post Condition
-   * A post-condition sending `FungibleConditionCode.Equal` uSTX or other fungible tokens.
+   * A post-condition sending tokens `FungibleConditionCode.Equal` (equal to) the given amount of uSTX or fungible-tokens.
    * Finalize with the chained `.ustx()` or `.ft(…)` method.
+   * @example
+   * ```
+   * import { Pc } from '@stacks/transactions';
+   * Pc.principal('STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6').willSendEq(100).stx();
+   * ```
    */
   willSendEq(amount: IntegerType) {
     return new PartialPcFtWithCode(
@@ -78,8 +84,13 @@ class PartialPcWithPrincipal {
 
   /**
    * ### Fungible Token Post Condition
-   * A post-condition sending `FungibleConditionCode.LessEqual` uSTX or other fungible tokens.
+   * A post-condition sending tokens `FungibleConditionCode.LessEqual` (less-than or equal to) the given amount of uSTX or fungible-tokens.
    * Finalize with the chained `.ustx()` or `.ft(…)` method.
+   * @example
+   * ```
+   * import { Pc } from '@stacks/transactions';
+   * Pc.principal('STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6').willSendLte(100).stx();
+   * ```
    */
   willSendLte(amount: IntegerType) {
     return new PartialPcFtWithCode(
@@ -92,8 +103,13 @@ class PartialPcWithPrincipal {
 
   /**
    * ### Fungible Token Post Condition
-   * A post-condition sending `FungibleConditionCode.Less` uSTX or other fungible tokens.
+   * A post-condition sending tokens `FungibleConditionCode.Less` (less-than) the given amount of uSTX or fungible-tokens.
    * Finalize with the chained `.ustx()` or `.ft(…)` method.
+   * @example
+   * ```
+   * import { Pc } from '@stacks/transactions';
+   * Pc.principal('STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6').willSendLt(100).stx();
+   * ```
    */
   willSendLt(amount: IntegerType) {
     return new PartialPcFtWithCode(
@@ -106,8 +122,13 @@ class PartialPcWithPrincipal {
 
   /**
    * ### Fungible Token Post Condition
-   * A post-condition sending `FungibleConditionCode.GreaterEqual` uSTX or other fungible tokens.
+   * A post-condition sending tokens `FungibleConditionCode.GreaterEqual` (greater-than or equal to) the given amount of uSTX or fungible-tokens.
    * Finalize with the chained `.ustx()` or `.ft(…)` method.
+   * @example
+   * ```
+   * import { Pc } from '@stacks/transactions';
+   * Pc.principal('STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6').willSendGte(100).stx();
+   * ```
    */
   willSendGte(amount: IntegerType) {
     return new PartialPcFtWithCode(
@@ -120,8 +141,13 @@ class PartialPcWithPrincipal {
 
   /**
    * ### Fungible Token Post Condition
-   * A post-condition sending `FungibleConditionCode.Greater` uSTX or other fungible tokens.
+   * A post-condition sending tokens `FungibleConditionCode.Greater` (greater-than) the given amount of uSTX or fungible-tokens.
    * Finalize with the chained `.ustx()` or `.ft(…)` method.
+   * @example
+   * ```
+   * import { Pc } from '@stacks/transactions';
+   * Pc.principal('STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6').willSendGt(100).stx();
+   * ```
    */
   willSendGt(amount: IntegerType) {
     return new PartialPcFtWithCode(
@@ -136,6 +162,11 @@ class PartialPcWithPrincipal {
    * ### NFT Post Condition
    * A post-condition which `NonFungibleConditionCode.Sends` an NFT.
    * Finalize with the chained `.nft(…)` method.
+   * @example
+   * ```
+   * import { Pc } from '@stacks/transactions';
+   * Pc.principal('STB4…K6.nft-contract').willSendAsset().nft('STB4…K6.super-nft::super', uintCV(1));
+   * ```
    */
   willSendAsset() {
     return new PartialPcNftWithCode(
@@ -149,6 +180,11 @@ class PartialPcWithPrincipal {
    * ### NFT Post Condition
    * A post-condition which `NonFungibleConditionCode.DoesNotSend` an NFT.
    * Finalize with the chained `.nft(…)` method.
+   * @example
+   * ```
+   * import { Pc } from '@stacks/transactions';
+   * Pc.principal('STB4…K6.nft-contract').willNotSendAsset().nft('STB4…K6.super-nft::super', uintCV(1));
+   * ```
    */
   willNotSendAsset() {
     return new PartialPcNftWithCode(
@@ -251,12 +287,14 @@ class PartialPcNftWithCode {
   }
 }
 
+/** @internal */
 function parseContractId(contractId: ContractIdString) {
   const [address, name] = contractId.split('.');
   if (!address || !name) throw new Error(`Invalid contract identifier: ${contractId}`);
   return [address, name];
 }
 
+/** @internal */
 function parseNft(nftAssetName: NftString) {
   const [principal, tokenName] = nftAssetName.split('::') as [ContractIdString, string];
   if (!principal || !tokenName)
@@ -265,6 +303,7 @@ function parseNft(nftAssetName: NftString) {
   return { contractAddress: address, contractName: name, tokenName };
 }
 
+/** @internal */
 function isContractIdString(value: AddressString | ContractIdString): value is ContractIdString {
   return value.includes('.');
 }

--- a/packages/transactions/tests/pc.test.ts
+++ b/packages/transactions/tests/pc.test.ts
@@ -1,0 +1,370 @@
+import {
+  createAssetInfo,
+  FungibleConditionCode,
+  makeContractFungiblePostCondition,
+  makeContractNonFungiblePostCondition,
+  makeContractSTXPostCondition,
+  makeStandardFungiblePostCondition,
+  makeStandardNonFungiblePostCondition,
+  makeStandardSTXPostCondition,
+  NonFungibleConditionCode,
+  Pc,
+  uintCV,
+} from '../src';
+
+const STANDARD_ADDRESS = 'ST1WT20920NVRQ892MS535R7XEMV6KD6M6X2HQPK3';
+
+const CONTRACT_ADDRESS = 'ST13F481SBR0R7Z6NMMH8YV2FJJYXA5JPA0AD3HP9';
+const CONTRACT_NAME = 'subnet-v1';
+
+const FT_CONTRACT_ADDRESS = 'ST13F481SBR0R7Z6NMMH8YV2FJJYXA5JPA0AD3HP9';
+const FT_CONTRACT_NAME = 'super-token';
+const FT_ASSET_NAME = 'SUP';
+
+const NFT_CONTRACT_ADDRESS = 'ST13F481SBR0R7Z6NMMH8YV2FJJYXA5JPA0AD3HP9';
+const NFT_CONTRACT_NAME = 'super-nft';
+const NFT_ASSET_NAME = 'super';
+const NFT_ASSET_ID = uintCV(21);
+
+describe('pc -- post condition builder', () => {
+  describe('invalid input', () => {
+    test('invalid addresses', () => {
+      expect(() => Pc.principal(STANDARD_ADDRESS).willSendEq(100).ustx()).not.toThrow();
+      expect(() => Pc.principal('invalid address').willSendEq(100).ustx()).toThrow();
+      expect(() => Pc.principal('invalid.address').willSendEq(100).ustx()).toThrow();
+
+      expect(() =>
+        Pc.principal(STANDARD_ADDRESS)
+          .willSendEq(100)
+          .ft('invalid' as any, FT_ASSET_NAME)
+      ).toThrow();
+      expect(() =>
+        Pc.principal(STANDARD_ADDRESS).willSendEq(100).ft('inv.alid', FT_ASSET_NAME)
+      ).toThrow();
+
+      expect(() =>
+        Pc.principal(STANDARD_ADDRESS)
+          .willSendAsset()
+          .nft(`${NFT_CONTRACT_ADDRESS}.${NFT_CONTRACT_NAME}`, NFT_ASSET_NAME, NFT_ASSET_ID)
+      ).not.toThrow();
+      expect(() =>
+        Pc.principal(STANDARD_ADDRESS)
+          .willSendAsset()
+          .nft('invalid' as any, NFT_ASSET_NAME, NFT_ASSET_ID)
+      ).toThrow();
+      expect(() =>
+        Pc.principal(STANDARD_ADDRESS).willSendAsset().nft('inv.alid', NFT_ASSET_NAME, NFT_ASSET_ID)
+      ).toThrow();
+    });
+  });
+
+  describe('standard principal', () => {
+    describe('stx post condition', () => {
+      test('100 ustx', () => {
+        const pc = Pc.principal(STANDARD_ADDRESS).willSendEq(100).ustx();
+        const postCondition = makeStandardSTXPostCondition(
+          STANDARD_ADDRESS,
+          FungibleConditionCode.Equal,
+          100
+        );
+        expect(pc).toEqual(postCondition);
+      });
+
+      test('lte 100 ustx', () => {
+        const pc = Pc.principal(STANDARD_ADDRESS).willSendLt(100).ustx();
+        const postCondition = makeStandardSTXPostCondition(
+          STANDARD_ADDRESS,
+          FungibleConditionCode.Less,
+          100
+        );
+        expect(pc).toEqual(postCondition);
+      });
+
+      test('lt 100 ustx', () => {
+        const pc = Pc.principal(STANDARD_ADDRESS).willSendLt(100).ustx();
+        const postCondition = makeStandardSTXPostCondition(
+          STANDARD_ADDRESS,
+          FungibleConditionCode.Less,
+          100
+        );
+        expect(pc).toEqual(postCondition);
+      });
+
+      test('gte 100 ustx', () => {
+        const pc = Pc.principal(STANDARD_ADDRESS).willSendGte(100).ustx();
+        const postCondition = makeStandardSTXPostCondition(
+          STANDARD_ADDRESS,
+          FungibleConditionCode.GreaterEqual,
+          100
+        );
+        expect(pc).toEqual(postCondition);
+      });
+
+      test('gt 100 ustx', () => {
+        const pc = Pc.principal(STANDARD_ADDRESS).willSendGt(100).ustx();
+        const postCondition = makeStandardSTXPostCondition(
+          STANDARD_ADDRESS,
+          FungibleConditionCode.Greater,
+          100
+        );
+        expect(pc).toEqual(postCondition);
+      });
+    });
+
+    describe('ft post condition', () => {
+      test('100 ft', () => {
+        const pc = Pc.principal(STANDARD_ADDRESS)
+          .willSendEq(100)
+          .ft(`${FT_CONTRACT_ADDRESS}.${FT_CONTRACT_NAME}`, FT_ASSET_NAME);
+        const postCondition = makeStandardFungiblePostCondition(
+          STANDARD_ADDRESS,
+          FungibleConditionCode.Equal,
+          100,
+          createAssetInfo(FT_CONTRACT_ADDRESS, FT_CONTRACT_NAME, FT_ASSET_NAME)
+        );
+        expect(pc).toEqual(postCondition);
+      });
+
+      test('lte 100 ft', () => {
+        const pc = Pc.principal(STANDARD_ADDRESS)
+          .willSendLt(100)
+          .ft(`${FT_CONTRACT_ADDRESS}.${FT_CONTRACT_NAME}`, FT_ASSET_NAME);
+        const postCondition = makeStandardFungiblePostCondition(
+          STANDARD_ADDRESS,
+          FungibleConditionCode.Less,
+          100,
+          createAssetInfo(FT_CONTRACT_ADDRESS, FT_CONTRACT_NAME, FT_ASSET_NAME)
+        );
+        expect(pc).toEqual(postCondition);
+      });
+
+      test('lt 100 ft', () => {
+        const pc = Pc.principal(STANDARD_ADDRESS)
+          .willSendLt(100)
+          .ft(`${FT_CONTRACT_ADDRESS}.${FT_CONTRACT_NAME}`, FT_ASSET_NAME);
+        const postCondition = makeStandardFungiblePostCondition(
+          STANDARD_ADDRESS,
+          FungibleConditionCode.Less,
+          100,
+          createAssetInfo(FT_CONTRACT_ADDRESS, FT_CONTRACT_NAME, FT_ASSET_NAME)
+        );
+        expect(pc).toEqual(postCondition);
+      });
+
+      test('gte 100 ft', () => {
+        const pc = Pc.principal(STANDARD_ADDRESS)
+          .willSendGte(100)
+          .ft(`${FT_CONTRACT_ADDRESS}.${FT_CONTRACT_NAME}`, FT_ASSET_NAME);
+        const postCondition = makeStandardFungiblePostCondition(
+          STANDARD_ADDRESS,
+          FungibleConditionCode.GreaterEqual,
+          100,
+          createAssetInfo(FT_CONTRACT_ADDRESS, FT_CONTRACT_NAME, FT_ASSET_NAME)
+        );
+        expect(pc).toEqual(postCondition);
+      });
+
+      test('gt 100 ft', () => {
+        const pc = Pc.principal(STANDARD_ADDRESS)
+          .willSendGt(100)
+          .ft(`${FT_CONTRACT_ADDRESS}.${FT_CONTRACT_NAME}`, FT_ASSET_NAME);
+        const postCondition = makeStandardFungiblePostCondition(
+          STANDARD_ADDRESS,
+          FungibleConditionCode.Greater,
+          100,
+          createAssetInfo(FT_CONTRACT_ADDRESS, FT_CONTRACT_NAME, FT_ASSET_NAME)
+        );
+        expect(pc).toEqual(postCondition);
+      });
+    });
+
+    describe('nft post condition', () => {
+      test('will send nft', () => {
+        const pc = Pc.principal(STANDARD_ADDRESS)
+          .willSendAsset()
+          .nft(`${NFT_CONTRACT_ADDRESS}.${NFT_CONTRACT_NAME}`, NFT_ASSET_NAME, NFT_ASSET_ID);
+        const postCondition = makeStandardNonFungiblePostCondition(
+          STANDARD_ADDRESS,
+          NonFungibleConditionCode.Sends,
+          createAssetInfo(NFT_CONTRACT_ADDRESS, NFT_CONTRACT_NAME, NFT_ASSET_NAME),
+          NFT_ASSET_ID
+        );
+        expect(pc).toEqual(postCondition);
+      });
+
+      test('will not send nft', () => {
+        const pc = Pc.principal(STANDARD_ADDRESS)
+          .willNotSendAsset()
+          .nft(`${NFT_CONTRACT_ADDRESS}.${NFT_CONTRACT_NAME}`, NFT_ASSET_NAME, NFT_ASSET_ID);
+        const postCondition = makeStandardNonFungiblePostCondition(
+          STANDARD_ADDRESS,
+          NonFungibleConditionCode.DoesNotSend,
+          createAssetInfo(NFT_CONTRACT_ADDRESS, NFT_CONTRACT_NAME, NFT_ASSET_NAME),
+          NFT_ASSET_ID
+        );
+        expect(pc).toEqual(postCondition);
+      });
+    });
+  });
+
+  describe('contract principal', () => {
+    describe('stx post condition', () => {
+      test('100 ustx', () => {
+        const pc = Pc.principal(`${CONTRACT_ADDRESS}.${CONTRACT_NAME}`).willSendEq(100).ustx();
+        const postCondition = makeContractSTXPostCondition(
+          CONTRACT_ADDRESS,
+          CONTRACT_NAME,
+          FungibleConditionCode.Equal,
+          100
+        );
+        expect(pc).toEqual(postCondition);
+      });
+
+      test('lte 100 ustx', () => {
+        const pc = Pc.principal(`${CONTRACT_ADDRESS}.${CONTRACT_NAME}`).willSendLt(100).ustx();
+        const postCondition = makeContractSTXPostCondition(
+          CONTRACT_ADDRESS,
+          CONTRACT_NAME,
+          FungibleConditionCode.Less,
+          100
+        );
+        expect(pc).toEqual(postCondition);
+      });
+
+      test('lt 100 ustx', () => {
+        const pc = Pc.principal(`${CONTRACT_ADDRESS}.${CONTRACT_NAME}`).willSendLt(100).ustx();
+        const postCondition = makeContractSTXPostCondition(
+          CONTRACT_ADDRESS,
+          CONTRACT_NAME,
+          FungibleConditionCode.Less,
+          100
+        );
+        expect(pc).toEqual(postCondition);
+      });
+
+      test('gte 100 ustx', () => {
+        const pc = Pc.principal(`${CONTRACT_ADDRESS}.${CONTRACT_NAME}`).willSendGte(100).ustx();
+        const postCondition = makeContractSTXPostCondition(
+          CONTRACT_ADDRESS,
+          CONTRACT_NAME,
+          FungibleConditionCode.GreaterEqual,
+          100
+        );
+        expect(pc).toEqual(postCondition);
+      });
+
+      test('gt 100 ustx', () => {
+        const pc = Pc.principal(`${CONTRACT_ADDRESS}.${CONTRACT_NAME}`).willSendGt(100).ustx();
+        const postCondition = makeContractSTXPostCondition(
+          CONTRACT_ADDRESS,
+          CONTRACT_NAME,
+          FungibleConditionCode.Greater,
+          100
+        );
+        expect(pc).toEqual(postCondition);
+      });
+    });
+
+    describe('ft post condition', () => {
+      test('100 ft', () => {
+        const pc = Pc.principal(`${CONTRACT_ADDRESS}.${CONTRACT_NAME}`)
+          .willSendEq(100)
+          .ft(`${FT_CONTRACT_ADDRESS}.${FT_CONTRACT_NAME}`, FT_ASSET_NAME);
+        const postCondition = makeContractFungiblePostCondition(
+          CONTRACT_ADDRESS,
+          CONTRACT_NAME,
+          FungibleConditionCode.Equal,
+          100,
+          createAssetInfo(FT_CONTRACT_ADDRESS, FT_CONTRACT_NAME, FT_ASSET_NAME)
+        );
+        expect(pc).toEqual(postCondition);
+      });
+
+      test('lte 100 ft', () => {
+        const pc = Pc.principal(`${CONTRACT_ADDRESS}.${CONTRACT_NAME}`)
+          .willSendLt(100)
+          .ft(`${FT_CONTRACT_ADDRESS}.${FT_CONTRACT_NAME}`, FT_ASSET_NAME);
+        const postCondition = makeContractFungiblePostCondition(
+          CONTRACT_ADDRESS,
+          CONTRACT_NAME,
+          FungibleConditionCode.Less,
+          100,
+          createAssetInfo(FT_CONTRACT_ADDRESS, FT_CONTRACT_NAME, FT_ASSET_NAME)
+        );
+        expect(pc).toEqual(postCondition);
+      });
+
+      test('lt 100 ft', () => {
+        const pc = Pc.principal(`${CONTRACT_ADDRESS}.${CONTRACT_NAME}`)
+          .willSendLt(100)
+          .ft(`${FT_CONTRACT_ADDRESS}.${FT_CONTRACT_NAME}`, FT_ASSET_NAME);
+        const postCondition = makeContractFungiblePostCondition(
+          CONTRACT_ADDRESS,
+          CONTRACT_NAME,
+          FungibleConditionCode.Less,
+          100,
+          createAssetInfo(FT_CONTRACT_ADDRESS, FT_CONTRACT_NAME, FT_ASSET_NAME)
+        );
+        expect(pc).toEqual(postCondition);
+      });
+
+      test('gte 100 ft', () => {
+        const pc = Pc.principal(`${CONTRACT_ADDRESS}.${CONTRACT_NAME}`)
+          .willSendGte(100)
+          .ft(`${FT_CONTRACT_ADDRESS}.${FT_CONTRACT_NAME}`, FT_ASSET_NAME);
+        const postCondition = makeContractFungiblePostCondition(
+          CONTRACT_ADDRESS,
+          CONTRACT_NAME,
+          FungibleConditionCode.GreaterEqual,
+          100,
+          createAssetInfo(FT_CONTRACT_ADDRESS, FT_CONTRACT_NAME, FT_ASSET_NAME)
+        );
+        expect(pc).toEqual(postCondition);
+      });
+
+      test('gt 100 ft', () => {
+        const pc = Pc.principal(`${CONTRACT_ADDRESS}.${CONTRACT_NAME}`)
+          .willSendGt(100)
+          .ft(`${FT_CONTRACT_ADDRESS}.${FT_CONTRACT_NAME}`, FT_ASSET_NAME);
+        const postCondition = makeContractFungiblePostCondition(
+          CONTRACT_ADDRESS,
+          CONTRACT_NAME,
+          FungibleConditionCode.Greater,
+          100,
+          createAssetInfo(FT_CONTRACT_ADDRESS, FT_CONTRACT_NAME, FT_ASSET_NAME)
+        );
+        expect(pc).toEqual(postCondition);
+      });
+    });
+
+    describe('nft post condition', () => {
+      test('will send nft', () => {
+        const pc = Pc.principal(`${CONTRACT_ADDRESS}.${CONTRACT_NAME}`)
+          .willSendAsset()
+          .nft(`${NFT_CONTRACT_ADDRESS}.${NFT_CONTRACT_NAME}`, NFT_ASSET_NAME, NFT_ASSET_ID);
+        const postCondition = makeContractNonFungiblePostCondition(
+          CONTRACT_ADDRESS,
+          CONTRACT_NAME,
+          NonFungibleConditionCode.Sends,
+          createAssetInfo(NFT_CONTRACT_ADDRESS, NFT_CONTRACT_NAME, NFT_ASSET_NAME),
+          NFT_ASSET_ID
+        );
+        expect(pc).toEqual(postCondition);
+      });
+
+      test('will not send nft', () => {
+        const pc = Pc.principal(`${CONTRACT_ADDRESS}.${CONTRACT_NAME}`)
+          .willNotSendAsset()
+          .nft(`${NFT_CONTRACT_ADDRESS}.${NFT_CONTRACT_NAME}`, NFT_ASSET_NAME, NFT_ASSET_ID);
+        const postCondition = makeContractNonFungiblePostCondition(
+          CONTRACT_ADDRESS,
+          CONTRACT_NAME,
+          NonFungibleConditionCode.DoesNotSend,
+          createAssetInfo(NFT_CONTRACT_ADDRESS, NFT_CONTRACT_NAME, NFT_ASSET_NAME),
+          NFT_ASSET_ID
+        );
+        expect(pc).toEqual(postCondition);
+      });
+    });
+  });
+});

--- a/packages/transactions/tests/pc.test.ts
+++ b/packages/transactions/tests/pc.test.ts
@@ -23,10 +23,20 @@ const FT_ASSET_NAME = 'SUP';
 
 const NFT_CONTRACT_ADDRESS = 'ST13F481SBR0R7Z6NMMH8YV2FJJYXA5JPA0AD3HP9';
 const NFT_CONTRACT_NAME = 'super-nft';
-const NFT_ASSET_NAME = 'super';
+const NFT_TOKEN_NAME = 'super';
 const NFT_ASSET_ID = uintCV(21);
 
 describe('pc -- post condition builder', () => {
+  test('fully-qualified token name', () => {
+    const pcA = Pc.principal(STANDARD_ADDRESS)
+      .willSendAsset()
+      .nft(`${NFT_CONTRACT_ADDRESS}.${NFT_CONTRACT_NAME}::${NFT_TOKEN_NAME}`, NFT_ASSET_ID);
+    const pcB = Pc.principal(STANDARD_ADDRESS)
+      .willSendAsset()
+      .nft(`${NFT_CONTRACT_ADDRESS}.${NFT_CONTRACT_NAME}`, NFT_TOKEN_NAME, NFT_ASSET_ID);
+    expect(pcA).toEqual(pcB);
+  });
+
   describe('invalid input', () => {
     test('invalid addresses', () => {
       expect(() => Pc.principal(STANDARD_ADDRESS).willSendEq(100).ustx()).not.toThrow();
@@ -45,15 +55,37 @@ describe('pc -- post condition builder', () => {
       expect(() =>
         Pc.principal(STANDARD_ADDRESS)
           .willSendAsset()
-          .nft(`${NFT_CONTRACT_ADDRESS}.${NFT_CONTRACT_NAME}`, NFT_ASSET_NAME, NFT_ASSET_ID)
+          .nft(`${NFT_CONTRACT_ADDRESS}.${NFT_CONTRACT_NAME}`, NFT_TOKEN_NAME, NFT_ASSET_ID)
       ).not.toThrow();
       expect(() =>
         Pc.principal(STANDARD_ADDRESS)
           .willSendAsset()
-          .nft('invalid' as any, NFT_ASSET_NAME, NFT_ASSET_ID)
+          .nft('invalid' as any, NFT_TOKEN_NAME, NFT_ASSET_ID)
       ).toThrow();
       expect(() =>
-        Pc.principal(STANDARD_ADDRESS).willSendAsset().nft('inv.alid', NFT_ASSET_NAME, NFT_ASSET_ID)
+        Pc.principal(STANDARD_ADDRESS).willSendAsset().nft('inv.alid', NFT_TOKEN_NAME, NFT_ASSET_ID)
+      ).toThrow();
+    });
+
+    test('invalid fully-qualified token name', () => {
+      expect(() =>
+        Pc.principal(STANDARD_ADDRESS)
+          .willSendAsset()
+          .nft(
+            // e.g. using ;; instead of ::
+            `${NFT_CONTRACT_ADDRESS}.${NFT_CONTRACT_NAME};;${NFT_TOKEN_NAME}` as any,
+            NFT_ASSET_ID
+          )
+      ).toThrow();
+
+      expect(() =>
+        Pc.principal(CONTRACT_ADDRESS)
+          .willSendAsset()
+          .nft(
+            // e.g. using , instead of .
+            `${NFT_CONTRACT_ADDRESS},${NFT_CONTRACT_NAME}::${NFT_TOKEN_NAME}` as any,
+            NFT_ASSET_ID
+          )
       ).toThrow();
     });
   });
@@ -182,11 +214,11 @@ describe('pc -- post condition builder', () => {
       test('will send nft', () => {
         const pc = Pc.principal(STANDARD_ADDRESS)
           .willSendAsset()
-          .nft(`${NFT_CONTRACT_ADDRESS}.${NFT_CONTRACT_NAME}`, NFT_ASSET_NAME, NFT_ASSET_ID);
+          .nft(`${NFT_CONTRACT_ADDRESS}.${NFT_CONTRACT_NAME}`, NFT_TOKEN_NAME, NFT_ASSET_ID);
         const postCondition = makeStandardNonFungiblePostCondition(
           STANDARD_ADDRESS,
           NonFungibleConditionCode.Sends,
-          createAssetInfo(NFT_CONTRACT_ADDRESS, NFT_CONTRACT_NAME, NFT_ASSET_NAME),
+          createAssetInfo(NFT_CONTRACT_ADDRESS, NFT_CONTRACT_NAME, NFT_TOKEN_NAME),
           NFT_ASSET_ID
         );
         expect(pc).toEqual(postCondition);
@@ -195,11 +227,11 @@ describe('pc -- post condition builder', () => {
       test('will not send nft', () => {
         const pc = Pc.principal(STANDARD_ADDRESS)
           .willNotSendAsset()
-          .nft(`${NFT_CONTRACT_ADDRESS}.${NFT_CONTRACT_NAME}`, NFT_ASSET_NAME, NFT_ASSET_ID);
+          .nft(`${NFT_CONTRACT_ADDRESS}.${NFT_CONTRACT_NAME}`, NFT_TOKEN_NAME, NFT_ASSET_ID);
         const postCondition = makeStandardNonFungiblePostCondition(
           STANDARD_ADDRESS,
           NonFungibleConditionCode.DoesNotSend,
-          createAssetInfo(NFT_CONTRACT_ADDRESS, NFT_CONTRACT_NAME, NFT_ASSET_NAME),
+          createAssetInfo(NFT_CONTRACT_ADDRESS, NFT_CONTRACT_NAME, NFT_TOKEN_NAME),
           NFT_ASSET_ID
         );
         expect(pc).toEqual(postCondition);
@@ -341,12 +373,12 @@ describe('pc -- post condition builder', () => {
       test('will send nft', () => {
         const pc = Pc.principal(`${CONTRACT_ADDRESS}.${CONTRACT_NAME}`)
           .willSendAsset()
-          .nft(`${NFT_CONTRACT_ADDRESS}.${NFT_CONTRACT_NAME}`, NFT_ASSET_NAME, NFT_ASSET_ID);
+          .nft(`${NFT_CONTRACT_ADDRESS}.${NFT_CONTRACT_NAME}`, NFT_TOKEN_NAME, NFT_ASSET_ID);
         const postCondition = makeContractNonFungiblePostCondition(
           CONTRACT_ADDRESS,
           CONTRACT_NAME,
           NonFungibleConditionCode.Sends,
-          createAssetInfo(NFT_CONTRACT_ADDRESS, NFT_CONTRACT_NAME, NFT_ASSET_NAME),
+          createAssetInfo(NFT_CONTRACT_ADDRESS, NFT_CONTRACT_NAME, NFT_TOKEN_NAME),
           NFT_ASSET_ID
         );
         expect(pc).toEqual(postCondition);
@@ -355,12 +387,12 @@ describe('pc -- post condition builder', () => {
       test('will not send nft', () => {
         const pc = Pc.principal(`${CONTRACT_ADDRESS}.${CONTRACT_NAME}`)
           .willNotSendAsset()
-          .nft(`${NFT_CONTRACT_ADDRESS}.${NFT_CONTRACT_NAME}`, NFT_ASSET_NAME, NFT_ASSET_ID);
+          .nft(`${NFT_CONTRACT_ADDRESS}.${NFT_CONTRACT_NAME}`, NFT_TOKEN_NAME, NFT_ASSET_ID);
         const postCondition = makeContractNonFungiblePostCondition(
           CONTRACT_ADDRESS,
           CONTRACT_NAME,
           NonFungibleConditionCode.DoesNotSend,
-          createAssetInfo(NFT_CONTRACT_ADDRESS, NFT_CONTRACT_NAME, NFT_ASSET_NAME),
+          createAssetInfo(NFT_CONTRACT_ADDRESS, NFT_CONTRACT_NAME, NFT_TOKEN_NAME),
           NFT_ASSET_ID
         );
         expect(pc).toEqual(postCondition);


### PR DESCRIPTION
> This PR was published to npm with the version `6.4.1-pr.eccf9dc.0`
> e.g. `npm install @stacks/common@6.4.1-pr.eccf9dc.0 --save-exact`<!-- Sticky Header Marker -->

### `Pc` Behavioral Builder Pattern ✨

- Inspired by Ruby style behavioral/readable chained method calls.
- Tries to fix very cumbersome current post-condition construction.

This PR introduces an easier way of constructing post-conditions. These can be very confusing for developers. This solution doesn't solve all problems, but is a good start imho.

> **Note**
> Marking as `@beta` for now to collect feedback from builders.
> I believe the syntax can be generally kept, but maybe folks have different opinions about capitalization, asset/nft/name/id naming, etc.

### Example

#### Before
```ts
import { FungibleConditionCode, makeStandardSTXPostCondition } from '@stacks/transactions';
const pc = makeStandardSTXPostCondition(
  'ST1WT20920NVRQ892MS535R7XEMV6KD6M6X2HQPK3',
  FungibleConditionCode.Equal,
  100
);
```
```ts
import { createAssetInfo, NonFungibleConditionCode.Sends, makeContractNonFungiblePostCondition, uintCV } from '@stacks/transactions';
const pc = makeContractNonFungiblePostCondition(
  'ST13F481SBR0R7Z6NMMH8YV2FJJYXA5JPA0AD3HP9',
  'subnet-v1',
  NonFungibleConditionCode.Sends,
  createAssetInfo('ST13F481SBR0R7Z6NMMH8YV2FJJYXA5JPA0AD3HP9', 'super-nft', 'super'),
  uintCV(21)
);
```
#### After
```ts
import { Pc } from '@stacks/transactions';
const pc = Pc.principal('ST1WT20920NVRQ892MS535R7XEMV6KD6M6X2HQPK3').willSendEq(100).ustx();
```

```ts
import { Pc, uintCV } from '@stacks/transactions';
const pc = Pc.principal(`ST13F481SBR0R7Z6NMMH8YV2FJJYXA5JPA0AD3HP9.subnet-v1`)
  .willSendAsset()
  .nft(`ST13F481SBR0R7Z6NMMH8YV2FJJYXA5JPA0AD3HP9.super-nft`, 'super', uintCV(21));
```
---

### Checklist

- [x] Unit tested updated code paths

<!-- Make sure to run `npm run test` locally to find problems faster -->
