### PR TITLE
Use StacksNetworkName instead of union type

### DIFF
--- a/packages/network/src/network.ts
+++ b/packages/network/src/network.ts
@@ -11,7 +11,7 @@ export interface NetworkConfig {
 }
 
 export const StacksNetworks = ['mainnet', 'testnet', 'devnet', 'mocknet'] as const;
-export type StacksNetworkName = typeof StacksNetworks[number];
+export type StacksNetworkName = (typeof StacksNetworks)[number];
 
 /**
  * @related {@link StacksMainnet}, {@link StacksTestnet}, {@link StacksDevnet}, {@link StacksMocknet}

--- a/packages/network/src/network.ts
+++ b/packages/network/src/network.ts
@@ -11,7 +11,7 @@ export interface NetworkConfig {
 }
 
 export const StacksNetworks = ['mainnet', 'testnet', 'devnet', 'mocknet'] as const;
-export type StacksNetworkName = (typeof StacksNetworks)[number];
+export type StacksNetworkName = typeof StacksNetworks[number];
 
 /**
  * @related {@link StacksMainnet}, {@link StacksTestnet}, {@link StacksDevnet}, {@link StacksMocknet}
@@ -125,7 +125,7 @@ export class StacksNetwork {
       })
       .then(nameInfo => {
         // the returned address _should_ be in the correct network ---
-        //  blockstackd gets into trouble because it tries to coerce back to mainnet
+        //  stacks node gets into trouble because it tries to coerce back to mainnet
         //  and the regtest transaction generation libraries want to use testnet addresses
         if (nameInfo.address) {
           return Object.assign({}, nameInfo, { address: nameInfo.address });

--- a/packages/stacking/src/constants.ts
+++ b/packages/stacking/src/constants.ts
@@ -26,7 +26,12 @@ export const BitcoinNetworkVersion = {
     P2PKH: 0x6f, // 111
     P2SH: 0xc4, // 196
   },
-  regtest: {
+  devnet: {
+    // equivalent to testnet for our purposes
+    P2PKH: 0x6f, // 111
+    P2SH: 0xc4, // 196
+  },
+  mocknet: {
     // equivalent to testnet for our purposes
     P2PKH: 0x6f, // 111
     P2SH: 0xc4, // 196
@@ -59,7 +64,8 @@ export const SEGWIT_V1_ADDR_PREFIX = /^(bc1p|tb1p|bcrt1p)/i;
 export const SegwitPrefix = {
   mainnet: 'bc',
   testnet: 'tb',
-  regtest: 'bcrt',
+  devnet: 'bcrt',
+  mocknet: 'bcrt',
 } as const;
 /** @ignore */
 export const SEGWIT_ADDR_PREFIXES = /^(bc|tb)/i;

--- a/packages/stacking/src/utils.ts
+++ b/packages/stacking/src/utils.ts
@@ -24,6 +24,7 @@ import {
   SEGWIT_V1_ADDR_PREFIX,
   StackingErrors,
 } from './constants';
+import { StacksNetworkName, StacksNetworks } from '@stacks/network';
 
 export class InvalidAddressError extends Error {
   innerError?: Error;
@@ -226,7 +227,7 @@ export function poxAddressToTuple(poxAddress: string) {
 
 function legacyHashModeToBtcAddressVersion(
   hashMode: PoXAddressVersion,
-  network: 'mainnet' | 'testnet' | 'regtest'
+  network: StacksNetworkName
 ): number {
   switch (hashMode) {
     case PoXAddressVersion.P2PKH:
@@ -244,9 +245,9 @@ function legacyHashModeToBtcAddressVersion(
 function _poxAddressToBtcAddress_Values(
   version: number,
   hashBytes: Uint8Array,
-  network: 'mainnet' | 'testnet' | 'regtest'
+  network: StacksNetworkName
 ): string {
-  if (!['mainnet', 'testnet', 'regtest'].includes(network)) throw new Error('Invalid network.');
+  if (!StacksNetworks.includes(network)) throw new Error('Invalid network.');
 
   switch (version) {
     case PoXAddressVersion.P2PKH:
@@ -271,7 +272,7 @@ function _poxAddressToBtcAddress_Values(
 
 function _poxAddressToBtcAddress_ClarityValue(
   poxAddrClarityValue: ClarityValue,
-  network: 'mainnet' | 'testnet' | 'regtest'
+  network: StacksNetworkName
 ): string {
   const poxAddr = extractPoxAddressFromClarityValue(poxAddrClarityValue);
   return _poxAddressToBtcAddress_Values(poxAddr.version, poxAddr.hashBytes, network);
@@ -280,11 +281,11 @@ function _poxAddressToBtcAddress_ClarityValue(
 export function poxAddressToBtcAddress(
   version: number,
   hashBytes: Uint8Array,
-  network: 'mainnet' | 'testnet' | 'regtest'
+  network: StacksNetworkName
 ): string;
 export function poxAddressToBtcAddress(
   poxAddrClarityValue: ClarityValue,
-  network: 'mainnet' | 'testnet' | 'regtest'
+  network: StacksNetworkName
 ): string;
 export function poxAddressToBtcAddress(...args: any[]): string {
   if (typeof args[0] === 'number') return _poxAddressToBtcAddress_Values(args[0], args[1], args[2]);


### PR DESCRIPTION
> This PR was published to npm with the version `6.5.4-pr.af5c701.0`
> e.g. `npm install @stacks/common@6.5.4-pr.af5c701.0 --save-exact`<!-- Sticky Header Marker -->

### Description

This PR replaces the duplicate union type for network names with StacksNetworkName

#### Breaking change
This PR requires an update of regtest network name to devnet or mocknet


### Checklist

- [x] Unit tested updated code paths
- [x] Tagged 1 of @janniks or @zone117x for review