### PR TITLE
chore: add cl helper

### DIFF
--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -614,12 +614,9 @@ export function concatArray(elements: (Uint8Array | number[] | number)[]) {
 }
 
 /**
- * Better `instanceof` check for ArrayBuffer types in different environments
+ * Better `instanceof` check for types in different environments
  * @ignore
  */
 export function isInstance(object: any, type: any) {
-  return (
-    object instanceof type ||
-    (object?.constructor?.name != null && object.constructor.name === type.name)
-  );
+  return object instanceof type || object?.constructor?.name?.toLowerCase() === type.name;
 }

--- a/packages/transactions/src/cl.ts
+++ b/packages/transactions/src/cl.ts
@@ -1,0 +1,180 @@
+import { asciiToBytes, hexToBytes, utf8ToBytes } from '@stacks/common';
+import {
+  BufferCV,
+  boolCV,
+  bufferCV,
+  contractPrincipalCV,
+  deserializeCV,
+  falseCV,
+  intCV,
+  listCV,
+  noneCV,
+  responseErrorCV,
+  responseOkCV,
+  serializeCV,
+  someCV,
+  standardPrincipalCV,
+  stringAsciiCV,
+  stringUtf8CV,
+  trueCV,
+  tupleCV,
+  uintCV,
+} from './clarity';
+
+// todo: https://github.com/hirosystems/clarinet/issues/786
+
+// Primitives //////////////////////////////////////////////////////////////////
+/**
+ * `Cl.bool` — Creates a Clarity boolean type, represented as a JS object
+ *
+ * Alias for {@link boolCV}
+ * @see {@link serialize}, {@link deserialize}
+ */
+export const bool = boolCV;
+/**
+ * `Cl.trueBool` — Creates a Clarity boolean `true` type, represented as a JS object
+ *
+ * Alias for {@link trueCV}
+ * @see {@link serialize}, {@link deserialize}
+ */
+export const trueBool = trueCV;
+/**
+ * `Cl.falseBool` — Creates a Clarity boolean `false` type, represented as a JS object
+ *
+ * Alias for {@link falseCV}
+ * @see {@link serialize}, {@link deserialize}
+ */
+export const falseBool = falseCV;
+
+/**
+ * `Cl.int` — Creates a Clarity `int` type, represented as a JS object
+ *
+ * Alias for {@link intCV}
+ * @see {@link serialize}, {@link deserialize}
+ */
+export const int = intCV;
+/**
+ * `Cl.uInt` — Creates a Clarity `uint` type, represented as a JS object
+ *
+ * Alias for {@link uintCV}
+ * @see {@link serialize}, {@link deserialize}
+ */
+export const uint = uintCV;
+/**
+ * `Cl.contractPrincipal` — Creates a Clarity contract `principal` type, represented as a JS object
+ *
+ * Alias for {@link contractPrincipalCV}
+ * @see {@link serialize}, {@link deserialize}
+ */
+export const contractPrincipal = contractPrincipalCV;
+/**
+ * `Cl.standardPrincipal` — Creates a Clarity standard `principal` type, represented as a JS object
+ *
+ * Alias for {@link standardPrincipalCV}
+ * @see {@link serialize}, {@link deserialize}
+ */
+export const standardPrincipal = standardPrincipalCV;
+// todo: add .principal method that detects `.` inside string for both standard and contract principals
+
+// Sequences ///////////////////////////////////////////////////////////////////
+/**
+ * `Cl.list` — Creates a Clarity `list` type, represented as a JS object
+ *
+ * Alias for {@link listCV}
+ * @see {@link serialize}, {@link deserialize}
+ */
+export const list = listCV;
+/**
+ * `Cl.stringAscii` — Creates a Clarity `string-ascii` type, represented as a JS object
+ *
+ * Alias for {@link stringAsciiCV}
+ * @see {@link serialize}, {@link deserialize}
+ */
+export const stringAscii = stringAsciiCV;
+/**
+ * `Cl.stringUtf8` — Creates a Clarity `string-utf8` type, represented as a JS object
+ *
+ * Alias for {@link stringUtf8CV}
+ * @see {@link serialize}, {@link deserialize}
+ */
+export const stringUtf8 = stringUtf8CV;
+/**
+ * `Cl.buffer` — Creates a Clarity `buffer` type, represented as a JS object
+ *
+ * Alias for {@link bufferCV}
+ * @see {@link serialize}, {@link deserialize}
+ */
+export const buffer = bufferCV;
+/**
+ * `Cl.bufferFromHex` — Converts bytes (from a hex string) to a Clarity `buffer` type, represented as a JS object
+ * @param hex bytes encoded as a hex string
+ * @returns input encoded as a {@link BufferCV}
+ */
+export const bufferFromHex = (hex: string) => bufferCV(hexToBytes(hex));
+/**
+ * `Cl.bufferFromAscii` — Converts bytes (from an ASCII string) to a Clarity `buffer` type, represented as a JS object
+ * @param hex bytes encoded as an ASCII string
+ * @returns input encoded as a {@link BufferCV}
+ */
+export const bufferFromAscii = (ascii: string) => bufferCV(asciiToBytes(ascii));
+/**
+ * `Cl.bufferFromUtf8` — Converts bytes (from an UTF-8 string) to a Clarity `buffer` type, represented as a JS object
+ * @param hex bytes encoded as a UTF-8 string
+ * @returns input encoded as a {@link BufferCV}
+ */
+export const bufferFromUtf8 = (utf8: string) => bufferCV(utf8ToBytes(utf8));
+
+// Composites //////////////////////////////////////////////////////////////////
+/**
+ * `Cl.none` — Creates a Clarity optional `none` type, represented as a JS object
+ *
+ * Alias for {@link noneCV}
+ * @see {@link serialize}, {@link deserialize}
+ */
+export const none = noneCV;
+/**
+ * `Cl.some` — Creates a Clarity optional `some` type, represented as a JS object
+ *
+ * Alias for {@link someCV}
+ * @see {@link serialize}, {@link deserialize}
+ */
+export const some = someCV;
+/**
+ * `Cl.ok` — Creates a Clarity response `ok` type, represented as a JS object
+ *
+ * Alias for {@link responseOkCV}
+ * @see {@link serialize}, {@link deserialize}
+ */
+export const ok = responseOkCV;
+/**
+ * `Cl.error` — Creates a Clarity response `error` type, represented as a JS object
+ *
+ * Alias for {@link responseErrorCV}
+ * @see {@link serialize}, {@link deserialize}
+ */
+export const error = responseErrorCV;
+/**
+ * `Cl.tuple` — Creates a Clarity `tuple` type, represented as a JS object
+ *
+ * Alias for {@link tupleCV}
+ * @see {@link serialize}, {@link deserialize}
+ */
+export const tuple = tupleCV;
+
+// Methods /////////////////////////////////////////////////////////////////////
+/**
+ * `Cl.serialize` — Serializes a Clarity JS object to the equivalent hex-encoded representation
+ *
+ * Alias for {@link serializeCV}
+ * @see {@link deserialize}
+ */
+export const serialize = serializeCV;
+/**
+ * `Cl.deserialize` — Deserializes a hex string to the equivalent Clarity JS object
+ *
+ * Alias for {@link deserializeCV}
+ * @see {@link serialize}
+ */
+export const deserialize = deserializeCV;
+
+// todo: add `deserializeReadable` methods that translates enums into name strings

--- a/packages/transactions/src/cl.ts
+++ b/packages/transactions/src/cl.ts
@@ -5,7 +5,6 @@ import {
   bufferCV,
   contractPrincipalCV,
   deserializeCV,
-  falseCV,
   intCV,
   listCV,
   noneCV,
@@ -16,7 +15,6 @@ import {
   standardPrincipalCV,
   stringAsciiCV,
   stringUtf8CV,
-  trueCV,
   tupleCV,
   uintCV,
 } from './clarity';
@@ -31,21 +29,6 @@ import {
  * @see {@link serialize}, {@link deserialize}
  */
 export const bool = boolCV;
-/**
- * `Cl.trueBool` — Creates a Clarity boolean `true` type, represented as a JS object
- *
- * Alias for {@link trueCV}
- * @see {@link serialize}, {@link deserialize}
- */
-export const trueBool = trueCV;
-/**
- * `Cl.falseBool` — Creates a Clarity boolean `false` type, represented as a JS object
- *
- * Alias for {@link falseCV}
- * @see {@link serialize}, {@link deserialize}
- */
-export const falseBool = falseCV;
-
 /**
  * `Cl.int` — Creates a Clarity `int` type, represented as a JS object
  *

--- a/packages/transactions/src/clarity/deserialize.ts
+++ b/packages/transactions/src/clarity/deserialize.ts
@@ -41,7 +41,7 @@ import { bytesToAscii, bytesToUtf8, hexToBytes } from '@stacks/common';
  * ```
  *
  * @visit
- * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts clarity test cases for more examples}
+ * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 export default function deserializeCV<T extends ClarityValue = ClarityValue>(
   serializedClarityValue: BytesReader | Uint8Array | string

--- a/packages/transactions/src/clarity/deserialize.ts
+++ b/packages/transactions/src/clarity/deserialize.ts
@@ -40,7 +40,7 @@ import { bytesToAscii, bytesToUtf8, hexToBytes } from '@stacks/common';
  *  // { type: 0, value: 100n }
  * ```
  *
- * @visit
+ * @see
  * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 export default function deserializeCV<T extends ClarityValue = ClarityValue>(

--- a/packages/transactions/src/clarity/serialize.ts
+++ b/packages/transactions/src/clarity/serialize.ts
@@ -147,7 +147,7 @@ function serializeStringUtf8CV(cv: StringUtf8CV) {
  *  // <Uint8Array 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 64>
  * ```
  *
- * @visit
+ * @see
  * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 export function serializeCV(value: ClarityValue): Uint8Array {

--- a/packages/transactions/src/clarity/serialize.ts
+++ b/packages/transactions/src/clarity/serialize.ts
@@ -148,7 +148,7 @@ function serializeStringUtf8CV(cv: StringUtf8CV) {
  * ```
  *
  * @visit
- * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts clarity test cases for more examples}
+ * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 export function serializeCV(value: ClarityValue): Uint8Array {
   switch (value.type) {

--- a/packages/transactions/src/clarity/types/booleanCV.ts
+++ b/packages/transactions/src/clarity/types/booleanCV.ts
@@ -24,7 +24,7 @@ interface FalseCV {
  * ```
  *
  * @visit
- * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts clarity test cases for more examples}
+ * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 const trueCV = (): BooleanCV => ({ type: ClarityType.BoolTrue });
 
@@ -42,7 +42,7 @@ const trueCV = (): BooleanCV => ({ type: ClarityType.BoolTrue });
  * ```
  *
  * @visit
- * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts clarity test cases for more examples}
+ * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 const falseCV = (): BooleanCV => ({ type: ClarityType.BoolFalse });
 
@@ -60,7 +60,7 @@ const falseCV = (): BooleanCV => ({ type: ClarityType.BoolFalse });
  * ```
  *
  * @visit
- * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts clarity test cases for more examples}
+ * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 const boolCV = (bool: boolean) => (bool ? trueCV() : falseCV());
 

--- a/packages/transactions/src/clarity/types/booleanCV.ts
+++ b/packages/transactions/src/clarity/types/booleanCV.ts
@@ -23,7 +23,7 @@ interface FalseCV {
  *  // { type: 3 }
  * ```
  *
- * @visit
+ * @see
  * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 const trueCV = (): BooleanCV => ({ type: ClarityType.BoolTrue });
@@ -41,7 +41,7 @@ const trueCV = (): BooleanCV => ({ type: ClarityType.BoolTrue });
  *  // { type: 4 }
  * ```
  *
- * @visit
+ * @see
  * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 const falseCV = (): BooleanCV => ({ type: ClarityType.BoolFalse });
@@ -59,7 +59,7 @@ const falseCV = (): BooleanCV => ({ type: ClarityType.BoolFalse });
  *  // { type: 4 }
  * ```
  *
- * @visit
+ * @see
  * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 const boolCV = (bool: boolean) => (bool ? trueCV() : falseCV());

--- a/packages/transactions/src/clarity/types/bufferCV.ts
+++ b/packages/transactions/src/clarity/types/bufferCV.ts
@@ -24,7 +24,7 @@ interface BufferCV {
  *  // this is a test
  * ```
  *
- * @visit
+ * @see
  * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 const bufferCV = (buffer: Uint8Array): BufferCV => {
@@ -53,7 +53,7 @@ const bufferCV = (buffer: Uint8Array): BufferCV => {
  *  // this is a test
  *```
  *
- * @visit
+ * @see
  * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 const bufferCVFromString = (str: string): BufferCV => bufferCV(utf8ToBytes(str));

--- a/packages/transactions/src/clarity/types/bufferCV.ts
+++ b/packages/transactions/src/clarity/types/bufferCV.ts
@@ -25,7 +25,7 @@ interface BufferCV {
  * ```
  *
  * @visit
- * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts clarity test cases for more examples}
+ * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 const bufferCV = (buffer: Uint8Array): BufferCV => {
   if (buffer.length > 1_000_000) {
@@ -54,7 +54,7 @@ const bufferCV = (buffer: Uint8Array): BufferCV => {
  *```
  *
  * @visit
- * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts clarity test cases for more examples}
+ * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 const bufferCVFromString = (str: string): BufferCV => bufferCV(utf8ToBytes(str));
 

--- a/packages/transactions/src/clarity/types/intCV.ts
+++ b/packages/transactions/src/clarity/types/intCV.ts
@@ -27,7 +27,7 @@ interface IntCV {
  *  // { type: 0, value: 100n }
  * ```
  *
- * @visit
+ * @see
  * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 const intCV = (value: IntegerType): IntCV => {
@@ -60,7 +60,7 @@ interface UIntCV {
  *  // { type: 1, value: 100n }
  * ```
  *
- * @visit
+ * @see
  * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 const uintCV = (value: IntegerType): UIntCV => {

--- a/packages/transactions/src/clarity/types/intCV.ts
+++ b/packages/transactions/src/clarity/types/intCV.ts
@@ -28,7 +28,7 @@ interface IntCV {
  * ```
  *
  * @visit
- * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts clarity test cases for more examples}
+ * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 const intCV = (value: IntegerType): IntCV => {
   const bigInt = intToBigInt(value, true);
@@ -61,7 +61,7 @@ interface UIntCV {
  * ```
  *
  * @visit
- * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts clarity test cases for more examples}
+ * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 const uintCV = (value: IntegerType): UIntCV => {
   const bigInt = intToBigInt(value, false);

--- a/packages/transactions/src/clarity/types/listCV.ts
+++ b/packages/transactions/src/clarity/types/listCV.ts
@@ -9,7 +9,7 @@ interface ListCV<T extends ClarityValue = ClarityValue> {
 /**
  * Create list of clarity types
  *
- * @param {ClarityValue[]} values list of  ClarityValues to be converted to ListCV clarity type
+ * @param {ClarityValue[]} list of ClarityValues to be converted to ListCV clarity type
  *
  * @returns {ListCV<T>} instance of type ListCV<T> of the provided values
  *

--- a/packages/transactions/src/clarity/types/listCV.ts
+++ b/packages/transactions/src/clarity/types/listCV.ts
@@ -22,7 +22,7 @@ interface ListCV<T extends ClarityValue = ClarityValue> {
  * ```
  *
  * @visit
- * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts clarity test cases for more examples}
+ * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 function listCV<T extends ClarityValue = ClarityValue>(values: T[]): ListCV<T> {
   return { type: ClarityType.List, list: values };

--- a/packages/transactions/src/clarity/types/listCV.ts
+++ b/packages/transactions/src/clarity/types/listCV.ts
@@ -21,7 +21,7 @@ interface ListCV<T extends ClarityValue = ClarityValue> {
  *  // { type: 11, list: [ { type: 0, value: 1n }, { type: 0, value: 2n }, { type: 0, value: 3n }, { type: 0, value: -4n } ] }
  * ```
  *
- * @visit
+ * @see
  * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 function listCV<T extends ClarityValue = ClarityValue>(values: T[]): ListCV<T> {

--- a/packages/transactions/src/clarity/types/listCV.ts
+++ b/packages/transactions/src/clarity/types/listCV.ts
@@ -9,9 +9,9 @@ interface ListCV<T extends ClarityValue = ClarityValue> {
 /**
  * Create list of clarity types
  *
- * @param {ClarityValue>values: T[]} list of  ClarityValues to be converted to ListCV clarity type
+ * @param {ClarityValue[]} values list of  ClarityValues to be converted to ListCV clarity type
  *
- * @returns {ListCV<T>} returns instance of type ListCV<T>
+ * @returns {ListCV<T>} instance of type ListCV<T> of the provided values
  *
  * @example
  * ```

--- a/packages/transactions/src/clarity/types/optionalCV.ts
+++ b/packages/transactions/src/clarity/types/optionalCV.ts
@@ -25,7 +25,7 @@ interface SomeCV<T extends ClarityValue = ClarityValue> {
  * ```
  *
  * @visit
- * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts clarity test cases for more examples}
+ * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 function noneCV(): NoneCV {
   return { type: ClarityType.OptionalNone };
@@ -47,7 +47,7 @@ function noneCV(): NoneCV {
  * ```
  *
  * @visit
- * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts clarity test cases for more examples}
+ * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 function someCV<T extends ClarityValue = ClarityValue>(value: T): OptionalCV<T> {
   return { type: ClarityType.OptionalSome, value };

--- a/packages/transactions/src/clarity/types/optionalCV.ts
+++ b/packages/transactions/src/clarity/types/optionalCV.ts
@@ -24,7 +24,7 @@ interface SomeCV<T extends ClarityValue = ClarityValue> {
  *  // { type: 9 }
  * ```
  *
- * @visit
+ * @see
  * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 function noneCV(): NoneCV {
@@ -46,7 +46,7 @@ function noneCV(): NoneCV {
  *  // { type: 10, value: { type: 3 } }
  * ```
  *
- * @visit
+ * @see
  * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 function someCV<T extends ClarityValue = ClarityValue>(value: T): OptionalCV<T> {

--- a/packages/transactions/src/clarity/types/principalCV.ts
+++ b/packages/transactions/src/clarity/types/principalCV.ts
@@ -1,7 +1,7 @@
-import { LengthPrefixedString, createAddress, createLPString } from '../../postcondition-types';
-import { Address, addressToString } from '../../common';
-import { ClarityType } from '../constants';
 import { utf8ToBytes } from '@stacks/common';
+import { Address, addressToString } from '../../common';
+import { LengthPrefixedString, createAddress, createLPString } from '../../postcondition-types';
+import { ClarityType } from '../constants';
 
 type PrincipalCV = StandardPrincipalCV | ContractPrincipalCV;
 
@@ -38,9 +38,7 @@ function principalCV(principal: string): PrincipalCV {
 
 /**
  * Converts stx address in to StandardPrincipalCV clarity type
- *
  * @param {addressString} string value to be converted to StandardPrincipalCV clarity type
- *
  * @returns {StandardPrincipalCV} returns instance of type StandardPrincipalCV
  *
  * @example
@@ -51,7 +49,7 @@ function principalCV(principal: string): PrincipalCV {
  *  // { type: 5, address: { type: 0, version: 22, hash160: 'a5d9d331000f5b79578ce56bd157f29a9056f0d6' } }
  * ```
  *
- * @visit
+ * @see
  * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts clarity test cases for more examples}
  */
 function standardPrincipalCV(addressString: string): StandardPrincipalCV {
@@ -61,9 +59,7 @@ function standardPrincipalCV(addressString: string): StandardPrincipalCV {
 
 /**
  * Converts stx address in to StandardPrincipalCV clarity type
- *
  * @param {addressString} string value to be converted to StandardPrincipalCV clarity type
- *
  * @returns {StandardPrincipalCV} returns instance of type StandardPrincipalCV
  *
  * @example
@@ -80,7 +76,7 @@ function standardPrincipalCV(addressString: string): StandardPrincipalCV {
  *  // { type: 5, address: { type: 0, version: 22, hash160: 'a5d9d331000f5b79578ce56bd157f29a9056f0d6' } }
  * ```
  *
- * @visit
+ * @see
  * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts clarity test cases for more examples}
  */
 function standardPrincipalCVFromAddress(address: Address): StandardPrincipalCV {
@@ -89,11 +85,8 @@ function standardPrincipalCVFromAddress(address: Address): StandardPrincipalCV {
 
 /**
  * Converts stx address in to ContractPrincipalCV clarity type
- *
  * @param {addressString} string value to be converted to ContractPrincipalCV clarity type
-
  * @param {contractName} string containing contract name
- *
  * @returns {ContractPrincipalCV} returns instance of type ContractPrincipalCV
  *
  * @example
@@ -104,7 +97,7 @@ function standardPrincipalCVFromAddress(address: Address): StandardPrincipalCV {
  *  // { type: 6, address: { type: 0, version: 22, hash160: 'a5d9d331000f5b79578ce56bd157f29a9056f0d6' }, contractName: { type: 2, content: 'test', lengthPrefixBytes: 1, maxLengthBytes: 128 } }
  * ```
  *
- * @visit
+ * @see
  * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts clarity test cases for more examples}
  */
 function contractPrincipalCV(addressString: string, contractName: string): ContractPrincipalCV {
@@ -115,11 +108,8 @@ function contractPrincipalCV(addressString: string, contractName: string): Contr
 
 /**
  * Create ContractPrincipalCV from Address type
- *
  * @param {address} address value to be converted to ContractPrincipalCV clarity type
- *
  * @param {contractName} contract name of type LengthPrefixedString
- *
  * @returns {ContractPrincipalCV} returns instance of type ContractPrincipalCV
  *
  * @example
@@ -131,7 +121,7 @@ function contractPrincipalCV(addressString: string, contractName: string): Contr
  *  // { type: 6, address: { type: 0, version: 22, hash160: 'a5d9d331000f5b79578ce56bd157f29a9056f0d6' }, contractName: { type: 2, content: 'test', lengthPrefixBytes: 1, maxLengthBytes: 128 } }
  * ```
  *
- * @visit
+ * @see
  * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts clarity test cases for more examples}
  */
 function contractPrincipalCVFromAddress(

--- a/packages/transactions/src/clarity/types/principalCV.ts
+++ b/packages/transactions/src/clarity/types/principalCV.ts
@@ -50,7 +50,7 @@ function principalCV(principal: string): PrincipalCV {
  * ```
  *
  * @see
- * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts clarity test cases for more examples}
+ * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 function standardPrincipalCV(addressString: string): StandardPrincipalCV {
   const addr = createAddress(addressString);
@@ -77,7 +77,7 @@ function standardPrincipalCV(addressString: string): StandardPrincipalCV {
  * ```
  *
  * @see
- * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts clarity test cases for more examples}
+ * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 function standardPrincipalCVFromAddress(address: Address): StandardPrincipalCV {
   return { type: ClarityType.PrincipalStandard, address };
@@ -98,7 +98,7 @@ function standardPrincipalCVFromAddress(address: Address): StandardPrincipalCV {
  * ```
  *
  * @see
- * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts clarity test cases for more examples}
+ * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 function contractPrincipalCV(addressString: string, contractName: string): ContractPrincipalCV {
   const addr = createAddress(addressString);
@@ -122,7 +122,7 @@ function contractPrincipalCV(addressString: string, contractName: string): Contr
  * ```
  *
  * @see
- * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts clarity test cases for more examples}
+ * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 function contractPrincipalCVFromAddress(
   address: Address,

--- a/packages/transactions/src/clarity/types/responseCV.ts
+++ b/packages/transactions/src/clarity/types/responseCV.ts
@@ -29,7 +29,7 @@ interface ResponseOkCV<T extends ClarityValue = ClarityValue> {
  *  // { type: 8, value: { type: 0, value: 1n } }
  * ```
  *
- * @visit
+ * @see
  * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 function responseErrorCV<T extends ClarityValue = ClarityValue>(value: T): ResponseErrorCV<T> {
@@ -52,7 +52,7 @@ function responseErrorCV<T extends ClarityValue = ClarityValue>(value: T): Respo
  *  // { type: 7, value: { type: 0, value: 1n } }
  * ```
  *
- * @visit
+ * @see
  * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 function responseOkCV<T extends ClarityValue = ClarityValue>(value: T): ResponseOkCV<T> {

--- a/packages/transactions/src/clarity/types/responseCV.ts
+++ b/packages/transactions/src/clarity/types/responseCV.ts
@@ -30,7 +30,7 @@ interface ResponseOkCV<T extends ClarityValue = ClarityValue> {
  * ```
  *
  * @visit
- * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts clarity test cases for more examples}
+ * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 function responseErrorCV<T extends ClarityValue = ClarityValue>(value: T): ResponseErrorCV<T> {
   return { type: ClarityType.ResponseErr, value };
@@ -53,7 +53,7 @@ function responseErrorCV<T extends ClarityValue = ClarityValue>(value: T): Respo
  * ```
  *
  * @visit
- * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts clarity test cases for more examples}
+ * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 function responseOkCV<T extends ClarityValue = ClarityValue>(value: T): ResponseOkCV<T> {
   return { type: ClarityType.ResponseOk, value };

--- a/packages/transactions/src/clarity/types/stringCV.ts
+++ b/packages/transactions/src/clarity/types/stringCV.ts
@@ -27,7 +27,7 @@ interface StringUtf8CV {
  * ```
  *
  * @visit
- * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts clarity test cases for more examples}
+ * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 const stringAsciiCV = (data: string): StringAsciiCV => {
   return { type: ClarityType.StringASCII, data };
@@ -50,21 +50,21 @@ const stringAsciiCV = (data: string): StringAsciiCV => {
  * ```
  *
  * @visit
- * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts clarity test cases for more examples}
+ * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 const stringUtf8CV = (data: string): StringUtf8CV => {
   return { type: ClarityType.StringUTF8, data };
 };
 
 /**
- *  @ignore
+ * @ignore
  */
 const stringCV = (data: string, encoding: 'ascii' | 'utf8'): StringAsciiCV | StringUtf8CV => {
   switch (encoding) {
     case 'ascii':
       return stringAsciiCV(data);
     case 'utf8':
-      return stringAsciiCV(data);
+      return stringUtf8CV(data);
   }
 };
 

--- a/packages/transactions/src/clarity/types/stringCV.ts
+++ b/packages/transactions/src/clarity/types/stringCV.ts
@@ -26,7 +26,7 @@ interface StringUtf8CV {
  *  // { type: 13, data: 'hello' }
  * ```
  *
- * @visit
+ * @see
  * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 const stringAsciiCV = (data: string): StringAsciiCV => {
@@ -49,7 +49,7 @@ const stringAsciiCV = (data: string): StringAsciiCV => {
  *  // { type: 13, data: 'hello' }
  * ```
  *
- * @visit
+ * @see
  * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 const stringUtf8CV = (data: string): StringUtf8CV => {

--- a/packages/transactions/src/clarity/types/tupleCV.ts
+++ b/packages/transactions/src/clarity/types/tupleCV.ts
@@ -29,7 +29,7 @@ interface TupleCV<T extends TupleData = TupleData> {
  * ```
  *
  * @visit
- * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts clarity test cases for more examples}
+ * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 function tupleCV<T extends ClarityValue = ClarityValue>(data: TupleData<T>): TupleCV<TupleData<T>> {
   for (const key in data) {

--- a/packages/transactions/src/clarity/types/tupleCV.ts
+++ b/packages/transactions/src/clarity/types/tupleCV.ts
@@ -28,7 +28,7 @@ interface TupleCV<T extends TupleData = TupleData> {
  *  // { type: 12, data: { c: { type: 3 }, b: { type: 4 }, a: { type: 3 } } }
  * ```
  *
- * @visit
+ * @see
  * {@link https://github.com/hirosystems/stacks.js/blob/master/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 function tupleCV<T extends ClarityValue = ClarityValue>(data: TupleData<T>): TupleCV<TupleData<T>> {

--- a/packages/transactions/src/index.ts
+++ b/packages/transactions/src/index.ts
@@ -1,50 +1,45 @@
-export { StacksTransaction, deserializeTransaction } from './transaction';
-
-export { BytesReader as BytesReader } from './bytesReader';
-
+export * from './authorization';
 export {
   Authorization,
-  StandardAuthorization,
-  SponsoredAuthorization,
   SpendingCondition,
+  SponsoredAuthorization,
+  StandardAuthorization,
   emptyMessageSignature,
   isSingleSig,
 } from './authorization';
-
+export * from './builders';
+export { BytesReader as BytesReader } from './bytesReader';
+export * as Cl from './cl';
+export * from './clarity';
+export * from './common';
+export * from './constants';
+export * from './contract-abi';
+export * from './keys';
 export {
-  TokenTransferPayload,
-  ContractCallPayload,
-  SmartContractPayload,
-  VersionedSmartContractPayload,
-  PoisonPayload,
   CoinbasePayload,
   CoinbasePayloadToAltRecipient,
-  serializePayload,
-  isTokenTransferPayload,
-  isContractCallPayload,
-  isSmartContractPayload,
-  isPoisonPayload,
+  ContractCallPayload,
+  PoisonPayload,
+  SmartContractPayload,
+  TokenTransferPayload,
+  VersionedSmartContractPayload,
   isCoinbasePayload,
+  isContractCallPayload,
+  isPoisonPayload,
+  isSmartContractPayload,
+  isTokenTransferPayload,
+  serializePayload,
 } from './payload';
-
+export * as Pc from './pc';
 export {
   createFungiblePostCondition,
   createNonFungiblePostCondition,
   createSTXPostCondition,
 } from './postcondition';
-
-export * from './clarity';
-export * from './keys';
-export * from './builders';
-export * from './types';
-export * from './constants';
-export * from './contract-abi';
-export * from './signer';
-export * from './authorization';
-export * from './utils';
-export * from './common';
-export * from './signature';
-export * from './structuredDataSignature';
 export * from './postcondition-types';
-
-export * as Pc from './pc';
+export * from './signature';
+export * from './signer';
+export * from './structuredDataSignature';
+export { StacksTransaction, deserializeTransaction } from './transaction';
+export * from './types';
+export * from './utils';

--- a/packages/transactions/tests/cl.test.ts
+++ b/packages/transactions/tests/cl.test.ts
@@ -1,0 +1,68 @@
+/* eslint-disable @typescript-eslint/ban-types */
+
+import { hexToBytes } from '@stacks/common';
+import {
+  Cl,
+  boolCV,
+  bufferCV,
+  contractPrincipalCV,
+  falseCV,
+  intCV,
+  listCV,
+  responseErrorCV,
+  responseOkCV,
+  standardPrincipalCV,
+  stringAsciiCV,
+  stringCV,
+  stringUtf8CV,
+  trueCV,
+  tupleCV,
+  uintCV,
+} from '../src';
+
+describe('Cl', () => {
+  const CV_EQUIVALENCES = [
+    { cv: uintCV, cl: Cl.uint, args: [3] },
+    { cv: intCV, cl: Cl.int, args: [-5] },
+    { cv: boolCV, cl: Cl.bool, args: [true] },
+    { cv: boolCV, cl: Cl.bool, args: [false] },
+    { cv: trueCV, cl: Cl.trueBool, args: [] },
+    { cv: falseCV, cl: Cl.falseBool, args: [] },
+    { cv: boolCV, cl: Cl.trueBool, args: [true] },
+    { cv: boolCV, cl: Cl.falseBool, args: [false] },
+    { cv: trueCV, cl: Cl.bool, args: [true] },
+    { cv: falseCV, cl: Cl.bool, args: [false] },
+    {
+      cv: standardPrincipalCV,
+      cl: Cl.standardPrincipal,
+      args: ['ST1HTBVD3JG9C05J7HBJTHGR0GGW7KXW28M5JS8QE'],
+    },
+    {
+      cv: contractPrincipalCV,
+      cl: Cl.contractPrincipal,
+      args: ['ST1HTBVD3JG9C05J7HBJTHGR0GGW7KXW28M5JS8QE', 'contract'],
+    },
+    { cv: listCV, cl: Cl.list, args: [[uintCV(1), Cl.uint(2)]] },
+    { cv: stringCV, cl: Cl.stringAscii, args: ['hello', 'ascii'] },
+    { cv: stringCV, cl: Cl.stringUtf8, args: ['hello', 'utf8'] },
+    { cv: stringAsciiCV, cl: Cl.stringAscii, args: ['hello'] },
+    { cv: stringUtf8CV, cl: Cl.stringUtf8, args: ['hello'] },
+    { cv: bufferCV, cl: Cl.buffer, args: [hexToBytes('beef')] },
+    { cv: responseOkCV, cl: Cl.ok, args: [Cl.uint(1)] },
+    { cv: responseErrorCV, cl: Cl.error, args: [Cl.int(-1)] },
+    { cv: tupleCV, cl: Cl.tuple, args: [{ a: Cl.uint(1), b: uintCV(2) }] },
+  ] as {
+    cv: Function;
+    cl: Function;
+    args: any[];
+  }[];
+
+  test.each(CV_EQUIVALENCES)('cv == cl', ({ cv, cl, args }) => {
+    const cvValue = cv(...args);
+    const clValue = cl(...args);
+    expect(clValue).toEqual(cvValue);
+
+    const wired = Cl.deserialize(Cl.serialize(clValue));
+    expect(wired).toEqual(clValue);
+  });
+});

--- a/packages/transactions/tests/cl.test.ts
+++ b/packages/transactions/tests/cl.test.ts
@@ -26,10 +26,6 @@ describe('Cl', () => {
     { cv: intCV, cl: Cl.int, args: [-5] },
     { cv: boolCV, cl: Cl.bool, args: [true] },
     { cv: boolCV, cl: Cl.bool, args: [false] },
-    { cv: trueCV, cl: Cl.trueBool, args: [] },
-    { cv: falseCV, cl: Cl.falseBool, args: [] },
-    { cv: boolCV, cl: Cl.trueBool, args: [true] },
-    { cv: boolCV, cl: Cl.falseBool, args: [false] },
     { cv: trueCV, cl: Cl.bool, args: [true] },
     { cv: falseCV, cl: Cl.bool, args: [false] },
     {


### PR DESCRIPTION
> This PR was published to npm with the version `6.5.1-pr.f11b880.0`
> e.g. `npm install @stacks/common@6.5.1-pr.f11b880.0 --save-exact`<!-- Sticky Header Marker -->

- closes https://github.com/hirosystems/stacks.js/issues/1444

## summary

Adds a `Cl` bundled export that allows better discovery of clarity methods and less importing.

## examples

NEW
```ts
import { Cl } from '@stacks/transactions'
const tup = Cl.tuple({ a: Cl.unit(2) })
```
VS previously
```ts
import { uintCV, tupleCV } from '@stacks/transactions'
const tup = tupleCV({ a: unitCV(2) })
```

---

## discussion

I'm still in love with the idea to add the type-constructors in uppercase, e.g. `Cl.Int(2)` _(lowercase `Cl.false` won't works since `false` is a keyword)_ and keep methods lowercase, e.g. `Cl.serialize(...)` to add more distinction (and potentially group more methods under a new namespace, similar to `Buffer.from`) -- but I realize it could be confusing.. 🤷‍♂ cc @hugocaillard  @lgalabru 