### PR TITLE
feat: cli option to decode serialized Clarity values

### DIFF
--- a/packages/cli/src/argparse.ts
+++ b/packages/cli/src/argparse.ts
@@ -424,7 +424,7 @@ export const CLI_ARGS = {
         '    {"type":"principal","value":"S08XXBDYXW8TQAZZZW8XXBDYXW8TQAZZZZ88551S"}\n' +
         '    $ echo 0x050011deadbeef11ababffff11deadbeef11ababffff | stx decode_cv -\n' +
         '    S08XXBDYXW8TQAZZZW8XXBDYXW8TQAZZZZ88551S\n',
-      group: 'Account Management',
+      group: 'Utilities',
     },
     convert_address: {
       type: 'array',

--- a/packages/cli/src/argparse.ts
+++ b/packages/cli/src/argparse.ts
@@ -422,7 +422,7 @@ export const CLI_ARGS = {
         '    S08XXBDYXW8TQAZZZW8XXBDYXW8TQAZZZZ88551S\n' +
         '    $ stx decode_cv --format json SPA2MZWV9N67TBYVWTE0PSSKMJ2F6YXW7CBE6YPW\n' +
         '    {"type":"principal","value":"S08XXBDYXW8TQAZZZW8XXBDYXW8TQAZZZZ88551S"}\n' +
-        '    $ echo SPA2MZWV9N67TBYVWTE0PSSKMJ2F6YXW7CBE6YPW | stx decode_cv -\n' +
+        '    $ echo 0x050011deadbeef11ababffff11deadbeef11ababffff | stx decode_cv -\n' +
         '    S08XXBDYXW8TQAZZZW8XXBDYXW8TQAZZZZ88551S\n',
       group: 'Account Management',
     },

--- a/packages/cli/src/argparse.ts
+++ b/packages/cli/src/argparse.ts
@@ -395,6 +395,37 @@ export const CLI_ARGS = {
         '\n',
       group: 'Account Management',
     },
+    decode_cv: {
+      type: 'array',
+      items: [
+        {
+          name: 'clarity_value',
+          type: 'string',
+          realtype: 'string',
+          pattern: '-|^(0x|0X)?[a-fA-F0-9]+$',
+        },
+        {
+          name: 'format',
+          type: 'string',
+          realtype: 'format',
+          pattern: '^(repr|pretty|json)$',
+        },
+      ],
+      minItems: 1,
+      maxItems: 4,
+      help:
+        'Decode a serialized Clarity value.\n' +
+        '\n' +
+        'Example:\n' +
+        '\n' +
+        '    $ stx decode_cv 0x050011deadbeef11ababffff11deadbeef11ababffff\n' +
+        '    S08XXBDYXW8TQAZZZW8XXBDYXW8TQAZZZZ88551S\n' +
+        '    $ stx decode_cv --format json SPA2MZWV9N67TBYVWTE0PSSKMJ2F6YXW7CBE6YPW\n' +
+        '    {"type":"principal","value":"S08XXBDYXW8TQAZZZW8XXBDYXW8TQAZZZZ88551S"}\n' +
+        '    $ echo SPA2MZWV9N67TBYVWTE0PSSKMJ2F6YXW7CBE6YPW | stx decode_cv -\n' +
+        '    S08XXBDYXW8TQAZZZW8XXBDYXW8TQAZZZZ88551S\n',
+      group: 'Account Management',
+    },
     convert_address: {
       type: 'array',
       items: [


### PR DESCRIPTION
> This PR was published to npm with the version `6.9.1-pr.b33d848.0`
> e.g. `npm install @stacks/common@6.9.1-pr.b33d848.0 --save-exact`<!-- Sticky Header Marker -->

### Description

New CLI feature to decode Clarity values into json/repr/pretty strings.

### Example

The `repr` format string is returned by default:
```shell
$ stx decode_cv 0b00000003000000000000000000000000000000000100000000000000000000000000000000020000000000000000000000000000000003
(list 1 2 3)
```

Use `--format json` to output JSON:
```shell
$ stx decode_cv --format json 0b00000003000000000000000000000000000000000100000000000000000000000000000000020000000000000000000000000000000003
{"type":"(list 3 int)","value":[{"type":"int","value":"1"},{"type":"int","value":"2"},{"type":"int","value":"3"}]}
```

Use `--format pretty` to output a pretty-print repr string:
```shell
$ stx decode_cv --format pretty 0b00000003000000000000000000000000000000000100000000000000000000000000000000020000000000000000000000000000000003
(list
  1
  2
  3
)
```

Values can also be piped into the command by using `-` in place of the value:
```shell
$ echo 0x050011deadbeef11ababffff11deadbeef11ababffff | stx decode_cv --format json -
{"type":"principal","value":"S08XXBDYXW8TQAZZZW8XXBDYXW8TQAZZZZ88551S"}
```

Real world example of decoding output from a Stacks node RPC call:
```shell
$ curl -sX POST 'https://stacks-node-api.testnet.stacks.co/v2/map_entry/ST000000000000000000002AMW42H/pox-3/delegation-state?proof=0' -H 'Content-Type: application/json' -d '"0x0c0000000107737461636b65720515f1a77e086d9de40dfa879175c4fb22f426950c5d"' | jq -r .data | stx decode_cv --format pretty -
(some {
  amount-ustx: u10000000,
  delegated-to: 'SND3WM4FYSYFZM2C8K62K1XJD97W6YTXET0N4C6A,
  pox-addr: none,
  until-burn-ht: (some u2540805)
})
```
---

### Checklist

- [x] Unit tested updated code paths
- [x] Tagged 1 of @janniks or @zone117x for review

