### PR TITLE
fix: update network obj

### DIFF
--- a/.github/.husky/commitlint.json
+++ b/.github/.husky/commitlint.json
@@ -10,6 +10,6 @@
     "subject-max-length": [0, "always"],
     "type-max-length": [0, "always"],
 
-    "subject-case": [0, "always", "sentence-case"]
+    "subject-case": [0, "always"]
   }
 }

--- a/.github/MIGRATION.md
+++ b/.github/MIGRATION.md
@@ -56,6 +56,7 @@ import { STACKS_DEVNET } from '@stacks/network';
 #### Impacts
 
 - @stacks/bns: `BnsContractAddress` was removed, since `.bootAddress` is now a part of the network objects.
+- @stacks/transactions: `AddressVersion` was moved to `@stacks/network`.
 
 ### StacksNodeApi
 

--- a/.github/MIGRATION.md
+++ b/.github/MIGRATION.md
@@ -3,6 +3,7 @@
 - [Stacks.js (\>=5.x.x) → (7.x.x)](#stacksjs-5xx--7xx)
   - [Breaking Changes](#breaking-changes)
   - [Stacks Network](#stacks-network)
+    - [Impacts](#impacts)
   - [StacksNodeApi](#stacksnodeapi)
   - [StacksNetwork to StacksNodeApi](#stacksnetwork-to-stacksnodeapi)
   - [Clarity Representation](#clarity-representation)
@@ -51,6 +52,10 @@ import { STACKS_MAINNET } from '@stacks/network';
 import { STACKS_TESTNET } from '@stacks/network';
 import { STACKS_DEVNET } from '@stacks/network';
 ```
+
+#### Impacts
+
+- @stacks/bns: `BnsContractAddress` was removed, since `.bootAddress` is now a part of the network objects.
 
 ### StacksNodeApi
 

--- a/packages/bns/src/index.ts
+++ b/packages/bns/src/index.ts
@@ -1,7 +1,6 @@
 import { ApiParam, IntegerType, utf8ToBytes } from '@stacks/common';
-import { ChainId, StacksNetwork } from '@stacks/network';
+import { StacksNetwork } from '@stacks/network';
 import {
-  AddressVersion,
   ClarityType,
   ClarityValue,
   FungibleConditionCode,
@@ -32,12 +31,6 @@ import {
 import { decodeFQN, getZonefileHash } from './utils';
 
 export const BNS_CONTRACT_NAME = 'bns';
-
-function getAddressVersion(network: StacksNetwork) {
-  return network.chainId === ChainId.Mainnet
-    ? AddressVersion.MainnetSingleSig
-    : AddressVersion.TestnetSingleSig;
-}
 
 export interface PriceFunction {
   base: IntegerType;
@@ -298,7 +291,7 @@ export async function buildPreorderNamespaceTx({
   const hashedSaltedNamespace = hash160(saltedNamespaceBytes);
 
   const burnSTXPostCondition = createSTXPostCondition(
-    publicKeyToAddress(getAddressVersion(network), publicKey),
+    publicKeyToAddress(network.addressVersion.singleSig, publicKey),
     FungibleConditionCode.Equal,
     stxToBurn
   );
@@ -521,7 +514,7 @@ export async function buildPreorderNameTx({
   const hashedSaltedName = hash160(saltedNamesBytes);
 
   const burnSTXPostCondition = createSTXPostCondition(
-    publicKeyToAddress(getAddressVersion(network), publicKey),
+    publicKeyToAddress(network.addressVersion.singleSig, publicKey),
     FungibleConditionCode.Equal,
     stxToBurn
   );
@@ -690,7 +683,7 @@ export async function buildTransferNameTx({
     zonefile ? someCV(bufferCV(getZonefileHash(zonefile))) : noneCV(),
   ];
   const postConditionSender = createNonFungiblePostCondition(
-    publicKeyToAddress(getAddressVersion(network), publicKey),
+    publicKeyToAddress(network.addressVersion.singleSig, publicKey),
     NonFungibleConditionCode.Sends,
     parseAssetString(`${network.bootAddress}.bns::names`),
     tupleCV({
@@ -810,7 +803,7 @@ export async function buildRenewNameTx({
     zonefile ? someCV(bufferCV(getZonefileHash(zonefile))) : noneCV(),
   ];
   const burnSTXPostCondition = createSTXPostCondition(
-    publicKeyToAddress(getAddressVersion(network), publicKey),
+    publicKeyToAddress(network.addressVersion.singleSig, publicKey),
     FungibleConditionCode.Equal,
     stxToBurn
   );

--- a/packages/bns/src/index.ts
+++ b/packages/bns/src/index.ts
@@ -33,17 +33,6 @@ import { decodeFQN, getZonefileHash } from './utils';
 
 export const BNS_CONTRACT_NAME = 'bns';
 
-export const enum BnsContractAddress {
-  mainnet = 'SP000000000000000000002Q6VF78',
-  testnet = 'ST000000000000000000002AMW42H',
-}
-
-function getBnsContractAddress(network: StacksNetwork) {
-  if (network.chainId === ChainId.Mainnet) return BnsContractAddress.mainnet;
-  else if (network.chainId == ChainId.Testnet) return BnsContractAddress.testnet;
-  else throw new Error(`Unexpected ChainID: ${network.chainId}`);
-}
-
 function getAddressVersion(network: StacksNetwork) {
   return network.chainId === ChainId.Mainnet
     ? AddressVersion.MainnetSingleSig
@@ -83,7 +72,7 @@ export interface BnsContractCallOptions {
 
 async function makeBnsContractCall(options: BnsContractCallOptions): Promise<StacksTransaction> {
   const txOptions: UnsignedContractCallOptions = {
-    contractAddress: getBnsContractAddress(options.network),
+    contractAddress: options.network.bootAddress,
     contractName: BNS_CONTRACT_NAME,
     functionName: options.functionName,
     functionArgs: options.functionArgs,
@@ -107,7 +96,7 @@ async function callReadOnlyBnsFunction(
   options: BnsReadOnlyOptions & ApiParam
 ): Promise<ClarityValue> {
   return callReadOnlyFunction({
-    contractAddress: getBnsContractAddress(options.network),
+    contractAddress: options.network.bootAddress,
     contractName: BNS_CONTRACT_NAME,
     functionName: options.functionName,
     senderAddress: options.senderAddress,
@@ -703,7 +692,7 @@ export async function buildTransferNameTx({
   const postConditionSender = createNonFungiblePostCondition(
     publicKeyToAddress(getAddressVersion(network), publicKey),
     NonFungibleConditionCode.Sends,
-    parseAssetString(`${getBnsContractAddress(network)}.bns::names`),
+    parseAssetString(`${network.bootAddress}.bns::names`),
     tupleCV({
       name: bufferCVFromString(name),
       namespace: bufferCVFromString(namespace),
@@ -712,7 +701,7 @@ export async function buildTransferNameTx({
   const postConditionReceiver = createNonFungiblePostCondition(
     newOwnerAddress,
     NonFungibleConditionCode.DoesNotSend,
-    parseAssetString(`${getBnsContractAddress(network)}.bns::names`),
+    parseAssetString(`${network.bootAddress}.bns::names`),
     tupleCV({
       name: bufferCVFromString(name),
       namespace: bufferCVFromString(namespace),

--- a/packages/bns/tests/bns.test.ts
+++ b/packages/bns/tests/bns.test.ts
@@ -22,19 +22,13 @@ import {
   uintCV,
 } from '@stacks/transactions';
 import fetchMock from 'jest-fetch-mock';
-import { BNS_CONTRACT_NAME, BnsContractAddress, PriceFunction } from '../src';
+import { BNS_CONTRACT_NAME, PriceFunction } from '../src';
 import { decodeFQN, getZonefileHash } from '../src/utils';
 
 beforeEach(() => {
   fetchMock.resetMocks();
   jest.resetModules();
 });
-
-function getBnsContractAddress(network: StacksNetwork) {
-  if (network.chainId === ChainId.Mainnet) return BnsContractAddress.mainnet;
-  else if (network.chainId == ChainId.Testnet) return BnsContractAddress.testnet;
-  else throw new Error(`Unexpected ChainID: ${network.chainId}`);
-}
 
 function getAddressVersion(network: StacksNetwork) {
   return network.chainId === ChainId.Mainnet
@@ -65,7 +59,7 @@ test('canRegisterName true', async () => {
   const bnsFunctionName = 'can-name-be-registered';
 
   const expectedReadOnlyFunctionCallOptions = {
-    contractAddress: BnsContractAddress.testnet,
+    contractAddress: STACKS_TESTNET.bootAddress,
     contractName: BNS_CONTRACT_NAME,
     functionName: bnsFunctionName,
     functionArgs: [
@@ -104,7 +98,7 @@ test('canRegisterName false', async () => {
   const bnsFunctionName = 'can-name-be-registered';
 
   const expectedReadOnlyFunctionCallOptions = {
-    contractAddress: BnsContractAddress.testnet,
+    contractAddress: STACKS_TESTNET.bootAddress,
     contractName: BNS_CONTRACT_NAME,
     functionName: bnsFunctionName,
     functionArgs: [
@@ -143,7 +137,7 @@ test('canRegisterName error', async () => {
   const bnsFunctionName = 'can-name-be-registered';
 
   const expectedReadOnlyFunctionCallOptions = {
-    contractAddress: BnsContractAddress.testnet,
+    contractAddress: STACKS_TESTNET.bootAddress,
     contractName: BNS_CONTRACT_NAME,
     functionName: bnsFunctionName,
     functionArgs: [
@@ -182,7 +176,7 @@ test('getNamespacePrice', async () => {
   const bnsFunctionName = 'get-namespace-price';
 
   const expectedReadOnlyFunctionCallOptions = {
-    contractAddress: BnsContractAddress.testnet,
+    contractAddress: STACKS_TESTNET.bootAddress,
     contractName: BNS_CONTRACT_NAME,
     functionName: bnsFunctionName,
     senderAddress: address,
@@ -217,7 +211,7 @@ test('getNamespacePrice error', async () => {
   const bnsFunctionName = 'get-namespace-price';
 
   const expectedReadOnlyFunctionCallOptions = {
-    contractAddress: BnsContractAddress.testnet,
+    contractAddress: STACKS_TESTNET.bootAddress,
     contractName: BNS_CONTRACT_NAME,
     functionName: bnsFunctionName,
     senderAddress: address,
@@ -255,7 +249,7 @@ test('getNamePrice', async () => {
   const bnsFunctionName = 'get-name-price';
 
   const expectedReadOnlyFunctionCallOptions = {
-    contractAddress: BnsContractAddress.testnet,
+    contractAddress: STACKS_TESTNET.bootAddress,
     contractName: BNS_CONTRACT_NAME,
     functionName: bnsFunctionName,
     senderAddress: address,
@@ -292,7 +286,7 @@ test('getNamePrice error', async () => {
   const bnsFunctionName = 'get-name-price';
 
   const expectedReadOnlyFunctionCallOptions = {
-    contractAddress: BnsContractAddress.testnet,
+    contractAddress: STACKS_TESTNET.bootAddress,
     contractName: BNS_CONTRACT_NAME,
     functionName: bnsFunctionName,
     senderAddress: address,
@@ -336,7 +330,7 @@ test('preorderNamespace', async () => {
     stxToBurn
   );
   const expectedBNSContractCallOptions = {
-    contractAddress: BnsContractAddress.testnet,
+    contractAddress: STACKS_TESTNET.bootAddress,
     contractName: BNS_CONTRACT_NAME,
     functionName: bnsFunctionName,
     functionArgs: [bufferCV(hash160(utf8ToBytes(`${namespace}${salt}`))), uintCV(stxToBurn)],
@@ -404,7 +398,7 @@ test('revealNamespace', async () => {
   const bnsFunctionName = 'namespace-reveal';
 
   const expectedBNSContractCallOptions = {
-    contractAddress: BnsContractAddress.testnet,
+    contractAddress: STACKS_TESTNET.bootAddress,
     contractName: BNS_CONTRACT_NAME,
     functionName: bnsFunctionName,
     functionArgs: [
@@ -471,7 +465,7 @@ test('importName', async () => {
   const bnsFunctionName = 'name-import';
 
   const expectedBNSContractCallOptions = {
-    contractAddress: BnsContractAddress.testnet,
+    contractAddress: STACKS_TESTNET.bootAddress,
     contractName: BNS_CONTRACT_NAME,
     functionName: bnsFunctionName,
     functionArgs: [
@@ -512,7 +506,7 @@ test('readyNamespace', async () => {
   const bnsFunctionName = 'namespace-ready';
 
   const expectedBNSContractCallOptions = {
-    contractAddress: BnsContractAddress.testnet,
+    contractAddress: STACKS_TESTNET.bootAddress,
     contractName: BNS_CONTRACT_NAME,
     functionName: bnsFunctionName,
     functionArgs: [bufferCVFromString(namespace)],
@@ -556,7 +550,7 @@ test('preorderName', async () => {
     stxToBurn
   );
   const expectedBNSContractCallOptions = {
-    contractAddress: BnsContractAddress.testnet,
+    contractAddress: STACKS_TESTNET.bootAddress,
     contractName: BNS_CONTRACT_NAME,
     functionName: bnsFunctionName,
     functionArgs: [
@@ -602,7 +596,7 @@ test('registerName', async () => {
   const { namespace, name } = decodeFQN(fullyQualifiedName);
 
   const expectedBNSContractCallOptions = {
-    contractAddress: BnsContractAddress.testnet,
+    contractAddress: STACKS_TESTNET.bootAddress,
     contractName: BNS_CONTRACT_NAME,
     functionName: bnsFunctionName,
     functionArgs: [
@@ -647,7 +641,7 @@ test('updateName', async () => {
   const { namespace, name } = decodeFQN(fullyQualifiedName);
 
   const expectedBNSContractCallOptions = {
-    contractAddress: BnsContractAddress.testnet,
+    contractAddress: STACKS_TESTNET.bootAddress,
     contractName: BNS_CONTRACT_NAME,
     functionName: bnsFunctionName,
     functionArgs: [
@@ -696,7 +690,7 @@ test('transferName', async () => {
   const nameTransferPostConditionOne = createNonFungiblePostCondition(
     publicKeyToAddress(getAddressVersion(network), publicKey),
     NonFungibleConditionCode.Sends,
-    parseAssetString(`${getBnsContractAddress(network)}.bns::names`),
+    parseAssetString(`${network.bootAddress}.bns::names`),
     tupleCV({
       name: bufferCVFromString(name),
       namespace: bufferCVFromString(namespace),
@@ -705,14 +699,14 @@ test('transferName', async () => {
   const nameTransferPostConditionTwo = createNonFungiblePostCondition(
     newOwnerAddress,
     NonFungibleConditionCode.DoesNotSend,
-    parseAssetString(`${getBnsContractAddress(network)}.bns::names`),
+    parseAssetString(`${network.bootAddress}.bns::names`),
     tupleCV({
       name: bufferCVFromString(name),
       namespace: bufferCVFromString(namespace),
     })
   );
   const expectedBNSContractCallOptions = {
-    contractAddress: BnsContractAddress.testnet,
+    contractAddress: STACKS_TESTNET.bootAddress,
     contractName: BNS_CONTRACT_NAME,
     functionName: bnsFunctionName,
     functionArgs: [
@@ -763,7 +757,7 @@ test('transferName optionalArguments', async () => {
   const nameTransferPostConditionOne = createNonFungiblePostCondition(
     publicKeyToAddress(getAddressVersion(network), publicKey),
     NonFungibleConditionCode.Sends,
-    parseAssetString(`${getBnsContractAddress(network)}.bns::names`),
+    parseAssetString(`${network.bootAddress}.bns::names`),
     tupleCV({
       name: bufferCVFromString(name),
       namespace: bufferCVFromString(namespace),
@@ -772,14 +766,14 @@ test('transferName optionalArguments', async () => {
   const nameTransferPostConditionTwo = createNonFungiblePostCondition(
     newOwnerAddress,
     NonFungibleConditionCode.DoesNotSend,
-    parseAssetString(`${getBnsContractAddress(network)}.bns::names`),
+    parseAssetString(`${network.bootAddress}.bns::names`),
     tupleCV({
       name: bufferCVFromString(name),
       namespace: bufferCVFromString(namespace),
     })
   );
   const expectedBNSContractCallOptions = {
-    contractAddress: BnsContractAddress.testnet,
+    contractAddress: STACKS_TESTNET.bootAddress,
     contractName: BNS_CONTRACT_NAME,
     functionName: bnsFunctionName,
     functionArgs: [
@@ -823,7 +817,7 @@ test('revokeName', async () => {
   const { namespace, name } = decodeFQN(fullyQualifiedName);
 
   const expectedBNSContractCallOptions = {
-    contractAddress: BnsContractAddress.testnet,
+    contractAddress: STACKS_TESTNET.bootAddress,
     contractName: BNS_CONTRACT_NAME,
     functionName: bnsFunctionName,
     functionArgs: [bufferCVFromString(namespace), bufferCVFromString(name)],
@@ -871,7 +865,7 @@ test('renewName', async () => {
     stxToBurn
   );
   const expectedBNSContractCallOptions = {
-    contractAddress: BnsContractAddress.testnet,
+    contractAddress: STACKS_TESTNET.bootAddress,
     contractName: BNS_CONTRACT_NAME,
     functionName: bnsFunctionName,
     functionArgs: [
@@ -926,7 +920,7 @@ test('renewName optionalArguments', async () => {
     stxToBurn
   );
   const expectedBNSContractCallOptions = {
-    contractAddress: BnsContractAddress.testnet,
+    contractAddress: STACKS_TESTNET.bootAddress,
     contractName: BNS_CONTRACT_NAME,
     functionName: bnsFunctionName,
     functionArgs: [

--- a/packages/bns/tests/bns.test.ts
+++ b/packages/bns/tests/bns.test.ts
@@ -1,7 +1,6 @@
 import { utf8ToBytes } from '@stacks/common';
-import { ChainId, STACKS_TESTNET, StacksNetwork } from '@stacks/network';
+import { STACKS_TESTNET } from '@stacks/network';
 import {
-  AddressVersion,
   FungibleConditionCode,
   NonFungibleConditionCode,
   bufferCV,
@@ -29,12 +28,6 @@ beforeEach(() => {
   fetchMock.resetMocks();
   jest.resetModules();
 });
-
-function getAddressVersion(network: StacksNetwork) {
-  return network.chainId === ChainId.Mainnet
-    ? AddressVersion.MainnetSingleSig
-    : AddressVersion.TestnetSingleSig;
-}
 
 test('canRegisterName true', async () => {
   const fullyQualifiedName = 'test.id';
@@ -325,7 +318,7 @@ test('preorderNamespace', async () => {
 
   const bnsFunctionName = 'namespace-preorder';
   const burnSTXPostCondition = createSTXPostCondition(
-    publicKeyToAddress(getAddressVersion(network), publicKey),
+    publicKeyToAddress(network.addressVersion.singleSig, publicKey),
     FungibleConditionCode.Equal,
     stxToBurn
   );
@@ -545,7 +538,7 @@ test('preorderName', async () => {
 
   const bnsFunctionName = 'name-preorder';
   const burnSTXPostCondition = createSTXPostCondition(
-    publicKeyToAddress(getAddressVersion(network), publicKey),
+    publicKeyToAddress(network.addressVersion.singleSig, publicKey),
     FungibleConditionCode.Equal,
     stxToBurn
   );
@@ -688,7 +681,7 @@ test('transferName', async () => {
 
   const { namespace, name } = decodeFQN(fullyQualifiedName);
   const nameTransferPostConditionOne = createNonFungiblePostCondition(
-    publicKeyToAddress(getAddressVersion(network), publicKey),
+    publicKeyToAddress(network.addressVersion.singleSig, publicKey),
     NonFungibleConditionCode.Sends,
     parseAssetString(`${network.bootAddress}.bns::names`),
     tupleCV({
@@ -755,7 +748,7 @@ test('transferName optionalArguments', async () => {
 
   const { namespace, name } = decodeFQN(fullyQualifiedName);
   const nameTransferPostConditionOne = createNonFungiblePostCondition(
-    publicKeyToAddress(getAddressVersion(network), publicKey),
+    publicKeyToAddress(network.addressVersion.singleSig, publicKey),
     NonFungibleConditionCode.Sends,
     parseAssetString(`${network.bootAddress}.bns::names`),
     tupleCV({
@@ -860,7 +853,7 @@ test('renewName', async () => {
 
   const { namespace, name } = decodeFQN(fullyQualifiedName);
   const burnSTXPostCondition = createSTXPostCondition(
-    publicKeyToAddress(getAddressVersion(network), publicKey),
+    publicKeyToAddress(network.addressVersion.singleSig, publicKey),
     FungibleConditionCode.Equal,
     stxToBurn
   );
@@ -915,7 +908,7 @@ test('renewName optionalArguments', async () => {
 
   const { namespace, name } = decodeFQN(fullyQualifiedName);
   const burnSTXPostCondition = createSTXPostCondition(
-    publicKeyToAddress(getAddressVersion(network), publicKey),
+    publicKeyToAddress(network.addressVersion.singleSig, publicKey),
     FungibleConditionCode.Equal,
     stxToBurn
   );

--- a/packages/network/src/constants.ts
+++ b/packages/network/src/constants.ts
@@ -34,6 +34,23 @@ export enum TransactionVersion {
   Testnet = 0x80,
 }
 
+/**
+ * Address versions for identifying address types in an encoded Stacks address.
+ * The address version is a single byte, indicating the address type.
+ * Every Stacks address starts with `S` followed by a single character indicating the address version.
+ * The second character is the c32-encoded AddressVersion byte.
+ */
+export enum AddressVersion {
+  /** `P` — A single-sig address for mainnet (starting with `SP`) */
+  MainnetSingleSig = 22,
+  /** `M` — A multi-sig address for mainnet (starting with `SM`) */
+  MainnetMultiSig = 20,
+  /** `T` — A single-sig address for testnet (starting with `ST`) */
+  TestnetSingleSig = 26,
+  /** `N` — A multi-sig address for testnet (starting with `SN`) */
+  TestnetMultiSig = 21,
+}
+
 export const DEFAULT_TRANSACTION_VERSION = TransactionVersion.Mainnet;
 
 /** @ignore */

--- a/packages/network/src/network.ts
+++ b/packages/network/src/network.ts
@@ -6,6 +6,7 @@ export interface StacksNetwork {
   transactionVersion: number; // todo: txVersion better?
   peerNetworkId: number;
   magicBytes: string;
+  bootAddress: string;
   // todo: add check32 character bytes string
 }
 
@@ -14,6 +15,7 @@ export const STACKS_MAINNET: StacksNetwork = {
   transactionVersion: TransactionVersion.Mainnet,
   peerNetworkId: PeerNetworkId.Mainnet,
   magicBytes: 'X2', // todo: comment bytes version of magic bytes
+  bootAddress: 'SP000000000000000000002Q6VF78',
 };
 
 export const STACKS_TESTNET: StacksNetwork = {
@@ -21,6 +23,7 @@ export const STACKS_TESTNET: StacksNetwork = {
   transactionVersion: TransactionVersion.Testnet,
   peerNetworkId: PeerNetworkId.Testnet,
   magicBytes: 'T2', // todo: comment bytes version of magic bytes
+  bootAddress: 'ST000000000000000000002AMW42H',
 };
 
 export const STACKS_DEVNET: StacksNetwork = {
@@ -54,7 +57,7 @@ export function networkFrom(network: StacksNetworkName | StacksNetwork) {
   return network;
 }
 
-export function deriveDefaultUrl(network: StacksNetwork | StacksNetworkName | undefined) {
+export function deriveDefaultUrl(network?: StacksNetwork | StacksNetworkName) {
   if (!network) return HIRO_MAINNET_URL; // default to mainnet if no network is given
 
   network = networkFrom(network);

--- a/packages/network/src/network.ts
+++ b/packages/network/src/network.ts
@@ -1,5 +1,5 @@
 import { DEVNET_URL, HIRO_MAINNET_URL, HIRO_TESTNET_URL } from '@stacks/common';
-import { ChainId, PeerNetworkId, TransactionVersion } from './constants';
+import { AddressVersion, ChainId, PeerNetworkId, TransactionVersion } from './constants';
 
 export interface StacksNetwork {
   chainId: number;
@@ -7,6 +7,10 @@ export interface StacksNetwork {
   peerNetworkId: number;
   magicBytes: string;
   bootAddress: string;
+  addressVersion: {
+    singleSig: number;
+    multiSig: number;
+  };
   // todo: add check32 character bytes string
 }
 
@@ -16,6 +20,10 @@ export const STACKS_MAINNET: StacksNetwork = {
   peerNetworkId: PeerNetworkId.Mainnet,
   magicBytes: 'X2', // todo: comment bytes version of magic bytes
   bootAddress: 'SP000000000000000000002Q6VF78',
+  addressVersion: {
+    singleSig: AddressVersion.MainnetSingleSig,
+    multiSig: AddressVersion.MainnetMultiSig,
+  },
 };
 
 export const STACKS_TESTNET: StacksNetwork = {
@@ -24,6 +32,10 @@ export const STACKS_TESTNET: StacksNetwork = {
   peerNetworkId: PeerNetworkId.Testnet,
   magicBytes: 'T2', // todo: comment bytes version of magic bytes
   bootAddress: 'ST000000000000000000002AMW42H',
+  addressVersion: {
+    singleSig: AddressVersion.TestnetSingleSig,
+    multiSig: AddressVersion.TestnetMultiSig,
+  },
 };
 
 export const STACKS_DEVNET: StacksNetwork = {

--- a/packages/transactions/src/builders.ts
+++ b/packages/transactions/src/builders.ts
@@ -20,7 +20,6 @@ import {
 import { ClarityValue, PrincipalCV } from './clarity';
 import {
   AddressHashMode,
-  AddressVersion,
   AnchorMode,
   ClarityVersion,
   FungibleConditionCode,
@@ -201,10 +200,7 @@ export async function makeUnsignedSTXTokenTransfer(
   }
 
   if (txOptions.nonce == null) {
-    const addressVersion =
-      options.network.transactionVersion === TransactionVersion.Mainnet
-        ? AddressVersion.MainnetSingleSig
-        : AddressVersion.TestnetSingleSig;
+    const addressVersion = network.addressVersion.singleSig;
     const address = c32address(addressVersion, transaction.auth.spendingCondition!.signer);
     const txNonce = await getNonce({ address, api: options.api });
     transaction.setNonce(txNonce);
@@ -418,10 +414,7 @@ export async function makeUnsignedContractDeploy(
   }
 
   if (txOptions.nonce === undefined || txOptions.nonce === null) {
-    const addressVersion =
-      options.network.transactionVersion === TransactionVersion.Mainnet
-        ? AddressVersion.MainnetSingleSig
-        : AddressVersion.TestnetSingleSig;
+    const addressVersion = network.addressVersion.singleSig;
     const address = c32address(addressVersion, transaction.auth.spendingCondition!.signer);
     const txNonce = await getNonce({ address, api: options.api });
     transaction.setNonce(txNonce);
@@ -578,10 +571,7 @@ export async function makeUnsignedContractCall(
   }
 
   if (txOptions.nonce === undefined || txOptions.nonce === null) {
-    const addressVersion =
-      network.transactionVersion === TransactionVersion.Mainnet
-        ? AddressVersion.MainnetSingleSig
-        : AddressVersion.TestnetSingleSig;
+    const addressVersion = network.addressVersion.singleSig;
     const address = c32address(addressVersion, transaction.auth.spendingCondition!.signer);
     const txNonce = await getNonce({ address, api: options.api });
     transaction.setNonce(txNonce);
@@ -822,6 +812,7 @@ export async function sponsorTransaction(
   const options = Object.assign(defaultOptions, sponsorOptions);
   options.api = defaultApiFromNetwork(options.network, sponsorOptions.api);
 
+  const network = networkFrom(options.network);
   const sponsorPubKey = privateKeyToPublic(options.sponsorPrivateKey);
 
   if (sponsorOptions.fee == null) {
@@ -845,10 +836,7 @@ export async function sponsorTransaction(
   }
 
   if (sponsorOptions.sponsorNonce == null) {
-    const addressVersion = whenTransactionVersion(options.transaction.version)({
-      [TransactionVersion.Mainnet]: AddressVersion.MainnetSingleSig,
-      [TransactionVersion.Testnet]: AddressVersion.TestnetSingleSig,
-    }); // detect address version from transaction version
+    const addressVersion = network.addressVersion.singleSig;
     const address = publicKeyToAddress(addressVersion, sponsorPubKey);
     const sponsorNonce = await getNonce({ address, api: options.api });
     options.sponsorNonce = sponsorNonce;

--- a/packages/transactions/src/constants.ts
+++ b/packages/transactions/src/constants.ts
@@ -169,22 +169,8 @@ export type MultiSigHashMode =
   | AddressHashMode.SerializeP2SHNonSequential
   | AddressHashMode.SerializeP2WSHNonSequential;
 
-/**
- * Address versions for identifying address types in an encoded Stacks address.
- * The address version is a single byte, indicating the address type.
- * Every Stacks address starts with `S` followed by a single character indicating the address version.
- * The second character is the c32-encoded AddressVersion byte.
- */
-export enum AddressVersion {
-  /** `P` — A single-sig address for mainnet (starting with `SP`) */
-  MainnetSingleSig = 22,
-  /** `M` — A multi-sig address for mainnet (starting with `SM`) */
-  MainnetMultiSig = 20,
-  /** `T` — A single-sig address for testnet (starting with `ST`) */
-  TestnetSingleSig = 26,
-  /** `N` — A multi-sig address for testnet (starting with `SN`) */
-  TestnetMultiSig = 21,
-}
+// re-export for backwards compatibility
+export { AddressVersion } from '@stacks/network';
 
 // todo: try to remove this
 export enum PubKeyEncoding {

--- a/packages/transactions/src/transaction.ts
+++ b/packages/transactions/src/transaction.ts
@@ -63,6 +63,7 @@ export class StacksTransaction {
   postConditionMode: PostConditionMode;
   postConditions: LengthPrefixedList;
 
+  // todo: next: change to opts object with `network` opt
   constructor(
     version: TransactionVersion,
     auth: Authorization,


### PR DESCRIPTION
> This PR was published to npm with the version `6.14.1-pr.36+395befac`
> e.g. `npm install @stacks/common@6.14.1-pr.36+395befac --save-exact`<!-- Sticky Header Marker -->

Use network object where possible, instead of enums