### PR TITLE
refactor: consolidate address types

### DIFF
--- a/packages/api/src/api.ts
+++ b/packages/api/src/api.ts
@@ -15,6 +15,7 @@ import {
 import {
   Cl,
   ClarityAbi,
+  ContractIdString,
   FeeEstimation,
   StacksTransaction,
   TxBroadcastResult,
@@ -100,7 +101,7 @@ export class StacksNodeApi {
    * Fetch a contract's ABI
    * @returns A promise that resolves to a ClarityAbi if the operation succeeds
    */
-  getAbi = async (contract: `${string}.${string}`): Promise<ClarityAbi> => {
+  getAbi = async (contract: ContractIdString): Promise<ClarityAbi> => {
     const [contractAddress, contractName] = contract.split('.');
     return getAbi({ contractAddress, contractName, api: this });
   };
@@ -188,7 +189,7 @@ export class StacksNodeApi {
   }
 
   /** Gets the value of a data-var if it exists in the given contract */
-  async getDataVar(contract: `${string}.${string}`, dataVarName: string) {
+  async getDataVar(contract: ContractIdString, dataVarName: string) {
     // todo: (contractAddress: string, contractName: string, dataVarName: string) overload?
     // todo: cleanup address/contract identifies types
     const contractPath = contract.replace('.', '/');

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -1,3 +1,5 @@
+import type { ContractIdString } from '@stacks/transactions';
+
 export interface V2CoreInfoResponse {
   burn_block_height: number;
   stable_pox_consensus: string;
@@ -11,7 +13,7 @@ export interface CycleInfoResponse {
 }
 
 export interface ContractVersionResponse {
-  contract_id: `${string}.${string}`;
+  contract_id: ContractIdString;
   activation_burnchain_block_height: number;
   first_reward_cycle_id: number;
 }

--- a/packages/transactions/src/pc.ts
+++ b/packages/transactions/src/pc.ts
@@ -28,12 +28,13 @@ import {
 /**
  * ### `Pc.` Post Condition Builder
  * @beta Interface may be subject to change in future releases.
- * @param {AddressString | ContractIdString} principal The principal to check, which should/should-not be sending assets. A string in the format "address" or "address.contractId".
+ * @param {AddressString | ContractIdString} principal The principal to check, which should/should-not be sending assets. A string in the format `<address>` or `<contractAddress>.<contractName>`.
  * @returns A partial post condition builder, which can be chained into a final post condition.
  * @example
  * ```
  * import { Pc } from '@stacks/transactions';
  * Pc.principal('STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6').willSendEq(10000).ustx();
+ * Pc.principal('STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6.mycontract').willSendGte(2000).ft();
  * ```
  */
 // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
@@ -218,6 +219,7 @@ class PartialPcFtWithCode {
    * ⚠ Amount of fungible tokens is denoted in the smallest unit of the token
    */
   ft(contractId: ContractIdString, tokenName: string) {
+    // todo: allow taking one arg (`Asset`) as well, overload
     const [address, name] = parseContractId(contractId);
     if (this.contractName) {
       return makeContractFungiblePostCondition(


### PR DESCRIPTION
> This PR was published to npm with the version `6.14.1-pr.37+2d149585`
> e.g. `npm install @stacks/common@6.14.1-pr.37+2d149585 --save-exact`<!-- Sticky Header Marker -->

- consolidate types