### PR TITLE
fix: update AccountExtendedBalances interface

### DIFF
--- a/packages/stacking/src/index.ts
+++ b/packages/stacking/src/index.ts
@@ -117,6 +117,7 @@ export interface AccountExtendedBalances {
     total_sent: IntegerType;
     total_received: IntegerType;
     locked: IntegerType;
+    lock_tx_id: string;
     lock_height: number;
     burnchain_lock_height: number;
     burnchain_unlock_height: number;


### PR DESCRIPTION
add lock_tx_id prop

### Description

Fixes #1437 
Adds the `lock_tx_id` property to the `AccountExtendedBalances` interface.

### Checklist

- [ ] Unit tested updated code paths
- [x] Tagged 1 of @janniks or @zone117x for review

<!-- Make sure to run `npm run test` locally to find problems faster -->
