### PR TITLE
chore: update amazon bucket values to invalid names

### DIFF
--- a/packages/auth/tests/auth.test.ts
+++ b/packages/auth/tests/auth.test.ts
@@ -533,7 +533,7 @@ test('profileLookUp', async () => {
 
   const mockZonefile = {
     zonefile:
-      '$ORIGIN ryan.id\n$TTL 3600\n_http._tcp IN URI 10 1 "https://blockstack.s3.amazonaws.com/ryan.id"\n',
+      '$ORIGIN ryan.id\n$TTL 3600\n_http._tcp IN URI 10 1 "https://_example_.s3.amazonaws.com/ryan.id"\n',
     address: 'SP3AMDH2ZZB8XQK467V9HV5CRQF2RPBZ4MDMSBHJZ',
   };
 

--- a/packages/auth/tests/sampleData.ts
+++ b/packages/auth/tests/sampleData.ts
@@ -1,10 +1,10 @@
-import * as fs from 'fs'
+import * as fs from 'fs';
 
-const TEST_DATA_DIR = './tests/testData'
+const TEST_DATA_DIR = './tests/testData';
 
 export const sampleNameRecords = {
-  ryan: JSON.parse(fs.readFileSync(`${TEST_DATA_DIR}/name-records/ryan.json`, 'utf8'))
-}
+  ryan: JSON.parse(fs.readFileSync(`${TEST_DATA_DIR}/name-records/ryan.json`, 'utf8')),
+};
 
 export const sampleProfiles = {
   balloonDog: JSON.parse(fs.readFileSync(`${TEST_DATA_DIR}/profiles/balloonDog.json`, 'utf8')),
@@ -15,16 +15,16 @@ export const sampleProfiles = {
   navalLegacy: JSON.parse(fs.readFileSync(`${TEST_DATA_DIR}/profiles/naval-legacy.json`, 'utf8')),
   navalLegacyConvert: JSON.parse(
     fs.readFileSync(`${TEST_DATA_DIR}/profiles/naval-legacy-convert.json`, 'utf8')
-  )
-}
+  ),
+};
 
 export const sampleTokenFiles = {
   ryan_apr20: {
-    url: 'https://blockstack.s3.amazonaws.com/ryan_apr20.id',
-    body: JSON.parse(fs.readFileSync(`${TEST_DATA_DIR}/token-files/ryan_apr20.json`, 'utf8'))
+    url: 'https://_example_.s3.amazonaws.com/ryan_apr20.id',
+    body: JSON.parse(fs.readFileSync(`${TEST_DATA_DIR}/token-files/ryan_apr20.json`, 'utf8')),
   },
   ryan: {
-    url: 'https://blockstack.s3.amazonaws.com/ryan.id',
-    body: JSON.parse(fs.readFileSync(`${TEST_DATA_DIR}/token-files/ryan.json`, 'utf8'))
-  }
-}
+    url: 'https://_example_.s3.amazonaws.com/ryan.id',
+    body: JSON.parse(fs.readFileSync(`${TEST_DATA_DIR}/token-files/ryan.json`, 'utf8')),
+  },
+};

--- a/packages/auth/tests/testData/profiles/larry.json
+++ b/packages/auth/tests/testData/profiles/larry.json
@@ -1,61 +1,61 @@
 {
-    "@type": "Person",
-    "account": [
-        {
-            "@type": "Account",
-            "identifier": "larrysalibra",
-            "proofType": "http",
-            "service": "twitter"
-        },
-        {
-            "@type": "Account",
-            "identifier": "larrysalibra",
-            "proofType": "http",
-            "service": "github"
-        },
-        {
-            "@type": "Account",
-            "identifier": "1EyuZ8qxdhHjcnTChwQLyQaN3cmdK55DkH",
-            "role": "payment",
-            "service": "bitcoin"
-        },
-        {
-            "@type": "Account",
-            "contentUrl": "http://pgp.mit.edu/pks/lookup?op=get&search=0xDE3B5425164C4849",
-            "identifier": "B516CB7A08819697B25E4694DE3B5425164C4849",
-            "role": "key",
-            "service": "pgp"
-        },
-        {
-            "@type": "Account",
-            "identifier": "larry.salibra",
-            "proofType": "http",
-            "proofUrl": "https://www.facebook.com/larry.salibra/posts/10100341028448093",
-            "service": "facebook"
-        }
-    ],
-    "address": {
-        "@type": "PostalAddress",
-        "addressLocality": "Hong Kong"
+  "@type": "Person",
+  "account": [
+    {
+      "@type": "Account",
+      "identifier": "larrysalibra",
+      "proofType": "http",
+      "service": "twitter"
     },
-    "description": "Blockchain, software, security. Decentralize the world (w/ #bitcoin)! \u8b58\u4e2d\u6587",
-    "image": [
-        {
-            "@type": "ImageObject",
-            "contentUrl": "https://s3.amazonaws.com/kd4/larry",
-            "name": "avatar"
-        },
-        {
-            "@type": "ImageObject",
-            "contentUrl": "https://s3.amazonaws.com/dx3/larry",
-            "name": "cover"
-        }
-    ],
-    "name": "Larry Salibra",
-    "website": [
-        {
-            "@type": "WebSite",
-            "url": "https://www.larrysalibra.com"
-        }
-    ]
+    {
+      "@type": "Account",
+      "identifier": "larrysalibra",
+      "proofType": "http",
+      "service": "github"
+    },
+    {
+      "@type": "Account",
+      "identifier": "1EyuZ8qxdhHjcnTChwQLyQaN3cmdK55DkH",
+      "role": "payment",
+      "service": "bitcoin"
+    },
+    {
+      "@type": "Account",
+      "contentUrl": "http://pgp.mit.edu/pks/lookup?op=get&search=0xDE3B5425164C4849",
+      "identifier": "B516CB7A08819697B25E4694DE3B5425164C4849",
+      "role": "key",
+      "service": "pgp"
+    },
+    {
+      "@type": "Account",
+      "identifier": "larry.salibra",
+      "proofType": "http",
+      "proofUrl": "https://www.facebook.com/larry.salibra/posts/10100341028448093",
+      "service": "facebook"
+    }
+  ],
+  "address": {
+    "@type": "PostalAddress",
+    "addressLocality": "Hong Kong"
+  },
+  "description": "Blockchain, software, security. Decentralize the world (w/ #bitcoin)! \u8b58\u4e2d\u6587",
+  "image": [
+    {
+      "@type": "ImageObject",
+      "contentUrl": "https://s3.amazonaws.com/_example_/larry",
+      "name": "avatar"
+    },
+    {
+      "@type": "ImageObject",
+      "contentUrl": "https://s3.amazonaws.com/_example_/larry",
+      "name": "cover"
+    }
+  ],
+  "name": "Larry Salibra",
+  "website": [
+    {
+      "@type": "WebSite",
+      "url": "https://www.larrysalibra.com"
+    }
+  ]
 }

--- a/packages/auth/tests/testData/profiles/naval-legacy-convert.json
+++ b/packages/auth/tests/testData/profiles/naval-legacy-convert.json
@@ -59,7 +59,7 @@
         "role": "key",
         "service": "pgp",
         "identifier": "07354EDF5C6CF2572847840D8FA3F960B62B7C41",
-        "contentUrl": "https://s3.amazonaws.com/pk9/naval"
+        "contentUrl": "https://s3.amazonaws.com/_example_/naval"
       }
     ]
   },

--- a/packages/auth/tests/testData/profiles/naval-legacy.json
+++ b/packages/auth/tests/testData/profiles/naval-legacy.json
@@ -19,7 +19,7 @@
   }, 
   "website": "https://angel.co/naval", 
   "pgp": {
-    "url": "https://s3.amazonaws.com/pk9/naval", 
+    "url": "https://s3.amazonaws.com/_example_/naval", 
     "fingerprint": "07354EDF5C6CF2572847840D8FA3F960B62B7C41"
   }, 
   "v": "0.2", 
@@ -28,7 +28,7 @@
   }, 
   "twitterUsername": "naval", 
   "graph": {
-    "url": "https://s3.amazonaws.com/grph/naval"
+    "url": "https://s3.amazonaws.com/_example_/naval"
   }, 
   "cover": {
     "url": "https://pbs.twimg.com/profile_banners/745273/1355705777/web_retina"

--- a/packages/auth/tests/testData/profiles/ryan.json
+++ b/packages/auth/tests/testData/profiles/ryan.json
@@ -1,68 +1,68 @@
 {
-  "@type": "Person", 
+  "@type": "Person",
   "account": [
     {
-      "service": "bitcoin", 
-      "@type": "Account", 
-      "identifier": "1LFS37yRSibwbf8CnXeCn5t1GKeTEZMmu9", 
+      "service": "bitcoin",
+      "@type": "Account",
+      "identifier": "1LFS37yRSibwbf8CnXeCn5t1GKeTEZMmu9",
       "role": "payment"
-    }, 
+    },
     {
-      "service": "pgp", 
-      "contentUrl": "https://s3.amazonaws.com/pk9/ryan", 
-      "@type": "Account", 
+      "service": "pgp",
+      "contentUrl": "https://s3.amazonaws.com/_example_/ryan",
+      "@type": "Account",
       "identifier": "1E4329E6634C75730D4D88C0638F2769D55B9837"
-    }, 
+    },
     {
-      "service": "openbazaar", 
-      "proofType": "http", 
-      "@type": "Account", 
-      "proofUrl": "https://www.facebook.com/msrobot0/posts/10153644446452759", 
+      "service": "openbazaar",
+      "proofType": "http",
+      "@type": "Account",
+      "proofUrl": "https://www.facebook.com/msrobot0/posts/10153644446452759",
       "identifier": "f2250123a6af138c86b30f3233b338961dc8fbc3"
-    }, 
+    },
     {
-      "service": "twitter", 
-      "proofType": "http", 
-      "@type": "Account", 
-      "proofUrl": "https://twitter.com/ryaneshea/status/765575388735082496", 
+      "service": "twitter",
+      "proofType": "http",
+      "@type": "Account",
+      "proofUrl": "https://twitter.com/ryaneshea/status/765575388735082496",
       "identifier": "ryaneshea"
-    }, 
+    },
     {
-      "service": "github", 
-      "proofType": "http", 
-      "@type": "Account", 
-      "proofUrl": "https://gist.github.com/shea256/a6dc1f3182f28bb2285feaef07a14340", 
+      "service": "github",
+      "proofType": "http",
+      "@type": "Account",
+      "proofUrl": "https://gist.github.com/shea256/a6dc1f3182f28bb2285feaef07a14340",
       "identifier": "shea256"
-    }, 
+    },
     {
-      "service": "facebook", 
-      "proofType": "http", 
-      "@type": "Account", 
-      "proofUrl": "https://www.facebook.com/ryaneshea/posts/10154182997407713", 
+      "service": "facebook",
+      "proofType": "http",
+      "@type": "Account",
+      "proofUrl": "https://www.facebook.com/ryaneshea/posts/10154182997407713",
       "identifier": "ryaneshea"
     }
-  ], 
+  ],
   "website": [
     {
-      "@type": "WebSite", 
+      "@type": "WebSite",
       "url": "http://shea.io"
     }
-  ], 
-  "description": "Co-founder of Blockstack Inc.", 
-  "name": "Ryan Shea", 
+  ],
+  "description": "Co-founder of Blockstack Inc.",
+  "name": "Ryan Shea",
   "address": {
-    "@type": "PostalAddress", 
+    "@type": "PostalAddress",
     "addressLocality": "New York"
-  }, 
+  },
   "image": [
     {
-      "@type": "ImageObject", 
-      "contentUrl": "https://s3.amazonaws.com/kd4/ryan", 
+      "@type": "ImageObject",
+      "contentUrl": "https://s3.amazonaws.com/_example_/ryan",
       "name": "avatar"
-    }, 
+    },
     {
-      "@type": "ImageObject", 
-      "contentUrl": "https://s3.amazonaws.com/dx3/ryan", 
+      "@type": "ImageObject",
+      "contentUrl": "https://s3.amazonaws.com/_example_/ryan",
       "name": "cover"
     }
   ]

--- a/packages/auth/tests/testData/token-files/ryan.json
+++ b/packages/auth/tests/testData/token-files/ryan.json
@@ -2,92 +2,92 @@
   {
     "decodedToken": {
       "header": {
-        "alg": "ES256K", 
+        "alg": "ES256K",
         "typ": "JWT"
-      }, 
+      },
       "payload": {
-        "issuedAt": "2016-12-21T02:20:24.575047", 
+        "issuedAt": "2016-12-21T02:20:24.575047",
         "claim": {
           "image": [
             {
-              "contentUrl": "https://s3.amazonaws.com/kd4/ryan", 
-              "name": "avatar", 
+              "contentUrl": "https://s3.amazonaws.com/_example_/ryan",
+              "name": "avatar",
               "@type": "ImageObject"
-            }, 
+            },
             {
-              "contentUrl": "https://s3.amazonaws.com/dx3/ryan", 
-              "name": "cover", 
+              "contentUrl": "https://s3.amazonaws.com/_example_/ryan",
+              "name": "cover",
               "@type": "ImageObject"
             }
-          ], 
-          "@type": "Person", 
+          ],
+          "@type": "Person",
           "website": [
             {
-              "url": "http://shea.io", 
+              "url": "http://shea.io",
               "@type": "WebSite"
             }
-          ], 
-          "description": "Co-founder of Blockstack Inc.", 
+          ],
+          "description": "Co-founder of Blockstack Inc.",
           "address": {
-            "addressLocality": "New York", 
+            "addressLocality": "New York",
             "@type": "PostalAddress"
-          }, 
+          },
           "account": [
             {
-              "identifier": "1LFS37yRSibwbf8CnXeCn5t1GKeTEZMmu9", 
-              "role": "payment", 
-              "@type": "Account", 
+              "identifier": "1LFS37yRSibwbf8CnXeCn5t1GKeTEZMmu9",
+              "role": "payment",
+              "@type": "Account",
               "service": "bitcoin"
-            }, 
+            },
             {
-              "contentUrl": "https://s3.amazonaws.com/pk9/ryan", 
-              "identifier": "1E4329E6634C75730D4D88C0638F2769D55B9837", 
-              "@type": "Account", 
+              "contentUrl": "https://s3.amazonaws.com/_example_/ryan",
+              "identifier": "1E4329E6634C75730D4D88C0638F2769D55B9837",
+              "@type": "Account",
               "service": "pgp"
-            }, 
+            },
             {
-              "identifier": "f2250123a6af138c86b30f3233b338961dc8fbc3", 
-              "proofType": "http", 
-              "proofUrl": "https://www.facebook.com/msrobot0/posts/10153644446452759", 
-              "service": "openbazaar", 
+              "identifier": "f2250123a6af138c86b30f3233b338961dc8fbc3",
+              "proofType": "http",
+              "proofUrl": "https://www.facebook.com/msrobot0/posts/10153644446452759",
+              "service": "openbazaar",
               "@type": "Account"
-            }, 
+            },
             {
-              "identifier": "ryaneshea", 
-              "proofType": "http", 
-              "proofUrl": "https://twitter.com/ryaneshea/status/765575388735082496", 
-              "service": "twitter", 
+              "identifier": "ryaneshea",
+              "proofType": "http",
+              "proofUrl": "https://twitter.com/ryaneshea/status/765575388735082496",
+              "service": "twitter",
               "@type": "Account"
-            }, 
+            },
             {
-              "identifier": "shea256", 
-              "proofType": "http", 
-              "proofUrl": "https://gist.github.com/shea256/a6dc1f3182f28bb2285feaef07a14340", 
-              "service": "github", 
+              "identifier": "shea256",
+              "proofType": "http",
+              "proofUrl": "https://gist.github.com/shea256/a6dc1f3182f28bb2285feaef07a14340",
+              "service": "github",
               "@type": "Account"
-            }, 
+            },
             {
-              "identifier": "ryaneshea", 
-              "proofType": "http", 
-              "proofUrl": "https://www.facebook.com/ryaneshea/posts/10154182997407713", 
-              "service": "facebook", 
+              "identifier": "ryaneshea",
+              "proofType": "http",
+              "proofUrl": "https://www.facebook.com/ryaneshea/posts/10154182997407713",
+              "service": "facebook",
               "@type": "Account"
             }
-          ], 
+          ],
           "name": "Ryan Shea"
-        }, 
-        "expiresAt": "2017-12-21T02:20:24.575047", 
+        },
+        "expiresAt": "2017-12-21T02:20:24.575047",
         "subject": {
           "publicKey": "0312ccf3255cb005e42c186aa3d2302083b306a52c1f0cb47b1119639f134e6695"
-        }, 
+        },
         "issuer": {
           "publicKey": "0312ccf3255cb005e42c186aa3d2302083b306a52c1f0cb47b1119639f134e6695"
         }
-      }, 
+      },
       "signature": "YVoNsoJCTMcXIwqa9D5kinkUrnyppsYus7Z-8cn7o9hA6_IG9zkoZGSvsIzfqqjG1mV8JNV1Nh04CZl1qrt1YQ"
-    }, 
-    "token": "eyJhbGciOiJFUzI1NksiLCJ0eXAiOiJKV1QifQ.eyJpc3N1ZWRBdCI6IjIwMTYtMTItMjFUMDI6MjA6MjQuNTc1MDQ3IiwiY2xhaW0iOnsiaW1hZ2UiOlt7ImNvbnRlbnRVcmwiOiJodHRwczovL3MzLmFtYXpvbmF3cy5jb20va2Q0L3J5YW4iLCJuYW1lIjoiYXZhdGFyIiwiQHR5cGUiOiJJbWFnZU9iamVjdCJ9LHsiY29udGVudFVybCI6Imh0dHBzOi8vczMuYW1hem9uYXdzLmNvbS9keDMvcnlhbiIsIm5hbWUiOiJjb3ZlciIsIkB0eXBlIjoiSW1hZ2VPYmplY3QifV0sIkB0eXBlIjoiUGVyc29uIiwid2Vic2l0ZSI6W3sidXJsIjoiaHR0cDovL3NoZWEuaW8iLCJAdHlwZSI6IldlYlNpdGUifV0sImFjY291bnQiOlt7ImlkZW50aWZpZXIiOiIxTEZTMzd5UlNpYndiZjhDblhlQ241dDFHS2VURVpNbXU5Iiwicm9sZSI6InBheW1lbnQiLCJAdHlwZSI6IkFjY291bnQiLCJzZXJ2aWNlIjoiYml0Y29pbiJ9LHsiY29udGVudFVybCI6Imh0dHBzOi8vczMuYW1hem9uYXdzLmNvbS9wazkvcnlhbiIsImlkZW50aWZpZXIiOiIxRTQzMjlFNjYzNEM3NTczMEQ0RDg4QzA2MzhGMjc2OUQ1NUI5ODM3IiwiQHR5cGUiOiJBY2NvdW50Iiwic2VydmljZSI6InBncCJ9LHsicHJvb2ZUeXBlIjoiaHR0cCIsImlkZW50aWZpZXIiOiJmMjI1MDEyM2E2YWYxMzhjODZiMzBmMzIzM2IzMzg5NjFkYzhmYmMzIiwicHJvb2ZVcmwiOiJodHRwczovL3d3dy5mYWNlYm9vay5jb20vbXNyb2JvdDAvcG9zdHMvMTAxNTM2NDQ0NDY0NTI3NTkiLCJzZXJ2aWNlIjoib3BlbmJhemFhciIsIkB0eXBlIjoiQWNjb3VudCJ9LHsicHJvb2ZUeXBlIjoiaHR0cCIsImlkZW50aWZpZXIiOiJyeWFuZXNoZWEiLCJwcm9vZlVybCI6Imh0dHBzOi8vdHdpdHRlci5jb20vcnlhbmVzaGVhL3N0YXR1cy83NjU1NzUzODg3MzUwODI0OTYiLCJzZXJ2aWNlIjoidHdpdHRlciIsIkB0eXBlIjoiQWNjb3VudCJ9LHsicHJvb2ZUeXBlIjoiaHR0cCIsImlkZW50aWZpZXIiOiJzaGVhMjU2IiwicHJvb2ZVcmwiOiJodHRwczovL2dpc3QuZ2l0aHViLmNvbS9zaGVhMjU2L2E2ZGMxZjMxODJmMjhiYjIyODVmZWFlZjA3YTE0MzQwIiwic2VydmljZSI6ImdpdGh1YiIsIkB0eXBlIjoiQWNjb3VudCJ9LHsicHJvb2ZUeXBlIjoiaHR0cCIsImlkZW50aWZpZXIiOiJyeWFuZXNoZWEiLCJwcm9vZlVybCI6Imh0dHBzOi8vd3d3LmZhY2Vib29rLmNvbS9yeWFuZXNoZWEvcG9zdHMvMTAxNTQxODI5OTc0MDc3MTMiLCJzZXJ2aWNlIjoiZmFjZWJvb2siLCJAdHlwZSI6IkFjY291bnQifV0sImFkZHJlc3MiOnsiYWRkcmVzc0xvY2FsaXR5IjoiTmV3IFlvcmsiLCJAdHlwZSI6IlBvc3RhbEFkZHJlc3MifSwiZGVzY3JpcHRpb24iOiJDby1mb3VuZGVyIG9mIEJsb2Nrc3RhY2sgSW5jLiIsIm5hbWUiOiJSeWFuIFNoZWEifSwiZXhwaXJlc0F0IjoiMjAxNy0xMi0yMVQwMjoyMDoyNC41NzUwNDciLCJpc3N1ZXIiOnsicHVibGljS2V5IjoiMDMxMmNjZjMyNTVjYjAwNWU0MmMxODZhYTNkMjMwMjA4M2IzMDZhNTJjMWYwY2I0N2IxMTE5NjM5ZjEzNGU2Njk1In0sInN1YmplY3QiOnsicHVibGljS2V5IjoiMDMxMmNjZjMyNTVjYjAwNWU0MmMxODZhYTNkMjMwMjA4M2IzMDZhNTJjMWYwY2I0N2IxMTE5NjM5ZjEzNGU2Njk1In19.YVoNsoJCTMcXIwqa9D5kinkUrnyppsYus7Z-8cn7o9hA6_IG9zkoZGSvsIzfqqjG1mV8JNV1Nh04CZl1qrt1YQ", 
-    "parentPublicKey": "0312ccf3255cb005e42c186aa3d2302083b306a52c1f0cb47b1119639f134e6695", 
+    },
+    "token": "eyJhbGciOiJFUzI1NksiLCJ0eXAiOiJKV1QifQ.eyJpc3N1ZWRBdCI6IjIwMTYtMTItMjFUMDI6MjA6MjQuNTc1MDQ3IiwiY2xhaW0iOnsiaW1hZ2UiOlt7ImNvbnRlbnRVcmwiOiJodHRwczovL3MzLmFtYXpvbmF3cy5jb20va2Q0L3J5YW4iLCJuYW1lIjoiYXZhdGFyIiwiQHR5cGUiOiJJbWFnZU9iamVjdCJ9LHsiY29udGVudFVybCI6Imh0dHBzOi8vczMuYW1hem9uYXdzLmNvbS9keDMvcnlhbiIsIm5hbWUiOiJjb3ZlciIsIkB0eXBlIjoiSW1hZ2VPYmplY3QifV0sIkB0eXBlIjoiUGVyc29uIiwid2Vic2l0ZSI6W3sidXJsIjoiaHR0cDovL3NoZWEuaW8iLCJAdHlwZSI6IldlYlNpdGUifV0sImFjY291bnQiOlt7ImlkZW50aWZpZXIiOiIxTEZTMzd5UlNpYndiZjhDblhlQ241dDFHS2VURVpNbXU5Iiwicm9sZSI6InBheW1lbnQiLCJAdHlwZSI6IkFjY291bnQiLCJzZXJ2aWNlIjoiYml0Y29pbiJ9LHsiY29udGVudFVybCI6Imh0dHBzOi8vczMuYW1hem9uYXdzLmNvbS9wazkvcnlhbiIsImlkZW50aWZpZXIiOiIxRTQzMjlFNjYzNEM3NTczMEQ0RDg4QzA2MzhGMjc2OUQ1NUI5ODM3IiwiQHR5cGUiOiJBY2NvdW50Iiwic2VydmljZSI6InBncCJ9LHsicHJvb2ZUeXBlIjoiaHR0cCIsImlkZW50aWZpZXIiOiJmMjI1MDEyM2E2YWYxMzhjODZiMzBmMzIzM2IzMzg5NjFkYzhmYmMzIiwicHJvb2ZVcmwiOiJodHRwczovL3d3dy5mYWNlYm9vay5jb20vbXNyb2JvdDAvcG9zdHMvMTAxNTM2NDQ0NDY0NTI3NTkiLCJzZXJ2aWNlIjoib3BlbmJhemFhciIsIkB0eXBlIjoiQWNjb3VudCJ9LHsicHJvb2ZUeXBlIjoiaHR0cCIsImlkZW50aWZpZXIiOiJyeWFuZXNoZWEiLCJwcm9vZlVybCI6Imh0dHBzOi8vdHdpdHRlci5jb20vcnlhbmVzaGVhL3N0YXR1cy83NjU1NzUzODg3MzUwODI0OTYiLCJzZXJ2aWNlIjoidHdpdHRlciIsIkB0eXBlIjoiQWNjb3VudCJ9LHsicHJvb2ZUeXBlIjoiaHR0cCIsImlkZW50aWZpZXIiOiJzaGVhMjU2IiwicHJvb2ZVcmwiOiJodHRwczovL2dpc3QuZ2l0aHViLmNvbS9zaGVhMjU2L2E2ZGMxZjMxODJmMjhiYjIyODVmZWFlZjA3YTE0MzQwIiwic2VydmljZSI6ImdpdGh1YiIsIkB0eXBlIjoiQWNjb3VudCJ9LHsicHJvb2ZUeXBlIjoiaHR0cCIsImlkZW50aWZpZXIiOiJyeWFuZXNoZWEiLCJwcm9vZlVybCI6Imh0dHBzOi8vd3d3LmZhY2Vib29rLmNvbS9yeWFuZXNoZWEvcG9zdHMvMTAxNTQxODI5OTc0MDc3MTMiLCJzZXJ2aWNlIjoiZmFjZWJvb2siLCJAdHlwZSI6IkFjY291bnQifV0sImFkZHJlc3MiOnsiYWRkcmVzc0xvY2FsaXR5IjoiTmV3IFlvcmsiLCJAdHlwZSI6IlBvc3RhbEFkZHJlc3MifSwiZGVzY3JpcHRpb24iOiJDby1mb3VuZGVyIG9mIEJsb2Nrc3RhY2sgSW5jLiIsIm5hbWUiOiJSeWFuIFNoZWEifSwiZXhwaXJlc0F0IjoiMjAxNy0xMi0yMVQwMjoyMDoyNC41NzUwNDciLCJpc3N1ZXIiOnsicHVibGljS2V5IjoiMDMxMmNjZjMyNTVjYjAwNWU0MmMxODZhYTNkMjMwMjA4M2IzMDZhNTJjMWYwY2I0N2IxMTE5NjM5ZjEzNGU2Njk1In0sInN1YmplY3QiOnsicHVibGljS2V5IjoiMDMxMmNjZjMyNTVjYjAwNWU0MmMxODZhYTNkMjMwMjA4M2IzMDZhNTJjMWYwY2I0N2IxMTE5NjM5ZjEzNGU2Njk1In19.YVoNsoJCTMcXIwqa9D5kinkUrnyppsYus7Z-8cn7o9hA6_IG9zkoZGSvsIzfqqjG1mV8JNV1Nh04CZl1qrt1YQ",
+    "parentPublicKey": "0312ccf3255cb005e42c186aa3d2302083b306a52c1f0cb47b1119639f134e6695",
     "encrypted": false
   }
 ]

--- a/packages/auth/tests/testData/token-files/ryan_apr20.json
+++ b/packages/auth/tests/testData/token-files/ryan_apr20.json
@@ -2,42 +2,42 @@
   {
     "decodedToken": {
       "header": {
-        "alg": "ES256K", 
+        "alg": "ES256K",
         "typ": "JWT"
-      }, 
+      },
       "payload": {
-        "issuedAt": "2016-04-20T12:25:14.453734", 
+        "issuedAt": "2016-04-20T12:25:14.453734",
         "claim": {
-          "account": [], 
-          "accounts": [], 
-          "@type": "Person", 
+          "account": [],
+          "accounts": [],
+          "@type": "Person",
           "image": [
             {
-              "contentUrl": "https://s3.amazonaws.com/97p/rv1.jpeg", 
-              "@type": "ImageObject", 
+              "contentUrl": "https://s3.amazonaws.com/_example_/rv1.jpeg",
+              "@type": "ImageObject",
               "name": "cover"
-            }, 
+            },
             {
-              "contentUrl": "https://s3.amazonaws.com/kd4/ryan_apr20", 
-              "@type": "ImageObject", 
+              "contentUrl": "https://s3.amazonaws.com/_example_/ryan_apr20",
+              "@type": "ImageObject",
               "name": "avatar"
             }
-          ], 
+          ],
           "name": "Ryan Shea"
-        }, 
-        "expiresAt": "2017-04-20T12:25:14.453734", 
+        },
+        "expiresAt": "2017-04-20T12:25:14.453734",
         "subject": {
           "publicKey": "02413d7c51118104cfe1b41e540b6c2acaaf91f1e2e22316df7448fb6070d582ec"
-        }, 
+        },
         "issuer": {
           "publicKey": "02413d7c51118104cfe1b41e540b6c2acaaf91f1e2e22316df7448fb6070d582ec"
         }
-      }, 
+      },
       "signature": "Xj3z975ccW6oxbrlm_YsdGNreuzERRxPoj0DyyJ9vygMYfUjsTQGcxsejmkSPYafTFd6TNIbNBTquutOKZvmBA"
-    }, 
-    "token": "eyJhbGciOiJFUzI1NksiLCJ0eXAiOiJKV1QifQ.eyJpc3N1ZWRBdCI6IjIwMTYtMDQtMjBUMTI6MjU6MTQuNDUzNzM0IiwiY2xhaW0iOnsiYWNjb3VudCI6W10sImFjY291bnRzIjpbXSwiQHR5cGUiOiJQZXJzb24iLCJpbWFnZSI6W3siY29udGVudFVybCI6Imh0dHBzOi8vczMuYW1hem9uYXdzLmNvbS85N3AvcnYxLmpwZWciLCJAdHlwZSI6IkltYWdlT2JqZWN0IiwibmFtZSI6ImNvdmVyIn0seyJjb250ZW50VXJsIjoiaHR0cHM6Ly9zMy5hbWF6b25hd3MuY29tL2tkNC9yeWFuX2FwcjIwIiwiQHR5cGUiOiJJbWFnZU9iamVjdCIsIm5hbWUiOiJhdmF0YXIifV0sIm5hbWUiOiJSeWFuIFNoZWEifSwiZXhwaXJlc0F0IjoiMjAxNy0wNC0yMFQxMjoyNToxNC40NTM3MzQiLCJpc3N1ZXIiOnsicHVibGljS2V5IjoiMDI0MTNkN2M1MTExODEwNGNmZTFiNDFlNTQwYjZjMmFjYWFmOTFmMWUyZTIyMzE2ZGY3NDQ4ZmI2MDcwZDU4MmVjIn0sInN1YmplY3QiOnsicHVibGljS2V5IjoiMDI0MTNkN2M1MTExODEwNGNmZTFiNDFlNTQwYjZjMmFjYWFmOTFmMWUyZTIyMzE2ZGY3NDQ4ZmI2MDcwZDU4MmVjIn19.Xj3z975ccW6oxbrlm_YsdGNreuzERRxPoj0DyyJ9vygMYfUjsTQGcxsejmkSPYafTFd6TNIbNBTquutOKZvmBA", 
-    "parentPublicKey": "02413d7c51118104cfe1b41e540b6c2acaaf91f1e2e22316df7448fb6070d582ec", 
-    "publicKey": "02413d7c51118104cfe1b41e540b6c2acaaf91f1e2e22316df7448fb6070d582ec", 
+    },
+    "token": "eyJhbGciOiJFUzI1NksiLCJ0eXAiOiJKV1QifQ.eyJpc3N1ZWRBdCI6IjIwMTYtMDQtMjBUMTI6MjU6MTQuNDUzNzM0IiwiY2xhaW0iOnsiYWNjb3VudCI6W10sImFjY291bnRzIjpbXSwiQHR5cGUiOiJQZXJzb24iLCJpbWFnZSI6W3siY29udGVudFVybCI6Imh0dHBzOi8vczMuYW1hem9uYXdzLmNvbS85N3AvcnYxLmpwZWciLCJAdHlwZSI6IkltYWdlT2JqZWN0IiwibmFtZSI6ImNvdmVyIn0seyJjb250ZW50VXJsIjoiaHR0cHM6Ly9zMy5hbWF6b25hd3MuY29tL2tkNC9yeWFuX2FwcjIwIiwiQHR5cGUiOiJJbWFnZU9iamVjdCIsIm5hbWUiOiJhdmF0YXIifV0sIm5hbWUiOiJSeWFuIFNoZWEifSwiZXhwaXJlc0F0IjoiMjAxNy0wNC0yMFQxMjoyNToxNC40NTM3MzQiLCJpc3N1ZXIiOnsicHVibGljS2V5IjoiMDI0MTNkN2M1MTExODEwNGNmZTFiNDFlNTQwYjZjMmFjYWFmOTFmMWUyZTIyMzE2ZGY3NDQ4ZmI2MDcwZDU4MmVjIn0sInN1YmplY3QiOnsicHVibGljS2V5IjoiMDI0MTNkN2M1MTExODEwNGNmZTFiNDFlNTQwYjZjMmFjYWFmOTFmMWUyZTIyMzE2ZGY3NDQ4ZmI2MDcwZDU4MmVjIn19.Xj3z975ccW6oxbrlm_YsdGNreuzERRxPoj0DyyJ9vygMYfUjsTQGcxsejmkSPYafTFd6TNIbNBTquutOKZvmBA",
+    "parentPublicKey": "02413d7c51118104cfe1b41e540b6c2acaaf91f1e2e22316df7448fb6070d582ec",
+    "publicKey": "02413d7c51118104cfe1b41e540b6c2acaaf91f1e2e22316df7448fb6070d582ec",
     "encrypted": false
   }
 ]

--- a/packages/profile/README.md
+++ b/packages/profile/README.md
@@ -39,11 +39,12 @@ const decodedToken = verifyProfileToken(token, publicKey);
 ```typescript
 import { makeProfileZoneFile } from '@stacks/profile';
 
-const fileUrl = 'https://mq9.s3.amazonaws.com/naval.id/profile.json';
+const fileUrl = 'https://_example_.s3.amazonaws.com/naval.id/profile.json';
 const origin = 'naval.id';
 const zoneFile = makeProfileZoneFile(origin, fileUrl);
 // zoneFile contents
 ```
+
 ### Profile to token
 
 ```typescript
@@ -52,7 +53,7 @@ import { signProfileToken, verifyProfileToken, extractProfile } from '@stacks/pr
 // Token received after signin in browser using auth or connect
 const token = '<insert profile token here>';
 const profile = extractProfile(token);
-// warning: Do not expose your private key by hard coding in code. Use env variables to load private keys.  
+// warning: Do not expose your private key by hard coding in code. Use env variables to load private keys.
 const privateKey = '<private key>'; // process.env.privateKey
 const publicKey = '<public key>';
 

--- a/packages/profile/tests/sampleData.ts
+++ b/packages/profile/tests/sampleData.ts
@@ -1,6 +1,6 @@
-import * as fs from 'fs'
+import * as fs from 'fs';
 
-const TEST_DATA_DIR = './tests/testData'
+const TEST_DATA_DIR = './tests/testData';
 
 export const sampleManifests = {
   helloBlockstack: {
@@ -14,15 +14,15 @@ export const sampleManifests = {
       {
         src: 'https://raw.githubusercontent.com/blockstack/blockstack-portal/master/app/images/app-hello-blockstack.png',
         sizes: '192x192',
-        type: 'image/png'
-      }
-    ]
-  }
-}
+        type: 'image/png',
+      },
+    ],
+  },
+};
 
 export const sampleNameRecords = {
-  ryan: JSON.parse(fs.readFileSync(`${TEST_DATA_DIR}/name-records/ryan.json`, 'utf8'))
-}
+  ryan: JSON.parse(fs.readFileSync(`${TEST_DATA_DIR}/name-records/ryan.json`, 'utf8')),
+};
 
 export const sampleProfiles = {
   balloonDog: JSON.parse(fs.readFileSync(`${TEST_DATA_DIR}/profiles/balloonDog.json`, 'utf8')),
@@ -33,94 +33,100 @@ export const sampleProfiles = {
   navalLegacy: JSON.parse(fs.readFileSync(`${TEST_DATA_DIR}/profiles/naval-legacy.json`, 'utf8')),
   navalLegacyConvert: JSON.parse(
     fs.readFileSync(`${TEST_DATA_DIR}/profiles/naval-legacy-convert.json`, 'utf8')
-  )
-}
+  ),
+};
 
 export const sampleTokenFiles = {
   ryan_apr20: {
-    url: 'https://blockstack.s3.amazonaws.com/ryan_apr20.id',
-    body: JSON.parse(fs.readFileSync(`${TEST_DATA_DIR}/token-files/ryan_apr20.json`, 'utf8'))
+    url: 'https://_example_.s3.amazonaws.com/ryan_apr20.id',
+    body: JSON.parse(fs.readFileSync(`${TEST_DATA_DIR}/token-files/ryan_apr20.json`, 'utf8')),
   },
   ryan: {
-    url: 'https://blockstack.s3.amazonaws.com/ryan.id',
-    body: JSON.parse(fs.readFileSync(`${TEST_DATA_DIR}/token-files/ryan.json`, 'utf8'))
-  }
-}
+    url: 'https://_example_.s3.amazonaws.com/ryan.id',
+    body: JSON.parse(fs.readFileSync(`${TEST_DATA_DIR}/token-files/ryan.json`, 'utf8')),
+  },
+};
 
 export const sampleProofs = {
   naval: JSON.parse(fs.readFileSync(`${TEST_DATA_DIR}/profiles/naval.proofs.json`, 'utf8')),
   larry: JSON.parse(fs.readFileSync(`${TEST_DATA_DIR}/profiles/larry.proofs.json`, 'utf8')),
   ken: JSON.parse(fs.readFileSync(`${TEST_DATA_DIR}/profiles/ken.proofs.json`, 'utf8')),
-  bruno: JSON.parse(fs.readFileSync(`${TEST_DATA_DIR}/profiles/bruno.proofs.json`, 'utf8'))
-}
+  bruno: JSON.parse(fs.readFileSync(`${TEST_DATA_DIR}/profiles/bruno.proofs.json`, 'utf8')),
+};
 
 export const sampleVerifications = {
   naval: {
     facebook: {
       url: 'https://www.facebook.com/navalr/posts/10152190734077261',
-      body: fs.readFileSync(`${TEST_DATA_DIR}/profiles/naval.verification.facebook.html`, 'utf8')
+      body: fs.readFileSync(`${TEST_DATA_DIR}/profiles/naval.verification.facebook.html`, 'utf8'),
     },
     github: {
       url: 'https://gist.github.com/navalr/f31a74054f859ec0ac6a',
-      body: fs.readFileSync(`${TEST_DATA_DIR}/profiles/naval.verification.github.html`, 'utf8')
+      body: fs.readFileSync(`${TEST_DATA_DIR}/profiles/naval.verification.github.html`, 'utf8'),
     },
     twitter: {
       url: 'https://twitter.com/naval/status/486609266212499456',
-      body: fs.readFileSync(`${TEST_DATA_DIR}/profiles/naval.verification.twitter.html`, 'utf8')
-    }
+      body: fs.readFileSync(`${TEST_DATA_DIR}/profiles/naval.verification.twitter.html`, 'utf8'),
+    },
   },
   larry: {
     facebook: {
       url: 'https://www.facebook.com/larry.salibra/posts/10100341028448093',
-      body: fs.readFileSync(`${TEST_DATA_DIR}/profiles/larry.verification.facebook.html`, 'utf8')
-    }
-  }
-}
+      body: fs.readFileSync(`${TEST_DATA_DIR}/profiles/larry.verification.facebook.html`, 'utf8'),
+    },
+  },
+};
 
 export const sampleAddressBasedVerifications = {
   larry: {
     facebook: {
       url: 'https://www.facebook.com/larrysalibra/posts/10100341028448094',
-      body: fs.readFileSync(`${TEST_DATA_DIR}/profiles/larry.verification.address.facebook.html`,
-                            'utf8')
-    }
+      body: fs.readFileSync(
+        `${TEST_DATA_DIR}/profiles/larry.verification.address.facebook.html`,
+        'utf8'
+      ),
+    },
   },
   ken: {
     github: {
       url: 'https://gist.github.com/yknl/37c763ab7bc6cf89b919212ef3f10676',
-      body: fs.readFileSync(`${TEST_DATA_DIR}/profiles/ken.verification.github.html`, 'utf8')
+      body: fs.readFileSync(`${TEST_DATA_DIR}/profiles/ken.verification.github.html`, 'utf8'),
     },
     twitter: {
       url: 'https://twitter.com/YukanL/status/903285763240022017',
-      body: fs.readFileSync(`${TEST_DATA_DIR}/profiles/ken.verification.twitter.html`, 'utf8')
+      body: fs.readFileSync(`${TEST_DATA_DIR}/profiles/ken.verification.twitter.html`, 'utf8'),
     },
     instagram: {
       url: 'https://www.instagram.com/p/BYj6UDwgaX7/',
-      body: fs.readFileSync(`${TEST_DATA_DIR}/profiles/ken.verification.instagram.html`, 'utf8')
+      body: fs.readFileSync(`${TEST_DATA_DIR}/profiles/ken.verification.instagram.html`, 'utf8'),
     },
     instagramRegression: {
       url: 'https://www.instagram.com/p/BYj6UDwgaX7/',
-      body: fs.readFileSync(`${TEST_DATA_DIR}/profiles/`
-                            + 'ken.verification.instagram.regression.html', 'utf8')
+      body: fs.readFileSync(
+        `${TEST_DATA_DIR}/profiles/` + 'ken.verification.instagram.regression.html',
+        'utf8'
+      ),
     },
     hackerNews: {
       url: 'https://news.ycombinator.com/user?id=yukanl',
-      body: fs.readFileSync(`${TEST_DATA_DIR}/profiles/ken.verification.hackernews.html`, 'utf8')
+      body: fs.readFileSync(`${TEST_DATA_DIR}/profiles/ken.verification.hackernews.html`, 'utf8'),
     },
     linkedIn: {
       url: 'https://www.linkedin.com/feed/update/urn:li:activity:6311587377647222784/',
-      body: fs.readFileSync(`${TEST_DATA_DIR}/profiles/ken.verification.linkedin.html`, 'utf8')
+      body: fs.readFileSync(`${TEST_DATA_DIR}/profiles/ken.verification.linkedin.html`, 'utf8'),
     },
     linkedInBroken: {
       url: 'https://www.linkedin.com/feed/update/urn:li:activity:6311587377647222784/',
-      body: fs.readFileSync(`${TEST_DATA_DIR}/profiles/ken.verification.linkedinbroken.html`,
-                            'utf8')
-    }
+      body: fs.readFileSync(
+        `${TEST_DATA_DIR}/profiles/ken.verification.linkedinbroken.html`,
+        'utf8'
+      ),
+    },
   },
   oscar: {
     linkedIn: {
       url: 'https://www.linkedin.com/feed/update/urn:li:activity:6504006525630189568/',
-      body: fs.readFileSync(`${TEST_DATA_DIR}/profiles/oscar.verification.linkedin.html`, 'utf8')
-    }
-  }
-}
+      body: fs.readFileSync(`${TEST_DATA_DIR}/profiles/oscar.verification.linkedin.html`, 'utf8'),
+    },
+  },
+};

--- a/packages/profile/tests/schema.test.ts
+++ b/packages/profile/tests/schema.test.ts
@@ -88,7 +88,7 @@ test('legacyFormat', () => {
 
 test('resolveZoneFileToPerson', () => {
   const zoneFile =
-    '$ORIGIN ryan.id\n$TTL 3600\n_http._tcp IN URI 10 1 "https://blockstack.s3.amazonaws.com/ryan.id"\n';
+    '$ORIGIN ryan.id\n$TTL 3600\n_http._tcp IN URI 10 1 "https://_example_.s3.amazonaws.com/ryan.id"\n';
   const ownerAddress = 'SP3AMDH2ZZB8XQK467V9HV5CRQF2RPBZ4MDMSBHJZ';
   fetchMock.once(JSON.stringify(sampleTokenFiles.ryan.body));
 

--- a/packages/profile/tests/testData/profiles/ken.verification.github.html
+++ b/packages/profile/tests/testData/profiles/ken.verification.github.html
@@ -1,508 +1,1069 @@
-<!DOCTYPE html>
+<!doctype html>
 <!-- saved from url=(0061)https://gist.github.com/yknl/37c763ab7bc6cf89b919212ef3f10676 -->
-<html lang="en"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    
-  <link rel="dns-prefetch" href="https://assets-cdn.github.com/">
-  <link rel="dns-prefetch" href="https://avatars0.githubusercontent.com/">
-  <link rel="dns-prefetch" href="https://avatars1.githubusercontent.com/">
-  <link rel="dns-prefetch" href="https://avatars2.githubusercontent.com/">
-  <link rel="dns-prefetch" href="https://avatars3.githubusercontent.com/">
-  <link rel="dns-prefetch" href="https://github-cloud.s3.amazonaws.com/">
-  <link rel="dns-prefetch" href="https://user-images.githubusercontent.com/">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 
-<meta content="origin-when-cross-origin" name="referrer">
+    <link rel="dns-prefetch" href="https://assets-cdn.github.com/" />
+    <link rel="dns-prefetch" href="https://avatars0.githubusercontent.com/" />
+    <link rel="dns-prefetch" href="https://avatars1.githubusercontent.com/" />
+    <link rel="dns-prefetch" href="https://avatars2.githubusercontent.com/" />
+    <link rel="dns-prefetch" href="https://avatars3.githubusercontent.com/" />
+    <link rel="dns-prefetch" href="https://_example_.s3.amazonaws.com/" />
+    <link rel="dns-prefetch" href="https://user-images.githubusercontent.com/" />
 
-  <link crossorigin="anonymous" href="./ken..verification.github_files/frameworks-7db951ed87f8f6cbd3a9e89c294e300cf23c1a83ad7ae64c70b8f99b21031340.css" integrity="sha256-fblR7Yf49svTqeicKU4wDPI8GoOteuZMcLj5myEDE0A=" media="all" rel="stylesheet">
-  <link crossorigin="anonymous" href="./ken..verification.github_files/github-7b4e17697260b0150413dc0cb251639730e0ff52161f1acbe15e4e90e59b6351.css" integrity="sha256-e04XaXJgsBUEE9wMslFjlzDg/1IWHxrL4V5OkOWbY1E=" media="all" rel="stylesheet">
-  
-  
-  <link crossorigin="anonymous" href="./ken..verification.github_files/site-955690c4e09b2eeb3627ae6048471522eb98b42054150bd855ad4183db364816.css" integrity="sha256-lVaQxOCbLus2J65gSEcVIuuYtCBUFQvYVa1Bg9s2SBY=" media="all" rel="stylesheet">
-  
+    <meta content="origin-when-cross-origin" name="referrer" />
 
-  <meta name="viewport" content="width=device-width">
-  
-  <title>Verify · GitHub</title>
-  <link rel="search" type="application/opensearchdescription+xml" href="https://gist.github.com/opensearch.xml" title="GitHub">
-  <link rel="fluid-icon" href="https://gist.github.com/fluidicon.png" title="GitHub">
-  <meta property="fb:app_id" content="1401488693436528">
+    <link
+      crossorigin="anonymous"
+      href="./ken..verification.github_files/frameworks-7db951ed87f8f6cbd3a9e89c294e300cf23c1a83ad7ae64c70b8f99b21031340.css"
+      integrity="sha256-fblR7Yf49svTqeicKU4wDPI8GoOteuZMcLj5myEDE0A="
+      media="all"
+      rel="stylesheet"
+    />
+    <link
+      crossorigin="anonymous"
+      href="./ken..verification.github_files/github-7b4e17697260b0150413dc0cb251639730e0ff52161f1acbe15e4e90e59b6351.css"
+      integrity="sha256-e04XaXJgsBUEE9wMslFjlzDg/1IWHxrL4V5OkOWbY1E="
+      media="all"
+      rel="stylesheet"
+    />
 
-    
-    <meta content="https://avatars2.githubusercontent.com/u/29081231?v=4&amp;s=400" property="og:image"><meta content="Gist" property="og:site_name"><meta content="object" property="og:type"><meta content="Verify" property="og:title"><meta content="https://gist.github.com/yknl/37c763ab7bc6cf89b919212ef3f10676" property="og:url">
+    <link
+      crossorigin="anonymous"
+      href="./ken..verification.github_files/site-955690c4e09b2eeb3627ae6048471522eb98b42054150bd855ad4183db364816.css"
+      integrity="sha256-lVaQxOCbLus2J65gSEcVIuuYtCBUFQvYVa1Bg9s2SBY="
+      media="all"
+      rel="stylesheet"
+    />
 
-  <link rel="assets" href="https://assets-cdn.github.com/">
-  
-  <meta name="pjax-timeout" content="1000">
-  
-  <meta name="request-id" content="E20D:4B42:42318:74725:59A83272" data-pjax-transient="">
-  
+    <meta name="viewport" content="width=device-width" />
 
-  <meta name="selected-link" value="gist_code" data-pjax-transient="">
+    <title>Verify · GitHub</title>
+    <link
+      rel="search"
+      type="application/opensearchdescription+xml"
+      href="https://gist.github.com/opensearch.xml"
+      title="GitHub"
+    />
+    <link rel="fluid-icon" href="https://gist.github.com/fluidicon.png" title="GitHub" />
+    <meta property="fb:app_id" content="1401488693436528" />
 
-  <meta name="google-site-verification" content="KT5gs8h0wvaagLKAVWq8bbeNwnZZK1r1XQysX3xurLU">
-<meta name="google-site-verification" content="ZzhVyEFwb7w3e0-uOTltm8Jsck2F5StVihD0exw2fsA">
-    <meta name="google-analytics" content="UA-3769691-4">
+    <meta
+      content="https://avatars2.githubusercontent.com/u/29081231?v=4&amp;s=400"
+      property="og:image"
+    />
+    <meta content="Gist" property="og:site_name" />
+    <meta content="object" property="og:type" />
+    <meta content="Verify" property="og:title" />
+    <meta
+      content="https://gist.github.com/yknl/37c763ab7bc6cf89b919212ef3f10676"
+      property="og:url"
+    />
 
-<meta content="collector.githubapp.com" name="octolytics-host"><meta content="gist" name="octolytics-app-id"><meta content="https://collector.githubapp.com/github-external/browser_event" name="octolytics-event-url"><meta content="E20D:4B42:42318:74725:59A83272" name="octolytics-dimension-request_id"><meta content="iad" name="octolytics-dimension-region_edge"><meta content="iad" name="octolytics-dimension-region_render">
-<meta content="/&lt;user-name&gt;/&lt;gist-id&gt;" data-pjax-transient="true" name="analytics-location">
+    <link rel="assets" href="https://assets-cdn.github.com/" />
 
+    <meta name="pjax-timeout" content="1000" />
 
+    <meta name="request-id" content="E20D:4B42:42318:74725:59A83272" data-pjax-transient="" />
 
+    <meta name="selected-link" value="gist_code" data-pjax-transient="" />
 
-  <meta class="js-ga-set" name="dimension1" content="Logged Out">
+    <meta name="google-site-verification" content="KT5gs8h0wvaagLKAVWq8bbeNwnZZK1r1XQysX3xurLU" />
+    <meta name="google-site-verification" content="ZzhVyEFwb7w3e0-uOTltm8Jsck2F5StVihD0exw2fsA" />
+    <meta name="google-analytics" content="UA-3769691-4" />
 
+    <meta content="collector.githubapp.com" name="octolytics-host" />
+    <meta content="gist" name="octolytics-app-id" />
+    <meta
+      content="https://collector.githubapp.com/github-external/browser_event"
+      name="octolytics-event-url"
+    />
+    <meta content="E20D:4B42:42318:74725:59A83272" name="octolytics-dimension-request_id" />
+    <meta content="iad" name="octolytics-dimension-region_edge" />
+    <meta content="iad" name="octolytics-dimension-region_render" />
+    <meta
+      content="/&lt;user-name&gt;/&lt;gist-id&gt;"
+      data-pjax-transient="true"
+      name="analytics-location"
+    />
 
+    <meta class="js-ga-set" name="dimension1" content="Logged Out" />
 
-    <meta content="true" name="octolytics-dimension-public"><meta content="76111202" name="octolytics-dimension-gist_id"><meta content="37c763ab7bc6cf89b919212ef3f10676" name="octolytics-dimension-gist_name"><meta content="false" name="octolytics-dimension-anonymous"><meta content="29081231" name="octolytics-dimension-owner_id"><meta content="yknl" name="octolytics-dimension-owner_login"><meta content="false" name="octolytics-dimension-forked">
+    <meta content="true" name="octolytics-dimension-public" />
+    <meta content="76111202" name="octolytics-dimension-gist_id" />
+    <meta content="37c763ab7bc6cf89b919212ef3f10676" name="octolytics-dimension-gist_name" />
+    <meta content="false" name="octolytics-dimension-anonymous" />
+    <meta content="29081231" name="octolytics-dimension-owner_id" />
+    <meta content="yknl" name="octolytics-dimension-owner_login" />
+    <meta content="false" name="octolytics-dimension-forked" />
 
-  <meta class="js-ga-set" name="dimension5" content="public">
-  <meta class="js-ga-set" name="dimension6" content="owned">
-  <meta class="js-ga-set" name="dimension7" content="unknown">
+    <meta class="js-ga-set" name="dimension5" content="public" />
+    <meta class="js-ga-set" name="dimension6" content="owned" />
+    <meta class="js-ga-set" name="dimension7" content="unknown" />
 
+    <meta name="hostname" content="gist.github.com" />
+    <meta name="user-login" content="" />
 
-      <meta name="hostname" content="gist.github.com">
-  <meta name="user-login" content="">
+    <meta name="expected-hostname" content="gist.github.com" />
+    <meta
+      name="js-proxy-site-detection-payload"
+      content="Y2IzNWU4YzUwZmFkN2Q1ZDJhNzAzY2RiZmU0YzAzOWY0ZWI1ZDNhZjQ4Njk1YTRmYjY0YTViODYxODExZDg2Nnx7InJlbW90ZV9hZGRyZXNzIjoiNjYuMTA4LjI0Mi4yMiIsInJlcXVlc3RfaWQiOiJFMjBEOjRCNDI6NDIzMTg6NzQ3MjU6NTlBODMyNzIiLCJ0aW1lc3RhbXAiOjE1MDQxOTUxODcsImhvc3QiOiJnaXRodWIuY29tIn0="
+    />
 
-      <meta name="expected-hostname" content="gist.github.com">
-    <meta name="js-proxy-site-detection-payload" content="Y2IzNWU4YzUwZmFkN2Q1ZDJhNzAzY2RiZmU0YzAzOWY0ZWI1ZDNhZjQ4Njk1YTRmYjY0YTViODYxODExZDg2Nnx7InJlbW90ZV9hZGRyZXNzIjoiNjYuMTA4LjI0Mi4yMiIsInJlcXVlc3RfaWQiOiJFMjBEOjRCNDI6NDIzMTg6NzQ3MjU6NTlBODMyNzIiLCJ0aW1lc3RhbXAiOjE1MDQxOTUxODcsImhvc3QiOiJnaXRodWIuY29tIn0=">
+    <meta name="html-safe-nonce" content="5d49a68ac634710d96f7767315769588bcab11f3" />
 
+    <meta http-equiv="x-pjax-version" content="6ce42d2e2fa6ec62762f8b0b7106bb52" />
 
-  <meta name="html-safe-nonce" content="5d49a68ac634710d96f7767315769588bcab11f3">
+    <link
+      href="https://gist.github.com/yknl.atom"
+      rel="alternate"
+      title="atom"
+      type="application/atom+xml"
+    />
 
-  <meta http-equiv="x-pjax-version" content="6ce42d2e2fa6ec62762f8b0b7106bb52">
-  
+    <link
+      crossorigin="anonymous"
+      href="./ken..verification.github_files/gist-a048a4bb52579456a311c5c5b5714d20a9f4e876138bdce7724e1a829cb48a82.css"
+      integrity="sha256-oEiku1JXlFajEcXFtXFNIKn06HYTi9znck4agpy0ioI="
+      media="all"
+      rel="stylesheet"
+    />
 
-      <link href="https://gist.github.com/yknl.atom" rel="alternate" title="atom" type="application/atom+xml">
-  
-  <link crossorigin="anonymous" href="./ken..verification.github_files/gist-a048a4bb52579456a311c5c5b5714d20a9f4e876138bdce7724e1a829cb48a82.css" integrity="sha256-oEiku1JXlFajEcXFtXFNIKn06HYTi9znck4agpy0ioI=" media="all" rel="stylesheet">
+    <meta name="browser-stats-url" content="https://api.github.com/_private/browser/stats" />
 
+    <meta name="browser-errors-url" content="https://api.github.com/_private/browser/errors" />
 
+    <link rel="mask-icon" href="https://assets-cdn.github.com/pinned-octocat.svg" color="#000000" />
+    <link rel="icon" type="image/x-icon" href="https://assets-cdn.github.com/favicon.ico" />
 
+    <meta name="theme-color" content="#1e2327" />
 
-  <meta name="browser-stats-url" content="https://api.github.com/_private/browser/stats">
-
-  <meta name="browser-errors-url" content="https://api.github.com/_private/browser/errors">
-
-  <link rel="mask-icon" href="https://assets-cdn.github.com/pinned-octocat.svg" color="#000000">
-  <link rel="icon" type="image/x-icon" href="https://assets-cdn.github.com/favicon.ico">
-
-<meta name="theme-color" content="#1e2327">
-
-
-  <meta name="u2f-support" content="true">
-
+    <meta name="u2f-support" content="true" />
   </head>
 
   <body class="logged-out env-production emoji-size-boost">
-    
+    <div class="position-relative js-header-wrapper">
+      <a
+        href="https://gist.github.com/yknl/37c763ab7bc6cf89b919212ef3f10676#start-of-content"
+        tabindex="1"
+        class="px-2 py-4 show-on-focus js-skip-to-content"
+        >Skip to content</a
+      >
+      <div id="js-pjax-loader-bar" class="pjax-loader-bar"><div class="progress"></div></div>
 
-  <div class="position-relative js-header-wrapper ">
-    <a href="https://gist.github.com/yknl/37c763ab7bc6cf89b919212ef3f10676#start-of-content" tabindex="1" class="px-2 py-4 show-on-focus js-skip-to-content">Skip to content</a>
-    <div id="js-pjax-loader-bar" class="pjax-loader-bar"><div class="progress"></div></div>
+      <div class="Header gist-header header-logged-out" role="banner">
+        <div class="container-lg px-3 clearfix">
+          <div class="d-flex flex-justify-between">
+            <div class="d-flex">
+              <a
+                href="https://gist.github.com/"
+                aria-label="Gist Homepage"
+                class="header-logo-wordmark"
+                data-hotkey="g d"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="octicon octicon-logo-github"
+                  height="28"
+                  version="1.1"
+                  viewBox="0 0 45 16"
+                  width="78"
+                >
+                  <path
+                    fill-rule="evenodd"
+                    d="M18.53 12.03h-.02c.009 0 .015.01.024.011h.006l-.01-.01zm.004.011c-.093.001-.327.05-.574.05-.78 0-1.05-.36-1.05-.83V8.13h1.59c.09 0 .16-.08.16-.19v-1.7c0-.09-.08-.17-.16-.17h-1.59V3.96c0-.08-.05-.13-.14-.13h-2.16c-.09 0-.14.05-.14.13v2.17s-1.09.27-1.16.28c-.08.02-.13.09-.13.17v1.36c0 .11.08.19.17.19h1.11v3.28c0 2.44 1.7 2.69 2.86 2.69.53 0 1.17-.17 1.27-.22.06-.02.09-.09.09-.16v-1.5a.177.177 0 0 0-.146-.18zm23.696-2.2c0-1.81-.73-2.05-1.5-1.97-.6.04-1.08.34-1.08.34v3.52s.49.34 1.22.36c1.03.03 1.36-.34 1.36-2.25zm2.43-.16c0 3.43-1.11 4.41-3.05 4.41-1.64 0-2.52-.83-2.52-.83s-.04.46-.09.52c-.03.06-.08.08-.14.08h-1.48c-.1 0-.19-.08-.19-.17l.02-11.11c0-.09.08-.17.17-.17h2.13c.09 0 .17.08.17.17v3.77s.82-.53 2.02-.53l-.01-.02c1.2 0 2.97.45 2.97 3.88zm-8.72-3.61H33.84c-.11 0-.17.08-.17.19v5.44s-.55.39-1.3.39-.97-.34-.97-1.09V6.25c0-.09-.08-.17-.17-.17h-2.14c-.09 0-.17.08-.17.17v5.11c0 2.2 1.23 2.75 2.92 2.75 1.39 0 2.52-.77 2.52-.77s.05.39.08.45c.02.05.09.09.16.09h1.34c.11 0 .17-.08.17-.17l.02-7.47c0-.09-.08-.17-.19-.17zm-23.7-.01h-2.13c-.09 0-.17.09-.17.2v7.34c0 .2.13.27.3.27h1.92c.2 0 .25-.09.25-.27V6.23c0-.09-.08-.17-.17-.17zm-1.05-3.38c-.77 0-1.38.61-1.38 1.38 0 .77.61 1.38 1.38 1.38.75 0 1.36-.61 1.36-1.38 0-.77-.61-1.38-1.36-1.38zm16.49-.25h-2.11c-.09 0-.17.08-.17.17v4.09h-3.31V2.6c0-.09-.08-.17-.17-.17h-2.13c-.09 0-.17.08-.17.17v11.11c0 .09.09.17.17.17h2.13c.09 0 .17-.08.17-.17V8.96h3.31l-.02 4.75c0 .09.08.17.17.17h2.13c.09 0 .17-.08.17-.17V2.6c0-.09-.08-.17-.17-.17zM8.81 7.35v5.74c0 .04-.01.11-.06.13 0 0-1.25.89-3.31.89-2.49 0-5.44-.78-5.44-5.92S2.58 1.99 5.1 2c2.18 0 3.06.49 3.2.58.04.05.06.09.06.14L7.94 4.5c0 .09-.09.2-.2.17-.36-.11-.9-.33-2.17-.33-1.47 0-3.05.42-3.05 3.73s1.5 3.7 2.58 3.7c.92 0 1.25-.11 1.25-.11v-2.3H4.88c-.11 0-.19-.08-.19-.17V7.35c0-.09.08-.17.19-.17h3.74c.11 0 .19.08.19.17z"
+                  ></path>
+                </svg>
+                <svg
+                  aria-hidden="true"
+                  class="octicon octicon-logo-gist"
+                  height="28"
+                  version="1.1"
+                  viewBox="0 0 25 16"
+                  width="40"
+                >
+                  <path
+                    fill-rule="evenodd"
+                    d="M4.7 8.73h2.45v4.02c-.55.27-1.64.34-2.53.34-2.56 0-3.47-2.2-3.47-5.05 0-2.85.91-5.06 3.48-5.06 1.28 0 2.06.23 3.28.73V2.66C7.27 2.33 6.25 2 4.63 2 1.13 2 0 4.69 0 8.03c0 3.34 1.11 6.03 4.63 6.03 1.64 0 2.81-.27 3.59-.64V7.73H4.7v1zm6.39 3.72V6.06h-1.05v6.28c0 1.25.58 1.72 1.72 1.72v-.89c-.48 0-.67-.16-.67-.7v-.02zm.25-8.72c0-.44-.33-.78-.78-.78s-.77.34-.77.78.33.78.77.78.78-.34.78-.78zm4.34 5.69c-1.5-.13-1.78-.48-1.78-1.17 0-.77.33-1.34 1.88-1.34 1.05 0 1.66.16 2.27.36v-.94c-.69-.3-1.52-.39-2.25-.39-2.2 0-2.92 1.2-2.92 2.31 0 1.08.47 1.88 2.73 2.08 1.55.13 1.77.63 1.77 1.34 0 .73-.44 1.42-2.06 1.42-1.11 0-1.86-.19-2.33-.36v.94c.5.2 1.58.39 2.33.39 2.38 0 3.14-1.2 3.14-2.41 0-1.28-.53-2.03-2.75-2.23h-.03zm8.58-2.47v-.86h-2.42v-2.5l-1.08.31v2.11l-1.56.44v.48h1.56v5c0 1.53 1.19 2.13 2.5 2.13.19 0 .52-.02.69-.05v-.89c-.19.03-.41.03-.61.03-.97 0-1.5-.39-1.5-1.34V6.94h2.42v.02-.01z"
+                  ></path>
+                </svg>
+              </a>
+              <div class="site-search js-site-search" role="search">
+                <div class="header-search" role="search">
+                  <!-- '"` --><!-- </textarea></xmp> -->
+                  <form
+                    accept-charset="UTF-8"
+                    action="https://gist.github.com/search"
+                    class="position-relative js-quicksearch-form"
+                    method="get"
+                  >
+                    <div style="margin: 0; padding: 0; display: inline">
+                      <input name="utf8" type="hidden" value="✓" />
+                    </div>
+                    <label class="header-search-wrapper form-control js-chromeless-input-container">
+                      <input
+                        type="text"
+                        class="form-control js-site-search-focus header-search-input"
+                        data-hotkey="s"
+                        name="q"
+                        placeholder="Search…"
+                        tabindex="1"
+                        autocorrect="off"
+                        autocomplete="off"
+                        autocapitalize="off"
+                      />
+                    </label>
+                  </form>
+                </div>
+              </div>
 
-    
-    
-    
+              <ul class="list-style-none d-flex flex-items-center text-bold pl-2" role="navigation">
+                <li>
+                  <a
+                    href="https://gist.github.com/discover"
+                    class="HeaderNavlink px-2"
+                    data-ga-click="Header, go to all gists, text:all gists"
+                    >All gists</a
+                  >
+                </li>
+                <li>
+                  <a
+                    href="https://github.com/"
+                    class="HeaderNavlink px-2"
+                    data-ga-click="Header, go to GitHub, text:GitHub"
+                    >GitHub</a
+                  >
+                </li>
+              </ul>
+            </div>
 
-
-
-        <div class="Header gist-header header-logged-out" role="banner">
-  <div class="container-lg px-3 clearfix">
-    <div class="d-flex flex-justify-between">
-      <div class="d-flex">
-        <a href="https://gist.github.com/" aria-label="Gist Homepage" class="header-logo-wordmark" data-hotkey="g d">
-          <svg aria-hidden="true" class="octicon octicon-logo-github" height="28" version="1.1" viewBox="0 0 45 16" width="78"><path fill-rule="evenodd" d="M18.53 12.03h-.02c.009 0 .015.01.024.011h.006l-.01-.01zm.004.011c-.093.001-.327.05-.574.05-.78 0-1.05-.36-1.05-.83V8.13h1.59c.09 0 .16-.08.16-.19v-1.7c0-.09-.08-.17-.16-.17h-1.59V3.96c0-.08-.05-.13-.14-.13h-2.16c-.09 0-.14.05-.14.13v2.17s-1.09.27-1.16.28c-.08.02-.13.09-.13.17v1.36c0 .11.08.19.17.19h1.11v3.28c0 2.44 1.7 2.69 2.86 2.69.53 0 1.17-.17 1.27-.22.06-.02.09-.09.09-.16v-1.5a.177.177 0 0 0-.146-.18zm23.696-2.2c0-1.81-.73-2.05-1.5-1.97-.6.04-1.08.34-1.08.34v3.52s.49.34 1.22.36c1.03.03 1.36-.34 1.36-2.25zm2.43-.16c0 3.43-1.11 4.41-3.05 4.41-1.64 0-2.52-.83-2.52-.83s-.04.46-.09.52c-.03.06-.08.08-.14.08h-1.48c-.1 0-.19-.08-.19-.17l.02-11.11c0-.09.08-.17.17-.17h2.13c.09 0 .17.08.17.17v3.77s.82-.53 2.02-.53l-.01-.02c1.2 0 2.97.45 2.97 3.88zm-8.72-3.61H33.84c-.11 0-.17.08-.17.19v5.44s-.55.39-1.3.39-.97-.34-.97-1.09V6.25c0-.09-.08-.17-.17-.17h-2.14c-.09 0-.17.08-.17.17v5.11c0 2.2 1.23 2.75 2.92 2.75 1.39 0 2.52-.77 2.52-.77s.05.39.08.45c.02.05.09.09.16.09h1.34c.11 0 .17-.08.17-.17l.02-7.47c0-.09-.08-.17-.19-.17zm-23.7-.01h-2.13c-.09 0-.17.09-.17.2v7.34c0 .2.13.27.3.27h1.92c.2 0 .25-.09.25-.27V6.23c0-.09-.08-.17-.17-.17zm-1.05-3.38c-.77 0-1.38.61-1.38 1.38 0 .77.61 1.38 1.38 1.38.75 0 1.36-.61 1.36-1.38 0-.77-.61-1.38-1.36-1.38zm16.49-.25h-2.11c-.09 0-.17.08-.17.17v4.09h-3.31V2.6c0-.09-.08-.17-.17-.17h-2.13c-.09 0-.17.08-.17.17v11.11c0 .09.09.17.17.17h2.13c.09 0 .17-.08.17-.17V8.96h3.31l-.02 4.75c0 .09.08.17.17.17h2.13c.09 0 .17-.08.17-.17V2.6c0-.09-.08-.17-.17-.17zM8.81 7.35v5.74c0 .04-.01.11-.06.13 0 0-1.25.89-3.31.89-2.49 0-5.44-.78-5.44-5.92S2.58 1.99 5.1 2c2.18 0 3.06.49 3.2.58.04.05.06.09.06.14L7.94 4.5c0 .09-.09.2-.2.17-.36-.11-.9-.33-2.17-.33-1.47 0-3.05.42-3.05 3.73s1.5 3.7 2.58 3.7c.92 0 1.25-.11 1.25-.11v-2.3H4.88c-.11 0-.19-.08-.19-.17V7.35c0-.09.08-.17.19-.17h3.74c.11 0 .19.08.19.17z"></path></svg>
-          <svg aria-hidden="true" class="octicon octicon-logo-gist" height="28" version="1.1" viewBox="0 0 25 16" width="40"><path fill-rule="evenodd" d="M4.7 8.73h2.45v4.02c-.55.27-1.64.34-2.53.34-2.56 0-3.47-2.2-3.47-5.05 0-2.85.91-5.06 3.48-5.06 1.28 0 2.06.23 3.28.73V2.66C7.27 2.33 6.25 2 4.63 2 1.13 2 0 4.69 0 8.03c0 3.34 1.11 6.03 4.63 6.03 1.64 0 2.81-.27 3.59-.64V7.73H4.7v1zm6.39 3.72V6.06h-1.05v6.28c0 1.25.58 1.72 1.72 1.72v-.89c-.48 0-.67-.16-.67-.7v-.02zm.25-8.72c0-.44-.33-.78-.78-.78s-.77.34-.77.78.33.78.77.78.78-.34.78-.78zm4.34 5.69c-1.5-.13-1.78-.48-1.78-1.17 0-.77.33-1.34 1.88-1.34 1.05 0 1.66.16 2.27.36v-.94c-.69-.3-1.52-.39-2.25-.39-2.2 0-2.92 1.2-2.92 2.31 0 1.08.47 1.88 2.73 2.08 1.55.13 1.77.63 1.77 1.34 0 .73-.44 1.42-2.06 1.42-1.11 0-1.86-.19-2.33-.36v.94c.5.2 1.58.39 2.33.39 2.38 0 3.14-1.2 3.14-2.41 0-1.28-.53-2.03-2.75-2.23h-.03zm8.58-2.47v-.86h-2.42v-2.5l-1.08.31v2.11l-1.56.44v.48h1.56v5c0 1.53 1.19 2.13 2.5 2.13.19 0 .52-.02.69-.05v-.89c-.19.03-.41.03-.61.03-.97 0-1.5-.39-1.5-1.34V6.94h2.42v.02-.01z"></path></svg>
-</a>
-        <div class="site-search js-site-search" role="search">
-            <div class="header-search" role="search">
-
-<!-- '"` --><!-- </textarea></xmp> --><form accept-charset="UTF-8" action="https://gist.github.com/search" class="position-relative js-quicksearch-form" method="get"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="✓"></div>
-  <label class="header-search-wrapper form-control js-chromeless-input-container">
-    <input type="text" class="form-control js-site-search-focus header-search-input" data-hotkey="s" name="q" placeholder="Search…" tabindex="1" autocorrect="off" autocomplete="off" autocapitalize="off">
-  </label>
-
-</form></div>
-
+            <div class="header-actions" role="navigation">
+              <a
+                href="https://gist.github.com/join?source=header-gist"
+                class="btn btn-primary"
+                data-ga-click="Header, sign up"
+                >Sign up for a GitHub account</a
+              >
+              <a
+                href="https://gist.github.com/auth/github?return_to=https%3A%2F%2Fgist.github.com%2Fyknl%2F37c763ab7bc6cf89b919212ef3f10676"
+                class="btn"
+                data-ga-click="Header, sign in"
+                >Sign in</a
+              >
+            </div>
+          </div>
         </div>
+      </div>
+    </div>
 
-        <ul class="list-style-none d-flex flex-items-center text-bold pl-2" role="navigation">
-          <li><a href="https://gist.github.com/discover" class="HeaderNavlink px-2" data-ga-click="Header, go to all gists, text:all gists">All gists</a></li>
-          <li><a href="https://github.com/" class="HeaderNavlink px-2" data-ga-click="Header, go to GitHub, text:GitHub">GitHub</a></li>
+    <div id="start-of-content" class="show-on-focus"></div>
+
+    <div id="js-flash-container"></div>
+
+    <div role="main">
+      <div itemscope="" itemtype="http://schema.org/Code">
+        <div id="gist-pjax-container" class="gist-content-wrapper" data-pjax-container="">
+          <div class="gist-detail-intro gist-banner">
+            <div class="container">
+              <a href="https://gist.github.com/" class="btn btn-outline float-right"
+                >Create a gist now</a
+              >
+              <p class="lead">Instantly share code, notes, and snippets.</p>
+            </div>
+          </div>
+
+          <div
+            class="gisthead pagehead repohead instapaper_ignore readability-menu experiment-repo-nav mb-4"
+          >
+            <div class="container">
+              <div class="container repohead-details-container">
+                <ul class="pagehead-actions">
+                  <li>
+                    <a
+                      href="https://gist.github.com/login?return_to=https%3A%2F%2Fgist.github.com%2Fyknl%2F37c763ab7bc6cf89b919212ef3f10676"
+                      aria-label="You must be signed in to star a gist"
+                      class="btn btn-sm btn-with-count tooltipped tooltipped-n"
+                      rel="nofollow"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="octicon octicon-star"
+                        height="16"
+                        version="1.1"
+                        viewBox="0 0 14 16"
+                        width="14"
+                      >
+                        <path
+                          fill-rule="evenodd"
+                          d="M14 6l-4.9-.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14 7 11.67 11.33 14l-.93-4.74z"
+                        ></path>
+                      </svg>
+                      Star
+                    </a>
+                    <a
+                      href="https://gist.github.com/yknl/37c763ab7bc6cf89b919212ef3f10676/stargazers"
+                      aria-label="0 users starred this gist"
+                      class="social-count"
+                    >
+                      0
+                    </a>
+                  </li>
+
+                  <li>
+                    <a
+                      href="https://gist.github.com/login?return_to=https%3A%2F%2Fgist.github.com%2Fyknl%2F37c763ab7bc6cf89b919212ef3f10676"
+                      aria-label="You must be signed in to fork a gist"
+                      class="btn btn-sm btn-with-count tooltipped tooltipped-n"
+                      rel="nofollow"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="octicon octicon-repo-forked"
+                        height="16"
+                        version="1.1"
+                        viewBox="0 0 10 16"
+                        width="10"
+                      >
+                        <path
+                          fill-rule="evenodd"
+                          d="M8 1a1.993 1.993 0 0 0-1 3.72V6L5 8 3 6V4.72A1.993 1.993 0 0 0 2 1a1.993 1.993 0 0 0-1 3.72V6.5l3 3v1.78A1.993 1.993 0 0 0 5 15a1.993 1.993 0 0 0 1-3.72V9.5l3-3V4.72A1.993 1.993 0 0 0 8 1zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3 10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3-10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"
+                        ></path>
+                      </svg>
+                      Fork
+                    </a>
+                    <a
+                      href="https://gist.github.com/yknl/37c763ab7bc6cf89b919212ef3f10676/forks"
+                      aria-label="0 users forked this gist"
+                      class="social-count"
+                    >
+                      0
+                    </a>
+                  </li>
+                </ul>
+
+                <h1 class="public css-truncate">
+                  <img
+                    alt="@yknl"
+                    class="avatar gist-avatar"
+                    height="26"
+                    src="./ken..verification.github_files/29081231"
+                    width="26"
+                  />
+                  <span class="author"
+                    ><a href="https://gist.github.com/yknl" class="url fn" rel="author"
+                      ><span itemprop="author">yknl</span></a
+                    ></span
+                  ><!--
+        --><span class="path-divider">/</span
+                  ><!--
+        --><strong itemprop="name" class="gist-header-title css-truncate-target"
+                    ><a href="https://gist.github.com/yknl/37c763ab7bc6cf89b919212ef3f10676"
+                      >Verify</a
+                    ></strong
+                  >
+
+                  <div class="d-block text-small text-gray">
+                    Created
+                    <time-ago datetime="2017-08-31T15:56:14Z" title="Aug 31, 2017, 11:56 AM EDT"
+                      >4 minutes ago</time-ago
+                    >
+                  </div>
+                </h1>
+              </div>
+
+              <div class="container gist-file-navigation">
+                <div class="float-right file-navigation-options" data-multiple="">
+                  <div class="file-navigation-option">
+                    <input type="hidden" name="protocol_type" value="clone" />
+
+                    <div class="select-menu js-menu-container js-select-menu">
+                      <div class="input-group js-select-button js-zeroclipboard-container">
+                        <div class="input-group-button">
+                          <button
+                            type="button"
+                            class="btn btn-sm select-menu-button js-menu-target"
+                            data-ga-click="Repository, clone Embed, location:repo overview"
+                            aria-expanded="false"
+                            aria-haspopup="true"
+                          >
+                            Embed
+                          </button>
+                        </div>
+                        <input
+                          type="text"
+                          class="form-control input-monospace input-sm js-zeroclipboard-target js-url-field"
+                          value='&lt;script src="https://gist.github.com/yknl/37c763ab7bc6cf89b919212ef3f10676.js"&gt;&lt;/script&gt;'
+                          aria-label='Clone this repository at &lt;script src="https://gist.github.com/yknl/37c763ab7bc6cf89b919212ef3f10676.js"&gt;&lt;/script&gt;'
+                          readonly=""
+                        />
+                        <div class="input-group-button">
+                          <button
+                            aria-label="Copy to clipboard"
+                            class="js-zeroclipboard btn btn-sm zeroclipboard-button tooltipped tooltipped-s"
+                            data-copied-hint="Copied!"
+                            type="button"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="octicon octicon-clippy"
+                              height="16"
+                              version="1.1"
+                              viewBox="0 0 14 16"
+                              width="14"
+                            >
+                              <path
+                                fill-rule="evenodd"
+                                d="M2 13h4v1H2v-1zm5-6H2v1h5V7zm2 3V8l-3 3 3 3v-2h5v-2H9zM4.5 9H2v1h2.5V9zM2 12h2.5v-1H2v1zm9 1h1v2c-.02.28-.11.52-.3.7-.19.18-.42.28-.7.3H1c-.55 0-1-.45-1-1V4c0-.55.45-1 1-1h3c0-1.11.89-2 2-2 1.11 0 2 .89 2 2h3c.55 0 1 .45 1 1v5h-1V6H1v9h10v-2zM2 5h8c0-.55-.45-1-1-1H8c-.55 0-1-.45-1-1s-.45-1-1-1-1 .45-1 1-.45 1-1 1H3c-.55 0-1 .45-1 1z"
+                              ></path>
+                            </svg>
+                          </button>
+                        </div>
+                      </div>
+
+                      <div class="select-menu-modal-holder">
+                        <div class="select-menu-modal js-menu-content">
+                          <div class="select-menu-header">
+                            <svg
+                              aria-label="Close"
+                              class="octicon octicon-x js-menu-close"
+                              height="16"
+                              role="img"
+                              version="1.1"
+                              viewBox="0 0 12 16"
+                              width="12"
+                            >
+                              <path
+                                fill-rule="evenodd"
+                                d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48z"
+                              ></path>
+                            </svg>
+                            <span class="select-menu-title">What would you like to do?</span>
+                          </div>
+
+                          <div class="select-menu-list js-navigation-container" role="menu">
+                            <div
+                              class="select-menu-item js-navigation-item selected"
+                              role="menuitem"
+                              tabindex="0"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="octicon octicon-check select-menu-item-icon"
+                                height="16"
+                                version="1.1"
+                                viewBox="0 0 12 16"
+                                width="12"
+                              >
+                                <path
+                                  fill-rule="evenodd"
+                                  d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5z"
+                                ></path>
+                              </svg>
+                              <div class="select-menu-item-text">
+                                <input
+                                  type="radio"
+                                  name="protocol_selector"
+                                  value="embed"
+                                  checked=""
+                                />
+                                <span class="select-menu-item-heading"> Embed </span>
+                                <span class="description"> Embed this gist in your website. </span>
+                                <span class="js-select-button-text hidden-select-button-text">
+                                  <div class="input-group-button">
+                                    <button
+                                      type="button"
+                                      class="btn btn-sm select-menu-button js-menu-target"
+                                      data-ga-click="Repository, clone Embed, location:repo overview"
+                                      aria-expanded="false"
+                                      aria-haspopup="true"
+                                    >
+                                      Embed
+                                    </button>
+                                  </div>
+                                  <input
+                                    type="text"
+                                    class="form-control input-monospace input-sm js-zeroclipboard-target js-url-field"
+                                    value='&lt;script src="https://gist.github.com/yknl/37c763ab7bc6cf89b919212ef3f10676.js"&gt;&lt;/script&gt;'
+                                    aria-label='Clone this repository at &lt;script src="https://gist.github.com/yknl/37c763ab7bc6cf89b919212ef3f10676.js"&gt;&lt;/script&gt;'
+                                    readonly=""
+                                  />
+                                  <div class="input-group-button">
+                                    <button
+                                      aria-label="Copy to clipboard"
+                                      class="js-zeroclipboard btn btn-sm zeroclipboard-button tooltipped tooltipped-s"
+                                      data-copied-hint="Copied!"
+                                      type="button"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="octicon octicon-clippy"
+                                        height="16"
+                                        version="1.1"
+                                        viewBox="0 0 14 16"
+                                        width="14"
+                                      >
+                                        <path
+                                          fill-rule="evenodd"
+                                          d="M2 13h4v1H2v-1zm5-6H2v1h5V7zm2 3V8l-3 3 3 3v-2h5v-2H9zM4.5 9H2v1h2.5V9zM2 12h2.5v-1H2v1zm9 1h1v2c-.02.28-.11.52-.3.7-.19.18-.42.28-.7.3H1c-.55 0-1-.45-1-1V4c0-.55.45-1 1-1h3c0-1.11.89-2 2-2 1.11 0 2 .89 2 2h3c.55 0 1 .45 1 1v5h-1V6H1v9h10v-2zM2 5h8c0-.55-.45-1-1-1H8c-.55 0-1-.45-1-1s-.45-1-1-1-1 .45-1 1-.45 1-1 1H3c-.55 0-1 .45-1 1z"
+                                        ></path>
+                                      </svg>
+                                    </button>
+                                  </div>
+                                </span>
+                              </div>
+                            </div>
+                            <div
+                              class="select-menu-item js-navigation-item"
+                              role="menuitem"
+                              tabindex="0"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="octicon octicon-check select-menu-item-icon"
+                                height="16"
+                                version="1.1"
+                                viewBox="0 0 12 16"
+                                width="12"
+                              >
+                                <path
+                                  fill-rule="evenodd"
+                                  d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5z"
+                                ></path>
+                              </svg>
+                              <div class="select-menu-item-text">
+                                <input type="radio" name="protocol_selector" value="share" />
+                                <span class="select-menu-item-heading"> Share </span>
+                                <span class="description"> Copy sharable URL for this gist. </span>
+                                <span class="js-select-button-text hidden-select-button-text">
+                                  <div class="input-group-button">
+                                    <button
+                                      type="button"
+                                      class="btn btn-sm select-menu-button js-menu-target"
+                                      data-ga-click="Repository, clone Share, location:repo overview"
+                                      aria-expanded="false"
+                                      aria-haspopup="true"
+                                    >
+                                      Share
+                                    </button>
+                                  </div>
+                                  <input
+                                    type="text"
+                                    class="form-control input-monospace input-sm js-zeroclipboard-target js-url-field"
+                                    value="https://gist.github.com/yknl/37c763ab7bc6cf89b919212ef3f10676"
+                                    aria-label="Clone this repository at https://gist.github.com/yknl/37c763ab7bc6cf89b919212ef3f10676"
+                                    readonly=""
+                                  />
+                                  <div class="input-group-button">
+                                    <button
+                                      aria-label="Copy to clipboard"
+                                      class="js-zeroclipboard btn btn-sm zeroclipboard-button tooltipped tooltipped-s"
+                                      data-copied-hint="Copied!"
+                                      type="button"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="octicon octicon-clippy"
+                                        height="16"
+                                        version="1.1"
+                                        viewBox="0 0 14 16"
+                                        width="14"
+                                      >
+                                        <path
+                                          fill-rule="evenodd"
+                                          d="M2 13h4v1H2v-1zm5-6H2v1h5V7zm2 3V8l-3 3 3 3v-2h5v-2H9zM4.5 9H2v1h2.5V9zM2 12h2.5v-1H2v1zm9 1h1v2c-.02.28-.11.52-.3.7-.19.18-.42.28-.7.3H1c-.55 0-1-.45-1-1V4c0-.55.45-1 1-1h3c0-1.11.89-2 2-2 1.11 0 2 .89 2 2h3c.55 0 1 .45 1 1v5h-1V6H1v9h10v-2zM2 5h8c0-.55-.45-1-1-1H8c-.55 0-1-.45-1-1s-.45-1-1-1-1 .45-1 1-.45 1-1 1H3c-.55 0-1 .45-1 1z"
+                                        ></path>
+                                      </svg>
+                                    </button>
+                                  </div>
+                                </span>
+                              </div>
+                            </div>
+                            <div
+                              class="select-menu-item js-navigation-item"
+                              role="menuitem"
+                              tabindex="0"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="octicon octicon-check select-menu-item-icon"
+                                height="16"
+                                version="1.1"
+                                viewBox="0 0 12 16"
+                                width="12"
+                              >
+                                <path
+                                  fill-rule="evenodd"
+                                  d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5z"
+                                ></path>
+                              </svg>
+                              <div class="select-menu-item-text">
+                                <input type="radio" name="protocol_selector" value="http" />
+                                <span class="select-menu-item-heading"> Clone via HTTPS </span>
+                                <span class="description">
+                                  Clone with Git or checkout with SVN using the repository's web
+                                  address.
+                                </span>
+                                <span class="js-select-button-text hidden-select-button-text">
+                                  <div class="input-group-button">
+                                    <button
+                                      type="button"
+                                      class="btn btn-sm select-menu-button js-menu-target"
+                                      data-ga-click="Repository, clone HTTPS, location:repo overview"
+                                      aria-expanded="false"
+                                      aria-haspopup="true"
+                                    >
+                                      HTTPS
+                                    </button>
+                                  </div>
+                                  <input
+                                    type="text"
+                                    class="form-control input-monospace input-sm js-zeroclipboard-target js-url-field"
+                                    value="https://gist.github.com/37c763ab7bc6cf89b919212ef3f10676.git"
+                                    aria-label="Clone this repository at https://gist.github.com/37c763ab7bc6cf89b919212ef3f10676.git"
+                                    readonly=""
+                                  />
+                                  <div class="input-group-button">
+                                    <button
+                                      aria-label="Copy to clipboard"
+                                      class="js-zeroclipboard btn btn-sm zeroclipboard-button tooltipped tooltipped-s"
+                                      data-copied-hint="Copied!"
+                                      type="button"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="octicon octicon-clippy"
+                                        height="16"
+                                        version="1.1"
+                                        viewBox="0 0 14 16"
+                                        width="14"
+                                      >
+                                        <path
+                                          fill-rule="evenodd"
+                                          d="M2 13h4v1H2v-1zm5-6H2v1h5V7zm2 3V8l-3 3 3 3v-2h5v-2H9zM4.5 9H2v1h2.5V9zM2 12h2.5v-1H2v1zm9 1h1v2c-.02.28-.11.52-.3.7-.19.18-.42.28-.7.3H1c-.55 0-1-.45-1-1V4c0-.55.45-1 1-1h3c0-1.11.89-2 2-2 1.11 0 2 .89 2 2h3c.55 0 1 .45 1 1v5h-1V6H1v9h10v-2zM2 5h8c0-.55-.45-1-1-1H8c-.55 0-1-.45-1-1s-.45-1-1-1-1 .45-1 1-.45 1-1 1H3c-.55 0-1 .45-1 1z"
+                                        ></path>
+                                      </svg>
+                                    </button>
+                                  </div>
+                                </span>
+                              </div>
+                            </div>
+                          </div>
+                          <div class="select-menu-list" role="menu">
+                            <a
+                              class="select-menu-item select-menu-action"
+                              href="https://help.github.com/articles/which-remote-url-should-i-use"
+                              target="_blank"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="octicon octicon-question select-menu-item-icon"
+                                height="16"
+                                version="1.1"
+                                viewBox="0 0 14 16"
+                                width="14"
+                              >
+                                <path
+                                  fill-rule="evenodd"
+                                  d="M6 10h2v2H6v-2zm4-3.5C10 8.64 8 9 8 9H6c0-.55.45-1 1-1h.5c.28 0 .5-.22.5-.5v-1c0-.28-.22-.5-.5-.5h-1c-.28 0-.5.22-.5.5V7H4c0-1.5 1.5-3 3-3s3 1 3 2.5zM7 2.3c3.14 0 5.7 2.56 5.7 5.7s-2.56 5.7-5.7 5.7A5.71 5.71 0 0 1 1.3 8c0-3.14 2.56-5.7 5.7-5.7zM7 1C3.14 1 0 4.14 0 8s3.14 7 7 7 7-3.14 7-7-3.14-7-7-7z"
+                                ></path>
+                              </svg>
+                              <div class="select-menu-item-text">Learn more about clone URLs</div>
+                            </a>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div class="file-navigation-option">
+                    <a
+                      href="https://desktop.github.com/"
+                      class="btn btn-sm tooltipped tooltipped-s tooltipped-multiline"
+                      aria-label="Save yknl/37c763ab7bc6cf89b919212ef3f10676 to your computer and use it in GitHub Desktop."
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="octicon octicon-desktop-download"
+                        height="16"
+                        version="1.1"
+                        viewBox="0 0 16 16"
+                        width="16"
+                      >
+                        <path
+                          fill-rule="evenodd"
+                          d="M4 6h3V0h2v6h3l-4 4-4-4zm11-4h-4v1h4v8H1V3h4V2H1c-.55 0-1 .45-1 1v9c0 .55.45 1 1 1h5.34c-.25.61-.86 1.39-2.34 2h8c-1.48-.61-2.09-1.39-2.34-2H15c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1z"
+                        ></path>
+                      </svg>
+                    </a>
+                  </div>
+
+                  <div class="file-navigation-option">
+                    <a
+                      href="https://gist.github.com/yknl/37c763ab7bc6cf89b919212ef3f10676/archive/8454aaecf3476ec145153edfb29180413fa89e39.zip"
+                      class="btn btn-sm"
+                      rel="nofollow"
+                      data-ga-click="Gist, download zip, location:gist overview"
+                    >
+                      Download ZIP
+                    </a>
+                  </div>
+                </div>
+
+                <div class="float-left">
+                  <nav
+                    class="reponav js-repo-nav js-sidenav-container-pjax"
+                    role="navigation"
+                    data-pjax="#gist-pjax-container"
+                  >
+                    <a
+                      href="https://gist.github.com/yknl/37c763ab7bc6cf89b919212ef3f10676"
+                      aria-label="Code"
+                      class="js-selected-navigation-item selected reponav-item"
+                      data-hotkey="g c"
+                      data-pjax="true"
+                      data-selected-links="gist_code /yknl/37c763ab7bc6cf89b919212ef3f10676"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="octicon octicon-code"
+                        height="16"
+                        version="1.1"
+                        viewBox="0 0 14 16"
+                        width="14"
+                      >
+                        <path
+                          fill-rule="evenodd"
+                          d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"
+                        ></path>
+                      </svg>
+                      Code
+                    </a>
+                    <a
+                      href="https://gist.github.com/yknl/37c763ab7bc6cf89b919212ef3f10676/revisions"
+                      aria-label="Revisions"
+                      class="js-selected-navigation-item reponav-item"
+                      data-hotkey="g r"
+                      data-pjax="true"
+                      data-selected-links="gist_revisions /yknl/37c763ab7bc6cf89b919212ef3f10676/revisions"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="octicon octicon-git-commit"
+                        height="16"
+                        version="1.1"
+                        viewBox="0 0 14 16"
+                        width="14"
+                      >
+                        <path
+                          fill-rule="evenodd"
+                          d="M10.86 7c-.45-1.72-2-3-3.86-3-1.86 0-3.41 1.28-3.86 3H0v2h3.14c.45 1.72 2 3 3.86 3 1.86 0 3.41-1.28 3.86-3H14V7h-3.14zM7 10.2c-1.22 0-2.2-.98-2.2-2.2 0-1.22.98-2.2 2.2-2.2 1.22 0 2.2.98 2.2 2.2 0 1.22-.98 2.2-2.2 2.2z"
+                        ></path>
+                      </svg>
+                      Revisions
+                      <span class="Counter">1</span>
+                    </a>
+                  </nav>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="container new-discussion-timeline experiment-repo-nav">
+            <div class="repository-content gist-content">
+              <div>
+                <div class="repository-meta js-details-container Details"></div>
+
+                <div class="js-gist-file-update-container js-task-list-container file-box">
+                  <div id="file-verify" class="file">
+                    <div class="file-header">
+                      <div class="file-actions">
+                        <a
+                          href="https://gist.github.com/yknl/37c763ab7bc6cf89b919212ef3f10676/raw/8454aaecf3476ec145153edfb29180413fa89e39/Verify"
+                          class="btn btn-sm"
+                          >Raw</a
+                        >
+                      </div>
+                      <div class="file-info">
+                        <span class="icon">
+                          <svg
+                            aria-hidden="true"
+                            class="octicon octicon-gist"
+                            height="16"
+                            version="1.1"
+                            viewBox="0 0 12 16"
+                            width="12"
+                          >
+                            <path
+                              fill-rule="evenodd"
+                              d="M7.5 5L10 7.5 7.5 10l-.75-.75L8.5 7.5 6.75 5.75 7.5 5zm-3 0L2 7.5 4.5 10l.75-.75L3.5 7.5l1.75-1.75L4.5 5zM0 13V2c0-.55.45-1 1-1h10c.55 0 1 .45 1 1v11c0 .55-.45 1-1 1H1c-.55 0-1-.45-1-1zm1 0h10V2H1v11z"
+                            ></path>
+                          </svg>
+                        </span>
+                        <a
+                          class="tooltipped tooltipped-s css-truncate"
+                          aria-label="Permalink"
+                          href="https://gist.github.com/yknl/37c763ab7bc6cf89b919212ef3f10676#file-verify"
+                        >
+                          <strong class="user-select-contain gist-blob-name css-truncate-target">
+                            Verify
+                          </strong>
+                        </a>
+                      </div>
+                    </div>
+
+                    <div itemprop="text" class="blob-wrapper data type-text">
+                      <table class="highlight tab-size js-file-line-container" data-tab-size="8">
+                        <tbody>
+                          <tr>
+                            <td
+                              id="file-verify-L1"
+                              class="blob-num js-line-number"
+                              data-line-number="1"
+                            ></td>
+                            <td id="file-verify-LC1" class="blob-code blob-code-inner js-file-line">
+                              Verifying my Blockstack ID is secured with the address
+                              1AtFqXxcckuoEN4iMNNe7n83c5nugxpzb5
+                            </td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                </div>
+
+                <a name="comments"></a>
+                <div
+                  class="discussion-timeline gist-discussion-timeline js-quote-selection-container"
+                >
+                  <div
+                    class="js-discussion js-socket-channel"
+                    data-channel="marked-as-read:gist:76111202"
+                  >
+                    <!-- Rendered timeline since 2017-08-31 08:56:15 -->
+                    <div
+                      id="partial-timeline-marker"
+                      class="js-timeline-marker js-updatable-content"
+                      data-url="/yknl/37c763ab7bc6cf89b919212ef3f10676/show_partial?partial=gist%2Ftimeline_marker&amp;since=1504194975"
+                      data-last-modified="Thu, 31 Aug 2017 15:56:15 GMT"
+                    ></div>
+
+                    <div class="discussion-timeline-actions">
+                      <div class="flash flash-warn mt-3">
+                        <a
+                          href="https://gist.github.com/join?source=comment-gist"
+                          class="btn btn-primary"
+                          rel="nofollow"
+                          >Sign up for free</a
+                        >
+                        <strong>to join this conversation on GitHub</strong>. Already have an
+                        account?
+                        <a
+                          href="https://gist.github.com/login?return_to=https%3A%2F%2Fgist.github.com%2Fyknl%2F37c763ab7bc6cf89b919212ef3f10676"
+                          rel="nofollow"
+                          >Sign in to comment</a
+                        >
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="modal-backdrop js-touch-events"></div>
+          </div>
+          <!-- /.container -->
+        </div>
+      </div>
+    </div>
+
+    <div class="footer container-lg px-3" role="contentinfo">
+      <div
+        class="position-relative d-flex flex-justify-between py-6 mt-6 f6 text-gray border-top border-gray-light"
+      >
+        <ul class="list-style-none d-flex flex-wrap">
+          <li class="mr-3">
+            © 2017 <span title="0.25380s from unicorn-1994362637-5xd1h">GitHub</span>, Inc.
+          </li>
+          <li class="mr-3">
+            <a href="https://github.com/site/terms" data-ga-click="Footer, go to terms, text:terms"
+              >Terms</a
+            >
+          </li>
+          <li class="mr-3">
+            <a
+              href="https://github.com/site/privacy"
+              data-ga-click="Footer, go to privacy, text:privacy"
+              >Privacy</a
+            >
+          </li>
+          <li class="mr-3">
+            <a
+              href="https://github.com/security"
+              data-ga-click="Footer, go to security, text:security"
+              >Security</a
+            >
+          </li>
+          <li class="mr-3">
+            <a href="https://status.github.com/" data-ga-click="Footer, go to status, text:status"
+              >Status</a
+            >
+          </li>
+          <li>
+            <a href="https://help.github.com/" data-ga-click="Footer, go to help, text:help"
+              >Help</a
+            >
+          </li>
+        </ul>
+
+        <a href="https://github.com/" aria-label="Homepage" class="footer-octicon" title="GitHub">
+          <svg
+            aria-hidden="true"
+            class="octicon octicon-mark-github"
+            height="24"
+            version="1.1"
+            viewBox="0 0 16 16"
+            width="24"
+          >
+            <path
+              fill-rule="evenodd"
+              d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"
+            ></path>
+          </svg>
+        </a>
+        <ul class="list-style-none d-flex flex-wrap">
+          <li class="mr-3">
+            <a href="https://github.com/contact" data-ga-click="Footer, go to contact, text:contact"
+              >Contact GitHub</a
+            >
+          </li>
+          <li class="mr-3">
+            <a href="https://developer.github.com/" data-ga-click="Footer, go to api, text:api"
+              >API</a
+            >
+          </li>
+          <li class="mr-3">
+            <a
+              href="https://training.github.com/"
+              data-ga-click="Footer, go to training, text:training"
+              >Training</a
+            >
+          </li>
+          <li class="mr-3">
+            <a href="https://shop.github.com/" data-ga-click="Footer, go to shop, text:shop"
+              >Shop</a
+            >
+          </li>
+          <li class="mr-3">
+            <a href="https://github.com/blog" data-ga-click="Footer, go to blog, text:blog">Blog</a>
+          </li>
+          <li>
+            <a href="https://github.com/about" data-ga-click="Footer, go to about, text:about"
+              >About</a
+            >
+          </li>
         </ul>
       </div>
-
-        <div class="header-actions" role="navigation">
-            <a href="https://gist.github.com/join?source=header-gist" class="btn btn-primary" data-ga-click="Header, sign up">Sign up for a GitHub account</a>
-          <a href="https://gist.github.com/auth/github?return_to=https%3A%2F%2Fgist.github.com%2Fyknl%2F37c763ab7bc6cf89b919212ef3f10676" class="btn" data-ga-click="Header, sign in">Sign in</a>
-        </div>
-    </div>
-  </div>
-</div>
-
-
-
-  </div>
-
-  <div id="start-of-content" class="show-on-focus"></div>
-
-    <div id="js-flash-container">
-</div>
-
-
-
-  <div role="main">
-        <div itemscope="" itemtype="http://schema.org/Code">
-    <div id="gist-pjax-container" class="gist-content-wrapper" data-pjax-container="">
-      
-
-
-  <div class="gist-detail-intro gist-banner">
-    <div class="container">
-      <a href="https://gist.github.com/" class="btn btn-outline float-right">Create a gist now</a>
-      <p class="lead">
-        Instantly share code, notes, and snippets.
-      </p>
-    </div>
-  </div>
-
-
-<div class="gisthead pagehead repohead instapaper_ignore readability-menu experiment-repo-nav mb-4">
-  <div class="container">
-    
-  
-<div class="container repohead-details-container">
-
-  <ul class="pagehead-actions">
-
-
-    <li>
-        <a href="https://gist.github.com/login?return_to=https%3A%2F%2Fgist.github.com%2Fyknl%2F37c763ab7bc6cf89b919212ef3f10676" aria-label="You must be signed in to star a gist" class="btn btn-sm btn-with-count tooltipped tooltipped-n" rel="nofollow">
-    <svg aria-hidden="true" class="octicon octicon-star" height="16" version="1.1" viewBox="0 0 14 16" width="14"><path fill-rule="evenodd" d="M14 6l-4.9-.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14 7 11.67 11.33 14l-.93-4.74z"></path></svg>
-    Star
-</a>
-  <a href="https://gist.github.com/yknl/37c763ab7bc6cf89b919212ef3f10676/stargazers" aria-label="0 users starred this gist" class="social-count">
-    0
-</a>
-    </li>
-
-      <li>
-          <a href="https://gist.github.com/login?return_to=https%3A%2F%2Fgist.github.com%2Fyknl%2F37c763ab7bc6cf89b919212ef3f10676" aria-label="You must be signed in to fork a gist" class="btn btn-sm btn-with-count tooltipped tooltipped-n" rel="nofollow">
-    <svg aria-hidden="true" class="octicon octicon-repo-forked" height="16" version="1.1" viewBox="0 0 10 16" width="10"><path fill-rule="evenodd" d="M8 1a1.993 1.993 0 0 0-1 3.72V6L5 8 3 6V4.72A1.993 1.993 0 0 0 2 1a1.993 1.993 0 0 0-1 3.72V6.5l3 3v1.78A1.993 1.993 0 0 0 5 15a1.993 1.993 0 0 0 1-3.72V9.5l3-3V4.72A1.993 1.993 0 0 0 8 1zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3 10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3-10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"></path></svg>
-    Fork
-</a>
-  <a href="https://gist.github.com/yknl/37c763ab7bc6cf89b919212ef3f10676/forks" aria-label="0 users forked this gist" class="social-count">
-    0
-</a>
-      </li>
-  </ul>
-
-  <h1 class="public css-truncate">
-    <img alt="@yknl" class="avatar gist-avatar" height="26" src="./ken..verification.github_files/29081231" width="26">
-    <span class="author"><a href="https://gist.github.com/yknl" class="url fn" rel="author"><span itemprop="author">yknl</span></a></span><!--
-        --><span class="path-divider">/</span><!--
-        --><strong itemprop="name" class="gist-header-title css-truncate-target"><a href="https://gist.github.com/yknl/37c763ab7bc6cf89b919212ef3f10676">Verify</a></strong>
-
-    <div class="d-block text-small text-gray">
-      Created <time-ago datetime="2017-08-31T15:56:14Z" title="Aug 31, 2017, 11:56 AM EDT">4 minutes ago</time-ago>
-    </div>
-  </h1>
-</div>
-
-<div class="container gist-file-navigation">
-  <div class="float-right file-navigation-options" data-multiple="">
-
-    <div class="file-navigation-option">
-  <input type="hidden" name="protocol_type" value="clone">
-
-  <div class="select-menu js-menu-container js-select-menu">
-    <div class="input-group js-select-button js-zeroclipboard-container">
-      <div class="input-group-button">
-  <button type="button" class="btn btn-sm select-menu-button js-menu-target" data-ga-click="Repository, clone Embed, location:repo overview" aria-expanded="false" aria-haspopup="true">
-    Embed
-  </button>
-</div>
-<input type="text" class="form-control input-monospace input-sm js-zeroclipboard-target js-url-field" value="&lt;script src=&quot;https://gist.github.com/yknl/37c763ab7bc6cf89b919212ef3f10676.js&quot;&gt;&lt;/script&gt;" aria-label="Clone this repository at &lt;script src=&quot;https://gist.github.com/yknl/37c763ab7bc6cf89b919212ef3f10676.js&quot;&gt;&lt;/script&gt;" readonly="">
-<div class="input-group-button">
-  <button aria-label="Copy to clipboard" class="js-zeroclipboard btn btn-sm zeroclipboard-button tooltipped tooltipped-s" data-copied-hint="Copied!" type="button"><svg aria-hidden="true" class="octicon octicon-clippy" height="16" version="1.1" viewBox="0 0 14 16" width="14"><path fill-rule="evenodd" d="M2 13h4v1H2v-1zm5-6H2v1h5V7zm2 3V8l-3 3 3 3v-2h5v-2H9zM4.5 9H2v1h2.5V9zM2 12h2.5v-1H2v1zm9 1h1v2c-.02.28-.11.52-.3.7-.19.18-.42.28-.7.3H1c-.55 0-1-.45-1-1V4c0-.55.45-1 1-1h3c0-1.11.89-2 2-2 1.11 0 2 .89 2 2h3c.55 0 1 .45 1 1v5h-1V6H1v9h10v-2zM2 5h8c0-.55-.45-1-1-1H8c-.55 0-1-.45-1-1s-.45-1-1-1-1 .45-1 1-.45 1-1 1H3c-.55 0-1 .45-1 1z"></path></svg></button>
-</div>
-
     </div>
 
-    <div class="select-menu-modal-holder">
-      <div class="select-menu-modal js-menu-content">
-        <div class="select-menu-header">
-          <svg aria-label="Close" class="octicon octicon-x js-menu-close" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48z"></path></svg>
-          <span class="select-menu-title">What would you like to do?</span>
-        </div>
+    <div id="ajax-error-message" class="ajax-error-message flash flash-error">
+      <svg
+        aria-hidden="true"
+        class="octicon octicon-alert"
+        height="16"
+        version="1.1"
+        viewBox="0 0 16 16"
+        width="16"
+      >
+        <path
+          fill-rule="evenodd"
+          d="M8.865 1.52c-.18-.31-.51-.5-.87-.5s-.69.19-.87.5L.275 13.5c-.18.31-.18.69 0 1 .19.31.52.5.87.5h13.7c.36 0 .69-.19.86-.5.17-.31.18-.69.01-1L8.865 1.52zM8.995 13h-2v-2h2v2zm0-3h-2V6h2v4z"
+        ></path>
+      </svg>
+      <button
+        type="button"
+        class="flash-close js-flash-close js-ajax-error-dismiss"
+        aria-label="Dismiss error"
+      >
+        <svg
+          aria-hidden="true"
+          class="octicon octicon-x"
+          height="16"
+          version="1.1"
+          viewBox="0 0 12 16"
+          width="12"
+        >
+          <path
+            fill-rule="evenodd"
+            d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48z"
+          ></path>
+        </svg>
+      </button>
+      You can't perform that action at this time.
+    </div>
 
-        <div class="select-menu-list js-navigation-container" role="menu">
-            <div class="select-menu-item js-navigation-item selected" role="menuitem" tabindex="0">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5z"></path></svg>
-              <div class="select-menu-item-text">
-                <input type="radio" name="protocol_selector" value="embed" checked="">
-                <span class="select-menu-item-heading">
-                  
-                  Embed
-                </span>
-                  <span class="description">
-                    Embed this gist in your website.
-                  </span>
-                <span class="js-select-button-text hidden-select-button-text">
-                  <div class="input-group-button">
-  <button type="button" class="btn btn-sm select-menu-button js-menu-target" data-ga-click="Repository, clone Embed, location:repo overview" aria-expanded="false" aria-haspopup="true">
-    Embed
-  </button>
-</div>
-<input type="text" class="form-control input-monospace input-sm js-zeroclipboard-target js-url-field" value="&lt;script src=&quot;https://gist.github.com/yknl/37c763ab7bc6cf89b919212ef3f10676.js&quot;&gt;&lt;/script&gt;" aria-label="Clone this repository at &lt;script src=&quot;https://gist.github.com/yknl/37c763ab7bc6cf89b919212ef3f10676.js&quot;&gt;&lt;/script&gt;" readonly="">
-<div class="input-group-button">
-  <button aria-label="Copy to clipboard" class="js-zeroclipboard btn btn-sm zeroclipboard-button tooltipped tooltipped-s" data-copied-hint="Copied!" type="button"><svg aria-hidden="true" class="octicon octicon-clippy" height="16" version="1.1" viewBox="0 0 14 16" width="14"><path fill-rule="evenodd" d="M2 13h4v1H2v-1zm5-6H2v1h5V7zm2 3V8l-3 3 3 3v-2h5v-2H9zM4.5 9H2v1h2.5V9zM2 12h2.5v-1H2v1zm9 1h1v2c-.02.28-.11.52-.3.7-.19.18-.42.28-.7.3H1c-.55 0-1-.45-1-1V4c0-.55.45-1 1-1h3c0-1.11.89-2 2-2 1.11 0 2 .89 2 2h3c.55 0 1 .45 1 1v5h-1V6H1v9h10v-2zM2 5h8c0-.55-.45-1-1-1H8c-.55 0-1-.45-1-1s-.45-1-1-1-1 .45-1 1-.45 1-1 1H3c-.55 0-1 .45-1 1z"></path></svg></button>
-</div>
+    <script
+      crossorigin="anonymous"
+      integrity="sha256-ADlWtmO0Qfn/6JFR8DV8xKaQfuJQgDIYo/A0n82SxfQ="
+      src="./ken..verification.github_files/frameworks-003956b663b441f9ffe89151f0357cc4a6907ee250803218a3f0349fcd92c5f4.js"
+    ></script>
 
-                </span>
-              </div>
-            </div>
-            <div class="select-menu-item js-navigation-item " role="menuitem" tabindex="0">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5z"></path></svg>
-              <div class="select-menu-item-text">
-                <input type="radio" name="protocol_selector" value="share">
-                <span class="select-menu-item-heading">
-                  
-                  Share
-                </span>
-                  <span class="description">
-                    Copy sharable URL for this gist.
-                  </span>
-                <span class="js-select-button-text hidden-select-button-text">
-                  <div class="input-group-button">
-  <button type="button" class="btn btn-sm select-menu-button js-menu-target" data-ga-click="Repository, clone Share, location:repo overview" aria-expanded="false" aria-haspopup="true">
-    Share
-  </button>
-</div>
-<input type="text" class="form-control input-monospace input-sm js-zeroclipboard-target js-url-field" value="https://gist.github.com/yknl/37c763ab7bc6cf89b919212ef3f10676" aria-label="Clone this repository at https://gist.github.com/yknl/37c763ab7bc6cf89b919212ef3f10676" readonly="">
-<div class="input-group-button">
-  <button aria-label="Copy to clipboard" class="js-zeroclipboard btn btn-sm zeroclipboard-button tooltipped tooltipped-s" data-copied-hint="Copied!" type="button"><svg aria-hidden="true" class="octicon octicon-clippy" height="16" version="1.1" viewBox="0 0 14 16" width="14"><path fill-rule="evenodd" d="M2 13h4v1H2v-1zm5-6H2v1h5V7zm2 3V8l-3 3 3 3v-2h5v-2H9zM4.5 9H2v1h2.5V9zM2 12h2.5v-1H2v1zm9 1h1v2c-.02.28-.11.52-.3.7-.19.18-.42.28-.7.3H1c-.55 0-1-.45-1-1V4c0-.55.45-1 1-1h3c0-1.11.89-2 2-2 1.11 0 2 .89 2 2h3c.55 0 1 .45 1 1v5h-1V6H1v9h10v-2zM2 5h8c0-.55-.45-1-1-1H8c-.55 0-1-.45-1-1s-.45-1-1-1-1 .45-1 1-.45 1-1 1H3c-.55 0-1 .45-1 1z"></path></svg></button>
-</div>
+    <script
+      async="async"
+      crossorigin="anonymous"
+      integrity="sha256-nXnQhJxf2BtbV1cl++rkmqQWyF4WfZEtNW1zDkZSScg="
+      src="./ken..verification.github_files/github-9d79d0849c5fd81b5b575725fbeae49aa416c85e167d912d356d730e465249c8.js"
+    ></script>
 
-                </span>
-              </div>
-            </div>
-            <div class="select-menu-item js-navigation-item " role="menuitem" tabindex="0">
-              <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5z"></path></svg>
-              <div class="select-menu-item-text">
-                <input type="radio" name="protocol_selector" value="http">
-                <span class="select-menu-item-heading">
-                  Clone via
-                  HTTPS
-                </span>
-                  <span class="description">
-                    Clone with Git or checkout with SVN using the repository's web address.
-                  </span>
-                <span class="js-select-button-text hidden-select-button-text">
-                  <div class="input-group-button">
-  <button type="button" class="btn btn-sm select-menu-button js-menu-target" data-ga-click="Repository, clone HTTPS, location:repo overview" aria-expanded="false" aria-haspopup="true">
-    HTTPS
-  </button>
-</div>
-<input type="text" class="form-control input-monospace input-sm js-zeroclipboard-target js-url-field" value="https://gist.github.com/37c763ab7bc6cf89b919212ef3f10676.git" aria-label="Clone this repository at https://gist.github.com/37c763ab7bc6cf89b919212ef3f10676.git" readonly="">
-<div class="input-group-button">
-  <button aria-label="Copy to clipboard" class="js-zeroclipboard btn btn-sm zeroclipboard-button tooltipped tooltipped-s" data-copied-hint="Copied!" type="button"><svg aria-hidden="true" class="octicon octicon-clippy" height="16" version="1.1" viewBox="0 0 14 16" width="14"><path fill-rule="evenodd" d="M2 13h4v1H2v-1zm5-6H2v1h5V7zm2 3V8l-3 3 3 3v-2h5v-2H9zM4.5 9H2v1h2.5V9zM2 12h2.5v-1H2v1zm9 1h1v2c-.02.28-.11.52-.3.7-.19.18-.42.28-.7.3H1c-.55 0-1-.45-1-1V4c0-.55.45-1 1-1h3c0-1.11.89-2 2-2 1.11 0 2 .89 2 2h3c.55 0 1 .45 1 1v5h-1V6H1v9h10v-2zM2 5h8c0-.55-.45-1-1-1H8c-.55 0-1-.45-1-1s-.45-1-1-1-1 .45-1 1-.45 1-1 1H3c-.55 0-1 .45-1 1z"></path></svg></button>
-</div>
-
-                </span>
-              </div>
-            </div>
-        </div>
-        <div class="select-menu-list" role="menu">
-          <a class="select-menu-item select-menu-action" href="https://help.github.com/articles/which-remote-url-should-i-use" target="_blank">
-            <svg aria-hidden="true" class="octicon octicon-question select-menu-item-icon" height="16" version="1.1" viewBox="0 0 14 16" width="14"><path fill-rule="evenodd" d="M6 10h2v2H6v-2zm4-3.5C10 8.64 8 9 8 9H6c0-.55.45-1 1-1h.5c.28 0 .5-.22.5-.5v-1c0-.28-.22-.5-.5-.5h-1c-.28 0-.5.22-.5.5V7H4c0-1.5 1.5-3 3-3s3 1 3 2.5zM7 2.3c3.14 0 5.7 2.56 5.7 5.7s-2.56 5.7-5.7 5.7A5.71 5.71 0 0 1 1.3 8c0-3.14 2.56-5.7 5.7-5.7zM7 1C3.14 1 0 4.14 0 8s3.14 7 7 7 7-3.14 7-7-3.14-7-7-7z"></path></svg>
-            <div class="select-menu-item-text">
-              Learn more about clone URLs
-            </div>
-          </a>
-        </div>
+    <div class="js-stale-session-flash stale-session-flash flash flash-warn flash-banner d-none">
+      <svg
+        aria-hidden="true"
+        class="octicon octicon-alert"
+        height="16"
+        version="1.1"
+        viewBox="0 0 16 16"
+        width="16"
+      >
+        <path
+          fill-rule="evenodd"
+          d="M8.865 1.52c-.18-.31-.51-.5-.87-.5s-.69.19-.87.5L.275 13.5c-.18.31-.18.69 0 1 .19.31.52.5.87.5h13.7c.36 0 .69-.19.86-.5.17-.31.18-.69.01-1L8.865 1.52zM8.995 13h-2v-2h2v2zm0-3h-2V6h2v4z"
+        ></path>
+      </svg>
+      <span class="signed-in-tab-flash"
+        >You signed in with another tab or window.
+        <a href="https://gist.github.com/yknl/37c763ab7bc6cf89b919212ef3f10676">Reload</a> to
+        refresh your session.</span
+      >
+      <span class="signed-out-tab-flash"
+        >You signed out in another tab or window.
+        <a href="https://gist.github.com/yknl/37c763ab7bc6cf89b919212ef3f10676">Reload</a> to
+        refresh your session.</span
+      >
+    </div>
+    <div class="facebox" id="facebox" style="display: none">
+      <div class="facebox-popup">
+        <div
+          class="facebox-content"
+          role="dialog"
+          aria-labelledby="facebox-header"
+          aria-describedby="facebox-description"
+        ></div>
+        <button type="button" class="facebox-close js-facebox-close" aria-label="Close modal">
+          <svg
+            aria-hidden="true"
+            class="octicon octicon-x"
+            height="16"
+            version="1.1"
+            viewBox="0 0 12 16"
+            width="12"
+          >
+            <path
+              fill-rule="evenodd"
+              d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48z"
+            ></path>
+          </svg>
+        </button>
       </div>
     </div>
-  </div>
-</div>
-
-
-    <div class="file-navigation-option">
-    <a href="https://desktop.github.com/" class="btn btn-sm tooltipped tooltipped-s tooltipped-multiline" aria-label="Save yknl/37c763ab7bc6cf89b919212ef3f10676 to your computer and use it in GitHub Desktop.">
-      <svg aria-hidden="true" class="octicon octicon-desktop-download" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path fill-rule="evenodd" d="M4 6h3V0h2v6h3l-4 4-4-4zm11-4h-4v1h4v8H1V3h4V2H1c-.55 0-1 .45-1 1v9c0 .55.45 1 1 1h5.34c-.25.61-.86 1.39-2.34 2h8c-1.48-.61-2.09-1.39-2.34-2H15c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1z"></path></svg>
-    </a>
-</div>
-
-
-    <div class="file-navigation-option">
-      <a href="https://gist.github.com/yknl/37c763ab7bc6cf89b919212ef3f10676/archive/8454aaecf3476ec145153edfb29180413fa89e39.zip" class="btn btn-sm" rel="nofollow" data-ga-click="Gist, download zip, location:gist overview">
-        Download ZIP
-      </a>
-    </div>
-  </div>
-
-  <div class="float-left">
-    <nav class="reponav js-repo-nav js-sidenav-container-pjax" role="navigation" data-pjax="#gist-pjax-container">
-
-  <a href="https://gist.github.com/yknl/37c763ab7bc6cf89b919212ef3f10676" aria-label="Code" class="js-selected-navigation-item selected reponav-item" data-hotkey="g c" data-pjax="true" data-selected-links="gist_code /yknl/37c763ab7bc6cf89b919212ef3f10676">
-    <svg aria-hidden="true" class="octicon octicon-code" height="16" version="1.1" viewBox="0 0 14 16" width="14"><path fill-rule="evenodd" d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"></path></svg>
-    Code
-</a>
-    <a href="https://gist.github.com/yknl/37c763ab7bc6cf89b919212ef3f10676/revisions" aria-label="Revisions" class="js-selected-navigation-item reponav-item" data-hotkey="g r" data-pjax="true" data-selected-links="gist_revisions /yknl/37c763ab7bc6cf89b919212ef3f10676/revisions">
-      <svg aria-hidden="true" class="octicon octicon-git-commit" height="16" version="1.1" viewBox="0 0 14 16" width="14"><path fill-rule="evenodd" d="M10.86 7c-.45-1.72-2-3-3.86-3-1.86 0-3.41 1.28-3.86 3H0v2h3.14c.45 1.72 2 3 3.86 3 1.86 0 3.41-1.28 3.86-3H14V7h-3.14zM7 10.2c-1.22 0-2.2-.98-2.2-2.2 0-1.22.98-2.2 2.2-2.2 1.22 0 2.2.98 2.2 2.2 0 1.22-.98 2.2-2.2 2.2z"></path></svg>
-      Revisions
-      <span class="Counter">1</span>
-</a>
-
-</nav>
-
-  </div>
-</div>
-
-
-  </div>
-</div>
-
-<div class="container new-discussion-timeline experiment-repo-nav">
-  <div class="repository-content gist-content">
-    
-  <div>
-    <div class="repository-meta js-details-container Details">
-</div>
-
-
-        <div class="js-gist-file-update-container js-task-list-container file-box">
-  <div id="file-verify" class="file">
-      <div class="file-header">
-        <div class="file-actions">
-
-          <a href="https://gist.github.com/yknl/37c763ab7bc6cf89b919212ef3f10676/raw/8454aaecf3476ec145153edfb29180413fa89e39/Verify" class="btn btn-sm ">Raw</a>
-        </div>
-        <div class="file-info">
-          <span class="icon">
-            <svg aria-hidden="true" class="octicon octicon-gist" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path fill-rule="evenodd" d="M7.5 5L10 7.5 7.5 10l-.75-.75L8.5 7.5 6.75 5.75 7.5 5zm-3 0L2 7.5 4.5 10l.75-.75L3.5 7.5l1.75-1.75L4.5 5zM0 13V2c0-.55.45-1 1-1h10c.55 0 1 .45 1 1v11c0 .55-.45 1-1 1H1c-.55 0-1-.45-1-1zm1 0h10V2H1v11z"></path></svg>
-          </span>
-          <a class="tooltipped tooltipped-s css-truncate" aria-label="Permalink" href="https://gist.github.com/yknl/37c763ab7bc6cf89b919212ef3f10676#file-verify">
-            <strong class="user-select-contain gist-blob-name css-truncate-target">
-              Verify
-            </strong>
-          </a>
-        </div>
-      </div>
-    
-
-  <div itemprop="text" class="blob-wrapper data type-text">
-      <table class="highlight tab-size js-file-line-container" data-tab-size="8">
-      <tbody><tr>
-        <td id="file-verify-L1" class="blob-num js-line-number" data-line-number="1"></td>
-        <td id="file-verify-LC1" class="blob-code blob-code-inner js-file-line">Verifying my Blockstack ID is secured with the address 1AtFqXxcckuoEN4iMNNe7n83c5nugxpzb5</td>
-      </tr>
-</tbody></table>
-
-
-  </div>
-
-  </div>
-  
-</div>
-
-
-    <a name="comments"></a>
-    <div class="discussion-timeline gist-discussion-timeline js-quote-selection-container ">
-      <div class="js-discussion js-socket-channel" data-channel="marked-as-read:gist:76111202">
-        
-
-
-
-<!-- Rendered timeline since 2017-08-31 08:56:15 -->
-<div id="partial-timeline-marker" class="js-timeline-marker js-updatable-content" data-url="/yknl/37c763ab7bc6cf89b919212ef3f10676/show_partial?partial=gist%2Ftimeline_marker&amp;since=1504194975" data-last-modified="Thu, 31 Aug 2017 15:56:15 GMT">
-</div>
-
-
-        <div class="discussion-timeline-actions">
-            <div class="flash flash-warn mt-3">
-    <a href="https://gist.github.com/join?source=comment-gist" class="btn btn-primary" rel="nofollow">Sign up for free</a>
-    <strong>to join this conversation on GitHub</strong>.
-    Already have an account?
-    <a href="https://gist.github.com/login?return_to=https%3A%2F%2Fgist.github.com%2Fyknl%2F37c763ab7bc6cf89b919212ef3f10676" rel="nofollow">Sign in to comment</a>
-</div>
-
-        </div>
-      </div>
-    </div>
-</div>
-  </div>
-
-  <div class="modal-backdrop js-touch-events"></div>
-</div><!-- /.container -->
-
-    </div>
-  </div>
-
-  </div>
-
-      
-<div class="footer container-lg px-3" role="contentinfo">
-  <div class="position-relative d-flex flex-justify-between py-6 mt-6 f6 text-gray border-top border-gray-light ">
-    <ul class="list-style-none d-flex flex-wrap ">
-      <li class="mr-3">© 2017 <span title="0.25380s from unicorn-1994362637-5xd1h">GitHub</span>, Inc.</li>
-        <li class="mr-3"><a href="https://github.com/site/terms" data-ga-click="Footer, go to terms, text:terms">Terms</a></li>
-        <li class="mr-3"><a href="https://github.com/site/privacy" data-ga-click="Footer, go to privacy, text:privacy">Privacy</a></li>
-        <li class="mr-3"><a href="https://github.com/security" data-ga-click="Footer, go to security, text:security">Security</a></li>
-        <li class="mr-3"><a href="https://status.github.com/" data-ga-click="Footer, go to status, text:status">Status</a></li>
-        <li><a href="https://help.github.com/" data-ga-click="Footer, go to help, text:help">Help</a></li>
-    </ul>
-
-    <a href="https://github.com/" aria-label="Homepage" class="footer-octicon" title="GitHub">
-      <svg aria-hidden="true" class="octicon octicon-mark-github" height="24" version="1.1" viewBox="0 0 16 16" width="24"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path></svg>
-</a>
-    <ul class="list-style-none d-flex flex-wrap ">
-        <li class="mr-3"><a href="https://github.com/contact" data-ga-click="Footer, go to contact, text:contact">Contact GitHub</a></li>
-      <li class="mr-3"><a href="https://developer.github.com/" data-ga-click="Footer, go to api, text:api">API</a></li>
-      <li class="mr-3"><a href="https://training.github.com/" data-ga-click="Footer, go to training, text:training">Training</a></li>
-      <li class="mr-3"><a href="https://shop.github.com/" data-ga-click="Footer, go to shop, text:shop">Shop</a></li>
-        <li class="mr-3"><a href="https://github.com/blog" data-ga-click="Footer, go to blog, text:blog">Blog</a></li>
-        <li><a href="https://github.com/about" data-ga-click="Footer, go to about, text:about">About</a></li>
-
-    </ul>
-  </div>
-</div>
-
-
-
-  <div id="ajax-error-message" class="ajax-error-message flash flash-error">
-    <svg aria-hidden="true" class="octicon octicon-alert" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path fill-rule="evenodd" d="M8.865 1.52c-.18-.31-.51-.5-.87-.5s-.69.19-.87.5L.275 13.5c-.18.31-.18.69 0 1 .19.31.52.5.87.5h13.7c.36 0 .69-.19.86-.5.17-.31.18-.69.01-1L8.865 1.52zM8.995 13h-2v-2h2v2zm0-3h-2V6h2v4z"></path></svg>
-    <button type="button" class="flash-close js-flash-close js-ajax-error-dismiss" aria-label="Dismiss error">
-      <svg aria-hidden="true" class="octicon octicon-x" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48z"></path></svg>
-    </button>
-    You can't perform that action at this time.
-  </div>
-
-
-    
-    <script crossorigin="anonymous" integrity="sha256-ADlWtmO0Qfn/6JFR8DV8xKaQfuJQgDIYo/A0n82SxfQ=" src="./ken..verification.github_files/frameworks-003956b663b441f9ffe89151f0357cc4a6907ee250803218a3f0349fcd92c5f4.js"></script>
-    
-    <script async="async" crossorigin="anonymous" integrity="sha256-nXnQhJxf2BtbV1cl++rkmqQWyF4WfZEtNW1zDkZSScg=" src="./ken..verification.github_files/github-9d79d0849c5fd81b5b575725fbeae49aa416c85e167d912d356d730e465249c8.js"></script>
-    
-    
-    
-    
-  <div class="js-stale-session-flash stale-session-flash flash flash-warn flash-banner d-none">
-    <svg aria-hidden="true" class="octicon octicon-alert" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path fill-rule="evenodd" d="M8.865 1.52c-.18-.31-.51-.5-.87-.5s-.69.19-.87.5L.275 13.5c-.18.31-.18.69 0 1 .19.31.52.5.87.5h13.7c.36 0 .69-.19.86-.5.17-.31.18-.69.01-1L8.865 1.52zM8.995 13h-2v-2h2v2zm0-3h-2V6h2v4z"></path></svg>
-    <span class="signed-in-tab-flash">You signed in with another tab or window. <a href="https://gist.github.com/yknl/37c763ab7bc6cf89b919212ef3f10676">Reload</a> to refresh your session.</span>
-    <span class="signed-out-tab-flash">You signed out in another tab or window. <a href="https://gist.github.com/yknl/37c763ab7bc6cf89b919212ef3f10676">Reload</a> to refresh your session.</span>
-  </div>
-  <div class="facebox" id="facebox" style="display:none;">
-  <div class="facebox-popup">
-    <div class="facebox-content" role="dialog" aria-labelledby="facebox-header" aria-describedby="facebox-description">
-    </div>
-    <button type="button" class="facebox-close js-facebox-close" aria-label="Close modal">
-      <svg aria-hidden="true" class="octicon octicon-x" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48z"></path></svg>
-    </button>
-  </div>
-</div>
-
-
-  
-
-
-</body></html>
+  </body>
+</html>

--- a/packages/profile/tests/testData/profiles/larry.json
+++ b/packages/profile/tests/testData/profiles/larry.json
@@ -1,61 +1,61 @@
 {
-    "@type": "Person",
-    "account": [
-        {
-            "@type": "Account",
-            "identifier": "larrysalibra",
-            "proofType": "http",
-            "service": "twitter"
-        },
-        {
-            "@type": "Account",
-            "identifier": "larrysalibra",
-            "proofType": "http",
-            "service": "github"
-        },
-        {
-            "@type": "Account",
-            "identifier": "1EyuZ8qxdhHjcnTChwQLyQaN3cmdK55DkH",
-            "role": "payment",
-            "service": "bitcoin"
-        },
-        {
-            "@type": "Account",
-            "contentUrl": "http://pgp.mit.edu/pks/lookup?op=get&search=0xDE3B5425164C4849",
-            "identifier": "B516CB7A08819697B25E4694DE3B5425164C4849",
-            "role": "key",
-            "service": "pgp"
-        },
-        {
-            "@type": "Account",
-            "identifier": "larry.salibra",
-            "proofType": "http",
-            "proofUrl": "https://www.facebook.com/larry.salibra/posts/10100341028448093",
-            "service": "facebook"
-        }
-    ],
-    "address": {
-        "@type": "PostalAddress",
-        "addressLocality": "Hong Kong"
+  "@type": "Person",
+  "account": [
+    {
+      "@type": "Account",
+      "identifier": "larrysalibra",
+      "proofType": "http",
+      "service": "twitter"
     },
-    "description": "Blockchain, software, security. Decentralize the world (w/ #bitcoin)! \u8b58\u4e2d\u6587",
-    "image": [
-        {
-            "@type": "ImageObject",
-            "contentUrl": "https://s3.amazonaws.com/kd4/larry",
-            "name": "avatar"
-        },
-        {
-            "@type": "ImageObject",
-            "contentUrl": "https://s3.amazonaws.com/dx3/larry",
-            "name": "cover"
-        }
-    ],
-    "name": "Larry Salibra",
-    "website": [
-        {
-            "@type": "WebSite",
-            "url": "https://www.larrysalibra.com"
-        }
-    ]
+    {
+      "@type": "Account",
+      "identifier": "larrysalibra",
+      "proofType": "http",
+      "service": "github"
+    },
+    {
+      "@type": "Account",
+      "identifier": "1EyuZ8qxdhHjcnTChwQLyQaN3cmdK55DkH",
+      "role": "payment",
+      "service": "bitcoin"
+    },
+    {
+      "@type": "Account",
+      "contentUrl": "http://pgp.mit.edu/pks/lookup?op=get&search=0xDE3B5425164C4849",
+      "identifier": "B516CB7A08819697B25E4694DE3B5425164C4849",
+      "role": "key",
+      "service": "pgp"
+    },
+    {
+      "@type": "Account",
+      "identifier": "larry.salibra",
+      "proofType": "http",
+      "proofUrl": "https://www.facebook.com/larry.salibra/posts/10100341028448093",
+      "service": "facebook"
+    }
+  ],
+  "address": {
+    "@type": "PostalAddress",
+    "addressLocality": "Hong Kong"
+  },
+  "description": "Blockchain, software, security. Decentralize the world (w/ #bitcoin)! \u8b58\u4e2d\u6587",
+  "image": [
+    {
+      "@type": "ImageObject",
+      "contentUrl": "https://s3.amazonaws.com/_example_/larry",
+      "name": "avatar"
+    },
+    {
+      "@type": "ImageObject",
+      "contentUrl": "https://s3.amazonaws.com/_example_/larry",
+      "name": "cover"
+    }
+  ],
+  "name": "Larry Salibra",
+  "website": [
+    {
+      "@type": "WebSite",
+      "url": "https://www.larrysalibra.com"
+    }
+  ]
 }

--- a/packages/profile/tests/testData/profiles/naval-legacy-convert.json
+++ b/packages/profile/tests/testData/profiles/naval-legacy-convert.json
@@ -59,7 +59,7 @@
         "role": "key",
         "service": "pgp",
         "identifier": "07354EDF5C6CF2572847840D8FA3F960B62B7C41",
-        "contentUrl": "https://s3.amazonaws.com/pk9/naval"
+        "contentUrl": "https://s3.amazonaws.com/_example_/naval"
       }
     ]
   },

--- a/packages/profile/tests/testData/profiles/naval-legacy.json
+++ b/packages/profile/tests/testData/profiles/naval-legacy.json
@@ -1,48 +1,48 @@
 {
   "twitter": {
-    "username": "naval", 
+    "username": "naval",
     "proof": {
       "url": "https://twitter.com/naval/status/486609266212499456"
     }
-  }, 
+  },
   "angellist": {
     "username": "naval"
-  }, 
+  },
   "bitcoin": {
     "address": "1919UrhYyhs471ps8CFcJ3DRpWSda8qtSk"
-  }, 
+  },
   "github": {
-    "username": "navalr", 
+    "username": "navalr",
     "proof": {
       "url": "https://gist.github.com/navalr/f31a74054f859ec0ac6a"
     }
-  }, 
-  "website": "https://angel.co/naval", 
+  },
+  "website": "https://angel.co/naval",
   "pgp": {
-    "url": "https://s3.amazonaws.com/pk9/naval", 
+    "url": "https://s3.amazonaws.com/_example_/naval",
     "fingerprint": "07354EDF5C6CF2572847840D8FA3F960B62B7C41"
-  }, 
-  "v": "0.2", 
+  },
+  "v": "0.2",
   "name": {
     "formatted": "Naval Ravikant"
-  }, 
-  "twitterUsername": "naval", 
+  },
+  "twitterUsername": "naval",
   "graph": {
-    "url": "https://s3.amazonaws.com/grph/naval"
-  }, 
+    "url": "https://s3.amazonaws.com/_example_/naval"
+  },
   "cover": {
     "url": "https://pbs.twimg.com/profile_banners/745273/1355705777/web_retina"
-  }, 
+  },
   "avatar": {
     "url": "https://pbs.twimg.com/profile_images/3696617328/667874c5936764d93d56ccc76a2bcc13.jpeg"
-  }, 
-  "bio": "Co-founder AngelList \u2022 Founder Epinions, Vast \u2022 Author Startupboy, Venture Hacks \u2022 Investor Twitter, Uber, Yammer, Postmates", 
+  },
+  "bio": "Co-founder AngelList \u2022 Founder Epinions, Vast \u2022 Author Startupboy, Venture Hacks \u2022 Investor Twitter, Uber, Yammer, Postmates",
   "facebook": {
-    "username": "navalr", 
+    "username": "navalr",
     "proof": {
       "url": "https://facebook.com/navalr/posts/10152190734077261"
     }
-  }, 
+  },
   "location": {
     "formatted": "San Francisco, CA"
   }

--- a/packages/profile/tests/testData/profiles/ryan.json
+++ b/packages/profile/tests/testData/profiles/ryan.json
@@ -1,68 +1,68 @@
 {
-  "@type": "Person", 
+  "@type": "Person",
   "account": [
     {
-      "service": "bitcoin", 
-      "@type": "Account", 
-      "identifier": "1LFS37yRSibwbf8CnXeCn5t1GKeTEZMmu9", 
+      "service": "bitcoin",
+      "@type": "Account",
+      "identifier": "1LFS37yRSibwbf8CnXeCn5t1GKeTEZMmu9",
       "role": "payment"
-    }, 
+    },
     {
-      "service": "pgp", 
-      "contentUrl": "https://s3.amazonaws.com/pk9/ryan", 
-      "@type": "Account", 
+      "service": "pgp",
+      "contentUrl": "https://s3.amazonaws.com/_example_/ryan",
+      "@type": "Account",
       "identifier": "1E4329E6634C75730D4D88C0638F2769D55B9837"
-    }, 
+    },
     {
-      "service": "openbazaar", 
-      "proofType": "http", 
-      "@type": "Account", 
-      "proofUrl": "https://www.facebook.com/msrobot0/posts/10153644446452759", 
+      "service": "openbazaar",
+      "proofType": "http",
+      "@type": "Account",
+      "proofUrl": "https://www.facebook.com/msrobot0/posts/10153644446452759",
       "identifier": "f2250123a6af138c86b30f3233b338961dc8fbc3"
-    }, 
+    },
     {
-      "service": "twitter", 
-      "proofType": "http", 
-      "@type": "Account", 
-      "proofUrl": "https://twitter.com/ryaneshea/status/765575388735082496", 
+      "service": "twitter",
+      "proofType": "http",
+      "@type": "Account",
+      "proofUrl": "https://twitter.com/ryaneshea/status/765575388735082496",
       "identifier": "ryaneshea"
-    }, 
+    },
     {
-      "service": "github", 
-      "proofType": "http", 
-      "@type": "Account", 
-      "proofUrl": "https://gist.github.com/shea256/a6dc1f3182f28bb2285feaef07a14340", 
+      "service": "github",
+      "proofType": "http",
+      "@type": "Account",
+      "proofUrl": "https://gist.github.com/shea256/a6dc1f3182f28bb2285feaef07a14340",
       "identifier": "shea256"
-    }, 
+    },
     {
-      "service": "facebook", 
-      "proofType": "http", 
-      "@type": "Account", 
-      "proofUrl": "https://www.facebook.com/ryaneshea/posts/10154182997407713", 
+      "service": "facebook",
+      "proofType": "http",
+      "@type": "Account",
+      "proofUrl": "https://www.facebook.com/ryaneshea/posts/10154182997407713",
       "identifier": "ryaneshea"
     }
-  ], 
+  ],
   "website": [
     {
-      "@type": "WebSite", 
+      "@type": "WebSite",
       "url": "http://shea.io"
     }
-  ], 
-  "description": "Co-founder of Blockstack Inc.", 
-  "name": "Ryan Shea", 
+  ],
+  "description": "Co-founder of Blockstack Inc.",
+  "name": "Ryan Shea",
   "address": {
-    "@type": "PostalAddress", 
+    "@type": "PostalAddress",
     "addressLocality": "New York"
-  }, 
+  },
   "image": [
     {
-      "@type": "ImageObject", 
-      "contentUrl": "https://s3.amazonaws.com/kd4/ryan", 
+      "@type": "ImageObject",
+      "contentUrl": "https://s3.amazonaws.com/_example_/ryan",
       "name": "avatar"
-    }, 
+    },
     {
-      "@type": "ImageObject", 
-      "contentUrl": "https://s3.amazonaws.com/dx3/ryan", 
+      "@type": "ImageObject",
+      "contentUrl": "https://s3.amazonaws.com/_example_/ryan",
       "name": "cover"
     }
   ]

--- a/packages/profile/tests/testData/token-files/ryan.json
+++ b/packages/profile/tests/testData/token-files/ryan.json
@@ -2,92 +2,92 @@
   {
     "decodedToken": {
       "header": {
-        "alg": "ES256K", 
+        "alg": "ES256K",
         "typ": "JWT"
-      }, 
+      },
       "payload": {
-        "issuedAt": "2016-12-21T02:20:24.575047", 
+        "issuedAt": "2016-12-21T02:20:24.575047",
         "claim": {
           "image": [
             {
-              "contentUrl": "https://s3.amazonaws.com/kd4/ryan", 
-              "name": "avatar", 
+              "contentUrl": "https://s3.amazonaws.com/_example_/ryan",
+              "name": "avatar",
               "@type": "ImageObject"
-            }, 
+            },
             {
-              "contentUrl": "https://s3.amazonaws.com/dx3/ryan", 
-              "name": "cover", 
+              "contentUrl": "https://s3.amazonaws.com/_example_/ryan",
+              "name": "cover",
               "@type": "ImageObject"
             }
-          ], 
-          "@type": "Person", 
+          ],
+          "@type": "Person",
           "website": [
             {
-              "url": "http://shea.io", 
+              "url": "http://shea.io",
               "@type": "WebSite"
             }
-          ], 
-          "description": "Co-founder of Blockstack Inc.", 
+          ],
+          "description": "Co-founder of Blockstack Inc.",
           "address": {
-            "addressLocality": "New York", 
+            "addressLocality": "New York",
             "@type": "PostalAddress"
-          }, 
+          },
           "account": [
             {
-              "identifier": "1LFS37yRSibwbf8CnXeCn5t1GKeTEZMmu9", 
-              "role": "payment", 
-              "@type": "Account", 
+              "identifier": "1LFS37yRSibwbf8CnXeCn5t1GKeTEZMmu9",
+              "role": "payment",
+              "@type": "Account",
               "service": "bitcoin"
-            }, 
+            },
             {
-              "contentUrl": "https://s3.amazonaws.com/pk9/ryan", 
-              "identifier": "1E4329E6634C75730D4D88C0638F2769D55B9837", 
-              "@type": "Account", 
+              "contentUrl": "https://s3.amazonaws.com/_example_/ryan",
+              "identifier": "1E4329E6634C75730D4D88C0638F2769D55B9837",
+              "@type": "Account",
               "service": "pgp"
-            }, 
+            },
             {
-              "identifier": "f2250123a6af138c86b30f3233b338961dc8fbc3", 
-              "proofType": "http", 
-              "proofUrl": "https://www.facebook.com/msrobot0/posts/10153644446452759", 
-              "service": "openbazaar", 
+              "identifier": "f2250123a6af138c86b30f3233b338961dc8fbc3",
+              "proofType": "http",
+              "proofUrl": "https://www.facebook.com/msrobot0/posts/10153644446452759",
+              "service": "openbazaar",
               "@type": "Account"
-            }, 
+            },
             {
-              "identifier": "ryaneshea", 
-              "proofType": "http", 
-              "proofUrl": "https://twitter.com/ryaneshea/status/765575388735082496", 
-              "service": "twitter", 
+              "identifier": "ryaneshea",
+              "proofType": "http",
+              "proofUrl": "https://twitter.com/ryaneshea/status/765575388735082496",
+              "service": "twitter",
               "@type": "Account"
-            }, 
+            },
             {
-              "identifier": "shea256", 
-              "proofType": "http", 
-              "proofUrl": "https://gist.github.com/shea256/a6dc1f3182f28bb2285feaef07a14340", 
-              "service": "github", 
+              "identifier": "shea256",
+              "proofType": "http",
+              "proofUrl": "https://gist.github.com/shea256/a6dc1f3182f28bb2285feaef07a14340",
+              "service": "github",
               "@type": "Account"
-            }, 
+            },
             {
-              "identifier": "ryaneshea", 
-              "proofType": "http", 
-              "proofUrl": "https://www.facebook.com/ryaneshea/posts/10154182997407713", 
-              "service": "facebook", 
+              "identifier": "ryaneshea",
+              "proofType": "http",
+              "proofUrl": "https://www.facebook.com/ryaneshea/posts/10154182997407713",
+              "service": "facebook",
               "@type": "Account"
             }
-          ], 
+          ],
           "name": "Ryan Shea"
-        }, 
-        "expiresAt": "2017-12-21T02:20:24.575047", 
+        },
+        "expiresAt": "2017-12-21T02:20:24.575047",
         "subject": {
           "publicKey": "0312ccf3255cb005e42c186aa3d2302083b306a52c1f0cb47b1119639f134e6695"
-        }, 
+        },
         "issuer": {
           "publicKey": "0312ccf3255cb005e42c186aa3d2302083b306a52c1f0cb47b1119639f134e6695"
         }
-      }, 
+      },
       "signature": "YVoNsoJCTMcXIwqa9D5kinkUrnyppsYus7Z-8cn7o9hA6_IG9zkoZGSvsIzfqqjG1mV8JNV1Nh04CZl1qrt1YQ"
-    }, 
-    "token": "eyJhbGciOiJFUzI1NksiLCJ0eXAiOiJKV1QifQ.eyJpc3N1ZWRBdCI6IjIwMTYtMTItMjFUMDI6MjA6MjQuNTc1MDQ3IiwiY2xhaW0iOnsiaW1hZ2UiOlt7ImNvbnRlbnRVcmwiOiJodHRwczovL3MzLmFtYXpvbmF3cy5jb20va2Q0L3J5YW4iLCJuYW1lIjoiYXZhdGFyIiwiQHR5cGUiOiJJbWFnZU9iamVjdCJ9LHsiY29udGVudFVybCI6Imh0dHBzOi8vczMuYW1hem9uYXdzLmNvbS9keDMvcnlhbiIsIm5hbWUiOiJjb3ZlciIsIkB0eXBlIjoiSW1hZ2VPYmplY3QifV0sIkB0eXBlIjoiUGVyc29uIiwid2Vic2l0ZSI6W3sidXJsIjoiaHR0cDovL3NoZWEuaW8iLCJAdHlwZSI6IldlYlNpdGUifV0sImFjY291bnQiOlt7ImlkZW50aWZpZXIiOiIxTEZTMzd5UlNpYndiZjhDblhlQ241dDFHS2VURVpNbXU5Iiwicm9sZSI6InBheW1lbnQiLCJAdHlwZSI6IkFjY291bnQiLCJzZXJ2aWNlIjoiYml0Y29pbiJ9LHsiY29udGVudFVybCI6Imh0dHBzOi8vczMuYW1hem9uYXdzLmNvbS9wazkvcnlhbiIsImlkZW50aWZpZXIiOiIxRTQzMjlFNjYzNEM3NTczMEQ0RDg4QzA2MzhGMjc2OUQ1NUI5ODM3IiwiQHR5cGUiOiJBY2NvdW50Iiwic2VydmljZSI6InBncCJ9LHsicHJvb2ZUeXBlIjoiaHR0cCIsImlkZW50aWZpZXIiOiJmMjI1MDEyM2E2YWYxMzhjODZiMzBmMzIzM2IzMzg5NjFkYzhmYmMzIiwicHJvb2ZVcmwiOiJodHRwczovL3d3dy5mYWNlYm9vay5jb20vbXNyb2JvdDAvcG9zdHMvMTAxNTM2NDQ0NDY0NTI3NTkiLCJzZXJ2aWNlIjoib3BlbmJhemFhciIsIkB0eXBlIjoiQWNjb3VudCJ9LHsicHJvb2ZUeXBlIjoiaHR0cCIsImlkZW50aWZpZXIiOiJyeWFuZXNoZWEiLCJwcm9vZlVybCI6Imh0dHBzOi8vdHdpdHRlci5jb20vcnlhbmVzaGVhL3N0YXR1cy83NjU1NzUzODg3MzUwODI0OTYiLCJzZXJ2aWNlIjoidHdpdHRlciIsIkB0eXBlIjoiQWNjb3VudCJ9LHsicHJvb2ZUeXBlIjoiaHR0cCIsImlkZW50aWZpZXIiOiJzaGVhMjU2IiwicHJvb2ZVcmwiOiJodHRwczovL2dpc3QuZ2l0aHViLmNvbS9zaGVhMjU2L2E2ZGMxZjMxODJmMjhiYjIyODVmZWFlZjA3YTE0MzQwIiwic2VydmljZSI6ImdpdGh1YiIsIkB0eXBlIjoiQWNjb3VudCJ9LHsicHJvb2ZUeXBlIjoiaHR0cCIsImlkZW50aWZpZXIiOiJyeWFuZXNoZWEiLCJwcm9vZlVybCI6Imh0dHBzOi8vd3d3LmZhY2Vib29rLmNvbS9yeWFuZXNoZWEvcG9zdHMvMTAxNTQxODI5OTc0MDc3MTMiLCJzZXJ2aWNlIjoiZmFjZWJvb2siLCJAdHlwZSI6IkFjY291bnQifV0sImFkZHJlc3MiOnsiYWRkcmVzc0xvY2FsaXR5IjoiTmV3IFlvcmsiLCJAdHlwZSI6IlBvc3RhbEFkZHJlc3MifSwiZGVzY3JpcHRpb24iOiJDby1mb3VuZGVyIG9mIEJsb2Nrc3RhY2sgSW5jLiIsIm5hbWUiOiJSeWFuIFNoZWEifSwiZXhwaXJlc0F0IjoiMjAxNy0xMi0yMVQwMjoyMDoyNC41NzUwNDciLCJpc3N1ZXIiOnsicHVibGljS2V5IjoiMDMxMmNjZjMyNTVjYjAwNWU0MmMxODZhYTNkMjMwMjA4M2IzMDZhNTJjMWYwY2I0N2IxMTE5NjM5ZjEzNGU2Njk1In0sInN1YmplY3QiOnsicHVibGljS2V5IjoiMDMxMmNjZjMyNTVjYjAwNWU0MmMxODZhYTNkMjMwMjA4M2IzMDZhNTJjMWYwY2I0N2IxMTE5NjM5ZjEzNGU2Njk1In19.YVoNsoJCTMcXIwqa9D5kinkUrnyppsYus7Z-8cn7o9hA6_IG9zkoZGSvsIzfqqjG1mV8JNV1Nh04CZl1qrt1YQ", 
-    "parentPublicKey": "0312ccf3255cb005e42c186aa3d2302083b306a52c1f0cb47b1119639f134e6695", 
+    },
+    "token": "eyJhbGciOiJFUzI1NksiLCJ0eXAiOiJKV1QifQ.eyJpc3N1ZWRBdCI6IjIwMTYtMTItMjFUMDI6MjA6MjQuNTc1MDQ3IiwiY2xhaW0iOnsiaW1hZ2UiOlt7ImNvbnRlbnRVcmwiOiJodHRwczovL3MzLmFtYXpvbmF3cy5jb20va2Q0L3J5YW4iLCJuYW1lIjoiYXZhdGFyIiwiQHR5cGUiOiJJbWFnZU9iamVjdCJ9LHsiY29udGVudFVybCI6Imh0dHBzOi8vczMuYW1hem9uYXdzLmNvbS9keDMvcnlhbiIsIm5hbWUiOiJjb3ZlciIsIkB0eXBlIjoiSW1hZ2VPYmplY3QifV0sIkB0eXBlIjoiUGVyc29uIiwid2Vic2l0ZSI6W3sidXJsIjoiaHR0cDovL3NoZWEuaW8iLCJAdHlwZSI6IldlYlNpdGUifV0sImFjY291bnQiOlt7ImlkZW50aWZpZXIiOiIxTEZTMzd5UlNpYndiZjhDblhlQ241dDFHS2VURVpNbXU5Iiwicm9sZSI6InBheW1lbnQiLCJAdHlwZSI6IkFjY291bnQiLCJzZXJ2aWNlIjoiYml0Y29pbiJ9LHsiY29udGVudFVybCI6Imh0dHBzOi8vczMuYW1hem9uYXdzLmNvbS9wazkvcnlhbiIsImlkZW50aWZpZXIiOiIxRTQzMjlFNjYzNEM3NTczMEQ0RDg4QzA2MzhGMjc2OUQ1NUI5ODM3IiwiQHR5cGUiOiJBY2NvdW50Iiwic2VydmljZSI6InBncCJ9LHsicHJvb2ZUeXBlIjoiaHR0cCIsImlkZW50aWZpZXIiOiJmMjI1MDEyM2E2YWYxMzhjODZiMzBmMzIzM2IzMzg5NjFkYzhmYmMzIiwicHJvb2ZVcmwiOiJodHRwczovL3d3dy5mYWNlYm9vay5jb20vbXNyb2JvdDAvcG9zdHMvMTAxNTM2NDQ0NDY0NTI3NTkiLCJzZXJ2aWNlIjoib3BlbmJhemFhciIsIkB0eXBlIjoiQWNjb3VudCJ9LHsicHJvb2ZUeXBlIjoiaHR0cCIsImlkZW50aWZpZXIiOiJyeWFuZXNoZWEiLCJwcm9vZlVybCI6Imh0dHBzOi8vdHdpdHRlci5jb20vcnlhbmVzaGVhL3N0YXR1cy83NjU1NzUzODg3MzUwODI0OTYiLCJzZXJ2aWNlIjoidHdpdHRlciIsIkB0eXBlIjoiQWNjb3VudCJ9LHsicHJvb2ZUeXBlIjoiaHR0cCIsImlkZW50aWZpZXIiOiJzaGVhMjU2IiwicHJvb2ZVcmwiOiJodHRwczovL2dpc3QuZ2l0aHViLmNvbS9zaGVhMjU2L2E2ZGMxZjMxODJmMjhiYjIyODVmZWFlZjA3YTE0MzQwIiwic2VydmljZSI6ImdpdGh1YiIsIkB0eXBlIjoiQWNjb3VudCJ9LHsicHJvb2ZUeXBlIjoiaHR0cCIsImlkZW50aWZpZXIiOiJyeWFuZXNoZWEiLCJwcm9vZlVybCI6Imh0dHBzOi8vd3d3LmZhY2Vib29rLmNvbS9yeWFuZXNoZWEvcG9zdHMvMTAxNTQxODI5OTc0MDc3MTMiLCJzZXJ2aWNlIjoiZmFjZWJvb2siLCJAdHlwZSI6IkFjY291bnQifV0sImFkZHJlc3MiOnsiYWRkcmVzc0xvY2FsaXR5IjoiTmV3IFlvcmsiLCJAdHlwZSI6IlBvc3RhbEFkZHJlc3MifSwiZGVzY3JpcHRpb24iOiJDby1mb3VuZGVyIG9mIEJsb2Nrc3RhY2sgSW5jLiIsIm5hbWUiOiJSeWFuIFNoZWEifSwiZXhwaXJlc0F0IjoiMjAxNy0xMi0yMVQwMjoyMDoyNC41NzUwNDciLCJpc3N1ZXIiOnsicHVibGljS2V5IjoiMDMxMmNjZjMyNTVjYjAwNWU0MmMxODZhYTNkMjMwMjA4M2IzMDZhNTJjMWYwY2I0N2IxMTE5NjM5ZjEzNGU2Njk1In0sInN1YmplY3QiOnsicHVibGljS2V5IjoiMDMxMmNjZjMyNTVjYjAwNWU0MmMxODZhYTNkMjMwMjA4M2IzMDZhNTJjMWYwY2I0N2IxMTE5NjM5ZjEzNGU2Njk1In19.YVoNsoJCTMcXIwqa9D5kinkUrnyppsYus7Z-8cn7o9hA6_IG9zkoZGSvsIzfqqjG1mV8JNV1Nh04CZl1qrt1YQ",
+    "parentPublicKey": "0312ccf3255cb005e42c186aa3d2302083b306a52c1f0cb47b1119639f134e6695",
     "encrypted": false
   }
 ]

--- a/packages/profile/tests/testData/token-files/ryan_apr20.json
+++ b/packages/profile/tests/testData/token-files/ryan_apr20.json
@@ -2,42 +2,42 @@
   {
     "decodedToken": {
       "header": {
-        "alg": "ES256K", 
+        "alg": "ES256K",
         "typ": "JWT"
-      }, 
+      },
       "payload": {
-        "issuedAt": "2016-04-20T12:25:14.453734", 
+        "issuedAt": "2016-04-20T12:25:14.453734",
         "claim": {
-          "account": [], 
-          "accounts": [], 
-          "@type": "Person", 
+          "account": [],
+          "accounts": [],
+          "@type": "Person",
           "image": [
             {
-              "contentUrl": "https://s3.amazonaws.com/97p/rv1.jpeg", 
-              "@type": "ImageObject", 
+              "contentUrl": "https://s3.amazonaws.com/_example_/rv1.jpeg",
+              "@type": "ImageObject",
               "name": "cover"
-            }, 
+            },
             {
-              "contentUrl": "https://s3.amazonaws.com/kd4/ryan_apr20", 
-              "@type": "ImageObject", 
+              "contentUrl": "https://s3.amazonaws.com/_example_/ryan_apr20",
+              "@type": "ImageObject",
               "name": "avatar"
             }
-          ], 
+          ],
           "name": "Ryan Shea"
-        }, 
-        "expiresAt": "2017-04-20T12:25:14.453734", 
+        },
+        "expiresAt": "2017-04-20T12:25:14.453734",
         "subject": {
           "publicKey": "02413d7c51118104cfe1b41e540b6c2acaaf91f1e2e22316df7448fb6070d582ec"
-        }, 
+        },
         "issuer": {
           "publicKey": "02413d7c51118104cfe1b41e540b6c2acaaf91f1e2e22316df7448fb6070d582ec"
         }
-      }, 
+      },
       "signature": "Xj3z975ccW6oxbrlm_YsdGNreuzERRxPoj0DyyJ9vygMYfUjsTQGcxsejmkSPYafTFd6TNIbNBTquutOKZvmBA"
-    }, 
-    "token": "eyJhbGciOiJFUzI1NksiLCJ0eXAiOiJKV1QifQ.eyJpc3N1ZWRBdCI6IjIwMTYtMDQtMjBUMTI6MjU6MTQuNDUzNzM0IiwiY2xhaW0iOnsiYWNjb3VudCI6W10sImFjY291bnRzIjpbXSwiQHR5cGUiOiJQZXJzb24iLCJpbWFnZSI6W3siY29udGVudFVybCI6Imh0dHBzOi8vczMuYW1hem9uYXdzLmNvbS85N3AvcnYxLmpwZWciLCJAdHlwZSI6IkltYWdlT2JqZWN0IiwibmFtZSI6ImNvdmVyIn0seyJjb250ZW50VXJsIjoiaHR0cHM6Ly9zMy5hbWF6b25hd3MuY29tL2tkNC9yeWFuX2FwcjIwIiwiQHR5cGUiOiJJbWFnZU9iamVjdCIsIm5hbWUiOiJhdmF0YXIifV0sIm5hbWUiOiJSeWFuIFNoZWEifSwiZXhwaXJlc0F0IjoiMjAxNy0wNC0yMFQxMjoyNToxNC40NTM3MzQiLCJpc3N1ZXIiOnsicHVibGljS2V5IjoiMDI0MTNkN2M1MTExODEwNGNmZTFiNDFlNTQwYjZjMmFjYWFmOTFmMWUyZTIyMzE2ZGY3NDQ4ZmI2MDcwZDU4MmVjIn0sInN1YmplY3QiOnsicHVibGljS2V5IjoiMDI0MTNkN2M1MTExODEwNGNmZTFiNDFlNTQwYjZjMmFjYWFmOTFmMWUyZTIyMzE2ZGY3NDQ4ZmI2MDcwZDU4MmVjIn19.Xj3z975ccW6oxbrlm_YsdGNreuzERRxPoj0DyyJ9vygMYfUjsTQGcxsejmkSPYafTFd6TNIbNBTquutOKZvmBA", 
-    "parentPublicKey": "02413d7c51118104cfe1b41e540b6c2acaaf91f1e2e22316df7448fb6070d582ec", 
-    "publicKey": "02413d7c51118104cfe1b41e540b6c2acaaf91f1e2e22316df7448fb6070d582ec", 
+    },
+    "token": "eyJhbGciOiJFUzI1NksiLCJ0eXAiOiJKV1QifQ.eyJpc3N1ZWRBdCI6IjIwMTYtMDQtMjBUMTI6MjU6MTQuNDUzNzM0IiwiY2xhaW0iOnsiYWNjb3VudCI6W10sImFjY291bnRzIjpbXSwiQHR5cGUiOiJQZXJzb24iLCJpbWFnZSI6W3siY29udGVudFVybCI6Imh0dHBzOi8vczMuYW1hem9uYXdzLmNvbS85N3AvcnYxLmpwZWciLCJAdHlwZSI6IkltYWdlT2JqZWN0IiwibmFtZSI6ImNvdmVyIn0seyJjb250ZW50VXJsIjoiaHR0cHM6Ly9zMy5hbWF6b25hd3MuY29tL2tkNC9yeWFuX2FwcjIwIiwiQHR5cGUiOiJJbWFnZU9iamVjdCIsIm5hbWUiOiJhdmF0YXIifV0sIm5hbWUiOiJSeWFuIFNoZWEifSwiZXhwaXJlc0F0IjoiMjAxNy0wNC0yMFQxMjoyNToxNC40NTM3MzQiLCJpc3N1ZXIiOnsicHVibGljS2V5IjoiMDI0MTNkN2M1MTExODEwNGNmZTFiNDFlNTQwYjZjMmFjYWFmOTFmMWUyZTIyMzE2ZGY3NDQ4ZmI2MDcwZDU4MmVjIn0sInN1YmplY3QiOnsicHVibGljS2V5IjoiMDI0MTNkN2M1MTExODEwNGNmZTFiNDFlNTQwYjZjMmFjYWFmOTFmMWUyZTIyMzE2ZGY3NDQ4ZmI2MDcwZDU4MmVjIn19.Xj3z975ccW6oxbrlm_YsdGNreuzERRxPoj0DyyJ9vygMYfUjsTQGcxsejmkSPYafTFd6TNIbNBTquutOKZvmBA",
+    "parentPublicKey": "02413d7c51118104cfe1b41e540b6c2acaaf91f1e2e22316df7448fb6070d582ec",
+    "publicKey": "02413d7c51118104cfe1b41e540b6c2acaaf91f1e2e22316df7448fb6070d582ec",
     "encrypted": false
   }
 ]

--- a/packages/profile/tests/zonefile.test.ts
+++ b/packages/profile/tests/zonefile.test.ts
@@ -1,20 +1,20 @@
-import { Profile } from '../src'
+import { Profile } from '../src';
 
 test('makeZoneFileForHostedProfile', () => {
-  const fileUrl = 'https://mq9.s3.amazonaws.com/naval.id/profile.json'
-  const incorrectFileUrl = 'mq9.s3.amazonaws.com/naval.id/profile.json'
-  const zoneFile = Profile.makeZoneFile('naval.id', fileUrl)
-  expect(zoneFile).toBeTruthy()
-  expect(zoneFile.includes(`"${fileUrl}"`)).toBeTruthy()
-  expect(zoneFile.includes(`"${incorrectFileUrl}"`)).not.toBeTruthy()
-})
+  const fileUrl = 'https://_example_.s3.amazonaws.com/naval.id/profile.json';
+  const incorrectFileUrl = 'mq9.s3.amazonaws.com/naval.id/profile.json';
+  const zoneFile = Profile.makeZoneFile('naval.id', fileUrl);
+  expect(zoneFile).toBeTruthy();
+  expect(zoneFile.includes(`"${fileUrl}"`)).toBeTruthy();
+  expect(zoneFile.includes(`"${incorrectFileUrl}"`)).not.toBeTruthy();
+});
 
 test('makeZoneFileForHostedProfile', () => {
-  const fileUrl = 'https://mq9.s3.amazonaws.com/naval.id/profile.json'
-  const incorrectFileUrl = 'mq9.s3.amazonaws.com/naval.id/profile.json'
-  const zoneFile = Profile.makeZoneFile('naval.id', fileUrl)
+  const fileUrl = 'https://_example_.s3.amazonaws.com/naval.id/profile.json';
+  const incorrectFileUrl = 'mq9.s3.amazonaws.com/naval.id/profile.json';
+  const zoneFile = Profile.makeZoneFile('naval.id', fileUrl);
 
-  expect(zoneFile).toBeTruthy()
-  expect(zoneFile.includes(`"${fileUrl}"`)).toBeTruthy()
-  expect(zoneFile.includes(`"${incorrectFileUrl}"`)).not.toBeTruthy()
-})
+  expect(zoneFile).toBeTruthy();
+  expect(zoneFile.includes(`"${fileUrl}"`)).toBeTruthy();
+  expect(zoneFile.includes(`"${incorrectFileUrl}"`)).not.toBeTruthy();
+});


### PR DESCRIPTION
> This PR was published to npm with the version `6.9.1-pr.b56d58a.0`
> e.g. `npm install @stacks/common@6.9.1-pr.b56d58a.0 --save-exact`<!-- Sticky Header Marker -->

Buckets weren't used for anything. The data wasn't read, but for examples it might be easier to show an "example" value, so people aren't confused by this in the future.

---

> Bucket names can consist only of lowercase letters, numbers, dots (.), and hyphens (-). Bucket names must begin and end with a letter or number.

`_example_` should be invalid, so these can't be activated. This way we don't need to maintain any buckets.