### PR TITLE
fix: migrate explorer domains from stacks.co to hiro.so

### DIFF
--- a/packages/bns/README.md
+++ b/packages/bns/README.md
@@ -1,6 +1,6 @@
 # `@stacks/bns`
 
-A package for interacting with the [BNS contract](https://explorer.stacks.co/txid/SP000000000000000000002Q6VF78.bns?chain=mainnet)
+A package for interacting with the [BNS contract](https://explorer.hiro.so/txid/SP000000000000000000002Q6VF78.bns?chain=mainnet)
 on the Stacks blockchain.
 
 ## What is BNS?

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -96,7 +96,7 @@ Example:
     stx call_contract_func SPBMRFRPPGCDE3F384WCJPK8PQJGZ8K9QKK7F59X contract_name contract_function 1 0 "$PAYMENT"
      {
        txid: '0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1',
-       transaction: 'https://explorer.stacks.co/txid/0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1'
+       transaction: 'https://explorer.hiro.so/txid/0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1'
      }
 
 ```
@@ -114,7 +114,7 @@ Example:
     stx call_read_only_contract_func SPBMRFRPPGCDE3F384WCJPK8PQJGZ8K9QKK7F59X contract_name contract_function SPBMRFRPPGCDE3F384WCJPK8PQJGZ8K9QKK7F59X
      {
        txid: '0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1',
-       transaction: 'https://explorer.stacks.co/txid/0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1'
+       transaction: 'https://explorer.hiro.so/txid/0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1'
      }
 
 ```
@@ -176,7 +176,7 @@ Example:
     stx deploy_contract ./my_contract.clar my_contract 1 0 "$PAYMENT"
      {
        txid: '0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1',
-       transaction: 'https://explorer.stacks.co/txid/0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1'
+       transaction: 'https://explorer.hiro.so/txid/0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1'
      }
 ```
 
@@ -240,7 +240,7 @@ Example:
     stx send_tokens SP1P10PS2T517S4SQGZT5WNX8R00G1ECTRKYCPMHY 12345 1 0 "$PAYMENT"
     {
        txid: '0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1',
-       transaction: 'https://explorer.stacks.co/txid/0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1'
+       transaction: 'https://explorer.hiro.so/txid/0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1'
     }
     a9d387a925fb0ba7a725fb1e11f2c3f1647473699dd5a147c312e6453d233456
 
@@ -267,7 +267,7 @@ Example:
     stx stack 10000000 20 16pm276FpJYpm7Dv3GEaRqTVvGPTdceoY4 136ff26efa5db6f06b28f9c8c7a0216a1a52598045162abfe435d13036154a1b01
      {
        txid: '0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1',
-       transaction: 'https://explorer.stacks.co/txid/0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1'
+       transaction: 'https://explorer.hiro.so/txid/0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1'
      }
 ```
 
@@ -321,7 +321,7 @@ Example:
       stx faucet ST3PWZ5M026785YW8YKKEH316DYPE4AC7NNTD9ADN
       {
         txid: '0xd33672dd4dbb0b88f733bc67b938359843123ca3be550ca87d487d067bd1b3c3',
-        transaction: 'https://explorer.stacks.co/txid/0xd33672dd4dbb0b88f733bc67b938359843123ca3be550ca87d487d067bd1b3c3?chain=testnet'
+        transaction: 'https://explorer.hiro.so/txid/0xd33672dd4dbb0b88f733bc67b938359843123ca3be550ca87d487d067bd1b3c3?chain=testnet'
       }
 ```
 

--- a/packages/cli/src/argparse.ts
+++ b/packages/cli/src/argparse.ts
@@ -347,7 +347,7 @@ export const CLI_ARGS = {
         '      contract_function 1 0 "$PAYMENT"\n' +
         '     {\n' +
         "       txid: '0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1'," +
-        "       transaction: 'https://explorer.stacks.co/txid/0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1'" +
+        "       transaction: 'https://explorer.hiro.so/txid/0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1'" +
         '     }\n' +
         '\n',
       group: 'Account Management',
@@ -392,7 +392,7 @@ export const CLI_ARGS = {
         '     contract_function SPBMRFRPPGCDE3F384WCJPK8PQJGZ8K9QKK7F59X\n' +
         '     {\n' +
         "       txid: '0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1'," +
-        "       transaction: 'https://explorer.stacks.co/txid/0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1'" +
+        "       transaction: 'https://explorer.hiro.so/txid/0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1'" +
         '     }\n' +
         '\n',
       group: 'Account Management',
@@ -528,7 +528,7 @@ export const CLI_ARGS = {
         '    $ stx deploy_contract ./my_contract.clar my_contract 1 0 "$PAYMENT"\n' +
         '     {\n' +
         "       txid: '0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1'," +
-        "       transaction: 'https://explorer.stacks.co/txid/0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1'" +
+        "       transaction: 'https://explorer.hiro.so/txid/0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1'" +
         '     }\n' +
         '\n',
       group: 'Account Management',
@@ -2355,7 +2355,7 @@ export const CLI_ARGS = {
         '    $ stx send_tokens SP1P10PS2T517S4SQGZT5WNX8R00G1ECTRKYCPMHY 12345 1 0 "$PAYMENT"\n' +
         '     {\n' +
         "       txid: '0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1'," +
-        "       transaction: 'https://explorer.stacks.co/txid/0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1'" +
+        "       transaction: 'https://explorer.hiro.so/txid/0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1'" +
         '     }\n' +
         '    a9d387a925fb0ba7a725fb1e11f2c3f1647473699dd5a147c312e6453d233456\n' +
         '\n' +
@@ -2422,7 +2422,7 @@ export const CLI_ARGS = {
         '    $ stx stack 10000000 20 16pm276FpJYpm7Dv3GEaRqTVvGPTdceoY4 136ff26efa5db6f06b28f9c8c7a0216a1a52598045162abfe435d13036154a1b01\n' +
         '     {\n' +
         "       txid: '0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1'," +
-        "       transaction: 'https://explorer.stacks.co/txid/0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1'" +
+        "       transaction: 'https://explorer.hiro.so/txid/0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1'" +
         '     }\n',
       group: 'Account Management',
     },

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -477,7 +477,7 @@ async function migrateSubdomains(network: CLINetworkAdapter, args: string[]): Pr
     .then(response => {
       if (response.txid)
         console.log(
-          `The transaction will take some time to complete. Track its progress using the explorer: https://explorer.stacks.co/txid/0x${response.txid}`
+          `The transaction will take some time to complete. Track its progress using the explorer: https://explorer.hiro.so/txid/0x${response.txid}`
         );
       return Promise.resolve(JSONStringify(response));
     })

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -763,9 +763,9 @@ export function answerToClarityValue(answer: any, arg: ClarityFunctionArg): Clar
 
 export function generateExplorerTxPageUrl(txid: string, network: StacksNetwork): string {
   if (network.version === TransactionVersion.Testnet) {
-    return `https://explorer.stacks.co/txid/0x${txid}?chain=testnet`;
+    return `https://explorer.hiro.so/txid/0x${txid}?chain=testnet`;
   } else {
-    return `https://explorer.stacks.co/txid/0x${txid}?chain=mainnet`;
+    return `https://explorer.hiro.so/txid/0x${txid}?chain=mainnet`;
   }
 }
 


### PR DESCRIPTION
> This PR was published to npm with the version `6.5.1-pr.7fad993.0`
> e.g. `npm install @stacks/common@6.5.1-pr.7fad993.0 --save-exact`<!-- Sticky Header Marker -->

