### PR TITLE
Fix typedoc build

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -54,12 +54,12 @@ jobs:
       - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - run: npx lerna publish --canary --force-publish --preid pr.$SHA --dist-tag pr --no-verify-access --no-push --no-git-tag-version --yes
+      - run: npx lerna publish --canary --force-publish --preid pr --dist-tag pr --no-verify-access --no-push --no-git-tag-version --yes
         env:
           SHA: ${{ steps.git-commit.outputs.sha }}
           SKIP_TESTS: true
       - id: published-version
-        run: echo "::set-output name=version::$(cat lerna.json | jq -r '.version')"
+        run: echo "::set-output name=version::$(cat packages/common/package.json | jq -r '.version')"
       - uses: janniks/pull-request-fixed-header@v1.0.1
         with:
           header: "> This PR was published to npm with the version `${{ steps.published-version.outputs.version }}`\n> e.g. `npm install @stacks/common@${{ steps.published-version.outputs.version }} --save-exact`"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,9 +7,7 @@
       "name": "Jest: api",
       "cwd": "${workspaceFolder}/packages/api",
       "program": "./node_modules/.bin/jest",
-      "args": [
-        "--runInBand"
-      ],
+      "args": ["--runInBand"],
       "console": "integratedTerminal"
     },
     {
@@ -18,9 +16,7 @@
       "name": "Jest: auth",
       "cwd": "${workspaceFolder}/packages/auth",
       "program": "./node_modules/.bin/jest",
-      "args": [
-        "--runInBand"
-      ],
+      "args": ["--runInBand"],
       "console": "integratedTerminal"
     },
     {
@@ -29,9 +25,7 @@
       "name": "Jest: bns",
       "cwd": "${workspaceFolder}/packages/bns",
       "program": "./node_modules/.bin/jest",
-      "args": [
-        "--runInBand"
-      ],
+      "args": ["--runInBand"],
       "console": "integratedTerminal"
     },
     {
@@ -40,9 +34,7 @@
       "name": "Jest: cli",
       "cwd": "${workspaceFolder}/packages/cli",
       "program": "./node_modules/.bin/jest",
-      "args": [
-        "--runInBand"
-      ],
+      "args": ["--runInBand"],
       "console": "integratedTerminal"
     },
     {
@@ -51,9 +43,7 @@
       "name": "Jest: common",
       "cwd": "${workspaceFolder}/packages/common",
       "program": "./node_modules/.bin/jest",
-      "args": [
-        "--runInBand"
-      ],
+      "args": ["--runInBand"],
       "console": "integratedTerminal"
     },
     {
@@ -62,20 +52,7 @@
       "name": "Jest: encryption",
       "cwd": "${workspaceFolder}/packages/encryption",
       "program": "./node_modules/.bin/jest",
-      "args": [
-        "--runInBand"
-      ],
-      "console": "integratedTerminal"
-    },
-    {
-      "type": "node",
-      "request": "launch",
-      "name": "Jest: keychain",
-      "cwd": "${workspaceFolder}/packages/keychain",
-      "program": "./node_modules/.bin/jest",
-      "args": [
-        "--runInBand"
-      ],
+      "args": ["--runInBand"],
       "console": "integratedTerminal"
     },
     {
@@ -84,9 +61,7 @@
       "name": "Jest: network",
       "cwd": "${workspaceFolder}/packages/network",
       "program": "./node_modules/.bin/jest",
-      "args": [
-        "--runInBand"
-      ],
+      "args": ["--runInBand"],
       "console": "integratedTerminal"
     },
     {
@@ -95,9 +70,7 @@
       "name": "Jest: profile",
       "cwd": "${workspaceFolder}/packages/profile",
       "program": "./node_modules/.bin/jest",
-      "args": [
-        "--runInBand"
-      ],
+      "args": ["--runInBand"],
       "console": "integratedTerminal"
     },
     {
@@ -106,9 +79,7 @@
       "name": "Jest: stacking",
       "cwd": "${workspaceFolder}/packages/stacking",
       "program": "./node_modules/.bin/jest",
-      "args": [
-        "--runInBand"
-      ],
+      "args": ["--runInBand"],
       "console": "integratedTerminal"
     },
     {
@@ -117,9 +88,7 @@
       "name": "Jest: storage",
       "cwd": "${workspaceFolder}/packages/storage",
       "program": "./node_modules/.bin/jest",
-      "args": [
-        "--runInBand"
-      ],
+      "args": ["--runInBand"],
       "console": "integratedTerminal"
     },
     {
@@ -128,10 +97,8 @@
       "name": "Jest: transactions",
       "cwd": "${workspaceFolder}/packages/transactions",
       "program": "./node_modules/.bin/jest",
-      "args": [
-        "--runInBand"
-      ],
+      "args": ["--runInBand"],
       "console": "integratedTerminal"
-    },
+    }
   ]
 }

--- a/configs/webpack.config.js
+++ b/configs/webpack.config.js
@@ -58,7 +58,6 @@ module.exports = {
       '@stacks/bns': '@stacks/bns/dist/esm',
       '@stacks/common': '@stacks/common/dist/esm',
       '@stacks/encryption': '@stacks/encryption/dist/esm',
-      '@stacks/keychain': '@stacks/keychain/dist/esm',
       '@stacks/network': '@stacks/network/dist/esm',
       '@stacks/profile': '@stacks/profile/dist/esm',
       '@stacks/stacking': '@stacks/stacking/dist/esm',

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,9 +39,9 @@
         "rimraf": "^5.0.1",
         "stream-http": "^3.2.0",
         "ts-jest": "^29.1.1",
-        "typedoc": "^0.25.1",
-        "typedoc-plugin-replace-text": "^3.2.0",
-        "typescript": "^5.2.2",
+        "typedoc": "0.24.8",
+        "typedoc-plugin-replace-text": "3.1.0",
+        "typescript": "5.1.6",
         "webpack": "^5.88.2",
         "webpack-bundle-analyzer": "^4.9.0",
         "webpack-cli": "^5.1.4"
@@ -1166,6 +1166,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@commitlint/load/node_modules/typescript": {
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@commitlint/message": {
@@ -23973,33 +23986,33 @@
       "dev": true
     },
     "node_modules/typedoc": {
-      "version": "0.25.13",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.25.13.tgz",
-      "integrity": "sha512-pQqiwiJ+Z4pigfOnnysObszLiU3mVLWAExSPf+Mu06G/qsc3wzbuM56SZQvONhHLncLUhYzOVkjFFpFfL5AzhQ==",
+      "version": "0.24.8",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.24.8.tgz",
+      "integrity": "sha512-ahJ6Cpcvxwaxfu4KtjA8qZNqS43wYt6JL27wYiIgl1vd38WW/KWX11YuAeZhuz9v+ttrutSsgK+XO1CjL1kA3w==",
       "dev": true,
       "dependencies": {
         "lunr": "^2.3.9",
         "marked": "^4.3.0",
-        "minimatch": "^9.0.3",
-        "shiki": "^0.14.7"
+        "minimatch": "^9.0.0",
+        "shiki": "^0.14.1"
       },
       "bin": {
         "typedoc": "bin/typedoc"
       },
       "engines": {
-        "node": ">= 16"
+        "node": ">= 14.14"
       },
       "peerDependencies": {
-        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x"
+        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x"
       }
     },
     "node_modules/typedoc-plugin-replace-text": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-replace-text/-/typedoc-plugin-replace-text-3.3.0.tgz",
-      "integrity": "sha512-Bn2bodwpbj98sYzcVMXjbeDdempncHY7jEvP9MCX4e5IfjO0xCaRAHIlpH+UoqqhB+4B1mc599E22W67kvua1w==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-replace-text/-/typedoc-plugin-replace-text-3.1.0.tgz",
+      "integrity": "sha512-MBt2xiqSS+TT+N+iz9qAXkHG+wSbTraBzybi6JK0AGxnTiQgmpAppiUvtgLrg/iQYZsjWiWmMXr4gf11pcz+Wg==",
       "dev": true,
       "peerDependencies": {
-        "typedoc": "^0.24.8 || 0.25.x"
+        "typedoc": "^0.24.8"
       }
     },
     "node_modules/typeforce": {
@@ -24008,9 +24021,9 @@
       "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
     },
     "node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -54,9 +54,9 @@
     "rimraf": "^5.0.1",
     "stream-http": "^3.2.0",
     "ts-jest": "^29.1.1",
-    "typedoc": "^0.25.1",
-    "typedoc-plugin-replace-text": "^3.2.0",
-    "typescript": "^5.2.2",
+    "typedoc": "^0.24.8",
+    "typedoc-plugin-replace-text": "^3.1.0",
+    "typescript": "^5.1.6",
     "webpack": "^5.88.2",
     "webpack-bundle-analyzer": "^4.9.0",
     "webpack-cli": "^5.1.4"

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -1,8 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "target": "ES2020"
-  },
   "include": ["src/**/*", "tests/**/*"],
   "typedocOptions": {
     "entryPoints": ["src/index.ts"]

--- a/packages/transactions/tsconfig.json
+++ b/packages/transactions/tsconfig.json
@@ -1,8 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "target": "ES2020"
-  },
   "include": ["src/**/*", "tests/**/*"],
   "typedocOptions": {
     "entryPoints": ["src/index.ts"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,6 @@
       "@stacks/cli": ["packages/cli/src"],
       "@stacks/common": ["packages/common/src"],
       "@stacks/encryption": ["packages/encryption/src"],
-      "@stacks/keychain": ["packages/keychain/src"],
       "@stacks/network": ["packages/network/src"],
       "@stacks/profile": ["packages/profile/src"],
       "@stacks/stacking": ["packages/stacking/src"],
@@ -32,7 +31,6 @@
       "packages/transactions",
       "packages/bns",
       "packages/common",
-      "packages/keychain",
       "packages/profile",
       "packages/storage",
       "packages/wallet-sdk"


### PR DESCRIPTION
> This PR was published to npm with the version `6.13.0`
> e.g. `npm install @stacks/common@6.13.0 --save-exact`<!-- Sticky Header Marker -->

- remove links to non existent package `keychain`
- downgrade typdoc to have docs build again