### PR TITLE
refactor!: update clarity representation

### DIFF
--- a/.github/.husky/commit-msg
+++ b/.github/.husky/commit-msg
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npx @commitlint/cli --extends @commitlint/config-conventional --edit "$1"
+npx @commitlint/cli --config .github/.husky/commitlint.json --edit "$1"

--- a/.github/.husky/commitlint.json
+++ b/.github/.husky/commitlint.json
@@ -1,0 +1,13 @@
+{
+  "extends": ["@commitlint/config-conventional"],
+  "rules": {
+    "body-max-length": [0, "always"],
+    "body-max-line-length": [0, "always"],
+    "footer-max-length": [0, "always"],
+    "footer-max-line-length": [0, "always"],
+    "header-max-length": [0, "always"],
+    "scope-max-length": [0, "always"],
+    "subject-max-length": [0, "always"],
+    "type-max-length": [0, "always"]
+  }
+}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -19,6 +19,8 @@ jobs:
         with:
           fetch-depth: 0
       - uses: wagoid/commitlint-github-action@v5
+        with:
+          configFile: .github/.husky/commitlint.json
 
   tests:
     needs: pre-run

--- a/packages/transactions/src/clarity/constants.ts
+++ b/packages/transactions/src/clarity/constants.ts
@@ -1,21 +1,52 @@
 /**
+ * Clarity type names used for the human-readable representation of Clarity values
+ */
+export enum ClarityType {
+  Int = 'int',
+  UInt = 'uint',
+  Buffer = 'buffer',
+  BoolTrue = 'true',
+  BoolFalse = 'false',
+  PrincipalStandard = 'address',
+  PrincipalContract = 'contract',
+  ResponseOk = 'ok',
+  ResponseErr = 'err',
+  OptionalNone = 'none',
+  OptionalSome = 'some',
+  List = 'list',
+  Tuple = 'tuple',
+  StringASCII = 'ascii',
+  StringUTF8 = 'utf8',
+}
+
+/**
  * Type IDs corresponding to each of the Clarity value types as described here:
  * {@link https://github.com/blockstack/blockstack-core/blob/sip/sip-005/sip/sip-005-blocks-and-transactions.md#clarity-value-representation}
  */
-export enum ClarityType {
-  Int = 0x00,
-  UInt = 0x01,
-  Buffer = 0x02,
-  BoolTrue = 0x03,
-  BoolFalse = 0x04,
-  PrincipalStandard = 0x05,
-  PrincipalContract = 0x06,
-  ResponseOk = 0x07,
-  ResponseErr = 0x08,
-  OptionalNone = 0x09,
-  OptionalSome = 0x0a,
-  List = 0x0b,
-  Tuple = 0x0c,
-  StringASCII = 0x0d,
-  StringUTF8 = 0x0e,
+export enum ClarityWireType {
+  int = 0x00,
+  uint = 0x01,
+  buffer = 0x02,
+  true = 0x03,
+  false = 0x04,
+  address = 0x05,
+  contract = 0x06,
+  ok = 0x07,
+  err = 0x08,
+  none = 0x09,
+  some = 0x0a,
+  list = 0x0b,
+  tuple = 0x0c,
+  ascii = 0x0d,
+  utf8 = 0x0e,
+}
+
+/** @ignore internal for now */
+export function clarityTypeToByte(type: ClarityType): ClarityWireType {
+  return ClarityWireType[type];
+}
+
+/** @ignore internal for now */
+export function clarityByteToType(wireType: ClarityWireType): ClarityType {
+  return ClarityWireType[wireType] as ClarityType; // numerical enums are bidirectional in TypeScript
 }

--- a/packages/transactions/src/clarity/deserialize.ts
+++ b/packages/transactions/src/clarity/deserialize.ts
@@ -1,5 +1,5 @@
 import {
-  ClarityType,
+  ClarityWireType,
   ClarityValue,
   intCV,
   uintCV,
@@ -43,7 +43,7 @@ import { bytesToAscii, bytesToUtf8, hexToBytes } from '@stacks/common';
  * @see
  * {@link https://github.com/hirosystems/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
-export default function deserializeCV<T extends ClarityValue = ClarityValue>(
+export function deserializeCV<T extends ClarityValue = ClarityValue>(
   serializedClarityValue: BytesReader | Uint8Array | string
 ): T {
   let bytesReader: BytesReader;
@@ -57,49 +57,49 @@ export default function deserializeCV<T extends ClarityValue = ClarityValue>(
   } else {
     bytesReader = serializedClarityValue;
   }
-  const type = bytesReader.readUInt8Enum(ClarityType, n => {
+  const type = bytesReader.readUInt8Enum(ClarityWireType, n => {
     throw new DeserializationError(`Cannot recognize Clarity Type: ${n}`);
   });
 
   switch (type) {
-    case ClarityType.Int:
+    case ClarityWireType.int:
       return intCV(bytesReader.readBytes(16)) as T;
 
-    case ClarityType.UInt:
+    case ClarityWireType.uint:
       return uintCV(bytesReader.readBytes(16)) as T;
 
-    case ClarityType.Buffer:
+    case ClarityWireType.buffer:
       const bufferLength = bytesReader.readUInt32BE();
       return bufferCV(bytesReader.readBytes(bufferLength)) as T;
 
-    case ClarityType.BoolTrue:
+    case ClarityWireType.true:
       return trueCV() as T;
 
-    case ClarityType.BoolFalse:
+    case ClarityWireType.false:
       return falseCV() as T;
 
-    case ClarityType.PrincipalStandard:
+    case ClarityWireType.address:
       const sAddress = deserializeAddress(bytesReader);
       return standardPrincipalCVFromAddress(sAddress) as T;
 
-    case ClarityType.PrincipalContract:
+    case ClarityWireType.contract:
       const cAddress = deserializeAddress(bytesReader);
       const contractName = deserializeLPString(bytesReader);
       return contractPrincipalCVFromAddress(cAddress, contractName) as T;
 
-    case ClarityType.ResponseOk:
+    case ClarityWireType.ok:
       return responseOkCV(deserializeCV(bytesReader)) as T;
 
-    case ClarityType.ResponseErr:
+    case ClarityWireType.err:
       return responseErrorCV(deserializeCV(bytesReader)) as T;
 
-    case ClarityType.OptionalNone:
+    case ClarityWireType.none:
       return noneCV() as T;
 
-    case ClarityType.OptionalSome:
+    case ClarityWireType.some:
       return someCV(deserializeCV(bytesReader)) as T;
 
-    case ClarityType.List:
+    case ClarityWireType.list:
       const listLength = bytesReader.readUInt32BE();
       const listContents: ClarityValue[] = [];
       for (let i = 0; i < listLength; i++) {
@@ -107,7 +107,7 @@ export default function deserializeCV<T extends ClarityValue = ClarityValue>(
       }
       return listCV(listContents) as T;
 
-    case ClarityType.Tuple:
+    case ClarityWireType.tuple:
       const tupleLength = bytesReader.readUInt32BE();
       const tupleContents: { [key: string]: ClarityValue } = {};
       for (let i = 0; i < tupleLength; i++) {
@@ -119,12 +119,12 @@ export default function deserializeCV<T extends ClarityValue = ClarityValue>(
       }
       return tupleCV(tupleContents) as T;
 
-    case ClarityType.StringASCII:
+    case ClarityWireType.ascii:
       const asciiStrLen = bytesReader.readUInt32BE();
       const asciiStr = bytesToAscii(bytesReader.readBytes(asciiStrLen));
       return stringAsciiCV(asciiStr) as T;
 
-    case ClarityType.StringUTF8:
+    case ClarityWireType.utf8:
       const utf8StrLen = bytesReader.readUInt32BE();
       const utf8Str = bytesToUtf8(bytesReader.readBytes(utf8StrLen));
       return stringUtf8CV(utf8Str) as T;

--- a/packages/transactions/src/clarity/index.ts
+++ b/packages/transactions/src/clarity/index.ts
@@ -1,4 +1,6 @@
-import {
+// todo: use `export *` for more exports here
+
+export {
   ClarityValue,
   getCVTypeString,
   cvToString,
@@ -6,15 +8,13 @@ import {
   cvToValue,
   isClarityType,
 } from './clarityValue';
-import { ClarityType } from './constants';
-import { BooleanCV, TrueCV, FalseCV, trueCV, falseCV, boolCV } from './types/booleanCV';
-import { IntCV, UIntCV, intCV, uintCV } from './types/intCV';
-import { BufferCV, bufferCV, bufferCVFromString } from './types/bufferCV';
-import { OptionalCV, NoneCV, SomeCV, noneCV, someCV, optionalCVOf } from './types/optionalCV';
+export * from './constants';
+export { BooleanCV, TrueCV, FalseCV, trueCV, falseCV, boolCV } from './types/booleanCV';
+export { IntCV, UIntCV, intCV, uintCV } from './types/intCV';
+export { BufferCV, bufferCV, bufferCVFromString } from './types/bufferCV';
+export { OptionalCV, NoneCV, SomeCV, noneCV, someCV, optionalCVOf } from './types/optionalCV';
 
-// todo: reduce manual re-exporting
-
-import {
+export {
   ResponseCV,
   ResponseOkCV,
   ResponseErrorCV,
@@ -22,7 +22,7 @@ import {
   responseErrorCV,
 } from './types/responseCV';
 
-import {
+export {
   StandardPrincipalCV,
   ContractPrincipalCV,
   standardPrincipalCV,
@@ -35,74 +35,14 @@ import {
   principalToString,
 } from './types/principalCV';
 
-import { ListCV, listCV } from './types/listCV';
-import { TupleCV, tupleCV } from './types/tupleCV';
-import {
+export { ListCV, listCV } from './types/listCV';
+export { TupleCV, tupleCV } from './types/tupleCV';
+export {
   StringAsciiCV,
   StringUtf8CV,
   stringUtf8CV,
   stringAsciiCV,
   stringCV,
 } from './types/stringCV';
-import { serializeCV } from './serialize';
-import deserializeCV from './deserialize';
-
-// Types
-export {
-  ClarityType,
-  ClarityValue,
-  BooleanCV,
-  TrueCV,
-  FalseCV,
-  IntCV,
-  UIntCV,
-  BufferCV,
-  OptionalCV,
-  NoneCV,
-  SomeCV,
-  ResponseCV,
-  ResponseOkCV,
-  ResponseErrorCV,
-  PrincipalCV,
-  StandardPrincipalCV,
-  ContractPrincipalCV,
-  ListCV,
-  TupleCV,
-  StringAsciiCV,
-  StringUtf8CV,
-};
-
-// Value construction functions
-export {
-  boolCV,
-  trueCV,
-  falseCV,
-  intCV,
-  uintCV,
-  bufferCV,
-  bufferCVFromString,
-  noneCV,
-  someCV,
-  optionalCVOf,
-  responseOkCV,
-  responseErrorCV,
-  principalCV,
-  standardPrincipalCV,
-  standardPrincipalCVFromAddress,
-  contractPrincipalCV,
-  contractPrincipalCVFromAddress,
-  contractPrincipalCVFromStandard,
-  listCV,
-  tupleCV,
-  stringCV,
-  stringAsciiCV,
-  stringUtf8CV,
-  getCVTypeString,
-  isClarityType,
-};
-
-// Serialization
-export { serializeCV, deserializeCV };
-
-// toString
-export { cvToString, cvToJSON, cvToValue, principalToString };
+export { serializeCV } from './serialize';
+export { deserializeCV } from './deserialize';

--- a/packages/transactions/src/clarity/serialize.ts
+++ b/packages/transactions/src/clarity/serialize.ts
@@ -22,23 +22,23 @@ import {
   TupleCV,
   ClarityValue,
 } from '.';
-import { ClarityType } from './constants';
+import { ClarityType, clarityTypeToByte } from './constants';
 
 import { SerializationError } from '../errors';
 import { StringAsciiCV, StringUtf8CV } from './types/stringCV';
 import { CLARITY_INT_BYTE_SIZE, CLARITY_INT_SIZE } from '../constants';
 
 function bytesWithTypeID(typeId: ClarityType, bytes: Uint8Array): Uint8Array {
-  return concatArray([typeId, bytes]);
+  return concatArray([clarityTypeToByte(typeId), bytes]);
 }
 
 function serializeBoolCV(value: BooleanCV): Uint8Array {
-  return new Uint8Array([value.type]);
+  return new Uint8Array([clarityTypeToByte(value.type)]);
 }
 
 function serializeOptionalCV(cv: OptionalCV): Uint8Array {
   if (cv.type === ClarityType.OptionalNone) {
-    return new Uint8Array([cv.type]);
+    return new Uint8Array([clarityTypeToByte(cv.type)]);
   } else {
     return bytesWithTypeID(cv.type, serializeCV(cv.value));
   }

--- a/packages/transactions/src/clarity/types/booleanCV.ts
+++ b/packages/transactions/src/clarity/types/booleanCV.ts
@@ -20,7 +20,7 @@ interface FalseCV {
  *  import { trueCV } from '@stacks/transactions';
  *
  *  const trueCV = trueCV();
- *  // { type: 3 }
+ *  // { type: 'true' }
  * ```
  *
  * @see
@@ -38,7 +38,7 @@ const trueCV = (): BooleanCV => ({ type: ClarityType.BoolTrue });
  *  import { falseCV } from '@stacks/transactions';
  *
  *  const falseCV = falseCV();
- *  // { type: 4 }
+ *  // { type: 'false' }
  * ```
  *
  * @see
@@ -56,7 +56,7 @@ const falseCV = (): BooleanCV => ({ type: ClarityType.BoolFalse });
  *  import { boolCV } from '@stacks/transactions';
  *
  *  const boolCV = boolCV(false);
- *  // { type: 4 }
+ *  // { type: 'false' }
  * ```
  *
  * @see

--- a/packages/transactions/src/clarity/types/bufferCV.ts
+++ b/packages/transactions/src/clarity/types/bufferCV.ts
@@ -19,7 +19,7 @@ interface BufferCV {
  *
  *  const buffer = utf8ToBytes('this is a test');
  *  const buf = bufferCV(buffer);
- *  // { type: 2, buffer: <Uint8Array 74 68 69 73 20 69 73 20 61 20 74 65 73 74> }
+ *  // { type: 'buffer', buffer: <Uint8Array 74 68 69 73 20 69 73 20 61 20 74 65 73 74> }
  *  const value = bytesToUtf8(buf.buffer);
  *  // this is a test
  * ```
@@ -48,7 +48,7 @@ const bufferCV = (buffer: Uint8Array): BufferCV => {
  *
  *  const str = 'this is a test';
  *  const buf = bufferCVFromString(str);
- *  // { type: 2, buffer: <Buffer 74 68 69 73 20 69 73 20 61 20 74 65 73 74> }
+ *  // { type: 'buffer', buffer: <Buffer 74 68 69 73 20 69 73 20 61 20 74 65 73 74> }
  *  const value = bytesToUtf8(buf.buffer);
  *  // this is a test
  *```

--- a/packages/transactions/src/clarity/types/intCV.ts
+++ b/packages/transactions/src/clarity/types/intCV.ts
@@ -24,7 +24,7 @@ interface IntCV {
  *  import { intCV } from '@stacks/transactions';
  *
  *  const value = intCV('100'); // parameter any of type: number | string | bigint | Uint8Array | BN
- *  // { type: 0, value: 100n }
+ *  // { type: 'int', value: 100n }
  * ```
  *
  * @see
@@ -57,7 +57,7 @@ interface UIntCV {
  *  import { uintCV } from '@stacks/transactions';
  *
  *  const value = uintCV('100'); // parameter any of type: number | string | bigint | Uint8Array | BN
- *  // { type: 1, value: 100n }
+ *  // { type: 'uint', value: 100n }
  * ```
  *
  * @see

--- a/packages/transactions/src/clarity/types/listCV.ts
+++ b/packages/transactions/src/clarity/types/listCV.ts
@@ -18,7 +18,7 @@ interface ListCV<T extends ClarityValue = ClarityValue> {
  *  import { listCV, intCV } from '@stacks/transactions';
  *
  *  const list = listCV([intCV(1), intCV(2), intCV(3), intCV(-4)]);
- *  // { type: 11, list: [ { type: 0, value: 1n }, { type: 0, value: 2n }, { type: 0, value: 3n }, { type: 0, value: -4n } ] }
+ *  // { type: 'list', list: [ { type: 0, value: 1n }, { type: 0, value: 2n }, { type: 0, value: 3n }, { type: 0, value: -4n } ] }
  * ```
  *
  * @see

--- a/packages/transactions/src/clarity/types/optionalCV.ts
+++ b/packages/transactions/src/clarity/types/optionalCV.ts
@@ -21,7 +21,7 @@ interface SomeCV<T extends ClarityValue = ClarityValue> {
  *  import { noneCV } from '@stacks/transactions';
  *
  *  const value = noneCV();
- *  // { type: 9 }
+ *  // { type: 'none' }
  * ```
  *
  * @see
@@ -43,7 +43,7 @@ function noneCV(): NoneCV {
  *  import { someCV, trueCV } from '@stacks/transactions';
  *
  *  const value = someCV(trueCV());
- *  // { type: 10, value: { type: 3 } }
+ *  // { type: 'some', value: { type: 'true' } }
  * ```
  *
  * @see

--- a/packages/transactions/src/clarity/types/principalCV.ts
+++ b/packages/transactions/src/clarity/types/principalCV.ts
@@ -46,7 +46,7 @@ function principalCV(principal: string): PrincipalCV {
  *  import { standardPrincipalCV } from '@stacks/transactions';
  *
  *  const addr = standardPrincipalCV('SP2JXKMSH007NPYAQHKJPQMAQYAD90NQGTVJVQ02B');
- *  // { type: 5, address: { type: 0, version: 22, hash160: 'a5d9d331000f5b79578ce56bd157f29a9056f0d6' } }
+ *  // { type: 'address', address: { type: 0, version: 22, hash160: 'a5d9d331000f5b79578ce56bd157f29a9056f0d6' } }
  * ```
  *
  * @see
@@ -73,7 +73,7 @@ function standardPrincipalCV(addressString: string): StandardPrincipalCV {
  *  };
  *
  *  const principalCV = standardPrincipalCVFromAddress(address);
- *  // { type: 5, address: { type: 0, version: 22, hash160: 'a5d9d331000f5b79578ce56bd157f29a9056f0d6' } }
+ *  // { type: 'address', address: { type: 0, version: 22, hash160: 'a5d9d331000f5b79578ce56bd157f29a9056f0d6' } }
  * ```
  *
  * @see
@@ -94,7 +94,7 @@ function standardPrincipalCVFromAddress(address: Address): StandardPrincipalCV {
  *  import { contractPrincipalCV } from '@stacks/transactions';
  *
  *  const contractAddress = contractPrincipalCV('SP2JXKMSH007NPYAQHKJPQMAQYAD90NQGTVJVQ02B', 'test');
- *  // { type: 6, address: { type: 0, version: 22, hash160: 'a5d9d331000f5b79578ce56bd157f29a9056f0d6' }, contractName: { type: 2, content: 'test', lengthPrefixBytes: 1, maxLengthBytes: 128 } }
+ *  // { type: 'contract', address: { type: 0, version: 22, hash160: 'a5d9d331000f5b79578ce56bd157f29a9056f0d6' }, contractName: { type: 2, content: 'test', lengthPrefixBytes: 1, maxLengthBytes: 128 } }
  * ```
  *
  * @see
@@ -118,7 +118,7 @@ function contractPrincipalCV(addressString: string, contractName: string): Contr
  *
  *  const contractAddressCV = contractPrincipalCVFromAddress(createAddress('SP2JXKMSH007NPYAQHKJPQMAQYAD90NQGTVJVQ02B'), createLPString('test'));
  *
- *  // { type: 6, address: { type: 0, version: 22, hash160: 'a5d9d331000f5b79578ce56bd157f29a9056f0d6' }, contractName: { type: 2, content: 'test', lengthPrefixBytes: 1, maxLengthBytes: 128 } }
+ *  // { type: 'contract', address: { type: 0, version: 22, hash160: 'a5d9d331000f5b79578ce56bd157f29a9056f0d6' }, contractName: { type: 2, content: 'test', lengthPrefixBytes: 1, maxLengthBytes: 128 } }
  * ```
  *
  * @see

--- a/packages/transactions/src/clarity/types/responseCV.ts
+++ b/packages/transactions/src/clarity/types/responseCV.ts
@@ -26,7 +26,7 @@ interface ResponseOkCV<T extends ClarityValue = ClarityValue> {
  *
  *  const respErrorCV = responseErrorCV(intCV(1));
  *
- *  // { type: 8, value: { type: 0, value: 1n } }
+ *  // { type: 'err', value: { type: 'int', value: 1n } }
  * ```
  *
  * @see
@@ -49,7 +49,7 @@ function responseErrorCV<T extends ClarityValue = ClarityValue>(value: T): Respo
  *
  *  const respOKCV = responseOkCV(intCV(1));
  *
- *  // { type: 7, value: { type: 0, value: 1n } }
+ *  // { type: 'ok', value: { type: 'int', value: 1n } }
  * ```
  *
  * @see

--- a/packages/transactions/src/clarity/types/stringCV.ts
+++ b/packages/transactions/src/clarity/types/stringCV.ts
@@ -23,7 +23,7 @@ interface StringUtf8CV {
  *
  *  const stringAscii = stringAsciiCV('test');
  *
- *  // { type: 13, data: 'hello' }
+ *  // { type: 'ascii', data: 'hello' }
  * ```
  *
  * @see
@@ -46,7 +46,7 @@ const stringAsciiCV = (data: string): StringAsciiCV => {
  *
  *  const stringUTF8 = stringUtf8CV('test');
  *
- *  // { type: 13, data: 'hello' }
+ *  // { type: 'utf8', data: 'hello' }
  * ```
  *
  * @see

--- a/packages/transactions/src/clarity/types/tupleCV.ts
+++ b/packages/transactions/src/clarity/types/tupleCV.ts
@@ -25,7 +25,7 @@ interface TupleCV<T extends TupleData = TupleData> {
  *    b: falseCV(),
  *    a: trueCV(),
  *  });
- *  // { type: 12, data: { c: { type: 3 }, b: { type: 4 }, a: { type: 3 } } }
+ *  // { type: 'tuple', data: { c: { type: 'true' }, b: { type: 'false' }, a: { type: 'true' } } }
  * ```
  *
  * @see

--- a/packages/transactions/src/index.ts
+++ b/packages/transactions/src/index.ts
@@ -98,7 +98,7 @@ export * from './postcondition-types';
 export * from './signature';
 export * from './signer';
 export * from './structuredDataSignature';
-export { StacksTransaction, deserializeTransaction } from './transaction';
+export * from './transaction';
 export * from './types';
 export * from './utils';
 export * from './fetch';

--- a/packages/transactions/tests/builder.test.ts
+++ b/packages/transactions/tests/builder.test.ts
@@ -39,7 +39,6 @@ import {
 } from '../src/authorization';
 import {
   SignedTokenTransferOptions,
-  estimateTransactionByteLength,
   makeContractCall,
   makeContractDeploy,
   makeContractFungiblePostCondition,
@@ -89,7 +88,11 @@ import { TokenTransferPayload, createTokenTransferPayload, serializePayload } fr
 import { createAssetInfo } from '../src/postcondition-types';
 import { createTransactionAuthField } from '../src/signature';
 import { TransactionSigner } from '../src/signer';
-import { StacksTransaction, deserializeTransaction } from '../src/transaction';
+import {
+  StacksTransaction,
+  deserializeTransaction,
+  estimateTransactionByteLength,
+} from '../src/transaction';
 import { cloneDeep } from '../src/utils';
 import { STACKS_TESTNET, TransactionVersion } from '@stacks/network';
 

--- a/packages/transactions/tests/clarity.test.ts
+++ b/packages/transactions/tests/clarity.test.ts
@@ -10,8 +10,11 @@ import { BytesReader } from '../src/bytesReader';
 import {
   bufferCV,
   BufferCV,
+  clarityByteToType,
   ClarityType,
+  clarityTypeToByte,
   ClarityValue,
+  ClarityWireType,
   contractPrincipalCV,
   contractPrincipalCVFromStandard,
   deserializeCV,
@@ -706,6 +709,73 @@ describe('Clarity Types', () => {
       assert(isClarityType(vInt, ClarityType.Int));
       const intTest: IntCV = vInt;
       intTest; // avoid the "value is never read warning"
+    });
+  });
+
+  describe('Clarity type wire format', () => {
+    test(clarityTypeToByte.name, () => {
+      expect(clarityTypeToByte(ClarityType.Int)).toEqual(0x00);
+      expect(clarityTypeToByte(ClarityType.Int)).toEqual(ClarityWireType.int);
+
+      expect(clarityTypeToByte(ClarityType.UInt)).toEqual(0x01);
+      expect(clarityTypeToByte(ClarityType.UInt)).toEqual(ClarityWireType.uint);
+
+      expect(clarityTypeToByte(ClarityType.Buffer)).toEqual(0x02);
+      expect(clarityTypeToByte(ClarityType.Buffer)).toEqual(ClarityWireType.buffer);
+
+      expect(clarityTypeToByte(ClarityType.BoolTrue)).toEqual(0x03);
+      expect(clarityTypeToByte(ClarityType.BoolTrue)).toEqual(ClarityWireType.true);
+
+      expect(clarityTypeToByte(ClarityType.BoolFalse)).toEqual(0x04);
+      expect(clarityTypeToByte(ClarityType.BoolFalse)).toEqual(ClarityWireType.false);
+
+      expect(clarityTypeToByte(ClarityType.PrincipalStandard)).toEqual(0x05);
+      expect(clarityTypeToByte(ClarityType.PrincipalStandard)).toEqual(ClarityWireType.address);
+
+      expect(clarityTypeToByte(ClarityType.PrincipalContract)).toEqual(0x06);
+      expect(clarityTypeToByte(ClarityType.PrincipalContract)).toEqual(ClarityWireType.contract);
+
+      expect(clarityTypeToByte(ClarityType.ResponseOk)).toEqual(0x07);
+      expect(clarityTypeToByte(ClarityType.ResponseOk)).toEqual(ClarityWireType.ok);
+
+      expect(clarityTypeToByte(ClarityType.ResponseErr)).toEqual(0x08);
+      expect(clarityTypeToByte(ClarityType.ResponseErr)).toEqual(ClarityWireType.err);
+
+      expect(clarityTypeToByte(ClarityType.OptionalNone)).toEqual(0x09);
+      expect(clarityTypeToByte(ClarityType.OptionalNone)).toEqual(ClarityWireType.none);
+
+      expect(clarityTypeToByte(ClarityType.OptionalSome)).toEqual(0x0a);
+      expect(clarityTypeToByte(ClarityType.OptionalSome)).toEqual(ClarityWireType.some);
+
+      expect(clarityTypeToByte(ClarityType.List)).toEqual(0x0b);
+      expect(clarityTypeToByte(ClarityType.List)).toEqual(ClarityWireType.list);
+
+      expect(clarityTypeToByte(ClarityType.Tuple)).toEqual(0x0c);
+      expect(clarityTypeToByte(ClarityType.Tuple)).toEqual(ClarityWireType.tuple);
+
+      expect(clarityTypeToByte(ClarityType.StringASCII)).toEqual(0x0d);
+      expect(clarityTypeToByte(ClarityType.StringASCII)).toEqual(ClarityWireType.ascii);
+
+      expect(clarityTypeToByte(ClarityType.StringUTF8)).toEqual(0x0e);
+      expect(clarityTypeToByte(ClarityType.StringUTF8)).toEqual(ClarityWireType.utf8);
+    });
+
+    test(clarityByteToType.name, () => {
+      expect(clarityByteToType(0x00)).toEqual(ClarityType.Int);
+      expect(clarityByteToType(0x01)).toEqual(ClarityType.UInt);
+      expect(clarityByteToType(0x02)).toEqual(ClarityType.Buffer);
+      expect(clarityByteToType(0x03)).toEqual(ClarityType.BoolTrue);
+      expect(clarityByteToType(0x04)).toEqual(ClarityType.BoolFalse);
+      expect(clarityByteToType(0x05)).toEqual(ClarityType.PrincipalStandard);
+      expect(clarityByteToType(0x06)).toEqual(ClarityType.PrincipalContract);
+      expect(clarityByteToType(0x07)).toEqual(ClarityType.ResponseOk);
+      expect(clarityByteToType(0x08)).toEqual(ClarityType.ResponseErr);
+      expect(clarityByteToType(0x09)).toEqual(ClarityType.OptionalNone);
+      expect(clarityByteToType(0x0a)).toEqual(ClarityType.OptionalSome);
+      expect(clarityByteToType(0x0b)).toEqual(ClarityType.List);
+      expect(clarityByteToType(0x0c)).toEqual(ClarityType.Tuple);
+      expect(clarityByteToType(0x0d)).toEqual(ClarityType.StringASCII);
+      expect(clarityByteToType(0x0e)).toEqual(ClarityType.StringUTF8);
     });
   });
 });


### PR DESCRIPTION
> This PR was published to npm with the version `6.11.4-pr.e279ac3.0`
> e.g. `npm install @stacks/common@6.11.4-pr.e279ac3.0 --save-exact`<!-- Sticky Header Marker -->

`build`
Update commitlint config to allow longer lines (e.g. when adding `BREAKING CHANGE` body to commit message.

`refactor!`
Introduce a new ClarityWireType to replace the existing ClarityType, which now is human-readable.


This is done in anticipation of https://github.com/stacksgov/sips/pull/166

### Next steps
In a future PR, I may update the `.buffer, .value` etc. to all follow a similar pattern (e.g. to all be `.value`)