### PR TITLE
refactor: cleanup transactions files

### DIFF
--- a/packages/transactions/src/address.ts
+++ b/packages/transactions/src/address.ts
@@ -1,35 +1,11 @@
-import {
-  AddressHashMode,
-  AddressVersion,
-  RECOVERABLE_ECDSA_SIG_LENGTH_BYTES,
-  StacksMessageType,
-} from './constants';
-
-import { c32address } from 'c32check';
-import { hexToBytes } from '@stacks/common';
 import { TransactionVersion } from '@stacks/network';
+import { c32address } from 'c32check';
+import { AddressHashMode, AddressVersion, StacksMessageType } from './constants';
 
 export interface Address {
   readonly type: StacksMessageType.Address;
   readonly version: AddressVersion;
   readonly hash160: string;
-}
-
-export interface MessageSignature {
-  readonly type: StacksMessageType.MessageSignature;
-  data: string;
-}
-
-export function createMessageSignature(signature: string): MessageSignature {
-  const length = hexToBytes(signature).byteLength;
-  if (length != RECOVERABLE_ECDSA_SIG_LENGTH_BYTES) {
-    throw Error('Invalid signature');
-  }
-
-  return {
-    type: StacksMessageType.MessageSignature,
-    data: signature,
-  };
 }
 
 /**

--- a/packages/transactions/src/authorization.ts
+++ b/packages/transactions/src/authorization.ts
@@ -17,20 +17,8 @@ import {
   StacksMessageType,
 } from './constants';
 
-import { cloneDeep, leftPadHex, txidFromData } from './utils';
-import {
-  TransactionAuthField,
-  serializeMessageSignature,
-  deserializeMessageSignature,
-} from './signature';
-import {
-  addressFromPublicKeys,
-  createEmptyAddress,
-  createLPList,
-  deserializeLPList,
-  serializeLPList,
-} from './types';
-
+import { BytesReader } from './bytesReader';
+import { DeserializationError, SigningError, VerificationError } from './errors';
 import {
   createStacksPublicKey,
   getPublicKey,
@@ -40,10 +28,20 @@ import {
   StacksPrivateKey,
   StacksPublicKey,
 } from './keys';
-
-import { MessageSignature } from './common';
-import { DeserializationError, SigningError, VerificationError } from './errors';
-import { BytesReader } from './bytesReader';
+import {
+  deserializeMessageSignature,
+  MessageSignature,
+  serializeMessageSignature,
+  TransactionAuthField,
+} from './signature';
+import {
+  addressFromPublicKeys,
+  createEmptyAddress,
+  createLPList,
+  deserializeLPList,
+  serializeLPList,
+} from './types';
+import { cloneDeep, leftPadHex, txidFromData } from './utils';
 
 export function emptyMessageSignature(): MessageSignature {
   return {

--- a/packages/transactions/src/clarity/types/principalCV.ts
+++ b/packages/transactions/src/clarity/types/principalCV.ts
@@ -1,7 +1,7 @@
 import { utf8ToBytes } from '@stacks/common';
-import { Address, addressToString } from '../../common';
 import { LengthPrefixedString, createAddress, createLPString } from '../../postcondition-types';
 import { ClarityType } from '../constants';
+import { Address, addressToString } from '../../address';
 
 type PrincipalCV = StandardPrincipalCV | ContractPrincipalCV;
 

--- a/packages/transactions/src/index.ts
+++ b/packages/transactions/src/index.ts
@@ -53,7 +53,6 @@ export { BytesReader } from './bytesReader';
  */
 export * as Cl from './cl';
 export * from './clarity';
-export * from './common';
 export * from './constants';
 export * from './contract-abi';
 export * from './keys';
@@ -95,10 +94,11 @@ export {
   createSTXPostCondition,
 } from './postcondition';
 export * from './postcondition-types';
+export * from './address';
 export * from './signature';
 export * from './signer';
 export * from './structuredDataSignature';
-export { StacksTransaction, deserializeTransaction } from './transaction';
+export * from './transaction';
 export * from './types';
 export * from './utils';
 export * from './fetch';

--- a/packages/transactions/src/keys.ts
+++ b/packages/transactions/src/keys.ts
@@ -22,13 +22,6 @@ import {
 import { c32address } from 'c32check';
 import { BytesReader } from './bytesReader';
 import {
-  addressFromVersionHash,
-  addressHashModeToVersion,
-  addressToString,
-  createMessageSignature,
-  MessageSignature,
-} from './common';
-import {
   AddressHashMode,
   AddressVersion,
   COMPRESSED_PUBKEY_LENGTH_BYTES,
@@ -38,6 +31,8 @@ import {
 } from './constants';
 import { hash160, hashP2PKH } from './utils';
 import { TransactionVersion } from '@stacks/network';
+import { addressFromVersionHash, addressHashModeToVersion, addressToString } from './address';
+import { createMessageSignature, MessageSignature } from './signature';
 
 /**
  * To use secp256k1.signSync set utils.hmacSha256Sync to a function using noble-hashes

--- a/packages/transactions/src/payload.ts
+++ b/packages/transactions/src/payload.ts
@@ -1,10 +1,8 @@
 import { concatArray, IntegerType, intToBigInt, intToBytes, writeUInt32BE } from '@stacks/common';
-import { ClarityVersion, COINBASE_BYTES_LENGTH, PayloadType, StacksMessageType } from './constants';
-
 import { BytesReader } from './bytesReader';
 import { ClarityValue, deserializeCV, serializeCV } from './clarity/';
 import { PrincipalCV, principalCV } from './clarity/types/principalCV';
-import { Address } from './common';
+import { ClarityVersion, COINBASE_BYTES_LENGTH, PayloadType, StacksMessageType } from './constants';
 import { createAddress, createLPString, LengthPrefixedString } from './postcondition-types';
 import {
   codeBodyString,
@@ -15,6 +13,7 @@ import {
   MemoString,
   serializeStacksMessage,
 } from './types';
+import { Address } from './address';
 
 export type Payload =
   | TokenTransferPayload

--- a/packages/transactions/src/postcondition-types.ts
+++ b/packages/transactions/src/postcondition-types.ts
@@ -1,3 +1,6 @@
+import { c32addressDecode } from 'c32check';
+import { Address } from './address';
+import { ClarityValue } from './clarity';
 import {
   FungibleConditionCode,
   MAX_STRING_LENGTH_BYTES,
@@ -6,9 +9,6 @@ import {
   PostConditionType,
   StacksMessageType,
 } from './constants';
-import { c32addressDecode } from 'c32check';
-import { Address } from './common';
-import { ClarityValue } from './clarity';
 import { exceedsMaxLengthBytes } from './utils';
 
 export interface StandardPrincipal {

--- a/packages/transactions/src/signature.ts
+++ b/packages/transactions/src/signature.ts
@@ -7,11 +7,24 @@ import {
   serializePublicKey,
   StacksPublicKey,
 } from './keys';
-
-import { createMessageSignature, MessageSignature } from './common';
-
-// @ts-ignore
 import { bytesToHex, concatArray, hexToBytes } from '@stacks/common';
+
+export interface MessageSignature {
+  readonly type: StacksMessageType.MessageSignature;
+  data: string;
+}
+
+export function createMessageSignature(signature: string): MessageSignature {
+  const length = hexToBytes(signature).byteLength;
+  if (length != RECOVERABLE_ECDSA_SIG_LENGTH_BYTES) {
+    throw Error('Invalid signature');
+  }
+
+  return {
+    type: StacksMessageType.MessageSignature,
+    data: signature,
+  };
+}
 
 export enum AuthFieldType {
   PublicKeyCompressed = 0x00,

--- a/packages/transactions/src/transaction.ts
+++ b/packages/transactions/src/transaction.ts
@@ -7,18 +7,13 @@ import {
   writeUInt32BE,
 } from '@stacks/common';
 import {
-  AddressHashMode,
-  AnchorMode,
-  anchorModeFrom,
-  AnchorModeName,
-  AuthType,
-  PayloadType,
-  PostConditionMode,
-  PubKeyEncoding,
-  RECOVERABLE_ECDSA_SIG_LENGTH_BYTES,
-  StacksMessageType,
-} from './constants';
-
+  ChainId,
+  DEFAULT_CHAIN_ID,
+  STACKS_MAINNET,
+  STACKS_TESTNET,
+  TransactionVersion,
+  whenTransactionVersion,
+} from '@stacks/network';
 import {
   Authorization,
   deserializeAuthorization,
@@ -34,27 +29,25 @@ import {
   SpendingConditionOpts,
   verifyOrigin,
 } from './authorization';
-import { createTransactionAuthField } from './signature';
-
-import { cloneDeep, txidFromData } from './utils';
-
-import { deserializePayload, Payload, PayloadInput, serializePayload } from './payload';
-
-import { createLPList, deserializeLPList, LengthPrefixedList, serializeLPList } from './types';
-
-import { isCompressed, StacksPrivateKey, StacksPublicKey } from './keys';
-
 import { BytesReader } from './bytesReader';
-
-import { SerializationError, SigningError } from './errors';
 import {
-  ChainId,
-  DEFAULT_CHAIN_ID,
-  STACKS_MAINNET,
-  STACKS_TESTNET,
-  TransactionVersion,
-  whenTransactionVersion,
-} from '@stacks/network';
+  AddressHashMode,
+  AnchorMode,
+  anchorModeFrom,
+  AnchorModeName,
+  AuthType,
+  PayloadType,
+  PostConditionMode,
+  PubKeyEncoding,
+  RECOVERABLE_ECDSA_SIG_LENGTH_BYTES,
+  StacksMessageType,
+} from './constants';
+import { SerializationError, SigningError } from './errors';
+import { isCompressed, StacksPrivateKey, StacksPublicKey } from './keys';
+import { deserializePayload, Payload, PayloadInput, serializePayload } from './payload';
+import { createTransactionAuthField } from './signature';
+import { createLPList, deserializeLPList, LengthPrefixedList, serializeLPList } from './types';
+import { cloneDeep, txidFromData } from './utils';
 
 export class StacksTransaction {
   version: TransactionVersion;

--- a/packages/transactions/src/types.ts
+++ b/packages/transactions/src/types.ts
@@ -8,55 +8,48 @@ import {
   intToHex,
   utf8ToBytes,
 } from '@stacks/common';
+import { StacksNetwork, StacksNetworkName, TransactionVersion } from '@stacks/network';
+import { BytesReader } from './bytesReader';
+import { ClarityValue, deserializeCV, serializeCV } from './clarity';
 import {
-  MEMO_MAX_LENGTH_BYTES,
   AddressHashMode,
   AddressVersion,
-  StacksMessageType,
+  FungibleConditionCode,
+  MEMO_MAX_LENGTH_BYTES,
+  NonFungibleConditionCode,
   PostConditionPrincipalId,
   PostConditionType,
-  FungibleConditionCode,
-  NonFungibleConditionCode,
+  StacksMessageType,
 } from './constants';
-
-import { StacksPublicKey, serializePublicKey, deserializePublicKey, isCompressed } from './keys';
-
+import { DeserializationError, SerializationError } from './errors';
+import { StacksPublicKey, deserializePublicKey, isCompressed, serializePublicKey } from './keys';
+import { Payload, deserializePayload, serializePayload } from './payload';
+import {
+  AssetInfo,
+  ContractPrincipal,
+  LengthPrefixedString,
+  PostCondition,
+  PostConditionPrincipal,
+  StandardPrincipal,
+  createLPString,
+} from './postcondition-types';
+import {
+  MessageSignature,
+  TransactionAuthField,
+  deserializeMessageSignature,
+  deserializeTransactionAuthField,
+  serializeMessageSignature,
+  serializeTransactionAuthField,
+} from './signature';
 import {
   exceedsMaxLengthBytes,
   hashP2PKH,
-  rightPadHexToLength,
   hashP2SH,
-  hashP2WSH,
   hashP2WPKH,
+  hashP2WSH,
+  rightPadHexToLength,
 } from './utils';
-
-import { BytesReader } from './bytesReader';
-import {
-  PostCondition,
-  StandardPrincipal,
-  ContractPrincipal,
-  PostConditionPrincipal,
-  LengthPrefixedString,
-  AssetInfo,
-  createLPString,
-} from './postcondition-types';
-import { Payload, deserializePayload, serializePayload } from './payload';
-import { DeserializationError, SerializationError } from './errors';
-import {
-  deserializeTransactionAuthField,
-  deserializeMessageSignature,
-  serializeMessageSignature,
-  serializeTransactionAuthField,
-  TransactionAuthField,
-} from './signature';
-import {
-  MessageSignature,
-  Address,
-  addressHashModeToVersion,
-  addressFromVersionHash,
-} from './common';
-import { ClarityValue, deserializeCV, serializeCV } from './clarity';
-import { StacksNetwork, StacksNetworkName, TransactionVersion } from '@stacks/network';
+import { Address, addressFromVersionHash, addressHashModeToVersion } from './address';
 
 export type StacksMessage =
   | Address

--- a/packages/transactions/tests/authorization.test.ts
+++ b/packages/transactions/tests/authorization.test.ts
@@ -1,3 +1,4 @@
+import { bytesToHex, concatArray } from '@stacks/common';
 import {
   createMultiSigSpendingCondition,
   createSingleSigSpendingCondition,
@@ -9,14 +10,10 @@ import {
   SponsoredAuthorization,
   StandardAuthorization,
 } from '../src/authorization';
-import { createMessageSignature } from '../src/common';
-import { createTransactionAuthField } from '../src/signature';
-
-import { AddressHashMode, AuthType, PubKeyEncoding } from '../src/constants';
-
-import { bytesToHex, concatArray } from '@stacks/common';
 import { BytesReader } from '../src/bytesReader';
+import { AddressHashMode, AuthType, PubKeyEncoding } from '../src/constants';
 import { createStacksPrivateKey, createStacksPublicKey, signWithKey } from '../src/keys';
+import { createMessageSignature, createTransactionAuthField } from '../src/signature';
 
 test('ECDSA recoverable signature', () => {
   const privKeyString = 'edf9aee84d9b7abc145504dde6726c64f369d37ee34ded868fabd876c26570bc';

--- a/packages/transactions/tests/builder.test.ts
+++ b/packages/transactions/tests/builder.test.ts
@@ -6,6 +6,7 @@ import {
   createFetchFn,
   utf8ToBytes,
 } from '@stacks/common';
+import { STACKS_TESTNET, TransactionVersion } from '@stacks/network';
 import * as fs from 'fs';
 import fetchMock from 'jest-fetch-mock';
 import {
@@ -39,7 +40,6 @@ import {
 } from '../src/authorization';
 import {
   SignedTokenTransferOptions,
-  estimateTransactionByteLength,
   makeContractCall,
   makeContractDeploy,
   makeContractFungiblePostCondition,
@@ -66,7 +66,6 @@ import {
   uintCV,
 } from '../src/clarity';
 import { principalCV } from '../src/clarity/types/principalCV';
-import { createMessageSignature } from '../src/common';
 import {
   AddressHashMode,
   AnchorMode,
@@ -87,11 +86,14 @@ import {
 } from '../src/keys';
 import { TokenTransferPayload, createTokenTransferPayload, serializePayload } from '../src/payload';
 import { createAssetInfo } from '../src/postcondition-types';
-import { createTransactionAuthField } from '../src/signature';
+import { createMessageSignature, createTransactionAuthField } from '../src/signature';
 import { TransactionSigner } from '../src/signer';
-import { StacksTransaction, deserializeTransaction } from '../src/transaction';
+import {
+  StacksTransaction,
+  deserializeTransaction,
+  estimateTransactionByteLength,
+} from '../src/transaction';
 import { cloneDeep } from '../src/utils';
-import { STACKS_TESTNET, TransactionVersion } from '@stacks/network';
 
 function setSignature(
   unsignedTransaction: StacksTransaction,

--- a/packages/transactions/tests/clarity.test.ts
+++ b/packages/transactions/tests/clarity.test.ts
@@ -6,40 +6,41 @@ import {
   hexToBytes,
   utf8ToBytes,
 } from '@stacks/common';
+import assert from 'assert';
+import { Cl, addressToString } from '../src';
 import { BytesReader } from '../src/bytesReader';
 import {
-  bufferCV,
   BufferCV,
   ClarityType,
   ClarityValue,
+  IntCV,
+  ListCV,
+  SomeCV,
+  StandardPrincipalCV,
+  StringAsciiCV,
+  StringUtf8CV,
+  TupleCV,
+  UIntCV,
+  bufferCV,
   contractPrincipalCV,
   contractPrincipalCVFromStandard,
   deserializeCV,
   falseCV,
-  IntCV,
   intCV,
   listCV,
-  ListCV,
   noneCV,
   responseErrorCV,
   responseOkCV,
   serializeCV,
   someCV,
-  SomeCV,
   standardPrincipalCV,
-  StandardPrincipalCV,
   standardPrincipalCVFromAddress,
   stringAsciiCV,
-  StringAsciiCV,
   stringUtf8CV,
-  StringUtf8CV,
   trueCV,
   tupleCV,
-  TupleCV,
   uintCV,
-  UIntCV,
 } from '../src/clarity';
-import { Cl } from '../src';
 import {
   cvToJSON,
   cvToString,
@@ -47,9 +48,7 @@ import {
   getCVTypeString,
   isClarityType,
 } from '../src/clarity/clarityValue';
-import { addressToString } from '../src/common';
 import { deserializeAddress } from '../src/types';
-import assert from 'assert';
 
 const ADDRESS = 'SP2JXKMSH007NPYAQHKJPQMAQYAD90NQGTVJVQ02B';
 

--- a/packages/transactions/tests/postcondition.test.ts
+++ b/packages/transactions/tests/postcondition.test.ts
@@ -13,7 +13,6 @@ import {
   createContractPrincipal,
   ContractPrincipal,
 } from '../src/postcondition-types';
-import { addressToString } from '../src/common';
 
 import {
   PostConditionType,
@@ -27,6 +26,7 @@ import { serializeDeserialize } from './macros';
 
 import { bufferCVFromString, BufferCV } from '../src/clarity';
 import { bytesToUtf8 } from '@stacks/common';
+import { addressToString } from '../src';
 
 test('STX post condition serialization and deserialization', () => {
   const postConditionType = PostConditionType.STX;

--- a/packages/transactions/tests/types.test.ts
+++ b/packages/transactions/tests/types.test.ts
@@ -1,25 +1,24 @@
+import { TransactionVersion } from '@stacks/network';
+import { BytesReader } from '../src/bytesReader';
+import { AddressHashMode, StacksMessageType } from '../src/constants';
+import { createStacksPublicKey } from '../src/keys';
 import {
-  createLPList,
-  serializeStacksMessage,
-  deserializeLPList,
-  addressFromHashMode,
-  LengthPrefixedList,
-  addressFromPublicKeys,
-} from '../src/types';
-import {
-  LengthPrefixedString,
   AssetInfo,
-  createLPString,
+  LengthPrefixedString,
   createAddress,
   createAssetInfo,
+  createLPString,
 } from '../src/postcondition-types';
-import { Address, addressToString } from '../src/common';
-import { AddressHashMode, StacksMessageType } from '../src/constants';
-
+import {
+  LengthPrefixedList,
+  addressFromHashMode,
+  addressFromPublicKeys,
+  createLPList,
+  deserializeLPList,
+  serializeStacksMessage,
+} from '../src/types';
 import { serializeDeserialize } from './macros';
-import { BytesReader } from '../src/bytesReader';
-import { createStacksPublicKey } from '../src/keys';
-import { TransactionVersion } from '@stacks/network';
+import { Address, addressToString } from '../src';
 
 test('Length prefixed strings serialization and deserialization', () => {
   const testString = 'test message string';


### PR DESCRIPTION
`non-breaking`

`@stacks/transactions`:
- move functions from `common` to files: `signature` and `address`
- auto-cleanup imports