### PR TITLE
build: fix circular dep issue

### DIFF
--- a/packages/transactions/src/index.ts
+++ b/packages/transactions/src/index.ts
@@ -100,4 +100,5 @@ export * from './signer';
 export * from './structuredDataSignature';
 export { StacksTransaction, deserializeTransaction } from './transaction';
 export * from './types';
+export * from './message-types';
 export * from './utils';

--- a/packages/transactions/src/keys.ts
+++ b/packages/transactions/src/keys.ts
@@ -38,7 +38,7 @@ import {
   UNCOMPRESSED_PUBKEY_LENGTH_BYTES,
 } from './constants';
 import { hash160, hashP2PKH } from './utils';
-import { StructuredDataSignature } from './structuredDataSignature';
+import { StructuredDataSignature } from './message-types';
 
 /**
  * To use secp256k1.signSync set utils.hmacSha256Sync to a function using noble-hashes

--- a/packages/transactions/src/message-types.ts
+++ b/packages/transactions/src/message-types.ts
@@ -1,0 +1,8 @@
+// todo: this file should hold the type definitions for more message types later
+//       needed now to fix a circular dependency issue in structuredDataSignature
+import { StacksMessageType } from './constants';
+
+export interface StructuredDataSignature {
+  readonly type: StacksMessageType.StructuredDataSignature;
+  data: string;
+}

--- a/packages/transactions/src/message-types.ts
+++ b/packages/transactions/src/message-types.ts
@@ -1,5 +1,5 @@
 // todo: this file should hold the type definitions for more message types later
-//       needed now to fix a circular dependency issue in structuredDataSignature
+// needed now to fix a circular dependency issue in structuredDataSignature
 import { StacksMessageType } from './constants';
 
 export interface StructuredDataSignature {

--- a/packages/transactions/src/structuredDataSignature.ts
+++ b/packages/transactions/src/structuredDataSignature.ts
@@ -4,6 +4,7 @@ import { bytesToHex, concatBytes, utf8ToBytes } from '@stacks/common';
 import { ClarityType, ClarityValue, serializeCV } from './clarity';
 import { StacksMessageType } from './constants';
 import { signMessageHashRsv, StacksPrivateKey } from './keys';
+import { StructuredDataSignature } from './message-types';
 
 // Refer to SIP018 https://github.com/stacksgov/sips/
 // > asciiToBytes('SIP018')
@@ -64,11 +65,6 @@ export function decodeStructuredDataSignature(
     domainHash,
     messageHash,
   };
-}
-
-export interface StructuredDataSignature {
-  readonly type: StacksMessageType.StructuredDataSignature;
-  data: string;
 }
 
 /**


### PR DESCRIPTION
> This PR was published to npm with the version `6.12.1-pr.5ca1638.0`
> e.g. `npm install @stacks/common@6.12.1-pr.5ca1638.0 --save-exact`<!-- Sticky Header Marker -->

This PR is needed to fix a circular dependency issue.
In the future I would like to move all the message-type definitions to this files, but it doesn't fit into the priorities right now :(