### PR TITLE
1578 nakamoto remove anchor mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "lerna": "^8.1.2",
         "madge": "^6.1.0",
         "path-browserify": "^1.0.1",
-        "prettier": "^3.0.1",
+        "prettier": "^3.2.5",
         "rimraf": "^5.0.1",
         "stream-http": "^3.2.0",
         "ts-jest": "^29.1.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "lerna": "^8.1.2",
     "madge": "^6.1.0",
     "path-browserify": "^1.0.1",
-    "prettier": "^3.0.1",
+    "prettier": "^3.2.5",
     "rimraf": "^5.0.1",
     "stream-http": "^3.2.0",
     "ts-jest": "^29.1.1",

--- a/packages/bns/src/index.ts
+++ b/packages/bns/src/index.ts
@@ -2,7 +2,6 @@ import { ApiParam, IntegerType, utf8ToBytes } from '@stacks/common';
 import { ChainId, StacksNetwork } from '@stacks/network';
 import {
   AddressVersion,
-  AnchorMode,
   ClarityType,
   ClarityValue,
   FungibleConditionCode,
@@ -91,7 +90,6 @@ async function makeBnsContractCall(options: BnsContractCallOptions): Promise<Sta
     publicKey: options.publicKey,
     validateWithAbi: false,
     network: options.network,
-    anchorMode: AnchorMode.Any,
     postConditions: options.postConditions,
   };
 

--- a/packages/bns/tests/bns.test.ts
+++ b/packages/bns/tests/bns.test.ts
@@ -2,7 +2,6 @@ import { utf8ToBytes } from '@stacks/common';
 import { ChainId, STACKS_TESTNET, StacksNetwork } from '@stacks/network';
 import {
   AddressVersion,
-  AnchorMode,
   FungibleConditionCode,
   NonFungibleConditionCode,
   bufferCV,
@@ -344,7 +343,6 @@ test('preorderNamespace', async () => {
     validateWithAbi: false,
     publicKey,
     network,
-    anchorMode: AnchorMode.Any,
     postConditions: [burnSTXPostCondition],
   };
 
@@ -438,7 +436,6 @@ test('revealNamespace', async () => {
     validateWithAbi: false,
     publicKey,
     network,
-    anchorMode: AnchorMode.Any,
   };
 
   expect(makeUnsignedContractCall).toHaveBeenCalledTimes(1);
@@ -486,7 +483,6 @@ test('importName', async () => {
     publicKey,
     network,
     validateWithAbi: false,
-    anchorMode: AnchorMode.Any,
   };
 
   expect(makeUnsignedContractCall).toHaveBeenCalledTimes(1);
@@ -523,7 +519,6 @@ test('readyNamespace', async () => {
     publicKey,
     network,
     validateWithAbi: false,
-    anchorMode: AnchorMode.Any,
   };
 
   expect(makeUnsignedContractCall).toHaveBeenCalledTimes(1);
@@ -571,7 +566,6 @@ test('preorderName', async () => {
     publicKey,
     network,
     validateWithAbi: false,
-    anchorMode: AnchorMode.Any,
     postConditions: [burnSTXPostCondition],
   };
 
@@ -620,7 +614,6 @@ test('registerName', async () => {
     publicKey,
     network,
     validateWithAbi: false,
-    anchorMode: AnchorMode.Any,
   };
 
   expect(makeUnsignedContractCall).toHaveBeenCalledTimes(1);
@@ -665,7 +658,6 @@ test('updateName', async () => {
     publicKey,
     network,
     validateWithAbi: false,
-    anchorMode: AnchorMode.Any,
   };
 
   expect(makeUnsignedContractCall).toHaveBeenCalledTimes(1);
@@ -732,7 +724,6 @@ test('transferName', async () => {
     publicKey,
     network,
     validateWithAbi: false,
-    anchorMode: AnchorMode.Any,
     postConditions: [nameTransferPostConditionOne, nameTransferPostConditionTwo],
   };
 
@@ -800,7 +791,6 @@ test('transferName optionalArguments', async () => {
     publicKey,
     network,
     validateWithAbi: false,
-    anchorMode: AnchorMode.Any,
     postConditions: [nameTransferPostConditionOne, nameTransferPostConditionTwo],
   };
 
@@ -840,7 +830,6 @@ test('revokeName', async () => {
     publicKey,
     network,
     validateWithAbi: false,
-    anchorMode: AnchorMode.Any,
   };
 
   expect(makeUnsignedContractCall).toHaveBeenCalledTimes(1);
@@ -895,7 +884,6 @@ test('renewName', async () => {
     publicKey,
     network,
     validateWithAbi: false,
-    anchorMode: AnchorMode.Any,
     postConditions: [burnSTXPostCondition],
   };
 
@@ -951,7 +939,6 @@ test('renewName optionalArguments', async () => {
     publicKey,
     network,
     validateWithAbi: false,
-    anchorMode: AnchorMode.Any,
     postConditions: [burnSTXPostCondition],
   };
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -5,7 +5,6 @@ import { buildPreorderNameTx, buildRegisterNameTx } from '@stacks/bns';
 import { bytesToHex, HIRO_MAINNET_URL, HIRO_TESTNET_URL } from '@stacks/common';
 import {
   ACCOUNT_PATH,
-  AnchorMode,
   broadcastTransaction,
   callReadOnlyFunction,
   Cl,
@@ -713,7 +712,6 @@ async function sendTokens(network: CLINetworkAdapter, args: string[]): Promise<s
     nonce,
     memo,
     network: api.network,
-    anchorMode: AnchorMode.Any,
   };
 
   const tx: StacksTransaction = await makeSTXTokenTransfer(options);
@@ -772,7 +770,6 @@ async function contractDeploy(network: CLINetworkAdapter, args: string[]): Promi
     nonce,
     network: api.network,
     postConditionMode: PostConditionMode.Allow,
-    anchorMode: AnchorMode.Any,
   };
 
   const tx = await makeContractDeploy(options);
@@ -853,7 +850,6 @@ async function contractFunctionCall(network: CLINetworkAdapter, args: string[]):
         nonce,
         network: api.network,
         postConditionMode: PostConditionMode.Allow,
-        anchorMode: AnchorMode.Any,
         api,
       };
 

--- a/packages/stacking/src/index.ts
+++ b/packages/stacking/src/index.ts
@@ -20,7 +20,6 @@ import {
   BurnchainRewardsTotal,
 } from '@stacks/stacks-blockchain-api-types';
 import {
-  AnchorMode,
   BufferCV,
   ClarityType,
   ClarityValue,
@@ -1018,7 +1017,6 @@ export class StackingClient {
       functionArgs,
       validateWithAbi: true,
       network: this.network,
-      anchorMode: AnchorMode.Any,
     };
     return callOptions;
   }
@@ -1060,7 +1058,6 @@ export class StackingClient {
       functionArgs,
       validateWithAbi: true,
       network: this.network,
-      anchorMode: AnchorMode.Any,
     };
     return callOptions;
   }
@@ -1099,7 +1096,6 @@ export class StackingClient {
       functionArgs,
       validateWithAbi: true,
       network: this.network,
-      anchorMode: AnchorMode.Any,
     };
     return callOptions;
   }
@@ -1132,7 +1128,6 @@ export class StackingClient {
       ],
       validateWithAbi: true,
       network: this.network,
-      anchorMode: AnchorMode.Any,
     };
     return callOptions;
   }
@@ -1169,7 +1164,6 @@ export class StackingClient {
       ],
       validateWithAbi: true,
       network: this.network,
-      anchorMode: AnchorMode.Any,
     };
 
     return callOptions;
@@ -1197,7 +1191,6 @@ export class StackingClient {
       functionArgs: [principalCV(stacker), address, uintCV(extendCount)],
       validateWithAbi: true,
       network: this.network,
-      anchorMode: AnchorMode.Any,
     };
 
     return callOptions;
@@ -1224,7 +1217,6 @@ export class StackingClient {
       functionArgs: [principalCV(stacker), address, uintCV(increaseBy)],
       validateWithAbi: true,
       network: this.network,
-      anchorMode: AnchorMode.Any,
     };
 
     return callOptions;
@@ -1267,7 +1259,6 @@ export class StackingClient {
       functionArgs,
       validateWithAbi: true,
       network: this.network,
-      anchorMode: AnchorMode.Any,
     };
     return callOptions;
   }
@@ -1311,7 +1302,6 @@ export class StackingClient {
       functionArgs,
       validateWithAbi: true,
       network: this.network,
-      anchorMode: AnchorMode.Any,
     };
     return callOptions;
   }
@@ -1353,7 +1343,6 @@ export class StackingClient {
       functionArgs,
       validateWithAbi: true,
       network: this.network,
-      anchorMode: AnchorMode.Any,
     };
     return callOptions;
   }
@@ -1368,7 +1357,6 @@ export class StackingClient {
       functionArgs: [],
       validateWithAbi: true,
       network: this.network,
-      anchorMode: AnchorMode.Any,
     };
     return callOptions;
   }

--- a/packages/stacking/tests/stacking.test.ts
+++ b/packages/stacking/tests/stacking.test.ts
@@ -4,7 +4,6 @@ import { HIRO_TESTNET_URL, bigIntToBytes, bytesToHex, hexToBytes } from '@stacks
 import { base58CheckDecode, getPublicKeyFromPrivate } from '@stacks/encryption';
 import { STACKS_MAINNET, STACKS_TESTNET } from '@stacks/network';
 import {
-  AnchorMode,
   ClarityType,
   ReadOnlyFunctionOptions,
   SignedContractCallOptions,
@@ -337,7 +336,6 @@ test('stack stx', async () => {
     validateWithAbi: true,
     network,
     senderKey: privateKey,
-    anchorMode: AnchorMode.Any,
     api: client.api,
   };
 
@@ -410,7 +408,6 @@ test('delegate stx', async () => {
     validateWithAbi: true,
     network,
     senderKey: privateKey,
-    anchorMode: AnchorMode.Any,
     api: client.api,
   };
 
@@ -475,7 +472,6 @@ test('delegate stx with empty optional parameters', async () => {
     validateWithAbi: true,
     network,
     senderKey: privateKey,
-    anchorMode: AnchorMode.Any,
     api: client.api,
   };
 
@@ -559,7 +555,6 @@ test('delegate stack stx with one delegator', async () => {
     validateWithAbi: true,
     network,
     senderKey: privateKey,
-    anchorMode: AnchorMode.Any,
     api: client.api,
   };
 
@@ -646,7 +641,6 @@ test('delegate stack stx with set nonce', async () => {
     network,
     senderKey: privateKey,
     nonce,
-    anchorMode: AnchorMode.Any,
     api: client.api,
   };
 
@@ -710,7 +704,6 @@ test('delegator commit', async () => {
     validateWithAbi: true,
     network,
     senderKey: privateKey,
-    anchorMode: AnchorMode.Any,
     api: client.api,
   };
 
@@ -760,7 +753,6 @@ test('revoke delegate stx', async () => {
     validateWithAbi: true,
     network,
     senderKey: privateKey,
-    anchorMode: AnchorMode.Any,
     api: client.api,
   };
 

--- a/packages/transactions/README.md
+++ b/packages/transactions/README.md
@@ -34,7 +34,7 @@ const privateKey = createStacksPrivateKey(key);
 ## STX Token Transfer Transaction
 
 ```typescript
-import { makeSTXTokenTransfer, broadcastTransaction, AnchorMode } from '@stacks/transactions';
+import { makeSTXTokenTransfer, broadcastTransaction } from '@stacks/transactions';
 
 const txOptions = {
   recipient: 'SP3FGQ8Z7JY9BWYZ5WM53E0M9NK7WHJF0691NZ159',
@@ -44,7 +44,6 @@ const txOptions = {
   memo: 'test memo',
   nonce: 0n, // set a nonce manually if you don't want builder to fetch from a Stacks node
   fee: 200n, // set a tx fee if you don't want the builder to estimate
-  anchorMode: AnchorMode.Any,
 };
 
 const transaction = await makeSTXTokenTransfer(txOptions);
@@ -61,7 +60,7 @@ const txId = broadcastResponse.txid;
 ## Smart Contract Deploy Transaction
 
 ```typescript
-import { makeContractDeploy, broadcastTransaction, AnchorMode } from '@stacks/transactions';
+import { makeContractDeploy, broadcastTransaction } from '@stacks/transactions';
 import { StacksTestnet, StacksMainnet } from '@stacks/network';
 import { readFileSync } from 'fs';
 
@@ -73,7 +72,6 @@ const txOptions = {
   codeBody: readFileSync('/path/to/contract.clar').toString(),
   senderKey: 'b244296d5907de9864c0b0d51f98a13c52890be0404e83f273144cd5b9960eed01',
   network,
-  anchorMode: AnchorMode.Any,
 };
 
 const transaction = await makeContractDeploy(txOptions);
@@ -88,7 +86,6 @@ const txId = broadcastResponse.txid;
 import {
   makeContractCall,
   broadcastTransaction,
-  AnchorMode,
   FungibleConditionCode,
   makeStandardSTXPostCondition,
   bufferCVFromString,
@@ -116,7 +113,6 @@ const txOptions = {
   validateWithAbi: true,
   network,
   postConditions,
-  anchorMode: AnchorMode.Any,
 };
 
 const transaction = await makeContractCall(txOptions);
@@ -141,7 +137,7 @@ To generate a sponsored transaction, first create and sign the transaction as th
 
 ```typescript
 import { bytesToHex } from '@stacks/common';
-import { makeContractCall, BufferCV, AnchorMode, bufferCVFromString } from '@stacks/transactions';
+import { makeContractCall, BufferCV, bufferCVFromString } from '@stacks/transactions';
 
 const txOptions = {
   contractAddress: 'SPBMRFRPPGCDE3F384WCJPK8PQJGZ8K9QKK7F59X',
@@ -152,7 +148,6 @@ const txOptions = {
   senderKey: 'b244296d5907de9864c0b0d51f98a13c52890be0404e83f273144cd5b9960eed01',
   validateWithAbi: true,
   sponsored: true,
-  anchorMode: AnchorMode.Any,
 };
 
 const transaction = await makeContractCall(txOptions);
@@ -206,7 +201,6 @@ import {
   TransactionSigner,
   standardPrincipalCV,
   BytesReader,
-  AnchorMode,
 } from '@stacks/transactions';
 
 const recipient = standardPrincipalCV('SP3FGQ8...');
@@ -233,7 +227,6 @@ const transaction = await makeUnsignedSTXTokenTransfer({
   memo,
   numSignatures: 2, // number of signature required
   publicKeys: pubKeyStrings, // public key string array with >= numSignatures elements
-  anchorMode: AnchorMode.Any,
 });
 
 const serializedTx = transaction.serialize();

--- a/packages/transactions/src/builders.ts
+++ b/packages/transactions/src/builders.ts
@@ -20,7 +20,6 @@ import {
   AddressHashMode,
   AddressVersion,
   AnchorMode,
-  AnchorModeName,
   ClarityVersion,
   FungibleConditionCode,
   NonFungibleConditionCode,
@@ -78,9 +77,6 @@ export type TokenTransferOptions = {
   nonce?: IntegerType;
   /** the network that the transaction will ultimately be broadcast to */
   network?: StacksNetworkName | StacksNetwork;
-  /** the transaction anchorMode, which specifies whether it should be
-   * included in an anchor block or a microblock */
-  anchorMode: AnchorModeName | AnchorMode;
   /** an arbitrary string to include in the transaction, must be less than 34 bytes */
   memo?: string;
   /** set to true if another account is sponsoring the transaction (covering the transaction fee) */
@@ -143,7 +139,7 @@ export async function makeUnsignedSTXTokenTransfer(
     payload,
     undefined, // no post conditions on STX transfers (see SIP-005)
     undefined, // no post conditions on STX transfers (see SIP-005)
-    options.anchorMode,
+    AnchorMode.Any,
     network.chainId
   );
 
@@ -225,9 +221,6 @@ export interface BaseContractDeployOptions {
   network?: StacksNetworkName | StacksNetwork;
   /** the node/API used for estimating fee & nonce (using the `api.fetchFn` */
   api?: ApiOpts;
-  /** the transaction anchorMode, which specifies whether it should be
-   * included in an anchor block or a microblock */
-  anchorMode: AnchorModeName | AnchorMode;
   /** the post condition mode, specifying whether or not post-conditions must fully cover all
    * transfered assets */
   postConditionMode?: PostConditionMode;
@@ -346,7 +339,7 @@ export async function makeUnsignedContractDeploy(
     payload,
     lpPostConditions,
     options.postConditionMode,
-    options.anchorMode,
+    AnchorMode.Any,
     network.chainId
   );
 
@@ -385,9 +378,6 @@ export interface ContractCallOptions {
   network?: StacksNetworkName | StacksNetwork;
   /** the node/API used for estimating fee & nonce (using the `api.fetchFn` */
   api?: ApiOpts;
-  /** the transaction anchorMode, which specifies whether it should be
-   * included in an anchor block or a microblock */
-  anchorMode: AnchorModeName | AnchorMode;
   /** the post condition mode, specifying whether or not post-conditions must fully cover all
    * transfered assets */
   postConditionMode?: PostConditionMode;
@@ -482,7 +472,7 @@ export async function makeUnsignedContractCall(
     payload,
     lpPostConditions,
     options.postConditionMode,
-    options.anchorMode,
+    AnchorMode.Any,
     network.chainId
   );
 

--- a/packages/transactions/src/constants.ts
+++ b/packages/transactions/src/constants.ts
@@ -71,6 +71,7 @@ export enum ClarityVersion {
  *
  * For more information about the kinds of Stacks blocks and the various
  * AnchorModes, check out {@link https://github.com/stacksgov/sips/blob/main/sips/sip-001/sip-001-burn-election.md SIP 001} and
+ * @deprecated `AnchorMode` is not needed in Stacks since the Nakamoto update.
  * {@link https://github.com/stacksgov/sips/blob/main/sips/sip-005/sip-005-blocks-and-transactions.md SIP 005}
  */
 export enum AnchorMode {
@@ -82,7 +83,9 @@ export enum AnchorMode {
   Any = 0x03,
 }
 
+/** @deprecated `AnchorMode` is not needed in Stacks since the Nakamoto update. */
 export const AnchorModeNames = ['onChainOnly', 'offChainOnly', 'any'] as const;
+/** @deprecated `AnchorMode` is not needed in Stacks since the Nakamoto update. */
 export type AnchorModeName = (typeof AnchorModeNames)[number];
 
 const AnchorModeMap = {

--- a/packages/transactions/src/transaction.ts
+++ b/packages/transactions/src/transaction.ts
@@ -36,7 +36,6 @@ import {
   anchorModeFrom,
   AnchorModeName,
   AuthType,
-  PayloadType,
   PostConditionMode,
   PubKeyEncoding,
   RECOVERABLE_ECDSA_SIG_LENGTH_BYTES,
@@ -86,25 +85,7 @@ export class StacksTransaction {
     this.postConditionMode = postConditionMode ?? PostConditionMode.Deny;
     this.postConditions = postConditions ?? createLPList([]);
 
-    if (anchorMode) {
-      this.anchorMode = anchorModeFrom(anchorMode);
-    } else {
-      switch (payload.payloadType) {
-        case PayloadType.Coinbase:
-        case PayloadType.CoinbaseToAltRecipient:
-        case PayloadType.NakamotoCoinbase:
-        case PayloadType.PoisonMicroblock:
-        case PayloadType.TenureChange:
-          this.anchorMode = AnchorMode.OnChainOnly;
-          break;
-        case PayloadType.ContractCall:
-        case PayloadType.SmartContract:
-        case PayloadType.VersionedSmartContract:
-        case PayloadType.TokenTransfer:
-          this.anchorMode = AnchorMode.Any;
-          break;
-      }
-    }
+    this.anchorMode = anchorModeFrom(anchorMode ?? AnchorMode.Any);
   }
 
   signBegin() {

--- a/packages/transactions/tests/builder.test.ts
+++ b/packages/transactions/tests/builder.test.ts
@@ -80,8 +80,6 @@ import {
 import { createMessageSignature } from '../src/common';
 import {
   AddressHashMode,
-  AnchorMode,
-  AnchorModeName,
   AuthType,
   ClarityVersion,
   FungibleConditionCode,
@@ -148,45 +146,6 @@ test('API key middleware - get nonce', async () => {
   expect(callHeaders.get('x-api-key')).toBe(apiKey);
 });
 
-const anchorModeNameCases: [AnchorModeName | AnchorMode, AnchorMode | null][] = [
-  ['onChainOnly', AnchorMode.OnChainOnly],
-  ['offChainOnly', AnchorMode.OffChainOnly],
-  ['any', AnchorMode.Any],
-  [AnchorMode.OnChainOnly, AnchorMode.OnChainOnly],
-  [AnchorMode.OffChainOnly, AnchorMode.OffChainOnly],
-  [AnchorMode.Any, AnchorMode.Any],
-  ['invalid' as AnchorModeName, null],
-  [0x20 as AnchorMode, null],
-];
-
-test.each(anchorModeNameCases)(
-  'Build transaction with AnchorMode name %p',
-  async (anchorModeName, anchorModeValue) => {
-    const recipient = standardPrincipalCV('SP3FGQ8Z7JY9BWYZ5WM53E0M9NK7WHJF0691NZ159');
-    const amount = 12345;
-    const fee = 0;
-    const nonce = 0;
-    const senderKey = 'edf9aee84d9b7abc145504dde6726c64f369d37ee34ded868fabd876c26570bc01';
-    const memo = 'test memo';
-    const txOptions: SignedTokenTransferOptions = {
-      recipient,
-      amount,
-      senderKey,
-      fee,
-      nonce,
-      memo,
-      anchorMode: anchorModeName,
-    };
-    if (anchorModeValue === null) {
-      expect.assertions(1);
-      await expect(makeSTXTokenTransfer(txOptions)).rejects.toThrow(/Invalid anchor mode/);
-    } else {
-      const transaction = await makeSTXTokenTransfer(txOptions);
-      expect(transaction.anchorMode).toBe(anchorModeValue);
-    }
-  }
-);
-
 test('Make STX token transfer with set tx fee', async () => {
   const recipient = standardPrincipalCV('SP3FGQ8Z7JY9BWYZ5WM53E0M9NK7WHJF0691NZ159');
   const amount = 12345;
@@ -202,7 +161,6 @@ test('Make STX token transfer with set tx fee', async () => {
     fee,
     nonce,
     memo,
-    anchorMode: AnchorMode.Any,
   });
   expect(() => transaction.verifyOrigin()).not.toThrow();
 
@@ -260,7 +218,6 @@ test('Make STX token transfer with fee estimate', async () => {
     nonce,
     senderKey,
     memo,
-    anchorMode: AnchorMode.Any,
   });
 
   expect(() => transaction.verifyOrigin()).not.toThrow();
@@ -295,7 +252,6 @@ test('Make STX token transfer with testnet', async () => {
     nonce,
     network: STACKS_TESTNET,
     memo: memo,
-    anchorMode: AnchorMode.Any,
   });
   expect(() => transaction.verifyOrigin()).not.toThrow();
 
@@ -319,7 +275,6 @@ test('Make STX token transfer with testnet string name', async () => {
     nonce: 0,
     network: 'testnet',
     memo: 'test memo',
-    anchorMode: AnchorMode.Any,
   });
   expect(() => transaction.verifyOrigin()).not.toThrow();
 
@@ -343,7 +298,6 @@ test('Throws making STX token transder with invalid network name', async () => {
     nonce: 0,
     network: 'invalidnet',
     memo: 'test memo',
-    anchorMode: AnchorMode.Any,
   };
 
   await expect(
@@ -371,7 +325,6 @@ test("STX token transfers don't take post conditions", async () => {
     nonce,
     memo,
     postConditions,
-    anchorMode: AnchorMode.Any,
   } as SignedTokenTransferOptions);
 
   const serialized = transaction.serialize();
@@ -410,7 +363,6 @@ test('Make Multi-Sig STX token transfer', async () => {
     memo: memo,
     numSignatures: 2,
     publicKeys: pubKeyStrings,
-    anchorMode: AnchorMode.Any,
   });
   const signer = new TransactionSigner(transaction);
   signer.signOrigin(privKeys[0]);
@@ -485,7 +437,6 @@ test('Should deserialize partially signed multi-Sig STX token transfer', async (
     memo: memo,
     numSignatures: 2,
     publicKeys: pubKeyStrings,
-    anchorMode: AnchorMode.Any,
   });
 
   const serializedTx = transaction.serialize();
@@ -562,7 +513,6 @@ test('Should throw error if multisig transaction is oversigned', async () => {
     memo: memo,
     numSignatures: 2,
     publicKeys: pubKeyStrings,
-    anchorMode: AnchorMode.Any,
   });
 
   const signer = new TransactionSigner(transaction);
@@ -606,7 +556,6 @@ test('Make Multi-Sig STX token transfer with two transaction signers', async () 
     memo: memo,
     numSignatures: 2,
     publicKeys: pubKeyStrings,
-    anchorMode: AnchorMode.Any,
   });
 
   const serializedTxUnsigned = transaction.serialize();
@@ -708,7 +657,6 @@ test('addSignature to an unsigned transaction', async () => {
     fee,
     nonce,
     publicKey,
-    anchorMode: AnchorMode.Any,
   });
 
   const nullSignature = (unsignedTx.auth.spendingCondition as any).signature.data;
@@ -740,7 +688,6 @@ test('Make versioned smart contract deploy', async () => {
     fee,
     nonce,
     network: STACKS_TESTNET,
-    anchorMode: AnchorMode.Any,
     clarityVersion: ClarityVersion.Clarity2,
   });
   expect(() => transaction.verifyOrigin()).not.toThrow();
@@ -767,7 +714,6 @@ test('Make smart contract deploy (defaults to versioned smart contract, as of 2.
     fee,
     nonce,
     network: STACKS_TESTNET,
-    anchorMode: AnchorMode.Any,
   });
   expect(() => transaction.verifyOrigin()).not.toThrow();
 
@@ -787,7 +733,6 @@ test('Make smart contract deploy with network string name (defaults to versioned
     fee: 0,
     nonce: 0,
     network: 'testnet',
-    anchorMode: AnchorMode.Any,
   });
   expect(() => transaction.verifyOrigin()).not.toThrow();
 
@@ -815,7 +760,6 @@ test('Make smart contract deploy unsigned', async () => {
     fee,
     nonce,
     network: STACKS_TESTNET,
-    anchorMode: AnchorMode.Any,
   });
 
   const serializedTx = transaction.serialize();
@@ -853,7 +797,6 @@ test('make a multi-sig contract deploy', async () => {
     fee,
     nonce,
     network: STACKS_TESTNET,
-    anchorMode: AnchorMode.Any,
   });
   expect(() => transaction.verifyOrigin()).not.toThrow();
   expect(transaction.auth.spendingCondition!.signer).toEqual(
@@ -877,7 +820,6 @@ test('Make smart contract deploy signed', async () => {
     fee,
     nonce,
     network: STACKS_TESTNET,
-    anchorMode: AnchorMode.Any,
   });
   expect(() => transaction.verifyOrigin()).not.toThrow();
 
@@ -910,7 +852,6 @@ test('Make contract-call', async () => {
     fee,
     nonce: 1,
     network: STACKS_TESTNET,
-    anchorMode: AnchorMode.Any,
   });
   expect(() => transaction.verifyOrigin()).not.toThrow();
 
@@ -935,7 +876,6 @@ test('Make contract-call with network string', async () => {
     fee: 0,
     nonce: 1,
     network: 'testnet',
-    anchorMode: AnchorMode.Any,
   });
   expect(() => transaction.verifyOrigin()).not.toThrow();
 
@@ -1007,7 +947,6 @@ test('Make contract-call with post conditions', async () => {
     network: STACKS_TESTNET,
     postConditions,
     postConditionMode: PostConditionMode.Deny,
-    anchorMode: AnchorMode.Any,
   });
   expect(() => transaction.verifyOrigin()).not.toThrow();
 
@@ -1052,7 +991,6 @@ test('Make contract-call with post condition allow mode', async () => {
     nonce: 1,
     network: STACKS_TESTNET,
     postConditionMode: PostConditionMode.Allow,
-    anchorMode: AnchorMode.Any,
   });
   expect(() => transaction.verifyOrigin()).not.toThrow();
 
@@ -1085,7 +1023,6 @@ test('addSignature to an unsigned contract call transaction', async () => {
     nonce: 1,
     network: STACKS_TESTNET,
     postConditionMode: PostConditionMode.Allow,
-    anchorMode: AnchorMode.Any,
   });
 
   const nullSignature = (unsignedTx.auth.spendingCondition as any).signature.data;
@@ -1130,7 +1067,6 @@ test('make a multi-sig contract call', async () => {
     nonce: 1,
     network: STACKS_TESTNET,
     postConditionMode: PostConditionMode.Allow,
-    anchorMode: AnchorMode.Any,
   });
   expect(() => transaction.verifyOrigin()).not.toThrow();
 
@@ -1155,7 +1091,6 @@ test('Estimate transaction transfer fee', async () => {
     fee,
     nonce,
     memo,
-    anchorMode: AnchorMode.Any,
   });
 
   const serialized = transaction.serialize();
@@ -1244,7 +1179,6 @@ test('Estimate transaction fee fallback', async () => {
     contractName: 'pox-2',
     functionName: 'delegate-stx',
     functionArgs: [uintCV(100_000), principalCV(poolAddress), noneCV(), noneCV()],
-    anchorMode: AnchorMode.OnChainOnly,
     nonce: 1,
     network: STACKS_TESTNET,
     api,
@@ -1302,7 +1236,6 @@ test('Single-sig transaction byte length must include signature', async () => {
     nonce,
     memo: memo,
     publicKey: publicKey,
-    anchorMode: AnchorMode.Any,
   });
 
   // Due to empty message signature space will be allocated for signature
@@ -1352,7 +1285,6 @@ test('Multi-sig transaction byte length must include the required signatures', a
     memo: memo,
     numSignatures: 3,
     publicKeys: pubKeyStrings,
-    anchorMode: AnchorMode.Any,
   });
 
   // Total length without signatures
@@ -1413,7 +1345,6 @@ test('Make STX token transfer with fetch account nonce', async () => {
     senderKey,
     fee,
     memo,
-    anchorMode: AnchorMode.Any,
     network: 'testnet',
   });
 
@@ -1448,7 +1379,6 @@ test('Make sponsored STX token transfer', async () => {
     nonce,
     memo: memo,
     sponsored: true,
-    anchorMode: AnchorMode.Any,
   });
 
   const preSponsorSerialized = bytesToHex(transaction.serialize());
@@ -1573,7 +1503,6 @@ test('Make sponsored STX token transfer with sponsor fee estimate', async () => 
     nonce,
     memo,
     sponsored: true,
-    anchorMode: AnchorMode.Any,
   });
 
   const sponsorOptions = {
@@ -1658,7 +1587,6 @@ test('Make sponsored STX token transfer with set tx fee', async () => {
     fee,
     nonce,
     sponsored: true,
-    anchorMode: AnchorMode.Any,
     api,
   });
 
@@ -1713,7 +1641,6 @@ test('Make sponsored contract deploy with sponsor fee estimate', async () => {
     fee,
     nonce,
     sponsored: true,
-    anchorMode: AnchorMode.Any,
     api,
   });
 
@@ -1773,7 +1700,6 @@ test('Make sponsored contract call with sponsor nonce fetch', async () => {
     fee,
     nonce,
     sponsored: true,
-    anchorMode: AnchorMode.Any,
     network: 'testnet',
   });
 
@@ -1828,7 +1754,6 @@ test('Transaction broadcast success', async () => {
     fee,
     nonce,
     memo,
-    anchorMode: AnchorMode.Any,
   });
 
   const txid = transaction.txid();
@@ -1853,7 +1778,6 @@ test('Transaction broadcast success with string network name', async () => {
     fee: 0,
     nonce: 0,
     memo: 'test memo',
-    anchorMode: AnchorMode.Any,
   });
 
   const txid = transaction.txid();
@@ -1878,7 +1802,6 @@ test('Transaction broadcast success with network detection', async () => {
     fee: 0,
     nonce: 0,
     memo: 'test memo',
-    anchorMode: AnchorMode.Any,
   });
 
   const txid = transaction.txid();
@@ -1910,7 +1833,6 @@ test('Transaction broadcast with attachment', async () => {
     fee,
     nonce,
     memo,
-    anchorMode: AnchorMode.Any,
   });
 
   const txid = transaction.txid();
@@ -1944,7 +1866,6 @@ test('Transaction broadcast returns error', async () => {
     fee,
     nonce,
     memo,
-    anchorMode: AnchorMode.Any,
   });
 
   const rejection = {
@@ -1981,7 +1902,6 @@ test('Transaction broadcast fails', async () => {
     fee,
     nonce,
     memo,
-    anchorMode: AnchorMode.Any,
   });
 
   fetchMock.mockOnce('test', { status: 400 });
@@ -2012,7 +1932,6 @@ test('Make contract-call with network ABI validation', async () => {
     network: STACKS_TESTNET,
     validateWithAbi: true,
     postConditionMode: PostConditionMode.Allow,
-    anchorMode: AnchorMode.Any,
   });
 
   expect(fetchMock.mock.calls.length).toEqual(1);
@@ -2042,7 +1961,6 @@ test('Make contract-call with provided ABI validation', async () => {
     nonce: 1,
     validateWithAbi: abi,
     postConditionMode: PostConditionMode.Allow,
-    anchorMode: AnchorMode.Any,
   });
 });
 
@@ -2070,7 +1988,6 @@ test('Make contract-call with network ABI validation failure', async () => {
       network: 'testnet',
       validateWithAbi: true,
       postConditionMode: PostConditionMode.Allow,
-      anchorMode: AnchorMode.Any,
     });
   } catch (e) {
     error = e;
@@ -2181,7 +2098,6 @@ test('StacksTransaction serialize/deserialize equality with an empty memo', asyn
     nonce: 0n,
     memo: '', // empty memo
     network: STACKS_MAINNET,
-    anchorMode: AnchorMode.Any,
     senderKey: 'edf9aee84d9b7abc145504dde6726c64f369d37ee34ded868fabd876c26570bc01',
   };
   const tx = await makeSTXTokenTransfer(options);
@@ -2200,7 +2116,6 @@ test('StacksTransaction serialize/deserialize equality with a memo', async () =>
     nonce: 0n,
     memo: 'Memento Mori',
     network: STACKS_MAINNET,
-    anchorMode: AnchorMode.Any,
     senderKey: 'edf9aee84d9b7abc145504dde6726c64f369d37ee34ded868fabd876c26570bc01',
   };
   const tx = await makeSTXTokenTransfer(options);
@@ -2219,7 +2134,6 @@ test('StacksTransaction serialize/deserialize equality with a memo ending in a z
     nonce: 0n,
     memo: bytesToUtf8(hexToBytes('0')), // null character
     network: STACKS_MAINNET,
-    anchorMode: AnchorMode.Any,
     senderKey: 'edf9aee84d9b7abc145504dde6726c64f369d37ee34ded868fabd876c26570bc01',
   };
   const tx = await makeSTXTokenTransfer(options);

--- a/packages/transactions/tests/fetchUtil.test.ts
+++ b/packages/transactions/tests/fetchUtil.test.ts
@@ -1,8 +1,7 @@
+import { createApiKeyMiddleware, createFetchFn } from '@stacks/common';
 import fetchMock from 'jest-fetch-mock';
 import { broadcastTransaction } from '../src';
 import { makeSTXTokenTransfer } from '../src/builders';
-import { AnchorMode } from '../src/constants';
-import { createApiKeyMiddleware, createFetchFn } from '@stacks/common';
 
 test('fetchFn is used in network requests', async () => {
   const apiKey = 'MY_KEY';
@@ -17,7 +16,6 @@ test('fetchFn is used in network requests', async () => {
     nonce: 0,
     senderKey: 'edf9aee84d9b7abc145504dde6726c64f369d37ee34ded868fabd876c26570bc01',
     memo: 'test memo',
-    anchorMode: AnchorMode.Any,
   });
 
   const txid = transaction.txid();


### PR DESCRIPTION
> This PR was published to npm with the version `6.13.0`
> e.g. `npm install @stacks/common@6.13.0 --save-exact`<!-- Sticky Header Marker -->

- remove anchor mode from builder methods, default to `.Any` -- this byte will be ignored by nodes in >= Nakamoto