### PR TITLE
feat: implement isClarityType

### DIFF
--- a/packages/transactions/src/clarity/clarityValue.ts
+++ b/packages/transactions/src/clarity/clarityValue.ts
@@ -13,6 +13,8 @@ import {
   StringUtf8CV,
   NoneCV,
   SomeCV,
+  TrueCV,
+  FalseCV,
 } from '.';
 
 import { principalToString } from './types/principalCV';
@@ -168,4 +170,42 @@ export function getCVTypeString(val: ClarityValue): string {
     case ClarityType.StringUTF8:
       return `(string-utf8 ${utf8ToBytes(val.data).length})`;
   }
+}
+
+type ClarityTypetoValue = {
+  [ClarityType.OptionalNone]: NoneCV;
+  [ClarityType.OptionalSome]: SomeCV;
+  [ClarityType.ResponseOk]: ResponseOkCV;
+  [ClarityType.ResponseErr]: ResponseErrorCV;
+  [ClarityType.BoolTrue]: TrueCV;
+  [ClarityType.BoolFalse]: FalseCV;
+  [ClarityType.Int]: IntCV;
+  [ClarityType.UInt]: UIntCV;
+  [ClarityType.StringASCII]: StringAsciiCV;
+  [ClarityType.StringUTF8]: StringUtf8CV;
+  [ClarityType.PrincipalStandard]: StandardPrincipalCV;
+  [ClarityType.PrincipalContract]: ContractPrincipalCV;
+  [ClarityType.List]: ListCV;
+  [ClarityType.Tuple]: TupleCV;
+  [ClarityType.Buffer]: BufferCV;
+};
+
+/**
+ * @description narrow down the type of a generic ClarityValue
+ * @example
+ * ```ts
+ * // some functions can return a generic `ClarityValue` type
+ * let value = callReadOnlyFunction();
+ * //  ^ ClarityValue
+ * // use `isClarityType` to narrow down the type
+ * assert(isClarityType(value, ClarityType.Int))
+ * console.log(value)
+ * //          ^ IntCV
+ * ```
+ */
+export function isClarityType<T extends ClarityType>(
+  input: ClarityValue,
+  withType: T
+): input is ClarityTypetoValue[T] {
+  return input.type === withType;
 }

--- a/packages/transactions/src/clarity/clarityValue.ts
+++ b/packages/transactions/src/clarity/clarityValue.ts
@@ -191,7 +191,7 @@ type ClarityTypetoValue = {
 };
 
 /**
- * @description narrow down the type of a generic ClarityValue
+ * Narrow down the type of a generic ClarityValue
  * @example
  * ```ts
  * // some functions can return a generic `ClarityValue` type

--- a/packages/transactions/src/clarity/index.ts
+++ b/packages/transactions/src/clarity/index.ts
@@ -1,4 +1,11 @@
-import { ClarityValue, getCVTypeString, cvToString, cvToJSON, cvToValue } from './clarityValue';
+import {
+  ClarityValue,
+  getCVTypeString,
+  cvToString,
+  cvToJSON,
+  cvToValue,
+  isClarityType,
+} from './clarityValue';
 import { ClarityType } from './constants';
 import { BooleanCV, TrueCV, FalseCV, trueCV, falseCV, boolCV } from './types/booleanCV';
 import { IntCV, UIntCV, intCV, uintCV } from './types/intCV';
@@ -91,6 +98,7 @@ export {
   stringAsciiCV,
   stringUtf8CV,
   getCVTypeString,
+  isClarityType,
 };
 
 // Serialization

--- a/packages/transactions/tests/clarity.test.ts
+++ b/packages/transactions/tests/clarity.test.ts
@@ -10,6 +10,7 @@ import { BytesReader } from '../src/bytesReader';
 import {
   bufferCV,
   BufferCV,
+  ClarityType,
   ClarityValue,
   contractPrincipalCV,
   contractPrincipalCVFromStandard,
@@ -38,7 +39,14 @@ import {
   uintCV,
   UIntCV,
 } from '../src/clarity';
-import { cvToJSON, cvToString, cvToValue, getCVTypeString } from '../src/clarity/clarityValue';
+import { Cl } from '../src';
+import {
+  cvToJSON,
+  cvToString,
+  cvToValue,
+  getCVTypeString,
+  isClarityType,
+} from '../src/clarity/clarityValue';
 import { addressToString } from '../src/common';
 import { deserializeAddress } from '../src/types';
 
@@ -423,9 +431,8 @@ describe('Clarity Types', () => {
 
       // Test lexicographic ordering of tuple keys (to match Node Buffer compare)
       const lexicographic = Object.keys(tuple.data).sort((a, b) => {
-        // eslint-disable-next-line node/prefer-global/buffer
         const bufA = Buffer.from(a);
-        // eslint-disable-next-line node/prefer-global/buffer
+
         const bufB = Buffer.from(b);
         return bufA.compare(bufB);
       });
@@ -676,6 +683,18 @@ describe('Clarity Types', () => {
       expect(typeString).toEqual(
         '(tuple (a int) (b uint) (c (buff 4)) (d bool) (e (optional bool)) (f (optional none)) (g principal) (h principal) (i (response bool UnknownType)) (j (response UnknownType bool)) (k (list 2 bool)) (l (tuple (a bool) (b bool))) (m (string-ascii 11)) (n (string-utf8 9)) (o (list 0 UnknownType)))'
       );
+    });
+  });
+
+  describe('Clarity type narrowing', () => {
+    it('can narrow strings', () => {
+      const vUint = Cl.uint(1) as ClarityValue;
+      expect(isClarityType(vUint, ClarityType.UInt)).toBeTruthy();
+      expect(isClarityType(vUint, ClarityType.Int)).toBeFalsy();
+
+      const vInt = Cl.int(1) as ClarityValue;
+      expect(isClarityType(vInt, ClarityType.Int)).toBeTruthy();
+      expect(isClarityType(vInt, ClarityType.UInt)).toBeFalsy();
     });
   });
 });

--- a/packages/transactions/tests/clarity.test.ts
+++ b/packages/transactions/tests/clarity.test.ts
@@ -49,6 +49,7 @@ import {
 } from '../src/clarity/clarityValue';
 import { addressToString } from '../src/common';
 import { deserializeAddress } from '../src/types';
+import assert from 'assert';
 
 const ADDRESS = 'SP2JXKMSH007NPYAQHKJPQMAQYAD90NQGTVJVQ02B';
 
@@ -695,6 +696,16 @@ describe('Clarity Types', () => {
       const vInt = Cl.int(1) as ClarityValue;
       expect(isClarityType(vInt, ClarityType.Int)).toBeTruthy();
       expect(isClarityType(vInt, ClarityType.UInt)).toBeFalsy();
+
+      // test the type assertion
+
+      assert(isClarityType(vUint, ClarityType.UInt));
+      const uintTest: UIntCV = vUint;
+      uintTest; // avoid the "value is never read warning"
+
+      assert(isClarityType(vInt, ClarityType.Int));
+      const intTest: IntCV = vInt;
+      intTest; // avoid the "value is never read warning"
     });
   });
 });


### PR DESCRIPTION
> This PR was published to npm with the version `6.9.1-pr.649c54e.0`
> e.g. `npm install @stacks/common@6.9.1-pr.649c54e.0 --save-exact`<!-- Sticky Header Marker -->

### Description

Implement a simple helper to narrow down the type of generic `ClarityValues`

Not sure about the naming. I'm open to suggestions

#### Breaking change?

/ 

### Example

Provided in the code

---

### Checklist

- [x] Unit tested updated code paths
- [x] Tagged 1 of @janniks or @zone117x for review

