### PR TITLE
fix: handle `NoEstimateAvailable` text error body

### DIFF
--- a/packages/transactions/src/builders.ts
+++ b/packages/transactions/src/builders.ts
@@ -209,9 +209,18 @@ export async function estimateTransaction(
   const response = await derivedNetwork.fetchFn(url, options);
 
   if (!response.ok) {
-    const body = await response.json().catch(() => ({}));
+    const body = await response.text().then(str => {
+      try {
+        return JSON.parse(str);
+      } catch (error) {
+        return str;
+      }
+    });
 
-    if (body?.reason === 'NoEstimateAvailable') {
+    if (
+      body?.reason === 'NoEstimateAvailable' ||
+      (typeof body === 'string' && body.includes('NoEstimateAvailable'))
+    ) {
       throw new NoEstimateAvailableError(body?.reason_data?.message ?? '');
     }
 

--- a/packages/transactions/tests/builder.test.ts
+++ b/packages/transactions/tests/builder.test.ts
@@ -1245,6 +1245,19 @@ test('Estimate transaction fee fallback', async () => {
   const resultEstimateFee = await estimateTransactionFeeWithFallback(tx, testnet);
   expect(resultEstimateFee).toBe(201n);
 
+  // Test with plain-text response
+  // http://localhost:3999/v2/fees/transaction
+  fetchMock.once(
+    `Estimator RPC endpoint failed to estimate tx TokenTransfer: NoEstimateAvailable`,
+    { status: 400 }
+  );
+
+  // http://localhost:3999/v2/fees/transfer
+  fetchMock.once('1');
+
+  const resultEstimateFee2 = await estimateTransactionFeeWithFallback(tx, testnet);
+  expect(resultEstimateFee2).toBe(201n);
+
   // http://localhost:3999/v2/fees/transaction
   fetchMock.once(
     `{"error":"Estimation could not be performed","reason":"NoEstimateAvailable","reason_data":{"message":"No estimate available for the provided payload."}}`,
@@ -1257,7 +1270,7 @@ test('Estimate transaction fee fallback', async () => {
   const doubleRate = await estimateTransactionFeeWithFallback(tx, testnet);
   expect(doubleRate).toBe(402n);
 
-  expect(fetchMock.mock.calls.length).toEqual(6);
+  expect(fetchMock.mock.calls.length).toEqual(8);
 });
 
 test('Single-sig transaction byte length must include signature', async () => {


### PR DESCRIPTION
> This PR was published to npm with the version `6.10.1-pr.ccf1faa.0`
> e.g. `npm install @stacks/common@6.10.1-pr.ccf1faa.0 --save-exact`<!-- Sticky Header Marker -->

The latest stacks-node in the next branch can have an error response as a text body (as opposed to json). Not sure if this is a regression in the stacks-node. Either way, this PR will handle the case of a `NoEstimateAvailable` text body response.