### PR TITLE
fix: add StacksDevnet constructor, closes #1470

### DIFF
--- a/packages/network/src/network.ts
+++ b/packages/network/src/network.ts
@@ -10,11 +10,11 @@ export interface NetworkConfig {
   fetchFn?: FetchFn;
 }
 
-export const StacksNetworks = ['mainnet', 'testnet'] as const;
+export const StacksNetworks = ['mainnet', 'testnet', 'devnet', 'mocknet'] as const;
 export type StacksNetworkName = (typeof StacksNetworks)[number];
 
 /**
- * @related {@link StacksMainnet}, {@link StacksTestnet}, {@link StacksMocknet}
+ * @related {@link StacksMainnet}, {@link StacksTestnet}, {@link StacksDevnet}, {@link StacksMocknet}
  */
 export class StacksNetwork {
   version = TransactionVersion.Mainnet;
@@ -42,6 +42,10 @@ export class StacksNetwork {
         return new StacksMainnet();
       case 'testnet':
         return new StacksTestnet();
+      case 'devnet':
+        return new StacksDevnet();
+      case 'mocknet':
+        return new StacksMocknet();
       default:
         throw new Error(
           `Invalid network name provided. Must be one of the following: ${StacksNetworks.join(
@@ -133,7 +137,7 @@ export class StacksNetwork {
 }
 
 /**
- * A {@link StacksNetwork} with default values for the Stacks mainnet.
+ * A {@link StacksNetwork} with the parameters for the Stacks mainnet.
  * Pass a `url` option to override the default Hiro hosted Stacks node API.
  * Pass a `fetchFn` option to customize the default networking functions.
  * @example
@@ -157,7 +161,16 @@ export class StacksMainnet extends StacksNetwork {
 }
 
 /**
- * Same as {@link StacksMainnet} but defaults to values for the Stacks testnet.
+ * A {@link StacksNetwork} with the parameters for the Stacks testnet.
+ * Pass a `url` option to override the default Hiro hosted Stacks node API.
+ * Pass a `fetchFn` option to customize the default networking functions.
+ * @example
+ * ```
+ * const network = new StacksTestnet();
+ * const network = new StacksTestnet({ url: "https://stacks-node-api.testnet.stacks.co" });
+ * const network = new StacksTestnet({ fetch: createFetchFn() });
+ * ```
+ * @related {@link createFetchFn}, {@link createApiKeyMiddleware}
  */
 export class StacksTestnet extends StacksNetwork {
   version = TransactionVersion.Testnet;
@@ -171,6 +184,9 @@ export class StacksTestnet extends StacksNetwork {
   }
 }
 
+/**
+ * A {@link StacksNetwork} using the testnet parameters, but `localhost:3999` as the API URL.
+ */
 export class StacksMocknet extends StacksNetwork {
   version = TransactionVersion.Testnet;
   chainId = ChainID.Testnet;
@@ -182,3 +198,6 @@ export class StacksMocknet extends StacksNetwork {
     });
   }
 }
+
+/** Alias for {@link StacksMocknet} */
+export const StacksDevnet = StacksMocknet;

--- a/packages/network/tests/network.test.ts
+++ b/packages/network/tests/network.test.ts
@@ -4,25 +4,33 @@ import {
   HIRO_TESTNET_DEFAULT,
   StacksMainnet,
   StacksMocknet,
+  StacksNetwork,
   StacksTestnet,
 } from '../src/network';
 
 describe('Setting coreApiUrl', () => {
-  test('it sets mainnet default url', () => {
+  it('sets mainnet default url', () => {
     const mainnet = new StacksMainnet();
     expect(mainnet.coreApiUrl).toEqual(HIRO_MAINNET_DEFAULT);
   });
-  test('it sets testnet url', () => {
+  it('sets testnet url', () => {
     const testnet = new StacksTestnet();
     expect(testnet.coreApiUrl).toEqual(HIRO_TESTNET_DEFAULT);
   });
-  test('it sets mocknet url', () => {
+  it('sets mocknet url', () => {
     const mocknet = new StacksMocknet();
     expect(mocknet.coreApiUrl).toEqual(HIRO_MOCKNET_DEFAULT);
   });
-  test('it sets custom url', () => {
+  it('sets custom url', () => {
     const customURL = 'https://customurl.com';
     const customNET = new StacksMainnet({ url: customURL });
     expect(customNET.coreApiUrl).toEqual(customURL);
   });
+});
+
+it('uses the correct constructor for stacks network from name strings', () => {
+  expect(StacksNetwork.fromName('mainnet').constructor.toString()).toContain('StacksMainnet');
+  expect(StacksNetwork.fromName('testnet').constructor.toString()).toContain('StacksTestnet');
+  expect(StacksNetwork.fromName('devnet').constructor.toString()).toContain('StacksMocknet'); // devnet is an alias for mocknet
+  expect(StacksNetwork.fromName('mocknet').constructor.toString()).toContain('StacksMocknet');
 });


### PR DESCRIPTION
> This PR was published to npm with the version `6.5.1-pr.9f6c5d2.0`
> e.g. `npm install @stacks/common@6.5.1-pr.9f6c5d2.0 --save-exact`<!-- Sticky Header Marker -->

