### PR TITLE
fix: add missing none type for delegation without until_burn_ht

### DIFF
--- a/packages/stacking/src/index.ts
+++ b/packages/stacking/src/index.ts
@@ -1349,7 +1349,7 @@ export class StackingClient {
             amount_micro_stx: BigInt(amountMicroStx.value),
             delegated_to: principalToString(delegatedTo),
             pox_address: poxAddress,
-            until_burn_ht: Number(untilBurnBlockHeight?.value),
+            until_burn_ht: untilBurnBlockHeight ? Number(untilBurnBlockHeight.value) : undefined,
           },
         };
       } else if (responseCV.type === ClarityType.OptionalNone) {

--- a/packages/transactions/src/keys.ts
+++ b/packages/transactions/src/keys.ts
@@ -142,7 +142,7 @@ export function compressPublicKey(publicKey: string | Uint8Array): StacksPublicK
 export function deserializePublicKey(bytesReader: BytesReader): StacksPublicKey {
   const fieldId = bytesReader.readUInt8();
   const keyLength =
-    fieldId !== 4 ? COMPRESSED_PUBKEY_LENGTH_BYTES : UNCOMPRESSED_PUBKEY_LENGTH_BYTES;
+    fieldId === 4 ? UNCOMPRESSED_PUBKEY_LENGTH_BYTES : COMPRESSED_PUBKEY_LENGTH_BYTES;
   return publicKeyFromBytes(concatArray([fieldId, bytesReader.readBytes(keyLength)]));
 }
 


### PR DESCRIPTION
> This PR was published to npm with the version `6.5.5-pr.7a775f1.0`
> e.g. `npm install @stacks/common@6.5.5-pr.7a775f1.0 --save-exact`<!-- Sticky Header Marker -->

- closes #1509 