### PR TITLE
fix: add missing signer topic

### DIFF
--- a/packages/stacking/src/utils.ts
+++ b/packages/stacking/src/utils.ts
@@ -399,6 +399,7 @@ export function ensureSignerArgsReadiness({
 export enum Pox4SignatureTopic {
   StackStx = 'stack-stx',
   AggregateCommit = 'agg-commit',
+  AggregateIncrease = 'agg-increase',
   StackExtend = 'stack-extend',
   StackIncrease = 'stack-increase',
 }


### PR DESCRIPTION
> This PR was published to npm with the version `6.13.1`
> e.g. `npm install @stacks/common@6.13.1 --save-exact`<!-- Sticky Header Marker -->

