### PR TITLE
docs: remove reference to todos tutorial

### DIFF
--- a/docs/feature-guides/authenticate-users-with-connect.md
+++ b/docs/feature-guides/authenticate-users-with-connect.md
@@ -25,8 +25,6 @@ Authentication allows users to identify themselves in an app while retaining com
 
 Users who register for your app can subsequently authenticate to any other app with support for the [Blockchain Naming System](https://docs.stacks.co/build-apps/references/bns) and vice versa.
 
-See the [To-dos example app](/example-apps/to-dos) for a concrete example of this feature in practice.
-
 ### Initiate `userSession`
 
 Apps keep track of user authentication state with the `userSession` object, initiated with the `UserSession` and `AppConfig` classes:


### PR DESCRIPTION
remove reference to deleted todos tutorial