### PR TITLE
fix: update pc types to allow strict type checking

### DIFF
--- a/packages/transactions/src/pc.ts
+++ b/packages/transactions/src/pc.ts
@@ -21,19 +21,16 @@ import { createAssetInfo, NonFungiblePostCondition } from './postcondition-types
 
 /**
  * An address string encoded as c32check
- * @internal
  */
 type AddressString = string;
 
 /**
  * A contract identifier string given as `<address>.<contract-name>`
- * @internal
  */
 type ContractIdString = `${string}.${string}`;
 
 /**
  * An asset identifier string given as `<contract-id>::<token-name>` aka `<contract-address>.<contract-name>::<token-name>`
- * @internal
  */
 type NftString = `${ContractIdString}::${string}`;
 


### PR DESCRIPTION
Remove @internal on types that are used in exported functions to allow strict type validation.

![Screenshot 2023-05-05 at 8 21 36 AM](https://user-images.githubusercontent.com/126361786/236459071-e251388a-f3ee-4eaa-824a-d91d9a92f56f.png)
