### PR TITLE
fix: update encodeClarityValue to parse buffers as hex

### DIFF
--- a/packages/transactions/src/contract-abi.ts
+++ b/packages/transactions/src/contract-abi.ts
@@ -1,22 +1,22 @@
-import { cloneDeep } from './utils';
+import { hexToBytes, utf8ToBytes } from '@stacks/common';
 import {
-  ClarityValue,
-  uintCV,
-  intCV,
-  contractPrincipalCV,
-  standardPrincipalCV,
-  noneCV,
-  bufferCV,
-  falseCV,
-  trueCV,
   ClarityType,
-  getCVTypeString,
+  ClarityValue,
+  bufferCV,
   bufferCVFromString,
+  contractPrincipalCV,
+  falseCV,
+  getCVTypeString,
+  intCV,
+  noneCV,
+  standardPrincipalCV,
+  trueCV,
+  uintCV,
 } from './clarity';
-import { ContractCallPayload } from './payload';
-import { NotImplementedError } from './errors';
 import { stringAsciiCV, stringUtf8CV } from './clarity/types/stringCV';
-import { utf8ToBytes } from '@stacks/common';
+import { NotImplementedError } from './errors';
+import { ContractCallPayload } from './payload';
+import { cloneDeep } from './utils';
 
 // From https://github.com/blockstack/stacks-blockchain-sidecar/blob/master/src/event-stream/contract-abi.ts
 
@@ -172,7 +172,7 @@ function encodeClarityValue(
     case ClarityAbiTypeId.ClarityAbiTypeNone:
       return noneCV();
     case ClarityAbiTypeId.ClarityAbiTypeBuffer:
-      return bufferCV(utf8ToBytes(val));
+      return bufferCV(hexToBytes(val));
     case ClarityAbiTypeId.ClarityAbiTypeStringAscii:
       return stringAsciiCV(val);
     case ClarityAbiTypeId.ClarityAbiTypeStringUtf8:


### PR DESCRIPTION
> This PR was published to npm with the version `6.13.2`
> e.g. `npm install @stacks/common@6.13.2 --save-exact`<!-- Sticky Header Marker -->

- fixes https://github.com/hirosystems/stacks.js/issues/1674