### PR TITLE
fix: update cli url

### DIFF
--- a/.github/MIGRATION.md
+++ b/.github/MIGRATION.md
@@ -1,11 +1,10 @@
 # Migration Guides
 
-- [Stacks.js (&lt;=4.x.x) → (5.x.x)](#stacksjs-4xx--5xx)
+- [Stacks.js (\<=4.x.x) → (5.x.x)](#stacksjs-4xx--5xx)
   - [Breaking Changes](#breaking-changes)
     - [Buffer to Uint8Array](#buffer-to-uint8array)
     - [Message Signing Prefix](#message-signing-prefix)
 - [blockstack.js → Stacks.js (1.x.x)](#blockstackjs--stacksjs-1xx)
-  - [Auth](#auth)
   - [Using blockstack.js](#using-blockstackjs)
     - [Using Blockstack Connect](#using-blockstack-connect)
   - [Storage](#storage)
@@ -122,8 +121,6 @@ if (userSession.isSignInPending()) {
 ```
 
 #### Using Blockstack Connect
-
-See full tutorial [here](https://docs.blockstack.org/authentication/connect)
 
 ```typescript
 // Configuring your app

--- a/packages/bns/README.md
+++ b/packages/bns/README.md
@@ -5,7 +5,7 @@ on the Stacks blockchain.
 
 ## What is BNS?
 
-The [Blockchain Naming System](https://docs.blockstack.org/build-apps/references/bns)
+The [Blockchain Naming System](https://docs.stacks.co/docs/stacks-academy/bns)
 (BNS) is a network system that binds Stacks usernames to off-chain
 state without relying on any central points of control.
 

--- a/packages/cli/src/argparse.ts
+++ b/packages/cli/src/argparse.ts
@@ -2149,58 +2149,59 @@ export const CLI_ARGS = {
         '    $ stx register_addr example.id "$ID_ADDRESS" "$PAYMENT" https://gaia.blockstack.org/hub',
       group: 'Blockstack ID Management',
     },
-    register_subdomain: {
-      type: 'array',
-      items: [
-        {
-          name: 'blockstack_id',
-          type: 'string',
-          realtype: 'blockstack_id',
-          pattern: SUBDOMAIN_PATTERN,
-        },
-        {
-          name: 'owner_key',
-          type: 'string',
-          realtype: 'private_key',
-          pattern: PRIVATE_KEY_PATTERN,
-        },
-        {
-          name: 'gaia_hub',
-          type: 'string',
-          realtype: 'url',
-        },
-        {
-          name: 'registrar',
-          type: 'string',
-          realtype: 'url',
-        },
-        {
-          name: 'zonefile',
-          type: 'string',
-          realtype: 'path',
-        },
-      ],
-      minItems: 4,
-      maxItems: 5,
-      help:
-        'Register a subdomain.  This will generate and sign a subdomain zone file record ' +
-        'with the given `GAIA_HUB` URL and send it to the given subdomain registrar (`REGISTRAR`).\n' +
-        '\n' +
-        'This command generates, signs, and uploads a profile to the `GAIA_HUB` url.  Note that the `GAIA_HUB` ' +
-        'argument must correspond to the *write* endpoint of your Gaia hub (i.e. you should be able ' +
-        "to run 'curl \"$GAIA_HUB/hub_info\"' successfully).  If you are using Blockstack PBC's default " +
-        'Gaia hub, this argument should be "https://hub.blockstack.org".\n' +
-        '\n' +
-        'WARNING: At this time, no validation will occur on the registrar URL.  Be sure that the URL ' +
-        'corresponds to the registrar for the on-chain name before running this command!\n' +
-        '\n' +
-        'Example:\n' +
-        '\n' +
-        '    $ export OWNER="6e50431b955fe73f079469b24f06480aee44e4519282686433195b3c4b5336ef01"\n' +
-        '    $ # NOTE: https://registrar.blockstack.org is the registrar for personal.id!\n' +
-        '    $ stx register_subdomain hello.personal.id "$OWNER" https://hub.blockstack.org https://registrar.blockstack.org\n',
-      group: 'Blockstack ID Management',
-    },
+    // todo: implement register_subdomain
+    // register_subdomain: {
+    //   type: 'array',
+    //   items: [
+    //     {
+    //       name: 'blockstack_id',
+    //       type: 'string',
+    //       realtype: 'blockstack_id',
+    //       pattern: SUBDOMAIN_PATTERN,
+    //     },
+    //     {
+    //       name: 'owner_key',
+    //       type: 'string',
+    //       realtype: 'private_key',
+    //       pattern: PRIVATE_KEY_PATTERN,
+    //     },
+    //     {
+    //       name: 'gaia_hub',
+    //       type: 'string',
+    //       realtype: 'url',
+    //     },
+    //     {
+    //       name: 'registrar',
+    //       type: 'string',
+    //       realtype: 'url',
+    //     },
+    //     {
+    //       name: 'zonefile',
+    //       type: 'string',
+    //       realtype: 'path',
+    //     },
+    //   ],
+    //   minItems: 4,
+    //   maxItems: 5,
+    //   help:
+    //     'Register a subdomain.  This will generate and sign a subdomain zone file record ' +
+    //     'with the given `GAIA_HUB` URL and send it to the given subdomain registrar (`REGISTRAR`).\n' +
+    //     '\n' +
+    //     'This command generates, signs, and uploads a profile to the `GAIA_HUB` url.  Note that the `GAIA_HUB` ' +
+    //     'argument must correspond to the *write* endpoint of your Gaia hub (i.e. you should be able ' +
+    //     "to run 'curl \"$GAIA_HUB/hub_info\"' successfully).  If you are using Blockstack PBC's default " +
+    //     'Gaia hub, this argument should be "https://hub.blockstack.org".\n' +
+    //     '\n' +
+    //     'WARNING: At this time, no validation will occur on the registrar URL.  Be sure that the URL ' +
+    //     'corresponds to the registrar for the on-chain name before running this command!\n' +
+    //     '\n' +
+    //     'Example:\n' +
+    //     '\n' +
+    //     '    $ export OWNER="6e50431b955fe73f079469b24f06480aee44e4519282686433195b3c4b5336ef01"\n' +
+    //     '    $ # NOTE: https://registrar.blockstack.org is the registrar for personal.id!\n' +
+    //     '    $ stx register_subdomain hello.personal.id "$OWNER" https://hub.blockstack.org https://registrar.blockstack.org\n',
+    //   group: 'Blockstack ID Management',
+    // },
     revoke: {
       type: 'array',
       items: [

--- a/packages/cli/src/argparse.ts
+++ b/packages/cli/src/argparse.ts
@@ -81,9 +81,9 @@ const LOG_CONFIG_DEFAULTS: CLI_LOG_CONFIG_TYPE = {
 };
 
 const CONFIG_DEFAULTS: CLI_CONFIG_TYPE = {
-  blockstackAPIUrl: 'http://stacks-node-api.stacks.co',
-  blockstackNodeUrl: 'http://stacks-node-api.stacks.co',
-  broadcastServiceUrl: 'http://stacks-node-api.stacks.co/v2/transactions',
+  blockstackAPIUrl: 'https://stacks-node-api.stacks.co',
+  blockstackNodeUrl: 'https://stacks-node-api.stacks.co',
+  broadcastServiceUrl: 'https://stacks-node-api.stacks.co/v2/transactions',
   utxoServiceUrl: 'https://blockchain.info',
   logConfig: LOG_CONFIG_DEFAULTS,
 };
@@ -96,13 +96,11 @@ const CONFIG_LOCALNET_DEFAULTS = {
   logConfig: Object.assign({}, LOG_CONFIG_DEFAULTS, { level: 'debug' }),
 };
 
-const PUBLIC_TESTNET_HOST = 'testnet-master.blockstack.org';
-
 const CONFIG_TESTNET_DEFAULTS = {
-  blockstackAPIUrl: `http://${PUBLIC_TESTNET_HOST}:20443`,
-  blockstackNodeUrl: `http://${PUBLIC_TESTNET_HOST}:20443`,
-  broadcastServiceUrl: `http://${PUBLIC_TESTNET_HOST}:20443/v2/transactions`,
-  utxoServiceUrl: `http://${PUBLIC_TESTNET_HOST}:18332`,
+  blockstackAPIUrl: `https://stacks-node-api.testnet.stacks.co`,
+  blockstackNodeUrl: `https://stacks-node-api.testnet.stacks.co`,
+  broadcastServiceUrl: `https://stacks-node-api.testnet.stacks.co/v2/transactions`,
+  utxoServiceUrl: `https://blockchain.info`, // todo: this likely doesn't work anymore
   logConfig: Object.assign({}, LOG_CONFIG_DEFAULTS, { level: 'debug' }),
 };
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1981,7 +1981,7 @@ const COMMANDS: Record<string, CommandFunction> = {
   profile_sign: profileSign,
   profile_store: profileStore,
   profile_verify: profileVerify,
-  // 'send_btc': sendBTC,
+  // 'send_btc': sendBTC, // todo: fix
   register: register,
   tx_preorder: preorder,
   send_tokens: sendTokens,

--- a/packages/wallet-sdk/README.md
+++ b/packages/wallet-sdk/README.md
@@ -157,7 +157,7 @@ interface Account {
 
 When a user restores their wallet in a new app, you can automatically restore any previously-used accounts from the same wallet. It will also restore any usernames owned by this user.
 
-The private keys used to encrypt this data is derived from the path `m/44/5757'/0'/1`. This data is stored in [Gaia](https://docs.blockstack.org/build-apps/references/gaia), the decentralized storage system in the Stacks network. Users can host their own Gaia hub, and this library's API can use that Gaia hub, if provided.
+The private keys used to encrypt this data is derived from the path `m/44/5757'/0'/1`. This data is stored in [Gaia](https://docs.stacks.co/docs/gaia/), the decentralized storage system in the Stacks network. Users can host their own Gaia hub, and this library's API can use that Gaia hub, if provided.
 
 ```typescript
 import { restoreWalletAccounts } from '@stacks/wallet-sdk';
@@ -172,7 +172,7 @@ const restoredWallet = await restoreWalletAccounts({
 
 ### Making an authentication response
 
-With an account, you can generate an authentication response, which conforms to the Stacks authentication protocol. The resulting `authResponse` is a string, representing a signed JSON web token. [Learn more about the authentication protocol](https://docs.blockstack.org/build-apps/guides/authentication#authresponse-payload-schema).
+With an account, you can generate an authentication response, which conforms to the Stacks authentication protocol. The resulting `authResponse` is a string, representing a signed JSON web token. [Learn more about the authentication protocol](https://docs.hiro.so/build-apps/authentication#authresponse-payload-schema).
 
 ```typescript
 // The transit public key is provided in an "authentication request"


### PR DESCRIPTION
> This PR was published to npm with the version `6.5.1-pr.1cfb461.0`
> e.g. `npm install @stacks/common@6.5.1-pr.1cfb461.0 --save-exact`<!-- Sticky Header Marker -->

- updates outdated urls
- closes #1481 