### PR TITLE
fix: add error throwing on too large fungible post-condition

### DIFF
--- a/packages/transactions/src/postcondition.ts
+++ b/packages/transactions/src/postcondition.ts
@@ -1,22 +1,20 @@
 import { IntegerType, intToBigInt } from '@stacks/common';
+import { ClarityValue } from './clarity';
 import {
-  PostConditionType,
   FungibleConditionCode,
   NonFungibleConditionCode,
+  PostConditionType,
   StacksMessageType,
 } from './constants';
-
 import {
   AssetInfo,
-  PostConditionPrincipal,
-  parseAssetInfoString,
-  parsePrincipalString,
-  STXPostCondition,
   FungiblePostCondition,
   NonFungiblePostCondition,
+  PostConditionPrincipal,
+  STXPostCondition,
+  parseAssetInfoString,
+  parsePrincipalString,
 } from './postcondition-types';
-
-import { ClarityValue } from './clarity';
 
 export function createSTXPostCondition(
   principal: string | PostConditionPrincipal,

--- a/packages/transactions/src/types.ts
+++ b/packages/transactions/src/types.ts
@@ -42,7 +42,7 @@ import {
   createLPString,
 } from './postcondition-types';
 import { Payload, deserializePayload, serializePayload } from './payload';
-import { DeserializationError } from './errors';
+import { DeserializationError, SerializationError } from './errors';
 import {
   deserializeTransactionAuthField,
   deserializeMessageSignature,
@@ -379,6 +379,9 @@ export function serializePostCondition(postCondition: PostCondition): Uint8Array
     postCondition.conditionType === PostConditionType.STX ||
     postCondition.conditionType === PostConditionType.Fungible
   ) {
+    // SIP-005: Maximal length of amount is 8 bytes
+    if (postCondition.amount > BigInt('0xffffffffffffffff'))
+      throw new SerializationError('The post-condition amount may not be larger than 8 bytes');
     bytesArray.push(intToBytes(postCondition.amount, false, 8));
   }
 


### PR DESCRIPTION
> This PR was published to npm with the version `6.11.2-pr.eb56e94.0`
> e.g. `npm install @stacks/common@6.11.2-pr.eb56e94.0 --save-exact`<!-- Sticky Header Marker -->

- closes #1611 