### PR TITLE
Get pubkey from structured data

### DIFF
--- a/packages/transactions/src/keys.ts
+++ b/packages/transactions/src/keys.ts
@@ -38,6 +38,7 @@ import {
   UNCOMPRESSED_PUBKEY_LENGTH_BYTES,
 } from './constants';
 import { hash160, hashP2PKH } from './utils';
+import { StructuredDataSignature } from './structuredDataSignature';
 
 /**
  * To use secp256k1.signSync set utils.hmacSha256Sync to a function using noble-hashes
@@ -89,7 +90,7 @@ export function createStacksPublicKey(key: string): StacksPublicKey {
 
 export function publicKeyFromSignatureVrs(
   messageHash: string,
-  messageSignature: MessageSignature,
+  messageSignature: MessageSignature | StructuredDataSignature,
   pubKeyEncoding = PubKeyEncoding.Compressed
 ): string {
   const parsedSignature = parseRecoverableSignatureVrs(messageSignature.data);
@@ -101,7 +102,7 @@ export function publicKeyFromSignatureVrs(
 
 export function publicKeyFromSignatureRsv(
   messageHash: string,
-  messageSignature: MessageSignature,
+  messageSignature: MessageSignature | StructuredDataSignature,
   pubKeyEncoding = PubKeyEncoding.Compressed
 ): string {
   return publicKeyFromSignatureVrs(


### PR DESCRIPTION
### Description

When setting up the `sign-message` script for [aibtcdev/agent-tools-ts](https://github.com/aibtcdev/agent-tools-ts/blob/main/src/wallet/sign-message.ts), we ran into an issue where we could not pass the type `StructuredDataSignature` to either of the `getPublicKeyFromSignature` methods.

After experimenting with this it was working in our initial tests, so we added the updated code back with a test to confirm it.

#### Breaking change?

More like an *unblocking* change :wink: 

### Example

You can now pass either `MessageSignature | StructuredDataSignature` to the getPublicKeyFromSignature method, detailed example is in the test file.

---

### Checklist

- [x] Unit tested updated code paths
- [x] Tagging @janniks based on our discussion in Discord

<!-- Make sure to run `npm run test` locally to find problems faster -->
