### PR TITLE
[next] feat: switch to simple string private keys

### DIFF
--- a/packages/bns/src/index.ts
+++ b/packages/bns/src/index.ts
@@ -1,39 +1,35 @@
 import { ApiParam, IntegerType, utf8ToBytes } from '@stacks/common';
+import { ChainId, StacksNetwork } from '@stacks/network';
 import {
+  AddressVersion,
   AnchorMode,
-  bufferCV,
-  callReadOnlyFunction,
   ClarityType,
   ClarityValue,
+  FungibleConditionCode,
+  NonFungibleConditionCode,
+  PostCondition,
+  ResponseErrorCV,
+  StacksTransaction,
+  UnsignedContractCallOptions,
+  bufferCV,
+  bufferCVFromString,
+  callReadOnlyFunction,
+  createNonFungiblePostCondition,
+  createSTXPostCondition,
   cvToString,
   getAddressFromPrivateKey,
   getCVTypeString,
   hash160,
   makeRandomPrivKey,
   makeUnsignedContractCall,
-  privateKeyToString,
-  ResponseErrorCV,
-  StacksTransaction,
-  standardPrincipalCV,
-  uintCV,
-  someCV,
   noneCV,
-  UnsignedContractCallOptions,
-  PostCondition,
-  createSTXPostCondition,
-  createStacksPublicKey,
-  publicKeyToAddress,
-  FungibleConditionCode,
-  AddressVersion,
-  createNonFungiblePostCondition,
-  NonFungibleConditionCode,
   parseAssetInfoString,
+  publicKeyToAddress,
+  someCV,
+  standardPrincipalCV,
   tupleCV,
-  bufferCVFromString,
+  uintCV,
 } from '@stacks/transactions';
-
-import { ChainId, StacksNetwork } from '@stacks/network';
-
 import { decodeFQN, getZonefileHash } from './utils';
 
 export const BNS_CONTRACT_NAME = 'bns';
@@ -154,7 +150,7 @@ export async function canRegisterName({
   // Create a random address as input to read-only function call
   // Not used by BNS contract function but required by core node API
   // https://github.com/blockstack/stacks-blockchain/blob/master/src/net/http.rs#L1796
-  const randomPrivateKey = privateKeyToString(makeRandomPrivKey());
+  const randomPrivateKey = makeRandomPrivKey();
   const randomAddress = getAddressFromPrivateKey(randomPrivateKey);
 
   return callReadOnlyBnsFunction({
@@ -199,7 +195,7 @@ export async function getNamespacePrice({
   // Create a random address as input to read-only function call
   // Not used by BNS contract function but required by core node API
   // https://github.com/blockstack/stacks-blockchain/blob/master/src/net/http.rs#L1796
-  const randomPrivateKey = privateKeyToString(makeRandomPrivKey());
+  const randomPrivateKey = makeRandomPrivKey();
   const randomAddress = getAddressFromPrivateKey(randomPrivateKey);
 
   return callReadOnlyBnsFunction({
@@ -254,7 +250,7 @@ export async function getNamePrice({
   // Create a random address as input to read-only function call
   // Not used by BNS contract function but required by core node API
   // https://github.com/blockstack/stacks-blockchain/blob/master/src/net/http.rs#L1796
-  const randomPrivateKey = privateKeyToString(makeRandomPrivKey());
+  const randomPrivateKey = makeRandomPrivKey();
   const randomAddress = getAddressFromPrivateKey(randomPrivateKey);
 
   return callReadOnlyBnsFunction({
@@ -315,7 +311,7 @@ export async function buildPreorderNamespaceTx({
   const hashedSaltedNamespace = hash160(saltedNamespaceBytes);
 
   const burnSTXPostCondition = createSTXPostCondition(
-    publicKeyToAddress(getAddressVersion(network), createStacksPublicKey(publicKey)),
+    publicKeyToAddress(getAddressVersion(network), publicKey),
     FungibleConditionCode.Equal,
     stxToBurn
   );
@@ -538,7 +534,7 @@ export async function buildPreorderNameTx({
   const hashedSaltedName = hash160(saltedNamesBytes);
 
   const burnSTXPostCondition = createSTXPostCondition(
-    publicKeyToAddress(getAddressVersion(network), createStacksPublicKey(publicKey)),
+    publicKeyToAddress(getAddressVersion(network), publicKey),
     FungibleConditionCode.Equal,
     stxToBurn
   );
@@ -707,7 +703,7 @@ export async function buildTransferNameTx({
     zonefile ? someCV(bufferCV(getZonefileHash(zonefile))) : noneCV(),
   ];
   const postConditionSender = createNonFungiblePostCondition(
-    publicKeyToAddress(getAddressVersion(network), createStacksPublicKey(publicKey)),
+    publicKeyToAddress(getAddressVersion(network), publicKey),
     NonFungibleConditionCode.Sends,
     parseAssetInfoString(`${getBnsContractAddress(network)}.bns::names`),
     tupleCV({
@@ -827,7 +823,7 @@ export async function buildRenewNameTx({
     zonefile ? someCV(bufferCV(getZonefileHash(zonefile))) : noneCV(),
   ];
   const burnSTXPostCondition = createSTXPostCondition(
-    publicKeyToAddress(getAddressVersion(network), createStacksPublicKey(publicKey)),
+    publicKeyToAddress(getAddressVersion(network), publicKey),
     FungibleConditionCode.Equal,
     stxToBurn
   );

--- a/packages/bns/tests/bns.test.ts
+++ b/packages/bns/tests/bns.test.ts
@@ -1,36 +1,30 @@
-import fetchMock from 'jest-fetch-mock';
-
-import {
-  responseOkCV,
-  responseErrorCV,
-  trueCV,
-  falseCV,
-  uintCV,
-  bufferCV,
-  hash160,
-  standardPrincipalCV,
-  noneCV,
-  AnchorMode,
-  someCV,
-  createSTXPostCondition,
-  publicKeyToAddress,
-  createStacksPublicKey,
-  FungibleConditionCode,
-  AddressVersion,
-  createNonFungiblePostCondition,
-  NonFungibleConditionCode,
-  parseAssetInfoString,
-  tupleCV,
-  bufferCVFromString,
-} from '@stacks/transactions';
-
-import { ChainId, STACKS_TESTNET, StacksNetwork } from '@stacks/network';
-
-import { BNS_CONTRACT_NAME, BnsContractAddress, PriceFunction } from '../src';
-
-import { decodeFQN, getZonefileHash } from '../src/utils';
-
 import { utf8ToBytes } from '@stacks/common';
+import { ChainId, STACKS_TESTNET, StacksNetwork } from '@stacks/network';
+import {
+  AddressVersion,
+  AnchorMode,
+  FungibleConditionCode,
+  NonFungibleConditionCode,
+  bufferCV,
+  bufferCVFromString,
+  createNonFungiblePostCondition,
+  createSTXPostCondition,
+  falseCV,
+  hash160,
+  noneCV,
+  parseAssetInfoString,
+  publicKeyToAddress,
+  responseErrorCV,
+  responseOkCV,
+  someCV,
+  standardPrincipalCV,
+  trueCV,
+  tupleCV,
+  uintCV,
+} from '@stacks/transactions';
+import fetchMock from 'jest-fetch-mock';
+import { BNS_CONTRACT_NAME, BnsContractAddress, PriceFunction } from '../src';
+import { decodeFQN, getZonefileHash } from '../src/utils';
 
 beforeEach(() => {
   fetchMock.resetMocks();
@@ -338,7 +332,7 @@ test('preorderNamespace', async () => {
 
   const bnsFunctionName = 'namespace-preorder';
   const burnSTXPostCondition = createSTXPostCondition(
-    publicKeyToAddress(getAddressVersion(network), createStacksPublicKey(publicKey)),
+    publicKeyToAddress(getAddressVersion(network), publicKey),
     FungibleConditionCode.Equal,
     stxToBurn
   );
@@ -562,7 +556,7 @@ test('preorderName', async () => {
 
   const bnsFunctionName = 'name-preorder';
   const burnSTXPostCondition = createSTXPostCondition(
-    publicKeyToAddress(getAddressVersion(network), createStacksPublicKey(publicKey)),
+    publicKeyToAddress(getAddressVersion(network), publicKey),
     FungibleConditionCode.Equal,
     stxToBurn
   );
@@ -708,7 +702,7 @@ test('transferName', async () => {
 
   const { namespace, name } = decodeFQN(fullyQualifiedName);
   const nameTransferPostConditionOne = createNonFungiblePostCondition(
-    publicKeyToAddress(getAddressVersion(network), createStacksPublicKey(publicKey)),
+    publicKeyToAddress(getAddressVersion(network), publicKey),
     NonFungibleConditionCode.Sends,
     parseAssetInfoString(`${getBnsContractAddress(network)}.bns::names`),
     tupleCV({
@@ -776,7 +770,7 @@ test('transferName optionalArguments', async () => {
 
   const { namespace, name } = decodeFQN(fullyQualifiedName);
   const nameTransferPostConditionOne = createNonFungiblePostCondition(
-    publicKeyToAddress(getAddressVersion(network), createStacksPublicKey(publicKey)),
+    publicKeyToAddress(getAddressVersion(network), publicKey),
     NonFungibleConditionCode.Sends,
     parseAssetInfoString(`${getBnsContractAddress(network)}.bns::names`),
     tupleCV({
@@ -883,7 +877,7 @@ test('renewName', async () => {
 
   const { namespace, name } = decodeFQN(fullyQualifiedName);
   const burnSTXPostCondition = createSTXPostCondition(
-    publicKeyToAddress(getAddressVersion(network), createStacksPublicKey(publicKey)),
+    publicKeyToAddress(getAddressVersion(network), publicKey),
     FungibleConditionCode.Equal,
     stxToBurn
   );
@@ -939,7 +933,7 @@ test('renewName optionalArguments', async () => {
 
   const { namespace, name } = decodeFQN(fullyQualifiedName);
   const burnSTXPostCondition = createSTXPostCondition(
-    publicKeyToAddress(getAddressVersion(network), createStacksPublicKey(publicKey)),
+    publicKeyToAddress(getAddressVersion(network), publicKey),
     FungibleConditionCode.Equal,
     stxToBurn
   );

--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -4,6 +4,8 @@ export const DEVNET_URL = 'http://localhost:3999';
 
 export const GAIA_URL = 'https://hub.blockstack.org';
 
+// todo: deduplicate magic variables
+
 /** @ignore internal */
 export const PRIVATE_KEY_COMPRESSED_LENGTH = 33;
 

--- a/packages/encryption/src/keys.ts
+++ b/packages/encryption/src/keys.ts
@@ -12,6 +12,7 @@ import {
 import base58 from 'bs58';
 import { hashRipemd160 } from './hashRipemd160';
 import { hashSha256Sync } from './sha2Hash';
+import { PrivateKey } from '../../transactions/src';
 
 const BITCOIN_PUBKEYHASH = 0x00;
 
@@ -96,7 +97,7 @@ export function publicKeyToBtcAddress(
  * @ignore
  * @returns a compressed public key
  */
-export function getPublicKeyFromPrivate(privateKey: string | Uint8Array): string {
+export function getPublicKeyFromPrivate(privateKey: PrivateKey): string {
   const privateKeyBytes = privateKeyToBytes(privateKey);
   // for backwards compatibility we always return a compressed public key, regardless of private key mode
   return bytesToHex(nobleGetPublicKey(privateKeyBytes.slice(0, 32), true));
@@ -105,8 +106,8 @@ export function getPublicKeyFromPrivate(privateKey: string | Uint8Array): string
 /**
  * @ignore
  */
-export function ecSign(messageHash: Uint8Array, hexPrivateKey: string | Uint8Array) {
-  return signSync(messageHash, privateKeyToBytes(hexPrivateKey).slice(0, 32), {
+export function ecSign(messageHash: Uint8Array, privateKey: PrivateKey) {
+  return signSync(messageHash, privateKeyToBytes(privateKey).slice(0, 32), {
     der: false,
   });
 }
@@ -114,14 +115,14 @@ export function ecSign(messageHash: Uint8Array, hexPrivateKey: string | Uint8Arr
 /**
  * @ignore
  */
-export function isValidPrivateKey(privateKey: string | Uint8Array): boolean {
+export function isValidPrivateKey(privateKey: PrivateKey): boolean {
   return utils.isValidPrivateKey(privateKeyToBytes(privateKey));
 }
 
 /**
  * @ignore
  */
-export function compressPrivateKey(privateKey: string | Uint8Array): Uint8Array {
+export function compressPrivateKey(privateKey: PrivateKey): Uint8Array {
   const privateKeyBytes = privateKeyToBytes(privateKey);
 
   return privateKeyBytes.length == PRIVATE_KEY_COMPRESSED_LENGTH

--- a/packages/transactions/src/keys.ts
+++ b/packages/transactions/src/keys.ts
@@ -14,8 +14,8 @@ import {
   hexToBytes,
   intToHex,
   parseRecoverableSignatureVrs,
-  privateKeyToBytes,
   PRIVATE_KEY_COMPRESSED_LENGTH,
+  privateKeyToBytes,
   signatureRsvToVrs,
   signatureVrsToRsv,
 } from '@stacks/common';
@@ -60,30 +60,32 @@ export interface StacksPublicKey {
 /** Creates a P2PKH address string from the given private key and tx version. */
 export function getAddressFromPrivateKey(
   /** Private key bytes or hex string */
-  privateKey: string | Uint8Array,
+  privateKey: PrivateKey,
   transactionVersion = TransactionVersion.Mainnet
 ): string {
-  const pubKey = pubKeyfromPrivKey(privateKey);
-  return getAddressFromPublicKey(pubKey.data, transactionVersion);
+  const publicKey = privateKeyToPublic(privateKey);
+  return getAddressFromPublicKey(publicKey, transactionVersion);
 }
 
+// todo: use network as last parameter instead of txversion param. next refactor
 /** Creates a P2PKH address string from the given public key and tx version. */
 export function getAddressFromPublicKey(
   /** Public key bytes or hex string */
-  publicKey: string | Uint8Array,
+  publicKey: PublicKey,
   transactionVersion = TransactionVersion.Mainnet
 ): string {
-  publicKey = typeof publicKey === 'string' ? publicKey : bytesToHex(publicKey);
+  publicKey = typeof publicKey === 'string' ? hexToBytes(publicKey) : publicKey;
   const addrVer = addressHashModeToVersion(AddressHashMode.SerializeP2PKH, transactionVersion);
-  const addr = addressFromVersionHash(addrVer, hashP2PKH(hexToBytes(publicKey)));
+  const addr = addressFromVersionHash(addrVer, hashP2PKH(publicKey));
   const addrString = addressToString(addr);
   return addrString;
 }
 
-export function createStacksPublicKey(key: string): StacksPublicKey {
+export function createStacksPublicKey(publicKey: PublicKey): StacksPublicKey {
+  publicKey = typeof publicKey === 'string' ? hexToBytes(publicKey) : publicKey;
   return {
     type: StacksMessageType.PublicKey,
-    data: hexToBytes(key),
+    data: publicKey,
   };
 }
 
@@ -111,64 +113,62 @@ export function publicKeyFromSignatureRsv(
   );
 }
 
-export function publicKeyFromBytes(data: Uint8Array): StacksPublicKey {
-  return { type: StacksMessageType.PublicKey, data };
+export function privateKeyToHex(publicKey: PublicKey): string {
+  return typeof publicKey === 'string' ? publicKey : bytesToHex(publicKey);
+}
+export const publicKeyToHex = privateKeyToHex;
+
+export function privateKeyIsCompressed(privateKey: PrivateKey): boolean {
+  const length = typeof privateKey === 'string' ? privateKey.length / 2 : privateKey.byteLength;
+  return length === PRIVATE_KEY_COMPRESSED_LENGTH;
 }
 
-export function isCompressed(key: StacksPublicKey): boolean {
-  return !bytesToHex(key.data).startsWith('04');
-}
-
-export function publicKeyToString(key: StacksPublicKey): string {
-  return bytesToHex(key.data);
+export function publicKeyIsCompressed(publicKey: PublicKey): boolean {
+  return !publicKeyToHex(publicKey).startsWith('04');
 }
 
 export function serializePublicKey(key: StacksPublicKey): Uint8Array {
   return key.data.slice();
 }
 
-export function pubKeyfromPrivKey(privateKey: string | Uint8Array): StacksPublicKey {
-  const privKey = createStacksPrivateKey(privateKey);
-  const publicKey = nobleGetPublicKey(privKey.data.slice(0, 32), privKey.compressed);
-  return createStacksPublicKey(bytesToHex(publicKey));
+/**
+ * Get the public key from a private key.
+ * Allows for "compressed" and "uncompressed" private keys.
+ * > Matches legacy `pubKeyfromPrivKey`, `getPublic` function behavior
+ */
+export function privateKeyToPublic(privateKey: PrivateKey): string {
+  privateKey = privateKeyToBytes(privateKey);
+  const isCompressed = privateKeyIsCompressed(privateKey);
+  return bytesToHex(nobleGetPublicKey(privateKey.slice(0, 32), isCompressed));
 }
 
-export function compressPublicKey(publicKey: string | Uint8Array): StacksPublicKey {
-  const hex = typeof publicKey === 'string' ? publicKey : bytesToHex(publicKey);
-  const compressed = Point.fromHex(hex).toHex(true);
-  return createStacksPublicKey(compressed);
+export function compressPublicKey(publicKey: PublicKey): string {
+  return Point.fromHex(publicKeyToHex(publicKey)).toHex(true);
 }
 
 export function deserializePublicKey(bytesReader: BytesReader): StacksPublicKey {
   const fieldId = bytesReader.readUInt8();
   const keyLength =
     fieldId === 4 ? UNCOMPRESSED_PUBKEY_LENGTH_BYTES : COMPRESSED_PUBKEY_LENGTH_BYTES;
-  return publicKeyFromBytes(concatArray([fieldId, bytesReader.readBytes(keyLength)]));
+  return createStacksPublicKey(concatArray([fieldId, bytesReader.readBytes(keyLength)]));
 }
 
-export interface StacksPrivateKey {
-  // "compressed" private key is a misnomer: https://web.archive.org/web/20220131144208/https://www.oreilly.com/library/view/mastering-bitcoin/9781491902639/ch04.html#comp_priv
-  // it actually means: should public keys be generated as "compressed" or "uncompressed" from this private key
-  compressed: boolean;
-  data: Uint8Array;
+// todo: double-check for deduplication, rename!
+export function makeRandomPrivKey(): string {
+  return bytesToHex(utils.randomPrivateKey());
 }
 
-export function createStacksPrivateKey(key: string | Uint8Array): StacksPrivateKey {
-  const data = privateKeyToBytes(key);
-  const compressed = data.length == PRIVATE_KEY_COMPRESSED_LENGTH;
-  return { data, compressed };
-}
-
-export function makeRandomPrivKey(): StacksPrivateKey {
-  return createStacksPrivateKey(utils.randomPrivateKey());
-}
+// todo: complete refactor
+export type PrivateKey = string | Uint8Array;
+export type PublicKey = string | Uint8Array;
 
 /**
  * @deprecated The Clarity compatible {@link signMessageHashRsv} is preferred, but differs in signature format
  * @returns A recoverable signature (in VRS order)
  */
-export function signWithKey(privateKey: StacksPrivateKey, messageHash: string): MessageSignature {
-  const [rawSignature, recoveryId] = signSync(messageHash, privateKey.data.slice(0, 32), {
+export function signWithKey(privateKey: PrivateKey, messageHash: string): MessageSignature {
+  privateKey = privateKeyToBytes(privateKey);
+  const [rawSignature, recoveryId] = signSync(messageHash, privateKey.slice(0, 32), {
     canonical: true,
     recovered: true,
   });
@@ -190,20 +190,14 @@ export function signMessageHashRsv({
   privateKey,
 }: {
   messageHash: string;
-  privateKey: StacksPrivateKey;
+  privateKey: PrivateKey;
 }): MessageSignature {
   const messageSignature = signWithKey(privateKey, messageHash);
   return { ...messageSignature, data: signatureVrsToRsv(messageSignature.data) };
 }
 
-export function getPublicKey(privateKey: StacksPrivateKey): StacksPublicKey {
-  return pubKeyfromPrivKey(privateKey.data);
-}
-
-export function privateKeyToString(privateKey: StacksPrivateKey): string {
-  return bytesToHex(privateKey.data);
-}
-
-export function publicKeyToAddress(version: AddressVersion, publicKey: StacksPublicKey): string {
-  return c32address(version, bytesToHex(hash160(publicKey.data)));
+// todo: use network as last parameter instead of addressversion param. next refactor
+export function publicKeyToAddress(version: AddressVersion, publicKey: PublicKey): string {
+  publicKey = typeof publicKey === 'string' ? hexToBytes(publicKey) : publicKey;
+  return c32address(version, bytesToHex(hash160(publicKey)));
 }

--- a/packages/transactions/src/signature.ts
+++ b/packages/transactions/src/signature.ts
@@ -96,7 +96,7 @@ export function serializeTransactionAuthField(field: TransactionAuthField): Uint
         bytesArray.push(serializePublicKey(field.contents));
       } else {
         bytesArray.push(AuthFieldType.PublicKeyUncompressed);
-        bytesArray.push(serializePublicKey(compressPublicKey(field.contents.data)));
+        bytesArray.push(hexToBytes(compressPublicKey(field.contents.data)));
       }
       break;
     case StacksMessageType.MessageSignature:

--- a/packages/transactions/src/signer.ts
+++ b/packages/transactions/src/signer.ts
@@ -1,10 +1,10 @@
 import { StacksTransaction } from './transaction';
 
-import { StacksPrivateKey, StacksPublicKey } from './keys';
-import { isSingleSig, nextVerification, SpendingConditionOpts } from './authorization';
-import { cloneDeep } from './utils';
+import { SpendingConditionOpts, isSingleSig, nextVerification } from './authorization';
 import { AuthType, PubKeyEncoding, StacksMessageType } from './constants';
 import { SigningError } from './errors';
+import { PrivateKey, StacksPublicKey } from './keys';
+import { cloneDeep } from './utils';
 
 export class TransactionSigner {
   transaction: StacksTransaction;
@@ -68,7 +68,7 @@ export class TransactionSigner {
     return signer;
   }
 
-  signOrigin(privateKey: StacksPrivateKey) {
+  signOrigin(privateKey: PrivateKey) {
     if (this.checkOverlap && this.originDone) {
       throw new SigningError('Cannot sign origin after sponsor key');
     }
@@ -111,7 +111,7 @@ export class TransactionSigner {
     this.transaction.appendPubkey(publicKey);
   }
 
-  signSponsor(privateKey: StacksPrivateKey) {
+  signSponsor(privateKey: PrivateKey) {
     if (this.transaction.auth === undefined) {
       throw new SigningError('"transaction.auth" is undefined');
     }

--- a/packages/transactions/src/structuredDataSignature.ts
+++ b/packages/transactions/src/structuredDataSignature.ts
@@ -1,9 +1,8 @@
 import { sha256 } from '@noble/hashes/sha256';
 import { bytesToHex, concatBytes, utf8ToBytes } from '@stacks/common';
-
 import { ClarityType, ClarityValue, serializeCV } from './clarity';
 import { StacksMessageType } from './constants';
-import { signMessageHashRsv, StacksPrivateKey } from './keys';
+import { PrivateKey, signMessageHashRsv } from './keys';
 
 // Refer to SIP018 https://github.com/stacksgov/sips/
 // > asciiToBytes('SIP018')
@@ -83,7 +82,7 @@ export function signStructuredData({
 }: {
   message: ClarityValue;
   domain: ClarityValue;
-  privateKey: StacksPrivateKey;
+  privateKey: PrivateKey;
 }): StructuredDataSignature {
   const structuredDataHash: string = bytesToHex(sha256(encodeStructuredData({ message, domain })));
 

--- a/packages/transactions/src/transaction.ts
+++ b/packages/transactions/src/transaction.ts
@@ -1,5 +1,4 @@
 import {
-  bytesToHex,
   concatArray,
   hexToBytes,
   IntegerType,
@@ -42,7 +41,7 @@ import { deserializePayload, Payload, PayloadInput, serializePayload } from './p
 
 import { createLPList, deserializeLPList, LengthPrefixedList, serializeLPList } from './types';
 
-import { isCompressed, StacksPrivateKey, StacksPublicKey } from './keys';
+import { PrivateKey, privateKeyIsCompressed, publicKeyIsCompressed, StacksPublicKey } from './keys';
 
 import { BytesReader } from './bytesReader';
 
@@ -125,7 +124,7 @@ export class StacksTransaction {
     return verifyOrigin(this.auth, this.verifyBegin());
   }
 
-  signNextOrigin(sigHash: string, privateKey: StacksPrivateKey): string {
+  signNextOrigin(sigHash: string, privateKey: PrivateKey): string {
     if (this.auth.spendingCondition === undefined) {
       throw new Error('"auth.spendingCondition" is undefined');
     }
@@ -135,7 +134,7 @@ export class StacksTransaction {
     return this.signAndAppend(this.auth.spendingCondition, sigHash, AuthType.Standard, privateKey);
   }
 
-  signNextSponsor(sigHash: string, privateKey: StacksPrivateKey): string {
+  signNextSponsor(sigHash: string, privateKey: PrivateKey): string {
     if (this.auth.authType === AuthType.Sponsored) {
       return this.signAndAppend(
         this.auth.sponsorSpendingCondition,
@@ -151,7 +150,7 @@ export class StacksTransaction {
   appendPubkey(publicKey: StacksPublicKey) {
     const cond = this.auth.spendingCondition;
     if (cond && !isSingleSig(cond)) {
-      const compressed = isCompressed(publicKey);
+      const compressed = publicKeyIsCompressed(publicKey.data);
       cond.fields.push(
         createTransactionAuthField(
           compressed ? PubKeyEncoding.Compressed : PubKeyEncoding.Uncompressed,
@@ -167,7 +166,7 @@ export class StacksTransaction {
     condition: SpendingConditionOpts,
     curSigHash: string,
     authType: AuthType,
-    privateKey: StacksPrivateKey
+    privateKey: PrivateKey
   ): string {
     const { nextSig, nextSigHash } = nextSignature(
       curSigHash,
@@ -179,7 +178,7 @@ export class StacksTransaction {
     if (isSingleSig(condition)) {
       condition.signature = nextSig;
     } else {
-      const compressed = bytesToHex(privateKey.data).endsWith('01');
+      const compressed = privateKeyIsCompressed(privateKey);
       condition.fields.push(
         createTransactionAuthField(
           compressed ? PubKeyEncoding.Compressed : PubKeyEncoding.Uncompressed,

--- a/packages/transactions/tests/authorization.test.ts
+++ b/packages/transactions/tests/authorization.test.ts
@@ -16,15 +16,14 @@ import { AddressHashMode, AuthType, PubKeyEncoding } from '../src/constants';
 
 import { bytesToHex, concatArray } from '@stacks/common';
 import { BytesReader } from '../src/bytesReader';
-import { createStacksPrivateKey, createStacksPublicKey, signWithKey } from '../src/keys';
+import { createStacksPublicKey, signWithKey } from '../src/keys';
 
 test('ECDSA recoverable signature', () => {
-  const privKeyString = 'edf9aee84d9b7abc145504dde6726c64f369d37ee34ded868fabd876c26570bc';
+  const privKey = 'edf9aee84d9b7abc145504dde6726c64f369d37ee34ded868fabd876c26570bc';
   const messagetoSign = 'eec72e6cd1ce0ac1dd1a0c260f099a8fc72498c80b3447f962fd5d39a3d70921';
   const correctSignature =
     '019901d8b1d67a7b853dc473d0609508ab2519ec370eabfef460aa0fd9234660' +
     '787970968562da9de8b024a7f36f946b2fdcbf39b2f59247267a9d72730f19276b';
-  const privKey = createStacksPrivateKey(privKeyString);
   const messageSignature = signWithKey(privKey, messagetoSign);
   expect(messageSignature.data).toBe(correctSignature);
 });
@@ -708,7 +707,7 @@ test('Single sig P2WPKH spending condition', () => {
   spP2WPKHCompressed.signer = '11'.repeat(20);
 
   // prettier-ignore
-  let spendingConditionP2WpkhCompressedBytes = [
+  const spendingConditionP2WpkhCompressedBytes = [
     // hash mode
     AddressHashMode.SerializeP2WPKH,
     // signer

--- a/packages/transactions/tests/clarity.test.ts
+++ b/packages/transactions/tests/clarity.test.ts
@@ -56,10 +56,10 @@ import assert from 'assert';
 
 const ADDRESS = 'SP2JXKMSH007NPYAQHKJPQMAQYAD90NQGTVJVQ02B';
 
-function serializeDeserialize<T extends ClarityValue>(value: T): ClarityValue {
+function serializeDeserialize<T extends ClarityValue>(value: T): T {
   const serializedDeserialized: Uint8Array = serializeCV(value);
   const bytesReader = new BytesReader(serializedDeserialized);
-  return deserializeCV(bytesReader);
+  return deserializeCV(bytesReader) as T;
 }
 
 describe('Clarity Types', () => {
@@ -322,7 +322,7 @@ describe('Clarity Types', () => {
       expect(max128.value.toString()).toBe('340282366920938463463374607431768211455');
       const serializedMax = serializeCV(max128);
       expect('0x' + bytesToHex(serializedMax.slice(1))).toBe('0xffffffffffffffffffffffffffffffff');
-      const serializedDeserializedMax = serializeDeserialize(max128) as IntCV;
+      const serializedDeserializedMax = serializeDeserialize(max128);
       expect(cvToString(serializedDeserializedMax)).toBe(cvToString(max128));
 
       // Min 128-bit integer
@@ -330,7 +330,7 @@ describe('Clarity Types', () => {
       expect(min128.value.toString()).toBe('0');
       const serializedMin = serializeCV(min128);
       expect('0x' + bytesToHex(serializedMin.slice(1))).toBe('0x00000000000000000000000000000000');
-      const serializedDeserializedMin = serializeDeserialize(min128) as IntCV;
+      const serializedDeserializedMin = serializeDeserialize(min128);
       expect(cvToString(serializedDeserializedMin)).toBe(cvToString(min128));
 
       // Out of bounds, too large
@@ -436,7 +436,6 @@ describe('Clarity Types', () => {
       // Test lexicographic ordering of tuple keys (to match Node Buffer compare)
       const lexicographic = Object.keys(tuple.data).sort((a, b) => {
         const bufA = Buffer.from(a);
-
         const bufB = Buffer.from(b);
         return bufA.compare(bufB);
       });

--- a/packages/transactions/tests/keys.test.ts
+++ b/packages/transactions/tests/keys.test.ts
@@ -2,8 +2,8 @@ import { sha256 } from '@noble/hashes/sha256';
 import {
   getPublicKey as nobleGetPublicKey,
   signSync as nobleSecp256k1Sign,
-  utils,
   verify as nobleSecp256k1Verify,
+  utils,
 } from '@noble/secp256k1';
 import {
   bytesToHex,
@@ -15,22 +15,20 @@ import {
 } from '@stacks/common';
 import { ec as EC } from 'elliptic';
 import {
+  PubKeyEncoding,
+  StacksMessageType,
   compressPublicKey,
-  createStacksPrivateKey,
+  createStacksPublicKey,
   getAddressFromPrivateKey,
   getAddressFromPublicKey,
-  getPublicKey,
   makeRandomPrivKey,
-  privateKeyToString,
-  PubKeyEncoding,
-  pubKeyfromPrivKey,
+  privateKeyToHex,
+  privateKeyToPublic,
   publicKeyFromSignatureRsv,
   publicKeyFromSignatureVrs,
-  publicKeyToString,
+  publicKeyToHex,
   signMessageHashRsv,
   signWithKey,
-  StacksMessageType,
-  StacksPublicKey,
 } from '../src';
 import { randomBytes } from '../src/utils';
 import { serializeDeserialize } from './macros';
@@ -40,43 +38,40 @@ import { TransactionVersion } from '@stacks/network';
 // Better do it once and reuse it
 const ec = new EC('secp256k1');
 
-test('pubKeyfromPrivKey', () => {
+test(privateKeyToPublic.name, () => {
   expect(
-    pubKeyfromPrivKey('edf9aee84d9b7abc145504dde6726c64f369d37ee34ded868fabd876c26570bc01').data
-      .byteLength
-  ).toBe(33);
+    privateKeyToPublic('edf9aee84d9b7abc145504dde6726c64f369d37ee34ded868fabd876c26570bc01').length
+  ).toBe(33 * 2);
   expect(
-    pubKeyfromPrivKey('edf9aee84d9b7abc145504dde6726c64f369d37ee34ded868fabd876c26570bc').data
-      .byteLength
-  ).toBe(65);
+    privateKeyToPublic('edf9aee84d9b7abc145504dde6726c64f369d37ee34ded868fabd876c26570bc').length
+  ).toBe(65 * 2);
 });
 
 test('Stacks public key and private keys', () => {
-  const privKeyString = 'edf9aee84d9b7abc145504dde6726c64f369d37ee34ded868fabd876c26570bc';
+  const privKey = 'edf9aee84d9b7abc145504dde6726c64f369d37ee34ded868fabd876c26570bc';
   const pubKeyString =
     '04ef788b3830c00abe8f64f62dc32fc863bc0b2cafeb073b6c8e1c7657d9c2c3ab' +
     '5b435d20ea91337cdd8c30dd7427bb098a5355e9c9bfad43797899b8137237cf';
-  const pubKey = pubKeyfromPrivKey(privKeyString);
-  expect(publicKeyToString(pubKey)).toBe(pubKeyString);
+  const pubKey = createStacksPublicKey(privateKeyToPublic(privKey));
+  expect(publicKeyToHex(pubKey.data)).toBe(pubKeyString);
 
-  const deserialized = serializeDeserialize(pubKey, StacksMessageType.PublicKey) as StacksPublicKey;
-  expect(publicKeyToString(deserialized)).toBe(pubKeyString);
+  const deserialized = serializeDeserialize(pubKey, StacksMessageType.PublicKey);
+  expect(bytesToHex(deserialized.data)).toBe(pubKeyString);
 
-  const privKey = createStacksPrivateKey(privKeyString);
-  expect(publicKeyToString(getPublicKey(privKey))).toBe(pubKeyString);
+  expect(privateKeyToPublic(privKey)).toBe(pubKeyString);
 
-  const randomKey = makeRandomPrivKey();
-  expect(privateKeyToString(randomKey).length).toEqual(64);
+  const randomKey = makeRandomPrivKey(); // defaults to uncompressed (i.e. no 01 suffix)
+  expect(privateKeyToHex(randomKey).length).toEqual(64);
 
-  expect(getAddressFromPrivateKey(privKeyString)).toBe('SPZG6BAY4JVR9RNAB1HY92B7Q208ZYY4HZEA9PX5');
-  expect(getAddressFromPrivateKey(hexToBytes(privKeyString))).toBe(
+  expect(getAddressFromPrivateKey(privKey)).toBe('SPZG6BAY4JVR9RNAB1HY92B7Q208ZYY4HZEA9PX5');
+  expect(getAddressFromPrivateKey(hexToBytes(privKey))).toBe(
     'SPZG6BAY4JVR9RNAB1HY92B7Q208ZYY4HZEA9PX5'
   );
 
-  expect(getAddressFromPrivateKey(privKeyString, TransactionVersion.Testnet)).toBe(
+  expect(getAddressFromPrivateKey(privKey, TransactionVersion.Testnet)).toBe(
     'STZG6BAY4JVR9RNAB1HY92B7Q208ZYY4HZG8ZXFM'
   );
-  expect(getAddressFromPrivateKey(hexToBytes(privKeyString), TransactionVersion.Testnet)).toBe(
+  expect(getAddressFromPrivateKey(hexToBytes(privKey), TransactionVersion.Testnet)).toBe(
     'STZG6BAY4JVR9RNAB1HY92B7Q208ZYY4HZG8ZXFM'
   );
 
@@ -92,7 +87,7 @@ test('Stacks public key and private keys', () => {
     'STZG6BAY4JVR9RNAB1HY92B7Q208ZYY4HZG8ZXFM'
   );
 
-  const compressedPubKey = bytesToHex(compressPublicKey(pubKey.data).data);
+  const compressedPubKey = compressPublicKey(pubKey.data);
   expect(compressedPubKey).toBe(
     '03ef788b3830c00abe8f64f62dc32fc863bc0b2cafeb073b6c8e1c7657d9c2c3ab'
   );
@@ -107,9 +102,7 @@ test('signWithKey', () => {
   //   )
   // >> true
 
-  const privateKey = createStacksPrivateKey(
-    'bcf62fdd286f9b30b2c289cce3189dbf3b502dcd955b2dc4f67d18d77f3e73c7'
-  );
+  const privateKey = 'bcf62fdd286f9b30b2c289cce3189dbf3b502dcd955b2dc4f67d18d77f3e73c7';
   const expectedMessageHash = 'a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e';
   const expectedSignatureVrs =
     '00f540e429fc6e8a4c27f2782479e739cae99aa21e8cb25d4436f333577bc791cd1d9672055dd1604dd5194b88076e4f859dd93c834785ed589ec38291698d4142';
@@ -130,9 +123,7 @@ test('signMessageHashRsv', () => {
   //   )
   // >> true
 
-  const privateKey = createStacksPrivateKey(
-    'bcf62fdd286f9b30b2c289cce3189dbf3b502dcd955b2dc4f67d18d77f3e73c7'
-  );
+  const privateKey = 'bcf62fdd286f9b30b2c289cce3189dbf3b502dcd955b2dc4f67d18d77f3e73c7';
   const expectedMessageHash = 'a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e';
   const expectedSignatureRsv =
     'f540e429fc6e8a4c27f2782479e739cae99aa21e8cb25d4436f333577bc791cd1d9672055dd1604dd5194b88076e4f859dd93c834785ed589ec38291698d414200';
@@ -146,9 +137,7 @@ test('signMessageHashRsv', () => {
 
 test('noble sign message', () => {
   // example from https://paulmillr.com/noble/
-  const privateKey = createStacksPrivateKey(
-    '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
-  );
+  const privateKey = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
   const expectedMessageHash = '011a775441ecb14943130a16f00cdd41818a83dd04372f3259e3ca7237e3cdaa';
   const expectedR = 114926983411733245831514739773229123958640458736536797227773647312126690926912n;
   const expectedS = 3148023981578716756961627923124903910422344826113324160219886779423594190576n;
@@ -165,9 +154,7 @@ test('noble sign message', () => {
 });
 
 test('Retrieve public key from rsv signature', () => {
-  const privKey = createStacksPrivateKey(
-    'edf9aee84d9b7abc145504dde6726c64f369d37ee34ded868fabd876c26570bc'
-  );
+  const privKey = 'edf9aee84d9b7abc145504dde6726c64f369d37ee34ded868fabd876c26570bc';
   const uncompressedPubKey =
     '04ef788b3830c00abe8f64f62dc32fc863bc0b2cafeb073b6c8e1c7657d9c2c3ab5b435d20ea91337cdd8c30dd7427bb098a5355e9c9bfad43797899b8137237cf';
   const compressedPubKey = '03ef788b3830c00abe8f64f62dc32fc863bc0b2cafeb073b6c8e1c7657d9c2c3ab';
@@ -192,9 +179,7 @@ test('Retrieve public key from rsv signature', () => {
 });
 
 test('Retrieve public key from vrs signature', () => {
-  const privateKey = createStacksPrivateKey(
-    'edf9aee84d9b7abc145504dde6726c64f369d37ee34ded868fabd876c26570bc'
-  );
+  const privateKey = 'edf9aee84d9b7abc145504dde6726c64f369d37ee34ded868fabd876c26570bc';
   const uncompressedPubKey =
     '04ef788b3830c00abe8f64f62dc32fc863bc0b2cafeb073b6c8e1c7657d9c2c3ab5b435d20ea91337cdd8c30dd7427bb098a5355e9c9bfad43797899b8137237cf';
   const compressedPubKey = '03ef788b3830c00abe8f64f62dc32fc863bc0b2cafeb073b6c8e1c7657d9c2c3ab';

--- a/packages/transactions/tests/macros.ts
+++ b/packages/transactions/tests/macros.ts
@@ -2,8 +2,11 @@ import { StacksMessage, serializeStacksMessage, deserializeStacksMessage } from 
 import { BytesReader } from '../src/bytesReader';
 import { StacksMessageType } from '../src/constants';
 
-export function serializeDeserialize(value: StacksMessage, type: StacksMessageType): StacksMessage {
+export function serializeDeserialize<V extends StacksMessage, T extends StacksMessageType>(
+  value: V,
+  type: T
+): V {
   const serialized = serializeStacksMessage(value);
   const byteReader = new BytesReader(serialized);
-  return deserializeStacksMessage(byteReader, type);
+  return deserializeStacksMessage(byteReader, type) as V;
 }

--- a/packages/transactions/tests/structuredDataSignature.test.ts
+++ b/packages/transactions/tests/structuredDataSignature.test.ts
@@ -2,7 +2,7 @@ import { sha256 } from '@noble/hashes/sha256';
 import { asciiToBytes, bytesToHex, hexToBytes } from '@stacks/common';
 import { verifyMessageSignatureRsv } from '@stacks/encryption';
 import { standardPrincipalCV, stringAsciiCV, trueCV, tupleCV, uintCV } from '../src/clarity';
-import { createStacksPrivateKey, publicKeyFromSignatureRsv, signMessageHashRsv } from '../src/keys';
+import { publicKeyFromSignatureRsv, signMessageHashRsv } from '../src/keys';
 import {
   decodeStructuredDataSignature,
   encodeStructuredData,
@@ -212,7 +212,7 @@ describe('SIP018 test vectors', () => {
   });
 
   test('Message signing', () => {
-    const privateKeyString = '753b7cc01a1a2e86221266a154af739463fce51219d97e4f856cd7200c3bd2a601';
+    const privateKey = '753b7cc01a1a2e86221266a154af739463fce51219d97e4f856cd7200c3bd2a601';
     const publicKey = '0390a5cac7c33fda49f70bc1b0866fa0ba7a9440d9de647fecb8132ceb76a94dfa';
     // const address = 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM';
     const domain = tupleCV({
@@ -224,7 +224,6 @@ describe('SIP018 test vectors', () => {
     const messageHash = '1bfdab6d4158313ce34073fbb8d6b0fc32c154d439def12247a0f44bb2225259';
     const expectedSignature =
       '8b94e45701d857c9f1d1d70e8b2ca076045dae4920fb0160be0642a68cd78de072ab527b5c5277a593baeb2a8b657c216b99f7abb5d14af35b4bf12ba6460ba401';
-    const privateKey = createStacksPrivateKey(privateKeyString);
     const computedSignature = signStructuredData({
       message,
       domain,
@@ -251,11 +250,11 @@ test('verifyMessageSignature works for both legacy/current and future message si
 
   const signature = signMessageHashRsv({
     messageHash: encodedMessageHash,
-    privateKey: createStacksPrivateKey(privateKey),
+    privateKey,
   });
   const signatureAlt = signMessageHashRsv({
     messageHash: encodedMessageHashAlt,
-    privateKey: createStacksPrivateKey(privateKey),
+    privateKey,
   });
 
   const publicKey = publicKeyFromSignatureRsv(encodedMessageHash, signature);

--- a/packages/wallet-sdk/tests/models/profile.test.ts
+++ b/packages/wallet-sdk/tests/models/profile.test.ts
@@ -1,5 +1,5 @@
 import { getPublicKeyFromPrivate } from '@stacks/encryption';
-import { makeRandomPrivKey, privateKeyToString } from '@stacks/transactions';
+import { makeRandomPrivKey } from '@stacks/transactions';
 import fetchMock from 'jest-fetch-mock';
 import { TokenVerifier } from 'jsontokens';
 import {
@@ -50,7 +50,7 @@ describe(signProfileForUpload, () => {
 
   test('sign with unknown private key', () => {
     const account = mockAccount;
-    account.stxPrivateKey = privateKeyToString(makeRandomPrivKey());
+    account.stxPrivateKey = makeRandomPrivKey();
     const profile = DEFAULT_PROFILE;
 
     const signedProfileString = signProfileForUpload({ profile, account });


### PR DESCRIPTION
- removes "wrapped" string private keys in favor of "flat" string/Uint8Array type aliases.
  - tldr: now we can just use string hex encoded private keys for all methods. before we often had to wrap with `createStacksPrivateKey(...)`