### PR TITLE
fix: allow contract principals in stackingclient

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25516,6 +25516,7 @@
       },
       "devDependencies": {
         "@stacks/blockchain-api-client": "^6.2.1",
+        "jest-fetch-mock": "^3.0.3",
         "process": "^0.11.10",
         "rimraf": "^3.0.2",
         "stream-browserify": "^3.0.0"

--- a/packages/stacking/package.json
+++ b/packages/stacking/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "@stacks/blockchain-api-client": "^6.2.1",
+    "jest-fetch-mock": "^3.0.3",
     "process": "^0.11.10",
     "rimraf": "^3.0.2",
     "stream-browserify": "^3.0.0"

--- a/packages/stacking/src/index.ts
+++ b/packages/stacking/src/index.ts
@@ -22,10 +22,10 @@ import {
   noneCV,
   OptionalCV,
   PrincipalCV,
+  principalCV,
   ResponseErrorCV,
   someCV,
   StacksTransaction,
-  standardPrincipalCV,
   TupleCV,
   TxBroadcastResult,
   uintCV,
@@ -1053,7 +1053,7 @@ export class StackingClient {
       functionName: 'delegate-stx',
       functionArgs: [
         uintCV(amountMicroStx),
-        standardPrincipalCV(delegateTo),
+        principalCV(delegateTo),
         untilBurnBlockHeight ? someCV(uintCV(untilBurnBlockHeight)) : noneCV(),
         address,
       ],
@@ -1086,7 +1086,7 @@ export class StackingClient {
       contractName,
       functionName: 'delegate-stack-stx',
       functionArgs: [
-        standardPrincipalCV(stacker),
+        principalCV(stacker),
         uintCV(amountMicroStx),
         address,
         uintCV(burnBlockHeight),
@@ -1117,7 +1117,7 @@ export class StackingClient {
       contractAddress,
       contractName,
       functionName: 'delegate-stack-extend',
-      functionArgs: [standardPrincipalCV(stacker), address, uintCV(extendCount)],
+      functionArgs: [principalCV(stacker), address, uintCV(extendCount)],
       validateWithAbi: true,
       network: this.network,
       anchorMode: AnchorMode.Any,
@@ -1143,7 +1143,7 @@ export class StackingClient {
       contractAddress,
       contractName,
       functionName: 'delegate-stack-increase',
-      functionArgs: [standardPrincipalCV(stacker), address, uintCV(increaseBy)],
+      functionArgs: [principalCV(stacker), address, uintCV(increaseBy)],
       validateWithAbi: true,
       network: this.network,
       anchorMode: AnchorMode.Any,
@@ -1253,7 +1253,7 @@ export class StackingClient {
       contractName,
       functionName,
       senderAddress: this.address,
-      functionArgs: [standardPrincipalCV(this.address)],
+      functionArgs: [principalCV(this.address)],
       network: this.network,
     }).then((responseCV: ClarityValue) => {
       if (responseCV.type === ClarityType.OptionalSome) {
@@ -1302,7 +1302,7 @@ export class StackingClient {
       contractName,
       functionName,
       senderAddress: this.address,
-      functionArgs: [standardPrincipalCV(this.address)],
+      functionArgs: [principalCV(this.address)],
       network: this.network,
     }).then((responseCV: ClarityValue) => {
       if (responseCV.type === ClarityType.OptionalSome) {

--- a/packages/stacking/tests/stacking.test.ts
+++ b/packages/stacking/tests/stacking.test.ts
@@ -22,6 +22,7 @@ import {
 import fetchMock from 'jest-fetch-mock';
 import { PoXAddressVersion, StackingErrors } from '../src/constants';
 import { decodeBtcAddress, poxAddressToBtcAddress } from '../src/utils';
+import { V2_POX_REGTEST } from './apiMockingHelpers';
 
 const poxInfo = {
   contract_id: 'ST000000000000000000002AMW42H.pox',
@@ -1066,4 +1067,20 @@ test('pox address to btc address', () => {
     expect(decodedAddress.version).toBe(item.version);
     expect(bytesToHex(decodedAddress.data)).toBe(bytesToHex(item.hashBytes));
   });
+});
+
+test('client operations with contract principal stacker', () => {
+  fetchMock.mockOnce(V2_POX_REGTEST);
+  fetchMock.mockOnce(
+    `{"balance":"0x0000000000000000000000001e22f616","locked":"0x00000000000000000000000000000000","unlock_height":0,"nonce":0}`
+  );
+  fetchMock.mockOnce(`{"okay":true,"result":"0x09"}`);
+
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { StackingClient } = require('../src'); // needed for jest.mock module
+  const client = new StackingClient(
+    'SP2HNY1HNF5X25VC7GZ3Y48JC4762AYFHKS061BM0.stacking-contract',
+    new StacksTestnet()
+  );
+  expect(async () => await client.getStatus()).not.toThrow();
 });


### PR DESCRIPTION
> This PR was published to npm with the version `6.4.1-pr.cfc5131.0`
> e.g. `npm install @stacks/common@6.4.1-pr.cfc5131.0 --save-exact`<!-- Sticky Header Marker -->

- fixes https://github.com/hirosystems/stacks.js/issues/1456