### PR TITLE
feat: Add `Cl.parse` Clarity value parser

### DIFF
--- a/packages/transactions/src/cl.ts
+++ b/packages/transactions/src/cl.ts
@@ -18,7 +18,8 @@ import {
   uintCV,
 } from './clarity';
 
-export { prettyPrint } from './clarity/prettyPrint';
+export { prettyPrint, stringify } from './clarity/prettyPrint';
+export { parse } from './clarity/parser';
 
 // todo: https://github.com/hirosystems/clarinet/issues/786
 

--- a/packages/transactions/src/clarity/parser.ts
+++ b/packages/transactions/src/clarity/parser.ts
@@ -280,13 +280,13 @@ function clErr(): Combinator {
 function clValue(map: (combinator: Combinator) => Combinator = v => v) {
   return either(
     [
+      clBuffer,
+      clAscii,
+      clUtf8,
       clInt,
       clUint,
       clBool,
       clPrincipal,
-      clAscii,
-      clBuffer,
-      clUtf8,
       clList,
       clTuple,
       clNone,

--- a/packages/transactions/src/clarity/parser.ts
+++ b/packages/transactions/src/clarity/parser.ts
@@ -291,6 +291,17 @@ function clValue(map: (combinator: Combinator) => Combinator = v => v) {
   );
 }
 
+/**
+ * Parse a piece of string text as Clarity value syntax.
+ * Supports all Clarity value types (primitives, sequences, composite types).
+ *
+ * @example
+ * ```
+ * const repr = Cl.parse("u4");
+ * const repr = Cl.parse(`"hello"`);
+ * const repr = Cl.parse('(tuple (a 1) (b 2))');
+ * ```
+ */
 export function parse(clarityValueString: string): ClarityValue {
   const result = clValue(entire)(clarityValueString);
   if (!result.success || !result.capture) throw 'Parse error'; // todo: we can add better error messages and add position tracking

--- a/packages/transactions/src/clarity/parser.ts
+++ b/packages/transactions/src/clarity/parser.ts
@@ -222,9 +222,43 @@ function clTuple(): Combinator {
   ]);
 }
 
+function clNone(): Combinator {
+  return capture(regex(/none/), Cl.none);
+}
+
+function clSome(): Combinator {
+  return parens(
+    sequence([regex(/some/), whitespace(), clValue()], c => Cl.some(c[0] as ClarityValue))
+  );
+}
+
+function clOk(): Combinator {
+  return parens(sequence([regex(/ok/), whitespace(), clValue()], c => Cl.ok(c[0] as ClarityValue)));
+}
+
+function clErr(): Combinator {
+  return parens(
+    sequence([regex(/err/), whitespace(), clValue()], c => Cl.error(c[0] as ClarityValue))
+  );
+}
+
 function clValue(map: (combinator: Combinator) => Combinator = v => v) {
   return either(
-    [clInt, clUint, clBool, clPrincipal, clAscii, clBuffer, clUtf8, clList, clTuple, clSome]
+    [
+      clInt,
+      clUint,
+      clBool,
+      clPrincipal,
+      clAscii,
+      clBuffer,
+      clUtf8,
+      clList,
+      clTuple,
+      clNone,
+      clSome,
+      clOk,
+      clErr,
+    ]
       .map(lazy)
       .map(map)
   );

--- a/packages/transactions/src/clarity/parser.ts
+++ b/packages/transactions/src/clarity/parser.ts
@@ -191,12 +191,25 @@ function clBuffer(): Combinator {
   return sequence([regex(/0x/), capture(regex(/[0-9a-fA-F]+/), Cl.bufferFromHex)]);
 }
 
+/** @ignore helper for string values, removes escaping and unescapes special characters */
+function unescape(input: string): string {
+  return input.replace(/\\\\/g, '\\').replace(/\\(.)/g, '$1');
+}
+
 function clAscii(): Combinator {
-  return sequence([regex(/"/), capture(regex(/[^"]*/), Cl.stringAscii), regex(/"/)]);
+  return sequence([
+    regex(/"/),
+    capture(regex(/(\\.|[^"])*/), t => Cl.stringAscii(unescape(t))),
+    regex(/"/),
+  ]);
 }
 
 function clUtf8(): Combinator {
-  return sequence([regex(/u"/), capture(regex(/[^"]*/), Cl.stringUtf8), regex(/"/)]);
+  return sequence([
+    regex(/u"/),
+    capture(regex(/(\\.|[^"])*/), t => Cl.stringUtf8(unescape(t))),
+    regex(/"/),
+  ]);
 }
 
 function clList(): Combinator {

--- a/packages/transactions/src/clarity/parser.ts
+++ b/packages/transactions/src/clarity/parser.ts
@@ -97,7 +97,6 @@ function sequence(
   };
 }
 
-// todo: push down if only used in `parens`
 function chain(
   combinators: Combinator[],
   reduce: (values: Capture[]) => Capture = v => v[0]

--- a/packages/transactions/src/clarity/parser.ts
+++ b/packages/transactions/src/clarity/parser.ts
@@ -210,7 +210,6 @@ function clList(): Combinator {
 }
 
 function clTuple(): Combinator {
-  // todo: add `(tuple` syntax
   const tupleCurly = chain([
     regex(/\{/),
     greedy(

--- a/packages/transactions/src/clarity/prettyPrint.ts
+++ b/packages/transactions/src/clarity/prettyPrint.ts
@@ -110,8 +110,8 @@ function prettyPrintWithDepth(cv: ClarityValue, space = 0, depth: number): strin
 }
 
 /**
- * @description format clarity values in clarity style strings
- * with the ability to prettify the result with line break end space indentation
+ * Format clarity values in clarity style strings with the ability to prettify
+ * the result with line break end space indentation.
  * @param cv The Clarity Value to format
  * @param space The indentation size of the output string. There's no indentation and no line breaks if space = 0
  * @example
@@ -126,6 +126,9 @@ function prettyPrintWithDepth(cv: ClarityValue, space = 0, depth: number): strin
  * // }
  * ```
  */
-export function prettyPrint(cv: ClarityValue, space = 0): string {
+export function stringify(cv: ClarityValue, space = 0): string {
   return prettyPrintWithDepth(cv, space, 0);
 }
+
+/** @deprecated alias for {@link Cl.stringify} */
+export const prettyPrint = stringify;

--- a/packages/transactions/tests/clarity.test.ts
+++ b/packages/transactions/tests/clarity.test.ts
@@ -734,11 +734,19 @@ const TEST_CASES_PARSER = [
   { input: '( list  1   2    3 )', expected: Cl.list([Cl.int(1), Cl.int(2), Cl.int(3)]) },
   { input: '( list )', expected: Cl.list([]) },
   { input: '(list)', expected: Cl.list([]) },
+  {
+    input: '{ id: u5, name: "clarity" }',
+    expected: Cl.tuple({ id: Cl.uint(5), name: Cl.stringAscii('clarity') }),
+  },
+  {
+    input: '{something : (list 3 2 1),}',
+    expected: Cl.tuple({ something: Cl.list([Cl.int(3), Cl.int(2), Cl.int(1)]) }),
+  },
 ] as const;
 
-test.each(TEST_CASES_PARSER)('clarity parser %p', ({ input, expected }) => {
+test.each(TEST_CASES_PARSER)('clarity parser', ({ input, expected }) => {
   const result = parse(input);
-
-  if (!result.success) throw 'parse fail';
-  expect(result.clarity).toEqual(expected);
+  expect(result).toEqual(expected);
 });
+
+// const TEST_CASES_PARSER_THROW = []; // todo: e.g. `{}`

--- a/packages/transactions/tests/clarity.test.ts
+++ b/packages/transactions/tests/clarity.test.ts
@@ -730,6 +730,7 @@ const TEST_CASES_PARSER = [
   { input: '0x68656c6c6f21', expected: Cl.bufferFromHex('68656c6c6f21') },
   { input: '"hello world"', expected: Cl.stringAscii('hello world') },
   { input: 'u"hello world"', expected: Cl.stringUtf8('hello world') },
+  { input: '"hello \\"world\\""', expected: Cl.stringAscii('hello "world"') },
   { input: '(list 1 2 3)', expected: Cl.list([Cl.int(1), Cl.int(2), Cl.int(3)]) },
   { input: '( list  1   2    3 )', expected: Cl.list([Cl.int(1), Cl.int(2), Cl.int(3)]) },
   { input: '( list )', expected: Cl.list([]) },

--- a/packages/transactions/tests/clarity.test.ts
+++ b/packages/transactions/tests/clarity.test.ts
@@ -742,9 +742,24 @@ const TEST_CASES_PARSER = [
     input: '{something : (list 3 2 1),}',
     expected: Cl.tuple({ something: Cl.list([Cl.int(3), Cl.int(2), Cl.int(1)]) }),
   },
+  { input: 'none', expected: Cl.none() },
+  { input: '( some u1 )', expected: Cl.some(Cl.uint(1)) },
+  { input: '(some none)', expected: Cl.some(Cl.none()) },
+  { input: '( ok  true   )', expected: Cl.ok(Cl.bool(true)) },
+  { input: '(err false)', expected: Cl.error(Cl.bool(false)) },
+  {
+    input: '( ok (list {id: 3} {id: 4} {id: 5} ))',
+    expected: Cl.ok(
+      Cl.list([
+        Cl.tuple({ id: Cl.int(3) }),
+        Cl.tuple({ id: Cl.int(4) }),
+        Cl.tuple({ id: Cl.int(5) }),
+      ])
+    ),
+  },
 ] as const;
 
-test.each(TEST_CASES_PARSER)('clarity parser', ({ input, expected }) => {
+test.each(TEST_CASES_PARSER)('clarity parser %p', ({ input, expected }) => {
   const result = parse(input);
   expect(result).toEqual(expected);
 });

--- a/packages/transactions/tests/clarity.test.ts
+++ b/packages/transactions/tests/clarity.test.ts
@@ -742,6 +742,13 @@ const TEST_CASES_PARSER = [
     input: '{something : (list 3 2 1),}',
     expected: Cl.tuple({ something: Cl.list([Cl.int(3), Cl.int(2), Cl.int(1)]) }),
   },
+  {
+    input: '( tuple ( something  (list 1 2 3)) (other "other" ) )',
+    expected: Cl.tuple({
+      something: Cl.list([Cl.int(1), Cl.int(2), Cl.int(3)]),
+      other: Cl.stringAscii('other'),
+    }),
+  },
   { input: 'none', expected: Cl.none() },
   { input: '( some u1 )', expected: Cl.some(Cl.uint(1)) },
   { input: '(some none)', expected: Cl.some(Cl.none()) },

--- a/packages/transactions/tests/clarity.test.ts
+++ b/packages/transactions/tests/clarity.test.ts
@@ -6,40 +6,41 @@ import {
   hexToBytes,
   utf8ToBytes,
 } from '@stacks/common';
+import assert from 'assert';
+import { Cl } from '../src';
 import { BytesReader } from '../src/bytesReader';
 import {
-  bufferCV,
   BufferCV,
   ClarityType,
   ClarityValue,
+  IntCV,
+  ListCV,
+  SomeCV,
+  StandardPrincipalCV,
+  StringAsciiCV,
+  StringUtf8CV,
+  TupleCV,
+  UIntCV,
+  bufferCV,
   contractPrincipalCV,
   contractPrincipalCVFromStandard,
   deserializeCV,
   falseCV,
-  IntCV,
   intCV,
   listCV,
-  ListCV,
   noneCV,
   responseErrorCV,
   responseOkCV,
   serializeCV,
   someCV,
-  SomeCV,
   standardPrincipalCV,
-  StandardPrincipalCV,
   standardPrincipalCVFromAddress,
   stringAsciiCV,
-  StringAsciiCV,
   stringUtf8CV,
-  StringUtf8CV,
   trueCV,
   tupleCV,
-  TupleCV,
   uintCV,
-  UIntCV,
 } from '../src/clarity';
-import { Cl } from '../src';
 import {
   cvToJSON,
   cvToString,
@@ -47,9 +48,9 @@ import {
   getCVTypeString,
   isClarityType,
 } from '../src/clarity/clarityValue';
+import { parse } from '../src/clarity/parser';
 import { addressToString } from '../src/common';
 import { deserializeAddress } from '../src/types';
-import assert from 'assert';
 
 const ADDRESS = 'SP2JXKMSH007NPYAQHKJPQMAQYAD90NQGTVJVQ02B';
 
@@ -708,4 +709,36 @@ describe('Clarity Types', () => {
       intTest; // avoid the "value is never read warning"
     });
   });
+});
+
+const TEST_CASES_PARSER = [
+  { input: '123', expected: Cl.int(123) },
+  { input: '0', expected: Cl.int(0) },
+  { input: '-15', expected: Cl.int(-15) },
+  { input: 'u123', expected: Cl.uint(123) },
+  { input: 'u0', expected: Cl.uint(0) },
+  { input: 'true', expected: Cl.bool(true) },
+  { input: 'false', expected: Cl.bool(false) },
+  {
+    input: "'SP2JXKMSH007NPYAQHKJPQMAQYAD90NQGTVJVQ02B",
+    expected: Cl.address('SP2JXKMSH007NPYAQHKJPQMAQYAD90NQGTVJVQ02B'),
+  },
+  {
+    input: "'SP2JXKMSH007NPYAQHKJPQMAQYAD90NQGTVJVQ02B.some-contract",
+    expected: Cl.address('SP2JXKMSH007NPYAQHKJPQMAQYAD90NQGTVJVQ02B.some-contract'),
+  },
+  { input: '0x68656c6c6f21', expected: Cl.bufferFromHex('68656c6c6f21') },
+  { input: '"hello world"', expected: Cl.stringAscii('hello world') },
+  { input: 'u"hello world"', expected: Cl.stringUtf8('hello world') },
+  { input: '(list 1 2 3)', expected: Cl.list([Cl.int(1), Cl.int(2), Cl.int(3)]) },
+  { input: '( list  1   2    3 )', expected: Cl.list([Cl.int(1), Cl.int(2), Cl.int(3)]) },
+  { input: '( list )', expected: Cl.list([]) },
+  { input: '(list)', expected: Cl.list([]) },
+] as const;
+
+test.each(TEST_CASES_PARSER)('clarity parser %p', ({ input, expected }) => {
+  const result = parse(input);
+
+  if (!result.success) throw 'parse fail';
+  expect(result.clarity).toEqual(expected);
 });

--- a/packages/transactions/tests/clarity.test.ts
+++ b/packages/transactions/tests/clarity.test.ts
@@ -743,6 +743,10 @@ const TEST_CASES_PARSER = [
     expected: Cl.tuple({ something: Cl.list([Cl.int(3), Cl.int(2), Cl.int(1)]) }),
   },
   {
+    input: '{ a: 0x68656c6c6f21 }',
+    expected: Cl.tuple({ a: Cl.bufferFromHex('68656c6c6f21') }),
+  },
+  {
     input: '( tuple ( something  (list 1 2 3)) (other "other" ) )',
     expected: Cl.tuple({
       something: Cl.list([Cl.int(1), Cl.int(2), Cl.int(3)]),


### PR DESCRIPTION
> This PR was published to npm with the version `6.15.0`
> e.g. `npm install @stacks/common@6.15.0 --save-exact`<!-- Sticky Header Marker -->

- Adds `Cl.parse`, which allows us to parse clarity syntax as JS representation `ClarityValue`. 
- Renames `prettyPrint` to `stringify` (matching `JSON.` more closely in naming) _got feedback from users that they were expecting `prettyPrint` to `console.log` and they were confused that there wasn't any output._


### Examples

```ts
Cl.parse(`"my string"`);
Cl.parse('-4');
Cl.parse('u5');
Cl.parse('false');
Cl.parse('{ a: 3 }');
Cl.parse('(list 1 2 3)');
```
