### PR TITLE
fix: Allow network name for more functions

### DIFF
--- a/packages/network/src/network.ts
+++ b/packages/network/src/network.ts
@@ -64,11 +64,13 @@ export function networkFromName(name: StacksNetworkName) {
   }
 }
 
+/** @ignore */
 export function networkFrom(network: StacksNetworkName | StacksNetwork) {
   if (typeof network === 'string') return networkFromName(network);
   return network;
 }
 
+/** @ignore */
 export function deriveDefaultUrl(network?: StacksNetwork | StacksNetworkName) {
   if (!network) return HIRO_MAINNET_URL; // default to mainnet if no network is given
 

--- a/packages/stacking/src/index.ts
+++ b/packages/stacking/src/index.ts
@@ -13,7 +13,7 @@ import {
   intToBigInt,
   isInstance,
 } from '@stacks/common';
-import { StacksNetwork } from '@stacks/network';
+import { StacksNetwork, StacksNetworkName, networkFrom } from '@stacks/network';
 import {
   BurnchainRewardListResponse,
   BurnchainRewardSlotHolderListResponse,
@@ -341,9 +341,14 @@ export class StackingClient {
 
   public api: StacksNodeApi;
 
-  constructor(opts: { address: string; network: StacksNetwork; api?: StacksNodeApi | ApiOpts }) {
+  // todo: make more constructor opts optional
+  constructor(opts: {
+    address: string;
+    network: StacksNetworkName | StacksNetwork;
+    api?: StacksNodeApi | ApiOpts;
+  }) {
     this.address = opts.address;
-    this.network = opts.network;
+    this.network = networkFrom(opts.network);
     this.api = isInstance(opts.api, StacksNodeApi)
       ? opts.api
       : new StacksNodeApi({ url: opts.api?.url, fetch: opts.api?.fetch, network: opts.network });

--- a/packages/stacking/src/utils.ts
+++ b/packages/stacking/src/utils.ts
@@ -6,7 +6,7 @@ import {
   base58CheckEncode,
   verifyMessageSignatureRsv,
 } from '@stacks/encryption';
-import { StacksNetwork, StacksNetworkName, StacksNetworks } from '@stacks/network';
+import { StacksNetwork, StacksNetworkName, StacksNetworks, networkFrom } from '@stacks/network';
 import {
   BufferCV,
   ClarityType,
@@ -317,6 +317,7 @@ export function poxAddressToBtcAddress(
   network: StacksNetworkName
 ): string;
 export function poxAddressToBtcAddress(...args: any[]): string {
+  // todo: allow these helpers to take a bitcoin network instead of a stacks network, once we have a concept of bitcoin networks in the codebase
   if (typeof args[0] === 'number') return _poxAddressToBtcAddress_Values(args[0], args[1], args[2]);
   return _poxAddressToBtcAddress_ClarityValue(args[0], args[1]);
 }
@@ -411,7 +412,7 @@ export interface Pox4SignatureOptions {
   rewardCycle: number;
   /** lock period (in cycles) */
   period: number;
-  network: StacksNetwork;
+  network: StacksNetworkName | StacksNetwork;
   /** Maximum amount of uSTX that can be locked during this function call */
   maxAmount: IntegerType;
   /** Random integer to prevent signature re-use */
@@ -472,10 +473,11 @@ export function pox4SignatureMessage({
   poxAddress,
   rewardCycle,
   period: lockPeriod,
-  network,
+  network: networkOrName,
   maxAmount,
   authId,
 }: Pox4SignatureOptions) {
+  const network = networkFrom(networkOrName);
   const message = tupleCV({
     'pox-addr': poxAddressToTuple(poxAddress),
     'reward-cycle': uintCV(rewardCycle),


### PR DESCRIPTION
> This PR was published to npm with the version `6.14.1-pr.38+42ca22b2`
> e.g. `npm install @stacks/common@6.14.1-pr.38+42ca22b2 --save-exact`<!-- Sticky Header Marker -->

- small refactor to increase the string network usage
