### PR TITLE
fix: update legacy API endpoints

### DIFF
--- a/docs/how-to-guides/how-to-integrate-stacking-delegation.md
+++ b/docs/how-to-guides/how-to-integrate-stacking-delegation.md
@@ -34,7 +34,7 @@ stacks make_keychain -t > delegator.json
 You can use the faucet to obtain testnet STX tokens for the test account. Replace `<stxAddress>` below with your address:
 
 ```sh
-curl -XPOST "https://stacks-node-api.testnet.stacks.co/extended/v1/faucets/stx?address=<stxAddress>&stacking=true"
+curl -XPOST "https://api.testnet.hiro.so/extended/v1/faucets/stx?address=<stxAddress>&stacking=true"
 ```
 
 ## Step 1: Integrate libraries

--- a/docs/how-to-guides/how-to-integrate-stacking.md
+++ b/docs/how-to-guides/how-to-integrate-stacking.md
@@ -157,7 +157,7 @@ const hasMinStxAmount = await client.hasMinimumStx();
 For testing purposes, you can use the faucet to obtain testnet STX tokens. Replace `<stxAddress>` below with your address:
 
 ```shell
-curl -XPOST "https://stacks-node-api.testnet.stacks.co/extended/v1/faucets/stx?address=<stxAddress>&stacking=true"
+curl -XPOST "https://api.testnet.hiro.so/extended/v1/faucets/stx?address=<stxAddress>&stacking=true"
 ```
 
 You'll have to wait a few minutes for the transaction to complete.
@@ -274,7 +274,7 @@ More details on the lifecycle of transactions can be found in the [transactions 
 Alternatively to the polling, the Stacks Blockchain API client library offers WebSockets. WebSockets can be used to subscribe to specific updates, like transaction status changes. Here is an example:
 
 ```js
-const client = await connectWebSocketClient('ws://stacks-node-api.blockstack.org/');
+const client = await connectWebSocketClient('ws://api.hiro.so/');
 
 // note: txId should be defined previously
 const sub = await client.subscribeAddressTransactions(txId, event => {
@@ -332,5 +332,5 @@ As an example, if you want to get the rewards paid to `btcAddress`, you can make
 
 ```shell
 # for mainnet, replace `testnet` with `mainnet`
-curl 'https://stacks-node-api.testnet.stacks.co/extended/v1/burnchain/rewards/<btcAddress>'
+curl 'https://api.testnet.hiro.so/extended/v1/burnchain/rewards/<btcAddress>'
 ```

--- a/packages/auth/src/constants.ts
+++ b/packages/auth/src/constants.ts
@@ -53,7 +53,7 @@ export const BLOCKSTACK_APP_PRIVATE_KEY_LABEL = 'blockstack-transit-private-key'
 /**
  * @ignore
  */
-export const DEFAULT_CORE_NODE = 'https://stacks-node-api.stacks.co';
+export const DEFAULT_CORE_NODE = 'https://api.hiro.so';
 /**
  * @ignore
  */

--- a/packages/auth/tests/auth.test.ts
+++ b/packages/auth/tests/auth.test.ts
@@ -558,7 +558,7 @@ test('profileLookUp', async () => {
   expect(fetchMock.mock.calls[0][0]).toEqual('http://potato:6270/v1/names/ryan.id');
   expect(fetchMock.mock.calls[1][0]).toEqual(sampleTokenFiles.ryan.url);
   expect(fetchMock.mock.calls[2][0]).toEqual(
-    'https://stacks-node-api.mainnet.stacks.co/v1/names/ryan.id'
+    'https://api.mainnet.hiro.so/v1/names/ryan.id'
   );
   expect(fetchMock.mock.calls[3][0]).toEqual(sampleTokenFiles.ryan.url);
 });

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1937,7 +1937,7 @@ function faucetCall(_: CLINetworkAdapter, args: string[]): Promise<string> {
 
   const apiConfig = new Configuration({
     fetchApi: crossfetch,
-    basePath: 'https://stacks-node-api.testnet.stacks.co',
+    basePath: 'https://api.testnet.hiro.so',
   });
 
   const faucets = new FaucetsApi(apiConfig);

--- a/packages/network/src/fetch.ts
+++ b/packages/network/src/fetch.ts
@@ -100,7 +100,7 @@ export function hostMatches(host: string, pattern: string | RegExp) {
  */
 export function createApiKeyMiddleware({
   apiKey,
-  host = /(.*)api(.*)\.stacks\.co$/i,
+  host = /(.*)api(.*)(\.stacks\.co|\.hiro\.so)$/i,
   httpHeader = 'x-api-key',
 }: ApiKeyMiddlewareOpts): FetchMiddleware {
   return {

--- a/packages/network/src/network.ts
+++ b/packages/network/src/network.ts
@@ -1,8 +1,8 @@
 import { TransactionVersion, ChainID } from '@stacks/common';
 import { createFetchFn, FetchFn } from './fetch';
 
-export const HIRO_MAINNET_DEFAULT = 'https://stacks-node-api.mainnet.stacks.co';
-export const HIRO_TESTNET_DEFAULT = 'https://stacks-node-api.testnet.stacks.co';
+export const HIRO_MAINNET_DEFAULT = 'https://api.mainnet.hiro.so';
+export const HIRO_TESTNET_DEFAULT = 'https://api.testnet.hiro.so';
 export const HIRO_MOCKNET_DEFAULT = 'http://localhost:3999';
 
 /**
@@ -28,7 +28,7 @@ export type StacksNetworkName = (typeof StacksNetworks)[number];
 export class StacksNetwork {
   version: TransactionVersion = TransactionVersion.Mainnet;
   chainId: ChainID = ChainID.Mainnet;
-  bnsLookupUrl = 'https://stacks-node-api.mainnet.stacks.co';
+  bnsLookupUrl = 'https://api.mainnet.hiro.so';
   broadcastEndpoint = '/v2/transactions';
   transferFeeEstimateEndpoint = '/v2/fees/transfer';
   transactionFeeEstimateEndpoint = '/v2/fees/transaction';
@@ -155,7 +155,7 @@ export class StacksNetwork {
  * @example
  * ```
  * const network = new StacksMainnet();
- * const network = new StacksMainnet({ url: "https://stacks-node-api.mainnet.stacks.co" });
+ * const network = new StacksMainnet({ url: "https://api.mainnet.hiro.so" });
  * const network = new StacksMainnet({ fetch: createFetchFn() });
  * ```
  * @related {@link createFetchFn}, {@link createApiKeyMiddleware}
@@ -179,7 +179,7 @@ export class StacksMainnet extends StacksNetwork {
  * @example
  * ```
  * const network = new StacksTestnet();
- * const network = new StacksTestnet({ url: "https://stacks-node-api.testnet.stacks.co" });
+ * const network = new StacksTestnet({ url: "https://api.testnet.hiro.so" });
  * const network = new StacksTestnet({ fetch: createFetchFn() });
  * ```
  * @related {@link createFetchFn}, {@link createApiKeyMiddleware}

--- a/packages/network/tests/fetchMiddleware.test.ts
+++ b/packages/network/tests/fetchMiddleware.test.ts
@@ -24,6 +24,9 @@ test('createApiKeyMiddleware adds x-api-key header to correct host request', asy
 
   await fetchFn('https://api.stacks.co');
   expect((fetchMock.mock.calls[1][1]?.headers as Headers)?.get('x-api-key')).toContain(apiKey);
+
+  await fetchFn('https://api.hiro.so');
+  expect((fetchMock.mock.calls[1][1]?.headers as Headers)?.get('x-api-key')).toContain(apiKey);
 });
 
 test('middleware calls pre and post', async () => {

--- a/packages/transactions/src/constants.ts
+++ b/packages/transactions/src/constants.ts
@@ -16,7 +16,7 @@ export const RECOVERABLE_ECDSA_SIG_LENGTH_BYTES = 65;
 export const COMPRESSED_PUBKEY_LENGTH_BYTES = 32;
 export const UNCOMPRESSED_PUBKEY_LENGTH_BYTES = 64;
 export const MEMO_MAX_LENGTH_BYTES = 34;
-export const DEFAULT_CORE_NODE_API_URL = 'https://stacks-node-api.mainnet.stacks.co';
+export const DEFAULT_CORE_NODE_API_URL = 'https://api.mainnet.hiro.so';
 
 // todo: add explicit enum values
 /**

--- a/packages/transactions/tests/builder.test.ts
+++ b/packages/transactions/tests/builder.test.ts
@@ -125,7 +125,7 @@ test('API key middleware - get nonce', async () => {
   expect(fetchNonce).toBe(123n);
   expect(fetchMock.mock.calls.length).toEqual(1);
   expect(fetchMock.mock.calls[0][0]).toEqual(
-    'https://stacks-node-api.mainnet.stacks.co/v2/accounts/STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6?proof=0'
+    'https://api.mainnet.hiro.so/v2/accounts/STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6?proof=0'
   );
   const callHeaders = new Headers(fetchMock.mock.calls[0][1]?.headers);
   expect(callHeaders.has('x-api-key')).toBeTruthy();

--- a/packages/wallet-sdk/src/utils.ts
+++ b/packages/wallet-sdk/src/utils.ts
@@ -20,7 +20,7 @@ export const getProfileURLFromZoneFile = async (
   name: string,
   fetchFn: FetchFn = createFetchFn()
 ) => {
-  const url = `https://stacks-node-api.stacks.co/v1/names/${name}`;
+  const url = `https://api.hiro.so/v1/names/${name}`;
   const res = await fetchFn(url);
   if (res.ok) {
     const nameInfo: NameInfoResponse = await res.json();

--- a/packages/wallet-sdk/tests/derive-keychain.test.ts
+++ b/packages/wallet-sdk/tests/derive-keychain.test.ts
@@ -143,7 +143,7 @@ test('derive derivation path with new username owned by address of stx derivatio
   expect(username).toEqual('public_profile_for_testing.id.blockstack');
   expect(stxDerivationType).toEqual(DerivationType.Wallet);
   expect(fetchMock.mock.calls[0][0]).toEqual(
-    `https://stacks-node-api.mainnet.stacks.co/v1/addresses/stacks/${WALLET_ADDRESS}`
+    `https://api.mainnet.hiro.so/v1/addresses/stacks/${WALLET_ADDRESS}`
   );
 });
 
@@ -165,10 +165,10 @@ test('derive derivation path with new username owned by address of data derivati
   expect(username).toEqual('public_profile_for_testing.id.blockstack');
   expect(stxDerivationType).toEqual(DerivationType.Data);
   expect(fetchMock.mock.calls[0][0]).toEqual(
-    `https://stacks-node-api.mainnet.stacks.co/v1/addresses/stacks/${WALLET_ADDRESS}`
+    `https://api.mainnet.hiro.so/v1/addresses/stacks/${WALLET_ADDRESS}`
   );
   expect(fetchMock.mock.calls[1][0]).toEqual(
-    `https://stacks-node-api.mainnet.stacks.co/v1/addresses/stacks/${DATA_ADDRESS}`
+    `https://api.mainnet.hiro.so/v1/addresses/stacks/${DATA_ADDRESS}`
   );
 });
 
@@ -239,5 +239,5 @@ test('fetch username defaults to mainnet', async () => {
     index: 0,
     derivationType: DerivationType.Wallet,
   });
-  expect(fetchMock.mock.calls[0][0]).toContain('stacks-node-api.mainnet');
+  expect(fetchMock.mock.calls[0][0]).toContain('api.mainnet');
 });

--- a/packages/wallet-sdk/tests/derive.test.ts
+++ b/packages/wallet-sdk/tests/derive.test.ts
@@ -142,7 +142,7 @@ test('derive derivation path with new username owned by address of stx derivatio
   expect(username).toEqual('public_profile_for_testing.id.blockstack');
   expect(stxDerivationType).toEqual(DerivationType.Wallet);
   expect(fetchMock.mock.calls[0][0]).toEqual(
-    `https://stacks-node-api.mainnet.stacks.co/v1/addresses/stacks/${WALLET_ADDRESS}`
+    `https://api.mainnet.hiro.so/v1/addresses/stacks/${WALLET_ADDRESS}`
   );
 });
 
@@ -164,10 +164,10 @@ test('derive derivation path with new username owned by address of data derivati
   expect(username).toEqual('public_profile_for_testing.id.blockstack');
   expect(stxDerivationType).toEqual(DerivationType.Data);
   expect(fetchMock.mock.calls[0][0]).toEqual(
-    `https://stacks-node-api.mainnet.stacks.co/v1/addresses/stacks/${WALLET_ADDRESS}`
+    `https://api.mainnet.hiro.so/v1/addresses/stacks/${WALLET_ADDRESS}`
   );
   expect(fetchMock.mock.calls[1][0]).toEqual(
-    `https://stacks-node-api.mainnet.stacks.co/v1/addresses/stacks/${DATA_ADDRESS}`
+    `https://api.mainnet.hiro.so/v1/addresses/stacks/${DATA_ADDRESS}`
   );
 });
 
@@ -238,5 +238,5 @@ test('fetch username defaults to mainnet', async () => {
     index: 0,
     derivationType: DerivationType.Wallet,
   });
-  expect(fetchMock.mock.calls[0][0]).toContain('stacks-node-api.mainnet');
+  expect(fetchMock.mock.calls[0][0]).toContain('api.mainnet');
 });


### PR DESCRIPTION
> This PR was published to npm with the version `6.11.3-pr.582c529.0`
> e.g. `npm install @stacks/common@6.11.3-pr.582c529.0 --save-exact`<!-- Sticky Header Marker -->

Update legacy API endpoints to hiro.so endpoints.
