### PR TITLE
fix: resolve circular dependencies

### DIFF
--- a/packages/transactions/src/common.ts
+++ b/packages/transactions/src/common.ts
@@ -20,6 +20,11 @@ export interface MessageSignature {
   data: string;
 }
 
+export interface StructuredDataSignature {
+  readonly type: StacksMessageType.StructuredDataSignature;
+  data: string;
+}
+
 export function createMessageSignature(signature: string): MessageSignature {
   const length = hexToBytes(signature).byteLength;
   if (length != RECOVERABLE_ECDSA_SIG_LENGTH_BYTES) {

--- a/packages/transactions/src/keys.ts
+++ b/packages/transactions/src/keys.ts
@@ -27,6 +27,7 @@ import {
   addressToString,
   createMessageSignature,
   MessageSignature,
+  StructuredDataSignature,
 } from './common';
 import {
   AddressHashMode,
@@ -38,7 +39,6 @@ import {
   UNCOMPRESSED_PUBKEY_LENGTH_BYTES,
 } from './constants';
 import { hash160, hashP2PKH } from './utils';
-import { StructuredDataSignature } from './structuredDataSignature';
 
 /**
  * To use secp256k1.signSync set utils.hmacSha256Sync to a function using noble-hashes

--- a/packages/transactions/src/structuredDataSignature.ts
+++ b/packages/transactions/src/structuredDataSignature.ts
@@ -4,6 +4,7 @@ import { bytesToHex, concatBytes, utf8ToBytes } from '@stacks/common';
 import { ClarityType, ClarityValue, serializeCV } from './clarity';
 import { StacksMessageType } from './constants';
 import { signMessageHashRsv, StacksPrivateKey } from './keys';
+import { StructuredDataSignature } from './common';
 
 // Refer to SIP018 https://github.com/stacksgov/sips/
 // > asciiToBytes('SIP018')
@@ -64,11 +65,6 @@ export function decodeStructuredDataSignature(
     domainHash,
     messageHash,
   };
-}
-
-export interface StructuredDataSignature {
-  readonly type: StacksMessageType.StructuredDataSignature;
-  data: string;
 }
 
 /**


### PR DESCRIPTION
> This PR was published to npm with the version `6.12.1-pr.2cf6997.0`
> e.g. `npm install @stacks/common@6.12.1-pr.2cf6997.0 --save-exact`<!-- Sticky Header Marker -->

### Description

There are circular dependencies between keys and structured data signature file.
`StructuredDataSignature` was moved to common.ts