### PR TITLE
1537 add peernetworkid constants

### DIFF
--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -1,24 +1,41 @@
+/**
+ * The **chain** ID.
+ * Is used for signing, so transactions can't be replayed on other chains.
+ */
 export enum ChainID {
   Testnet = 0x80000000,
   Mainnet = 0x00000001,
 }
 
+/**
+ * The **transaction** version.
+ * Is used for signing, so transactions can't be replayed on other networks.
+ */
 export enum TransactionVersion {
   Mainnet = 0x00,
   Testnet = 0x80,
 }
 
 /**
- * @ignore
+ * The **peer** network ID.
+ * Typically not used in signing, but used for broadcasting to the P2P network.
+ * It can also be used to determine the parent of a subnet.
+ *
+ * Attention:
+ * For mainnet/testnet the v2/info response `.network_id` refers to the chain ID
+ * For subnets the v2/info response `.network_id` refers to the peer network ID and the chain ID (they are the same for subnets)
+ * The `.parent_network_id` refers to the actual peer network ID (of the parent) in both cases
  */
+export enum PeerNetworkID {
+  Mainnet = 0x17000000,
+  Testnet = 0xff000000,
+}
+
+/** @ignore internal */
 export const PRIVATE_KEY_COMPRESSED_LENGTH = 33;
 
-/**
- * @ignore
- */
+/** @ignore internal */
 export const PRIVATE_KEY_UNCOMPRESSED_LENGTH = 32;
 
-/**
- * @ignore
- */
+/** @ignore internal */
 export const BLOCKSTACK_DEFAULT_GAIA_HUB_URL = 'https://hub.blockstack.org';

--- a/packages/network/src/network.ts
+++ b/packages/network/src/network.ts
@@ -5,15 +5,24 @@ export const HIRO_MAINNET_DEFAULT = 'https://stacks-node-api.mainnet.stacks.co';
 export const HIRO_TESTNET_DEFAULT = 'https://stacks-node-api.testnet.stacks.co';
 export const HIRO_MOCKNET_DEFAULT = 'http://localhost:3999';
 
+/**
+ * Used for constructing Network instances
+ * @related {@link StacksNetwork}, {@link StacksMainnet}, {@link StacksTestnet}, {@link StacksDevnet}, {@link StacksMocknet}
+ */
 export interface NetworkConfig {
+  /** The base API/node URL for the network fetch calls */
   url: string;
+  /** An optional custom fetch function to override default behaviors */
   fetchFn?: FetchFn;
 }
 
+/** @ignore internal */
 export const StacksNetworks = ['mainnet', 'testnet', 'devnet', 'mocknet'] as const;
+/** The enum-style names of different common Stacks networks */
 export type StacksNetworkName = (typeof StacksNetworks)[number];
 
 /**
+ * The base class for Stacks networks. Typically used via its subclasses.
  * @related {@link StacksMainnet}, {@link StacksTestnet}, {@link StacksDevnet}, {@link StacksMocknet}
  */
 export class StacksNetwork {
@@ -36,6 +45,7 @@ export class StacksNetwork {
     this.fetchFn = networkConfig.fetchFn ?? createFetchFn();
   }
 
+  /** A static network constructor from a network name */
   static fromName = (networkName: StacksNetworkName): StacksNetwork => {
     switch (networkName) {
       case 'mainnet':
@@ -55,6 +65,7 @@ export class StacksNetwork {
     }
   };
 
+  /** @ignore internal */
   static fromNameOrNetwork = (network: StacksNetworkName | StacksNetwork) => {
     if (typeof network !== 'string' && 'version' in network) {
       return network;
@@ -63,6 +74,7 @@ export class StacksNetwork {
     return StacksNetwork.fromName(network);
   };
 
+  /** Returns `true` if the network is configured to 'mainnet', based on the TransactionVersion */
   isMainnet = () => this.version === TransactionVersion.Mainnet;
   getBroadcastApiUrl = () => `${this.coreApiUrl}${this.broadcastEndpoint}`;
   getTransferFeeEstimateApiUrl = () => `${this.coreApiUrl}${this.transferFeeEstimateEndpoint}`;


### PR DESCRIPTION
> This PR was published to npm with the version `6.8.1-pr.b6546e9.0`
> e.g. `npm install @stacks/common@6.8.1-pr.b6546e9.0 --save-exact`<!-- Sticky Header Marker -->

- add peer network id