### PR TITLE
docs: update typedoc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,9 +39,9 @@
         "rimraf": "^5.0.1",
         "stream-http": "^3.2.0",
         "ts-jest": "^29.1.1",
-        "typedoc": "^0.24.8",
-        "typedoc-plugin-replace-text": "^3.1.0",
-        "typescript": "^5.1.6",
+        "typedoc": "^0.25.1",
+        "typedoc-plugin-replace-text": "^3.2.0",
+        "typescript": "^5.2.2",
         "webpack": "^5.88.2",
         "webpack-bundle-analyzer": "^4.9.0",
         "webpack-cli": "^5.1.4"
@@ -22276,33 +22276,33 @@
       "dev": true
     },
     "node_modules/typedoc": {
-      "version": "0.24.8",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.24.8.tgz",
-      "integrity": "sha512-ahJ6Cpcvxwaxfu4KtjA8qZNqS43wYt6JL27wYiIgl1vd38WW/KWX11YuAeZhuz9v+ttrutSsgK+XO1CjL1kA3w==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.25.1.tgz",
+      "integrity": "sha512-c2ye3YUtGIadxN2O6YwPEXgrZcvhlZ6HlhWZ8jQRNzwLPn2ylhdGqdR8HbyDRyALP8J6lmSANILCkkIdNPFxqA==",
       "dev": true,
       "dependencies": {
         "lunr": "^2.3.9",
         "marked": "^4.3.0",
-        "minimatch": "^9.0.0",
+        "minimatch": "^9.0.3",
         "shiki": "^0.14.1"
       },
       "bin": {
         "typedoc": "bin/typedoc"
       },
       "engines": {
-        "node": ">= 14.14"
+        "node": ">= 16"
       },
       "peerDependencies": {
-        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x"
+        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x"
       }
     },
     "node_modules/typedoc-plugin-replace-text": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-replace-text/-/typedoc-plugin-replace-text-3.1.0.tgz",
-      "integrity": "sha512-MBt2xiqSS+TT+N+iz9qAXkHG+wSbTraBzybi6JK0AGxnTiQgmpAppiUvtgLrg/iQYZsjWiWmMXr4gf11pcz+Wg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-replace-text/-/typedoc-plugin-replace-text-3.2.0.tgz",
+      "integrity": "sha512-PeshV35JQersAcm9AbL3KqvdY9VZUhnIVsQ+XYIaHn7WR98INDN+QenwdpgmlKkijFOe+wsWudOs5z9RPBVpFg==",
       "dev": true,
       "peerDependencies": {
-        "typedoc": "^0.24.8"
+        "typedoc": "^0.24.8 || 0.25.x"
       }
     },
     "node_modules/typedoc/node_modules/brace-expansion": {
@@ -22335,9 +22335,9 @@
       "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
     },
     "node_modules/typescript": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -54,9 +54,9 @@
     "rimraf": "^5.0.1",
     "stream-http": "^3.2.0",
     "ts-jest": "^29.1.1",
-    "typedoc": "^0.24.8",
-    "typedoc-plugin-replace-text": "^3.1.0",
-    "typescript": "^5.1.6",
+    "typedoc": "^0.25.1",
+    "typedoc-plugin-replace-text": "^3.2.0",
+    "typescript": "^5.2.2",
     "webpack": "^5.88.2",
     "webpack-bundle-analyzer": "^4.9.0",
     "webpack-cli": "^5.1.4"


### PR DESCRIPTION
> This PR was published to npm with the version `6.9.1-pr.0e2e54f.0`
> e.g. `npm install @stacks/common@6.9.1-pr.0e2e54f.0 --save-exact`<!-- Sticky Header Marker -->

