### PR TITLE
fix: add missing fields from `PoxInfo`

### DIFF
--- a/packages/stacking/src/index.ts
+++ b/packages/stacking/src/index.ts
@@ -83,10 +83,12 @@ export interface PoxInfo {
   reward_slots: number;
   current_cycle: CycleInfo;
   next_cycle: CycleInfo & {
+    min_increment_ustx: number;
     prepare_phase_start_block_height: number;
     blocks_until_prepare_phase: number;
     reward_phase_start_block_height: number;
     blocks_until_reward_phase: number;
+    ustx_until_pox_rejection: number;
   };
 }
 


### PR DESCRIPTION
### Description

Adds `min_increment_ustx` and `ustx_until_pox_rejection` to the `next_cycle` in the `PoxInfo` interface.

#### Breaking change?

No.

### Example

It is helpful to have these fields available in the typed object.


### Checklist

- [ ] Unit tested updated code paths
- [ ] Tagged 1 of @janniks or @zone117x for review