### PR TITLE
docs: add migration docs

### DIFF
--- a/.github/MIGRATION.md
+++ b/.github/MIGRATION.md
@@ -35,8 +35,8 @@ The `@stacks/network` package exports the following network objects:
 
 - `STACKS_MAINNET`
 - `STACKS_TESTNET`
-- `STACKS_MOCKNET`
-- `STACKS_DEVNET` (alias for `STACKS_MOCKNET`)
+- `STACKS_DEVNET`
+- `STACKS_MOCKNET` (alias for `STACKS_DEVNET`)
 
 ```ts
 import { STACKS_MAINNET } from '@stacks/network';

--- a/.github/MIGRATION.md
+++ b/.github/MIGRATION.md
@@ -41,7 +41,6 @@ The `@stacks/network` package exports the following network objects:
 ```ts
 import { STACKS_MAINNET } from '@stacks/network';
 import { STACKS_TESTNET } from '@stacks/network';
-import { STACKS_MOCKNET } from '@stacks/network';
 import { STACKS_DEVNET } from '@stacks/network';
 ```
 

--- a/.github/MIGRATION.md
+++ b/.github/MIGRATION.md
@@ -24,7 +24,7 @@
 
 ### Breaking Changes
 
-- The `@stacks/network` `new StacksNetwork()` objects were removed. Instead `@stacks/network` now exports objects like `STACKS_MAINNET`, which are static (and shouldn't be changed for most use-cases). [Read more...](#stacks-network)
+- The `@stacks/network` `new StacksNetwork()` objects were removed. Instead `@stacks/network` now exports the objects `STACKS_MAINNET`, `STACKS_TESNET`, and `STACKS_DEVNET`, which are static (and shouldn't be changed for most use-cases). [Read more...](#stacks-network)
 - The `ClarityType` enum was replaced by a readable version. The previous (wire format compatible) enum is still available as `ClarityWireType`. [Read more...](#clarity-representation)
 
 ### Stacks Network


### PR DESCRIPTION
[next]

Adds content to the MIGRATION.md document in the repo.