### PR TITLE
[1] feat!: stacksjs refactor

### DIFF
--- a/packages/common/src/config.ts
+++ b/packages/common/src/config.ts
@@ -1,10 +1,8 @@
-// import { network } from './network'
-
 /**
  * @ignore
+ * todo: remove this file (needed for CLI?)
  */
 const config = {
-  // network: network.defaults.MAINNET_DEFAULT,
   network: {
     layer1: 'placeholder',
   },

--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -1,41 +1,9 @@
-/**
- * The **chain** ID.
- * Is used for signing, so transactions can't be replayed on other chains.
- */
-export enum ChainID {
-  Testnet = 0x80000000,
-  Mainnet = 0x00000001,
-}
-
-/**
- * The **transaction** version.
- * Is used for signing, so transactions can't be replayed on other networks.
- */
-export enum TransactionVersion {
-  Mainnet = 0x00,
-  Testnet = 0x80,
-}
-
-/**
- * The **peer** network ID.
- * Typically not used in signing, but used for broadcasting to the P2P network.
- * It can also be used to determine the parent of a subnet.
- *
- * **Attention:**
- * For mainnet/testnet the v2/info response `.network_id` refers to the chain ID.
- * For subnets the v2/info response `.network_id` refers to the peer network ID and the chain ID (they are the same for subnets).
- * The `.parent_network_id` refers to the actual peer network ID (of the parent) in both cases.
- */
-export enum PeerNetworkID {
-  Mainnet = 0x17000000,
-  Testnet = 0xff000000,
-}
+export const HIRO_MAINNET_URL = 'https://api.mainnet.hiro.so';
+export const HIRO_TESTNET_URL = 'https://api.testnet.hiro.so';
+export const DEVNET_URL = 'http://localhost:3999';
 
 /** @ignore internal */
 export const PRIVATE_KEY_COMPRESSED_LENGTH = 33;
 
 /** @ignore internal */
 export const PRIVATE_KEY_UNCOMPRESSED_LENGTH = 32;
-
-/** @ignore internal */
-export const BLOCKSTACK_DEFAULT_GAIA_HUB_URL = 'https://hub.blockstack.org';

--- a/packages/common/src/fetch.ts
+++ b/packages/common/src/fetch.ts
@@ -1,5 +1,3 @@
-import 'cross-fetch/polyfill';
-
 // Define a default request options and allow modification using getters, setters
 // Reference: https://developer.mozilla.org/en-US/docs/Web/API/Request/Request
 const defaultFetchOpts: RequestInit = {
@@ -49,6 +47,15 @@ export async function fetchWrapper(input: RequestInfo, init?: RequestInit): Prom
 }
 
 export type FetchFn = (url: string, init?: RequestInit) => Promise<Response>;
+
+/** @ignore Internally used for letting networking functions specify "API" options */
+export type ApiParam = {
+  /** Optional API object (for `.url` and `.fetch`) used for API/Node, defaults to use mainnet */
+  api?: {
+    url: string;
+    fetch: FetchFn;
+  };
+};
 
 export interface RequestContext {
   fetch: FetchFn;

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -6,3 +6,5 @@ export * from './constants';
 export * from './signatures';
 export * from './keys';
 export * from './buffer';
+export * from './types';
+export * from './fetch';

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -1,0 +1,2 @@
+/** Hex-encoded string (without a 0x prefix) */
+export type Hex = string; // todo: should prefix always be allowed?

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -390,7 +390,18 @@ export function intToBigInt(value: IntegerType, signed: boolean): bigint {
  * Adds a `0x` prefix to a string if it does not already have one.
  */
 export function with0x(value: string): string {
-  return value.startsWith('0x') ? value : `0x${value}`;
+  return /^0x/i.test(value) // startsWith('0x') case insensitive
+    ? value
+    : `0x${value}`;
+}
+
+/**
+ * Removes the `0x` prefix of a string if it has one.
+ */
+export function without0x(value: string): string {
+  return /^0x/i.test(value) // startsWith('0x') case insensitive
+    ? value.slice(2)
+    : value;
 }
 
 /**
@@ -620,4 +631,13 @@ export function concatArray(elements: (Uint8Array | number[] | number)[]) {
  */
 export function isInstance(object: any, type: any) {
   return object instanceof type || object?.constructor?.name?.toLowerCase() === type.name;
+}
+
+/**
+ * Checks whether a string is a valid hex string, and has a length of 64 characters.
+ */
+export function validateHash256(hex: string): boolean {
+  hex = without0x(hex);
+  if (hex.length !== 64) return false;
+  return /^[0-9a-fA-F]+$/.test(hex);
 }

--- a/packages/common/tests/utils.test.ts
+++ b/packages/common/tests/utils.test.ts
@@ -8,6 +8,7 @@ import {
   toTwos,
   bigIntToBytes,
   intToBigInt,
+  validateHash256,
 } from '../src';
 import BN from 'bn.js';
 
@@ -165,4 +166,24 @@ test('Should accept bn.js instance', () => {
   const nativeBigInt = intToBigInt(bn, false);
 
   expect(nativeBigInt.toString()).toEqual(value);
+});
+
+describe(validateHash256, () => {
+  const TXID = '117a6522b4e9ec27ff10bbe3940a4a07fd58e5352010b4143992edb05a7130c7';
+
+  test.each([
+    { txid: TXID, expected: true }, // without 0x
+    { txid: `0x${TXID}`, expected: true }, // with 0x
+    { txid: TXID.split('30c7')[0], expected: false }, // too short
+    {
+      txid: 'Failed to deserialize posted transaction: Invalid Stacks string: non-printable or non-ASCII string',
+      expected: false, // string without txid
+    },
+    {
+      txid: `Failed to deserialize posted transaction: Invalid Stacks string: non-printable or non-ASCII string. ${TXID}`,
+      expected: false, // string with txid
+    },
+  ])('txid is validated as hash 256', ({ txid, expected }) => {
+    expect(validateHash256(txid)).toEqual(expected);
+  });
 });

--- a/packages/network/src/index.ts
+++ b/packages/network/src/index.ts
@@ -1,2 +1,1 @@
-export * from './fetch';
 export * from './network';

--- a/packages/network/src/network.ts
+++ b/packages/network/src/network.ts
@@ -1,5 +1,5 @@
 import { TransactionVersion, ChainID } from '@stacks/common';
-import { createFetchFn, FetchFn } from './fetch';
+import { createFetchFn, FetchFn } from '../../common/src/fetch';
 
 export const HIRO_MAINNET_DEFAULT = 'https://api.mainnet.hiro.so';
 export const HIRO_TESTNET_DEFAULT = 'https://api.testnet.hiro.so';

--- a/packages/network/src/network.ts
+++ b/packages/network/src/network.ts
@@ -1,5 +1,5 @@
 import { TransactionVersion, ChainID } from '@stacks/common';
-import { createFetchFn, FetchFn } from '../../common/src/fetch';
+import { createFetchFn, FetchFn } from '@stacks/common';
 
 export const HIRO_MAINNET_DEFAULT = 'https://api.mainnet.hiro.so';
 export const HIRO_TESTNET_DEFAULT = 'https://api.testnet.hiro.so';

--- a/packages/network/tests/fetch.test.ts
+++ b/packages/network/tests/fetch.test.ts
@@ -1,5 +1,5 @@
 import fetchMock from 'jest-fetch-mock';
-import { fetchWrapper, getFetchOptions, setFetchOptions } from '../../common/src/fetch';
+import { fetchWrapper, getFetchOptions, setFetchOptions } from '@stacks/common';
 
 test('Verify fetch private options', async () => {
   const defaultOptioins = getFetchOptions();

--- a/packages/network/tests/fetch.test.ts
+++ b/packages/network/tests/fetch.test.ts
@@ -1,5 +1,5 @@
 import fetchMock from 'jest-fetch-mock';
-import { fetchWrapper, getFetchOptions, setFetchOptions } from '../src/fetch';
+import { fetchWrapper, getFetchOptions, setFetchOptions } from '../../common/src/fetch';
 
 test('Verify fetch private options', async () => {
   const defaultOptioins = getFetchOptions();

--- a/packages/network/tests/fetchMiddleware.test.ts
+++ b/packages/network/tests/fetchMiddleware.test.ts
@@ -5,7 +5,7 @@ import {
   FetchMiddleware,
   RequestContext,
   ResponseContext,
-} from '../../common/src/fetch';
+} from '@stacks/common';
 
 beforeEach(() => {
   fetchMock.resetMocks();

--- a/packages/network/tests/fetchMiddleware.test.ts
+++ b/packages/network/tests/fetchMiddleware.test.ts
@@ -5,7 +5,7 @@ import {
   FetchMiddleware,
   RequestContext,
   ResponseContext,
-} from '../src/fetch';
+} from '../../common/src/fetch';
 
 beforeEach(() => {
   fetchMock.resetMocks();


### PR DESCRIPTION
### EPIC 🏰 _Breaking Refactoring Stacks.js_

**Goal:** Make network/networking more obvious and less confusing for developers. While the default code will stay largely the same for most users, it should become more clear what node URL, and fetch implementation is used when.

![291331642-81426bac-a6b0-4273-8c37-f92f4c8d8db6](https://github.com/hirosystems/stacks.js/assets/6362150/3153e0dd-a721-46c8-960d-9f380ddec3b7)


  - Move to a network OBJECT approach (similar to bitcoin-js, micro-btc-signer, and others). The network will not be an instantiated class, but a static exported object with all information that might be relevant (txVersion, magicBytes, etc.)
  - Remove `fetch` functions from network and introduce `StacksNodeApi`, which can derive it's URL from a network, but should be treated separately -- more closely mirroring to what's actually happening in the background. Can be seen as a maintained API client, with post-processing of responses.
  - The majority of users doesn't realize network is also setting changes for "networking"
    - Most users don't customize fetchFn or URL. For users hosting their own node the only change becomes `{ api: { url: "my-node.com" }, ...}` in the params of most relevant tx functions.




Supersedes https://github.com/hirosystems/stacks.js/pull/1596

**@ Reviewers:**  ✨
Please feel free to leave any feedback on these PRs. Going over the code will show what it's like to code in the new style. So any ideas and feedback (especially negative) is welcome 🙏

---

This PR:
- removes duplicate definitions for next steps
- refactors common package

--- 

> Split into multiple PRs for easier reviewing

`next`
    ↑
`feat/next-cleanup-common-files` this PR 🟢
    ↑
`feat/next-add-new-network` #1623 
    ↑
`feat/next-add-api-package` #1624 
    ↑
`feat/next-update-api-stacking` #1625
    ↑
`feat/next-update-cli` #1626