### PR TITLE
refactor: move address types

### DIFF
--- a/packages/transactions/src/cl.ts
+++ b/packages/transactions/src/cl.ts
@@ -117,7 +117,6 @@ export const contractPrincipal = contractPrincipalCV;
  * @see {@link serialize}, {@link deserialize}
  */
 export const standardPrincipal = standardPrincipalCV;
-// todo: add .principal method that detects `.` inside string for both standard and contract principals
 
 // Sequences ///////////////////////////////////////////////////////////////////
 /**

--- a/packages/transactions/src/keys.ts
+++ b/packages/transactions/src/keys.ts
@@ -197,8 +197,8 @@ export function signWithKey(privateKey: PrivateKey, messageHash: string): Messag
 }
 
 /**
- * Signs a message using a private key. The resulting signature along with the
- * original message can be verified using {@link verifyMessageSignatureRsv}
+ * Signs a message hash using a private key. The resulting signature along with
+ * the original message can be verified using {@link verifyMessageSignatureRsv}
  * @returns A recoverable signature (in RSV order)
  */
 export function signMessageHashRsv({

--- a/packages/transactions/src/pc.ts
+++ b/packages/transactions/src/pc.ts
@@ -10,12 +10,12 @@ import {
 import { ClarityValue } from './clarity';
 import { FungibleConditionCode, NonFungibleConditionCode } from './constants';
 import {
-  AddressString,
   AssetString,
   ContractIdString,
-  createAsset,
   NonFungiblePostCondition,
+  createAsset,
 } from './postcondition-types';
+import { AddressString } from './types';
 
 /// `Pc.` Post Condition Builder
 //

--- a/packages/transactions/src/postcondition-types.ts
+++ b/packages/transactions/src/postcondition-types.ts
@@ -12,11 +12,6 @@ import { ClarityValue } from './clarity';
 import { exceedsMaxLengthBytes } from './utils';
 
 /**
- * An address string encoded as c32check
- */
-export type AddressString = string;
-
-/**
  * A contract identifier string given as `<address>.<contract-name>`
  */
 export type ContractIdString = `${string}.${string}`;

--- a/packages/transactions/src/types.ts
+++ b/packages/transactions/src/types.ts
@@ -61,6 +61,11 @@ import {
   rightPadHexToLength,
 } from './utils';
 
+/**
+ * An address string encoded as c32check
+ */
+export type AddressString = string;
+
 export type StacksMessage =
   | Address
   | PostConditionPrincipal


### PR DESCRIPTION
> This PR was published to npm with the version `6.14.1-pr.39+c07b3fe7`
> e.g. `npm install @stacks/common@6.14.1-pr.39+c07b3fe7 --save-exact`<!-- Sticky Header Marker -->

Tiny refactor to move to better fitting file