### PR TITLE
feat: sort tuple properties in cl pretty print

### DIFF
--- a/packages/transactions/src/clarity/prettyPrint.ts
+++ b/packages/transactions/src/clarity/prettyPrint.ts
@@ -66,9 +66,7 @@ function formatTuple(cv: TupleCV, space: number, depth = 1): string {
   const spaceBefore = formatSpace(space, depth, false);
   const endSpace = formatSpace(space, depth, true);
 
-  return `{${spaceBefore}${items
-    .sort((a, b) => a[0].localeCompare(b[0]))
-    .join(`,${spaceBefore}`)}${endSpace}}`;
+  return `{${spaceBefore}${items.sort().join(`,${spaceBefore}`)}${endSpace}}`;
 }
 
 function exhaustiveCheck(param: never): never {

--- a/packages/transactions/src/clarity/prettyPrint.ts
+++ b/packages/transactions/src/clarity/prettyPrint.ts
@@ -41,14 +41,16 @@ function formatList(cv: ListCV, space: number, depth = 1): string {
 
 /**
  * @description format Tuple clarity values in clarity style strings
+ * the keys are alphabetically sorted
  * with the ability to prettify the result with line break end space indentation
  * @example
  * ```ts
- * formatTuple(Cl.tuple({ id: Cl.uint(1) }))
- * // { id: u1 }
+ * formatTuple(Cl.tuple({ id: Cl.uint(1), age: Cl.uint(20) }))
+ * // { age: 20, id: u1 }
  *
- * formatTuple(Cl.tuple({ id: Cl.uint(1) }, 2))
+ * formatTuple(Cl.tuple({ id: Cl.uint(1), age: Cl.uint(20) }, 2))
  * // {
+ * //   age: 20,
  * //   id: u1
  * // }
  * ```
@@ -64,7 +66,9 @@ function formatTuple(cv: TupleCV, space: number, depth = 1): string {
   const spaceBefore = formatSpace(space, depth, false);
   const endSpace = formatSpace(space, depth, true);
 
-  return `{${spaceBefore}${items.join(`,${spaceBefore}`)}${endSpace}}`;
+  return `{${spaceBefore}${items
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .join(`,${spaceBefore}`)}${endSpace}}`;
 }
 
 function exhaustiveCheck(param: never): never {
@@ -114,11 +118,12 @@ function prettyPrintWithDepth(cv: ClarityValue, space = 0, depth: number): strin
  * @param space The indentation size of the output string. There's no indentation and no line breaks if space = 0
  * @example
  * ```ts
- * prettyPrint(Cl.tuple({ id: Cl.some(Cl.uint(1)) }))
- * // { id: (some u1) }
+ * prettyPrint(Cl.tuple({ id: Cl.uint(1), age: Cl.some(Cl.uint(42)) }))
+ * // { age: (some u42), id: u1 }
  *
- * prettyPrint(Cl.tuple({ id: Cl.uint(1) }, 2))
+ * prettyPrint(Cl.tuple({ id: Cl.uint(1), age: Cl.some(Cl.uint(42)) }, 2))
  * // {
+ * //   age: (some u42),
  * //   id: u1
  * // }
  * ```

--- a/packages/transactions/tests/prettyPrint.test.ts
+++ b/packages/transactions/tests/prettyPrint.test.ts
@@ -109,25 +109,25 @@ describe.only('test format of Stacks.js clarity values into clarity style string
 
     const expected = `{
   id: u1,
-  messageAscii: "hello world",
-  someMessageUtf8: (some u"hello world"),
   items: (some (list
     (ok {
-      id: u1,
-      owner: (some 'ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG),
-      valid: (ok u2),
       history: (some (list
         u1
         u2
-      ))
+      )),
+      id: u1,
+      owner: (some 'ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG),
+      valid: (ok u2)
     })
     (ok {
+      history: none,
       id: u2,
       owner: none,
-      valid: (err u1000),
-      history: none
+      valid: (err u1000)
     })
-  ))
+  )),
+  messageAscii: "hello world",
+  someMessageUtf8: (some u"hello world")
 }`;
 
     const result = Cl.prettyPrint(value, 2);


### PR DESCRIPTION
> This PR was published to npm with the version `6.11.4-pr.3d18e85.0`
> e.g. `npm install @stacks/common@6.11.4-pr.3d18e85.0 --save-exact`<!-- Sticky Header Marker -->

### Description

Change `Cl.prettyPrint` so that it sorts properties in a tuple.
This an opinionated change and I could do it in Clarinet, but it kind of make sense to have it natively here as well. I would understand if one disagrees though.

#### Breaking change?

Not really, in the sense that developers shouldn't rely on the property output of this method, this is mostly for debugging

### Example

`Cl.prettyPrint` is used in the clarinet sdk to show output diffs in tests.
Because the output is just a string, Vitest can fail to properly render the diff of the properties of the expected tuple vs the actual tuple are not in the same order

See below where only the value of `a` changes.
```
- Expected
+ Received

  (some {
-   d: u1010000000,
-   a: u1,
+   b: u1013,
    c: u75,
-   b: u1013
+   a: u0,
+   d: u1010000000
  })
```

With this PR, it would display

```
- Expected
+ Received

  (some {
-   a: u1,
+   a: u0,
    b: u1013,
    c: u75,
    d: u1010000000
  })
```

Clarinet already does this sorting in `expectTuple`, but this is actually needed for every composite types (some, ok, err, list, tuple) and with nested values. It could be done at the clarinet level but Cl.prettyPrint already handle the recursive nature of clarity values.

---

### Checklist

- [x] Unit tested updated code paths
- [x] Tagged 1 of @janniks for review

<!-- Make sure to run `npm run test` locally to find problems faster -->
