### PR TITLE
refactor!: Rename message types

### DIFF
--- a/.github/MIGRATION.md
+++ b/.github/MIGRATION.md
@@ -11,6 +11,7 @@
   - [Asset Helper Methods](#asset-helper-methods)
   - [CLI](#cli)
   - [Triplesec](#triplesec)
+  - [Advanced: WireType](#advanced-wiretype)
 - [Stacks.js (\<=4.x.x) → (5.x.x)](#stacksjs-4xx--5xx)
   - [Breaking Changes](#breaking-changes-1)
     - [Buffer to Uint8Array](#buffer-to-uint8array)
@@ -35,6 +36,7 @@
 - The `AssetInfo` type was renamed to `Asset` for accuracy. The `Asset` helper methods were also renamed to to remove the `Info` suffix. [Read more...](#asset-helper-methods)
 - Remove legacy CLI methods. [Read more...](#cli)
 - Disable legacy `triplesec` mnemonic encryption support. [Read more...](#triplesec)
+- **Advanced:** Rename `MessageType` and related concepts to `WireType`. [Read more...](#advanced-wiretype)
 
 ### Stacks Network
 
@@ -184,6 +186,8 @@ For easier migrating, renaming the following methods is possible to keep the pre
 - `deserializeMessageSignature` → `deserializeMessageSignatureBytes`
 - `serializePostCondition` → `serializePostConditionBytes`
 - `deserializePostCondition` → `deserializePostConditionBytes`
+- `serializeStacksMessage` → `serializeStacksWireBytes`
+- `deserializeStacksMessage` → `deserializeStacksWireBytes`
 
 ### Asset Helper Methods
 
@@ -203,6 +207,16 @@ The following interfaces and methods were renamed:
 Support for encrypting/decrypting mnemonics with `triplesec` was removed.
 This impacts the methods: `decrypt`, `decryptMnemonic`, and `decryptLegacy`.
 Make sure to update your code to if mnemonics are stored somewhere encrypted using the legacy method.
+
+### Advanced: WireType
+
+Renamed internals to avoid confusion between "message" and wire-format for serialization.
+This is only used for advanced serialization use-cases internally and should not be needed for most users.
+
+- `StacksMessage` → `StacksWire`
+- `StacksMessageType` → `StacksWireType`
+- `serializeStacksMessage` → `serializeStacksWireBytes`
+- `deserializeStacksMessage` → `deserializeStacksWireBytes`
 
 ## Stacks.js (&lt;=4.x.x) → (5.x.x)
 

--- a/packages/transactions/src/common.ts
+++ b/packages/transactions/src/common.ts
@@ -2,7 +2,7 @@ import {
   AddressHashMode,
   AddressVersion,
   RECOVERABLE_ECDSA_SIG_LENGTH_BYTES,
-  StacksMessageType,
+  StacksWireType,
 } from './constants';
 
 import { c32address } from 'c32check';
@@ -10,13 +10,13 @@ import { hexToBytes } from '@stacks/common';
 import { TransactionVersion } from '@stacks/network';
 
 export interface Address {
-  readonly type: StacksMessageType.Address;
+  readonly type: StacksWireType.Address;
   readonly version: AddressVersion;
   readonly hash160: string;
 }
 
 export interface MessageSignature {
-  readonly type: StacksMessageType.MessageSignature;
+  readonly type: StacksWireType.MessageSignature;
   data: string;
 }
 
@@ -27,7 +27,7 @@ export function createMessageSignature(signature: string): MessageSignature {
   }
 
   return {
-    type: StacksMessageType.MessageSignature,
+    type: StacksWireType.MessageSignature,
     data: signature,
   };
 }
@@ -74,7 +74,7 @@ export function addressHashModeToVersion(
 }
 
 export function addressFromVersionHash(version: AddressVersion, hash: string): Address {
-  return { type: StacksMessageType.Address, version, hash160: hash };
+  return { type: StacksWireType.Address, version, hash160: hash };
 }
 
 export function addressToString(address: Address): string {

--- a/packages/transactions/src/constants.ts
+++ b/packages/transactions/src/constants.ts
@@ -16,7 +16,7 @@ export const MEMO_MAX_LENGTH_BYTES = 34;
  * The type of message that is being serialized.
  * Used internally for serializing and deserializing messages.
  */
-export enum StacksMessageType {
+export enum StacksWireType {
   Address,
   Principal,
   LengthPrefixedString,
@@ -31,10 +31,10 @@ export enum StacksMessageType {
   TransactionAuthField,
 }
 
-type WhenMessageTypeMap<T> = Record<StacksMessageType, T>;
+type WhenWireTypeMap<T> = Record<StacksWireType, T>;
 
-export function whenMessageType(messageType: StacksMessageType) {
-  return <T>(messageTypeMap: WhenMessageTypeMap<T>): T => messageTypeMap[messageType];
+export function whenWireType(wireType: StacksWireType) {
+  return <T>(wireTypeMap: WhenWireTypeMap<T>): T => wireTypeMap[wireType];
 }
 
 /**

--- a/packages/transactions/src/keys.ts
+++ b/packages/transactions/src/keys.ts
@@ -43,7 +43,7 @@ import {
   AddressVersion,
   COMPRESSED_PUBKEY_LENGTH_BYTES,
   PubKeyEncoding,
-  StacksMessageType,
+  StacksWireType,
   UNCOMPRESSED_PUBKEY_LENGTH_BYTES,
 } from './constants';
 import { StructuredDataSignature } from './message-types';
@@ -63,7 +63,7 @@ utils.hmacSha256Sync = (key: Uint8Array, ...msgs: Uint8Array[]) => {
 };
 
 export interface StacksPublicKey {
-  readonly type: StacksMessageType.PublicKey;
+  readonly type: StacksWireType.PublicKey;
   readonly data: Uint8Array;
 }
 
@@ -94,7 +94,7 @@ export function getAddressFromPublicKey(
 export function createStacksPublicKey(publicKey: PublicKey): StacksPublicKey {
   publicKey = typeof publicKey === 'string' ? hexToBytes(publicKey) : publicKey;
   return {
-    type: StacksMessageType.PublicKey,
+    type: StacksWireType.PublicKey,
     data: publicKey,
   };
 }

--- a/packages/transactions/src/message-types.ts
+++ b/packages/transactions/src/message-types.ts
@@ -1,8 +1,8 @@
 // todo: this file should hold the type definitions for more message types later
 // needed now to fix a circular dependency issue in structuredDataSignature
-import { StacksMessageType } from './constants';
+import { StacksWireType } from './constants';
 
 export interface StructuredDataSignature {
-  readonly type: StacksMessageType.StructuredDataSignature;
+  readonly type: StacksWireType.StructuredDataSignature;
   data: string;
 }

--- a/packages/transactions/src/payload.ts
+++ b/packages/transactions/src/payload.ts
@@ -25,7 +25,7 @@ import {
   ClarityVersion,
   COINBASE_BYTES_LENGTH,
   PayloadType,
-  StacksMessageType,
+  StacksWireType,
   VRF_PROOF_BYTES_LENGTH,
 } from './constants';
 import { createAddress, createLPString, LengthPrefixedString } from './postcondition-types';
@@ -36,7 +36,7 @@ import {
   deserializeLPStringBytes,
   deserializeMemoStringBytes,
   MemoString,
-  serializeStacksMessageBytes,
+  serializeStacksWireBytes,
 } from './types';
 import { PrincipalCV } from './clarity/types';
 
@@ -68,7 +68,7 @@ export function isCoinbasePayload(p: Payload): p is CoinbasePayload {
 }
 
 export interface TokenTransferPayload {
-  readonly type: StacksMessageType.Payload;
+  readonly type: StacksWireType.Payload;
   readonly payloadType: PayloadType.TokenTransfer;
   readonly recipient: PrincipalCV;
   readonly amount: bigint;
@@ -99,7 +99,7 @@ export function createTokenTransferPayload(
   }
 
   return {
-    type: StacksMessageType.Payload,
+    type: StacksWireType.Payload,
     payloadType: PayloadType.TokenTransfer,
     recipient,
     amount: intToBigInt(amount, false),
@@ -108,7 +108,7 @@ export function createTokenTransferPayload(
 }
 
 export interface ContractCallPayload {
-  readonly type: StacksMessageType.Payload;
+  readonly type: StacksWireType.Payload;
   readonly payloadType: PayloadType.ContractCall;
   readonly contractAddress: Address;
   readonly contractName: LengthPrefixedString;
@@ -133,7 +133,7 @@ export function createContractCallPayload(
   }
 
   return {
-    type: StacksMessageType.Payload,
+    type: StacksWireType.Payload,
     payloadType: PayloadType.ContractCall,
     contractAddress,
     contractName,
@@ -143,14 +143,14 @@ export function createContractCallPayload(
 }
 
 export interface SmartContractPayload {
-  readonly type: StacksMessageType.Payload;
+  readonly type: StacksWireType.Payload;
   readonly payloadType: PayloadType.SmartContract;
   readonly contractName: LengthPrefixedString;
   readonly codeBody: LengthPrefixedString;
 }
 
 export interface VersionedSmartContractPayload {
-  readonly type: StacksMessageType.Payload;
+  readonly type: StacksWireType.Payload;
   readonly payloadType: PayloadType.VersionedSmartContract;
   readonly clarityVersion: ClarityVersion;
   readonly contractName: LengthPrefixedString;
@@ -171,7 +171,7 @@ export function createSmartContractPayload(
 
   if (typeof clarityVersion === 'number') {
     return {
-      type: StacksMessageType.Payload,
+      type: StacksWireType.Payload,
       payloadType: PayloadType.VersionedSmartContract,
       clarityVersion,
       contractName,
@@ -179,7 +179,7 @@ export function createSmartContractPayload(
     };
   }
   return {
-    type: StacksMessageType.Payload,
+    type: StacksWireType.Payload,
     payloadType: PayloadType.SmartContract,
     contractName,
     codeBody,
@@ -187,22 +187,22 @@ export function createSmartContractPayload(
 }
 
 export interface PoisonPayload {
-  readonly type: StacksMessageType.Payload;
+  readonly type: StacksWireType.Payload;
   readonly payloadType: PayloadType.PoisonMicroblock;
 }
 
 export function createPoisonPayload(): PoisonPayload {
-  return { type: StacksMessageType.Payload, payloadType: PayloadType.PoisonMicroblock };
+  return { type: StacksWireType.Payload, payloadType: PayloadType.PoisonMicroblock };
 }
 
 export interface CoinbasePayload {
-  readonly type: StacksMessageType.Payload;
+  readonly type: StacksWireType.Payload;
   readonly payloadType: PayloadType.Coinbase;
   readonly coinbaseBytes: Uint8Array;
 }
 
 export interface CoinbasePayloadToAltRecipient {
-  readonly type: StacksMessageType.Payload;
+  readonly type: StacksWireType.Payload;
   readonly payloadType: PayloadType.CoinbaseToAltRecipient;
   readonly coinbaseBytes: Uint8Array;
   readonly recipient: PrincipalCV;
@@ -218,21 +218,21 @@ export function createCoinbasePayload(
 
   if (altRecipient != undefined) {
     return {
-      type: StacksMessageType.Payload,
+      type: StacksWireType.Payload,
       payloadType: PayloadType.CoinbaseToAltRecipient,
       coinbaseBytes,
       recipient: altRecipient,
     };
   }
   return {
-    type: StacksMessageType.Payload,
+    type: StacksWireType.Payload,
     payloadType: PayloadType.Coinbase,
     coinbaseBytes,
   };
 }
 
 export interface NakamotoCoinbasePayload {
-  readonly type: StacksMessageType.Payload;
+  readonly type: StacksWireType.Payload;
   readonly payloadType: PayloadType.NakamotoCoinbase;
   readonly coinbaseBytes: Uint8Array;
   readonly recipient?: PrincipalCV;
@@ -253,7 +253,7 @@ export function createNakamotoCoinbasePayload(
   }
 
   return {
-    type: StacksMessageType.Payload,
+    type: StacksWireType.Payload,
     payloadType: PayloadType.NakamotoCoinbase,
     coinbaseBytes,
     recipient: recipient.type === ClarityType.OptionalSome ? recipient.value : undefined,
@@ -269,7 +269,7 @@ export enum TenureChangeCause {
 }
 
 export interface TenureChangePayload {
-  readonly type: StacksMessageType.Payload;
+  readonly type: StacksWireType.Payload;
   readonly payloadType: PayloadType.TenureChange;
   /**
    * The consensus hash of this tenure (hex string). Corresponds to the
@@ -309,7 +309,7 @@ export function createTenureChangePayload(
   publicKeyHash: string
 ): TenureChangePayload {
   return {
-    type: StacksMessageType.Payload,
+    type: StacksWireType.Payload,
     payloadType: PayloadType.TenureChange,
     tenureHash,
     previousTenureHash,
@@ -333,12 +333,12 @@ export function serializePayloadBytes(payload: PayloadInput): Uint8Array {
     case PayloadType.TokenTransfer:
       bytesArray.push(serializeCVBytes(payload.recipient));
       bytesArray.push(intToBytes(payload.amount, false, 8));
-      bytesArray.push(serializeStacksMessageBytes(payload.memo));
+      bytesArray.push(serializeStacksWireBytes(payload.memo));
       break;
     case PayloadType.ContractCall:
-      bytesArray.push(serializeStacksMessageBytes(payload.contractAddress));
-      bytesArray.push(serializeStacksMessageBytes(payload.contractName));
-      bytesArray.push(serializeStacksMessageBytes(payload.functionName));
+      bytesArray.push(serializeStacksWireBytes(payload.contractAddress));
+      bytesArray.push(serializeStacksWireBytes(payload.contractName));
+      bytesArray.push(serializeStacksWireBytes(payload.functionName));
       const numArgs = new Uint8Array(4);
       writeUInt32BE(numArgs, payload.functionArgs.length, 0);
       bytesArray.push(numArgs);
@@ -347,13 +347,13 @@ export function serializePayloadBytes(payload: PayloadInput): Uint8Array {
       });
       break;
     case PayloadType.SmartContract:
-      bytesArray.push(serializeStacksMessageBytes(payload.contractName));
-      bytesArray.push(serializeStacksMessageBytes(payload.codeBody));
+      bytesArray.push(serializeStacksWireBytes(payload.contractName));
+      bytesArray.push(serializeStacksWireBytes(payload.codeBody));
       break;
     case PayloadType.VersionedSmartContract:
       bytesArray.push(payload.clarityVersion);
-      bytesArray.push(serializeStacksMessageBytes(payload.contractName));
-      bytesArray.push(serializeStacksMessageBytes(payload.codeBody));
+      bytesArray.push(serializeStacksWireBytes(payload.contractName));
+      bytesArray.push(serializeStacksWireBytes(payload.codeBody));
       break;
     case PayloadType.PoisonMicroblock:
       // TODO: implement

--- a/packages/transactions/src/postcondition-types.ts
+++ b/packages/transactions/src/postcondition-types.ts
@@ -4,7 +4,7 @@ import {
   NonFungibleConditionCode,
   PostConditionPrincipalId,
   PostConditionType,
-  StacksMessageType,
+  StacksWireType,
 } from './constants';
 import { c32addressDecode } from 'c32check';
 import { Address } from './common';
@@ -22,34 +22,34 @@ export type ContractIdString = `${string}.${string}`;
 export type AssetString = `${ContractIdString}::${string}`;
 
 export interface StandardPrincipal {
-  readonly type: StacksMessageType.Principal;
+  readonly type: StacksWireType.Principal;
   readonly prefix: PostConditionPrincipalId.Standard;
   readonly address: Address;
 }
 
 export interface ContractPrincipal {
-  readonly type: StacksMessageType.Principal;
+  readonly type: StacksWireType.Principal;
   readonly prefix: PostConditionPrincipalId.Contract;
   readonly address: Address;
   readonly contractName: LengthPrefixedString;
 }
 
 export interface LengthPrefixedString {
-  readonly type: StacksMessageType.LengthPrefixedString;
+  readonly type: StacksWireType.LengthPrefixedString;
   readonly content: string;
   readonly lengthPrefixBytes: number;
   readonly maxLengthBytes: number;
 }
 
 export interface Asset {
-  readonly type: StacksMessageType.Asset;
+  readonly type: StacksWireType.Asset;
   readonly address: Address;
   readonly contractName: LengthPrefixedString;
   readonly assetName: LengthPrefixedString;
 }
 
 export interface STXPostCondition {
-  readonly type: StacksMessageType.PostCondition;
+  readonly type: StacksWireType.PostCondition;
   readonly conditionType: PostConditionType.STX;
   readonly principal: PostConditionPrincipal;
   readonly conditionCode: FungibleConditionCode;
@@ -57,7 +57,7 @@ export interface STXPostCondition {
 }
 
 export interface FungiblePostCondition {
-  readonly type: StacksMessageType.PostCondition;
+  readonly type: StacksWireType.PostCondition;
   readonly conditionType: PostConditionType.Fungible;
   readonly principal: PostConditionPrincipal;
   readonly conditionCode: FungibleConditionCode;
@@ -66,7 +66,7 @@ export interface FungiblePostCondition {
 }
 
 export interface NonFungiblePostCondition {
-  readonly type: StacksMessageType.PostCondition;
+  readonly type: StacksWireType.PostCondition;
   readonly conditionType: PostConditionType.NonFungible;
   readonly principal: PostConditionPrincipal;
   readonly conditionCode: NonFungibleConditionCode;
@@ -104,7 +104,7 @@ export function createLPString(
     throw new Error(`String length exceeds maximum bytes ${maxLength}`);
   }
   return {
-    type: StacksMessageType.LengthPrefixedString,
+    type: StacksWireType.LengthPrefixedString,
     content,
     lengthPrefixBytes: prefixLength,
     maxLengthBytes: maxLength,
@@ -113,7 +113,7 @@ export function createLPString(
 
 export function createAsset(addressString: string, contractName: string, assetName: string): Asset {
   return {
-    type: StacksMessageType.Asset,
+    type: StacksWireType.Asset,
     address: createAddress(addressString),
     contractName: createLPString(contractName),
     assetName: createLPString(assetName),
@@ -123,7 +123,7 @@ export function createAsset(addressString: string, contractName: string, assetNa
 export function createAddress(c32AddressString: string): Address {
   const addressData = c32addressDecode(c32AddressString);
   return {
-    type: StacksMessageType.Address,
+    type: StacksWireType.Address,
     version: addressData[0],
     hash160: addressData[1],
   };
@@ -153,7 +153,7 @@ export function createContractPrincipal(
   const addr = createAddress(addressString);
   const name = createLPString(contractName);
   return {
-    type: StacksMessageType.Principal,
+    type: StacksWireType.Principal,
     prefix: PostConditionPrincipalId.Contract,
     address: addr,
     contractName: name,
@@ -163,7 +163,7 @@ export function createContractPrincipal(
 export function createStandardPrincipal(addressString: string): StandardPrincipal {
   const addr = createAddress(addressString);
   return {
-    type: StacksMessageType.Principal,
+    type: StacksWireType.Principal,
     prefix: PostConditionPrincipalId.Standard,
     address: addr,
   };

--- a/packages/transactions/src/postcondition.ts
+++ b/packages/transactions/src/postcondition.ts
@@ -4,7 +4,7 @@ import {
   FungibleConditionCode,
   NonFungibleConditionCode,
   PostConditionType,
-  StacksMessageType,
+  StacksWireType,
 } from './constants';
 import {
   Asset,
@@ -27,7 +27,7 @@ export function createSTXPostCondition(
   }
 
   return {
-    type: StacksMessageType.PostCondition,
+    type: StacksWireType.PostCondition,
     conditionType: PostConditionType.STX,
     principal,
     conditionCode,
@@ -49,7 +49,7 @@ export function createFungiblePostCondition(
   }
 
   return {
-    type: StacksMessageType.PostCondition,
+    type: StacksWireType.PostCondition,
     conditionType: PostConditionType.Fungible,
     principal,
     conditionCode,
@@ -72,7 +72,7 @@ export function createNonFungiblePostCondition(
   }
 
   return {
-    type: StacksMessageType.PostCondition,
+    type: StacksWireType.PostCondition,
     conditionType: PostConditionType.NonFungible,
     principal,
     conditionCode,

--- a/packages/transactions/src/signer.ts
+++ b/packages/transactions/src/signer.ts
@@ -6,7 +6,7 @@ import {
   isSingleSig,
   nextVerification,
 } from './authorization';
-import { AddressHashMode, AuthType, PubKeyEncoding, StacksMessageType } from './constants';
+import { AddressHashMode, AuthType, PubKeyEncoding, StacksWireType } from './constants';
 import { SigningError } from './errors';
 import { StacksPublicKey } from './keys';
 import { StacksTransaction } from './transaction';
@@ -33,14 +33,14 @@ export class TransactionSigner {
     if (spendingCondition && !isSingleSig(spendingCondition)) {
       if (
         spendingCondition.fields.filter(
-          field => field.contents.type === StacksMessageType.MessageSignature
+          field => field.contents.type === StacksWireType.MessageSignature
         ).length >= spendingCondition.signaturesRequired
       ) {
         throw new Error('SpendingCondition has more signatures than are expected');
       }
 
       spendingCondition.fields.forEach(field => {
-        if (field.contents.type !== StacksMessageType.MessageSignature) return;
+        if (field.contents.type !== StacksWireType.MessageSignature) return;
 
         const signature = field.contents;
         const nextVerify = nextVerification(
@@ -99,7 +99,7 @@ export class TransactionSigner {
       if (
         this.checkOversign &&
         spendingCondition.fields.filter(
-          field => field.contents.type === StacksMessageType.MessageSignature
+          field => field.contents.type === StacksWireType.MessageSignature
         ).length >= spendingCondition.signaturesRequired
       ) {
         throw new Error('Origin would have too many signatures');

--- a/packages/transactions/src/structuredDataSignature.ts
+++ b/packages/transactions/src/structuredDataSignature.ts
@@ -1,7 +1,7 @@
 import { sha256 } from '@noble/hashes/sha256';
 import { PrivateKey, bytesToHex, concatBytes, utf8ToBytes } from '@stacks/common';
 import { ClarityType, ClarityValue, serializeCVBytes } from './clarity';
-import { StacksMessageType } from './constants';
+import { StacksWireType } from './constants';
 import { StructuredDataSignature } from './message-types';
 import { signMessageHashRsv } from './keys';
 
@@ -88,6 +88,6 @@ export function signStructuredData({
   });
   return {
     data,
-    type: StacksMessageType.StructuredDataSignature,
+    type: StacksWireType.StructuredDataSignature,
   };
 }

--- a/packages/transactions/src/transaction.ts
+++ b/packages/transactions/src/transaction.ts
@@ -39,7 +39,7 @@ import {
   PostConditionMode,
   PubKeyEncoding,
   RECOVERABLE_ECDSA_SIG_LENGTH_BYTES,
-  StacksMessageType,
+  StacksWireType,
   anchorModeFrom,
 } from './constants';
 import { SerializationError, SigningError } from './errors';
@@ -281,7 +281,7 @@ export function deserializeTransaction(tx: string | Uint8Array | BytesReader) {
   const postConditionMode = bytesReader.readUInt8Enum(PostConditionMode, n => {
     throw new Error(`Could not parse ${n} as PostConditionMode`);
   });
-  const postConditions = deserializeLPListBytes(bytesReader, StacksMessageType.PostCondition);
+  const postConditions = deserializeLPListBytes(bytesReader, StacksWireType.PostCondition);
   const payload = deserializePayloadBytes(bytesReader);
 
   return new StacksTransaction(
@@ -324,7 +324,7 @@ export function estimateTransactionByteLength(transaction: StacksTransaction): n
 
     // Find number of existing signatures if the transaction is signed or partially signed
     const existingSignatures = multiSigSpendingCondition.fields.filter(
-      field => field.contents.type === StacksMessageType.MessageSignature
+      field => field.contents.type === StacksWireType.MessageSignature
     ).length; // existingSignatures will be 0 if its a unsigned transaction
 
     // Estimate total signature bytes size required for this multi-sig transaction

--- a/packages/transactions/src/types.ts
+++ b/packages/transactions/src/types.ts
@@ -26,7 +26,7 @@ import {
   NonFungibleConditionCode,
   PostConditionPrincipalId,
   PostConditionType,
-  StacksMessageType,
+  StacksWireType,
 } from './constants';
 import { DeserializationError, SerializationError } from './errors';
 import {
@@ -47,7 +47,7 @@ import {
 } from './postcondition-types';
 import {
   TransactionAuthField,
-  deserializeMessageSignature,
+  deserializeMessageSignatureBytes,
   deserializeTransactionAuthFieldBytes,
   serializeMessageSignatureBytes,
   serializeTransactionAuthFieldBytes,
@@ -66,7 +66,7 @@ import {
  */
 export type AddressString = string;
 
-export type StacksMessage =
+export type StacksWire =
   | Address
   | PostConditionPrincipal
   | LengthPrefixedString
@@ -79,74 +79,74 @@ export type StacksMessage =
   | TransactionAuthField
   | MessageSignature;
 
-export function serializeStacksMessage(message: StacksMessage): string {
-  return bytesToHex(serializeStacksMessageBytes(message));
+export function serializeStacksWire(wire: StacksWire): string {
+  return bytesToHex(serializeStacksWireBytes(wire));
 }
 /** @ignore */
-export function serializeStacksMessageBytes(message: StacksMessage): Uint8Array {
-  switch (message.type) {
-    case StacksMessageType.Address:
-      return serializeAddressBytes(message);
-    case StacksMessageType.Principal:
-      return serializePrincipalBytes(message);
-    case StacksMessageType.LengthPrefixedString:
-      return serializeLPStringBytes(message);
-    case StacksMessageType.MemoString:
-      return serializeMemoStringBytes(message);
-    case StacksMessageType.Asset:
-      return serializeAssetBytes(message);
-    case StacksMessageType.PostCondition:
-      return serializePostConditionBytes(message);
-    case StacksMessageType.PublicKey:
-      return serializePublicKeyBytes(message);
-    case StacksMessageType.LengthPrefixedList:
-      return serializeLPListBytes(message);
-    case StacksMessageType.Payload:
-      return serializePayloadBytes(message);
-    case StacksMessageType.TransactionAuthField:
-      return serializeTransactionAuthFieldBytes(message);
-    case StacksMessageType.MessageSignature:
-      return serializeMessageSignatureBytes(message);
+export function serializeStacksWireBytes(wire: StacksWire): Uint8Array {
+  switch (wire.type) {
+    case StacksWireType.Address:
+      return serializeAddressBytes(wire);
+    case StacksWireType.Principal:
+      return serializePrincipalBytes(wire);
+    case StacksWireType.LengthPrefixedString:
+      return serializeLPStringBytes(wire);
+    case StacksWireType.MemoString:
+      return serializeMemoStringBytes(wire);
+    case StacksWireType.Asset:
+      return serializeAssetBytes(wire);
+    case StacksWireType.PostCondition:
+      return serializePostConditionBytes(wire);
+    case StacksWireType.PublicKey:
+      return serializePublicKeyBytes(wire);
+    case StacksWireType.LengthPrefixedList:
+      return serializeLPListBytes(wire);
+    case StacksWireType.Payload:
+      return serializePayloadBytes(wire);
+    case StacksWireType.TransactionAuthField:
+      return serializeTransactionAuthFieldBytes(wire);
+    case StacksWireType.MessageSignature:
+      return serializeMessageSignatureBytes(wire);
   }
 }
 
-export function deserializeStacksMessage(
+export function deserializeStacksWireBytes(
   bytesReader: BytesReader,
-  type: StacksMessageType,
-  listType?: StacksMessageType
-): StacksMessage {
+  type: StacksWireType,
+  listType?: StacksWireType
+): StacksWire {
   switch (type) {
-    case StacksMessageType.Address:
+    case StacksWireType.Address:
       return deserializeAddressBytes(bytesReader);
-    case StacksMessageType.Principal:
+    case StacksWireType.Principal:
       return deserializePrincipalBytes(bytesReader);
-    case StacksMessageType.LengthPrefixedString:
+    case StacksWireType.LengthPrefixedString:
       return deserializeLPStringBytes(bytesReader);
-    case StacksMessageType.MemoString:
+    case StacksWireType.MemoString:
       return deserializeMemoStringBytes(bytesReader);
-    case StacksMessageType.Asset:
+    case StacksWireType.Asset:
       return deserializeAssetBytes(bytesReader);
-    case StacksMessageType.PostCondition:
+    case StacksWireType.PostCondition:
       return deserializePostConditionBytes(bytesReader);
-    case StacksMessageType.PublicKey:
+    case StacksWireType.PublicKey:
       return deserializePublicKeyBytes(bytesReader);
-    case StacksMessageType.Payload:
+    case StacksWireType.Payload:
       return deserializePayloadBytes(bytesReader);
-    case StacksMessageType.LengthPrefixedList:
+    case StacksWireType.LengthPrefixedList:
       if (!listType) {
-        throw new DeserializationError('No List Type specified');
+        throw new DeserializationError('No list type specified');
       }
       return deserializeLPListBytes(bytesReader, listType);
-    case StacksMessageType.MessageSignature:
-      return deserializeMessageSignature(bytesReader);
+    case StacksWireType.MessageSignature:
+      return deserializeMessageSignatureBytes(bytesReader);
     default:
-      throw new Error('Could not recognize StacksMessageType');
+      throw new Error('Could not recognize StacksWireType');
   }
 }
 
 export function createEmptyAddress(): Address {
   return {
-    type: StacksMessageType.Address,
+    type: StacksWireType.Address,
     version: AddressVersion.MainnetSingleSig,
     hash160: '0'.repeat(40),
   };
@@ -230,7 +230,7 @@ export function deserializeAddressBytes(serialized: Uint8Array | BytesReader): A
   const version = hexToInt(bytesToHex(bytesReader.readBytes(1)));
   const data = bytesToHex(bytesReader.readBytes(20));
 
-  return { type: StacksMessageType.Address, version, hash160: data };
+  return { type: StacksWireType.Address, version, hash160: data };
 }
 
 export function serializePrincipal(principal: PostConditionPrincipal): string {
@@ -262,11 +262,11 @@ export function deserializePrincipalBytes(
   });
   const address = deserializeAddressBytes(bytesReader);
   if (prefix === PostConditionPrincipalId.Standard) {
-    return { type: StacksMessageType.Principal, prefix, address } as StandardPrincipal;
+    return { type: StacksWireType.Principal, prefix, address } as StandardPrincipal;
   }
   const contractName = deserializeLPStringBytes(bytesReader);
   return {
-    type: StacksMessageType.Principal,
+    type: StacksWireType.Principal,
     prefix,
     address,
     contractName,
@@ -313,7 +313,7 @@ export function codeBodyString(content: string): LengthPrefixedString {
 }
 
 export interface MemoString {
-  readonly type: StacksMessageType.MemoString;
+  readonly type: StacksWireType.MemoString;
   readonly content: string;
 }
 
@@ -321,7 +321,7 @@ export function createMemoString(content: string): MemoString {
   if (content && exceedsMaxLengthBytes(content, MEMO_MAX_LENGTH_BYTES)) {
     throw new Error(`Memo exceeds maximum length of ${MEMO_MAX_LENGTH_BYTES} bytes`);
   }
-  return { type: StacksMessageType.MemoString, content };
+  return { type: StacksWireType.MemoString, content };
 }
 
 export function serializeMemoString(memoString: MemoString): string {
@@ -346,7 +346,7 @@ export function deserializeMemoStringBytes(serialized: Uint8Array | BytesReader)
     : new BytesReader(serialized);
   let content = bytesToUtf8(bytesReader.readBytes(MEMO_MAX_LENGTH_BYTES));
   content = content.replace(/\u0000*$/, ''); // remove all trailing unicode null characters
-  return { type: StacksMessageType.MemoString, content };
+  return { type: StacksWireType.MemoString, content };
 }
 
 export function serializeAsset(info: Asset): string {
@@ -370,7 +370,7 @@ export function deserializeAssetBytes(serialized: Uint8Array | BytesReader): Ass
     ? serialized
     : new BytesReader(serialized);
   return {
-    type: StacksMessageType.Asset,
+    type: StacksWireType.Asset,
     address: deserializeAddressBytes(bytesReader),
     contractName: deserializeLPStringBytes(bytesReader),
     assetName: deserializeLPStringBytes(bytesReader),
@@ -378,17 +378,17 @@ export function deserializeAssetBytes(serialized: Uint8Array | BytesReader): Ass
 }
 
 export interface LengthPrefixedList {
-  readonly type: StacksMessageType.LengthPrefixedList;
+  readonly type: StacksWireType.LengthPrefixedList;
   readonly lengthPrefixBytes: number;
-  readonly values: StacksMessage[];
+  readonly values: StacksWire[];
 }
 
-export function createLPList<T extends StacksMessage>(
+export function createLPList<T extends StacksWire>(
   values: T[],
   lengthPrefixBytes?: number
 ): LengthPrefixedList {
   return {
-    type: StacksMessageType.LengthPrefixedList,
+    type: StacksWireType.LengthPrefixedList,
     lengthPrefixBytes: lengthPrefixBytes || 4,
     values,
   };
@@ -403,7 +403,7 @@ export function serializeLPListBytes(lpList: LengthPrefixedList): Uint8Array {
   const bytesArray = [];
   bytesArray.push(hexToBytes(intToHex(list.length, lpList.lengthPrefixBytes)));
   for (const l of list) {
-    bytesArray.push(serializeStacksMessageBytes(l));
+    bytesArray.push(serializeStacksWireBytes(l));
   }
   return concatArray(bytesArray);
 }
@@ -411,7 +411,7 @@ export function serializeLPListBytes(lpList: LengthPrefixedList): Uint8Array {
 // todo: `next` refactor for inversion of control
 export function deserializeLPList(
   serialized: string,
-  type: StacksMessageType,
+  type: StacksWireType,
   lengthPrefixBytes?: number
 ): LengthPrefixedList {
   return deserializeLPListBytes(hexToBytes(serialized), type, lengthPrefixBytes);
@@ -419,7 +419,7 @@ export function deserializeLPList(
 /** @ignore */
 export function deserializeLPListBytes(
   serialized: Uint8Array | BytesReader,
-  type: StacksMessageType,
+  type: StacksWireType,
   lengthPrefixBytes?: number
 ): LengthPrefixedList {
   const bytesReader = isInstance(serialized, BytesReader)
@@ -427,28 +427,28 @@ export function deserializeLPListBytes(
     : new BytesReader(serialized);
   const length = hexToInt(bytesToHex(bytesReader.readBytes(lengthPrefixBytes || 4)));
 
-  const l: StacksMessage[] = [];
+  const l: StacksWire[] = [];
   for (let index = 0; index < length; index++) {
     switch (type) {
-      case StacksMessageType.Address:
+      case StacksWireType.Address:
         l.push(deserializeAddressBytes(bytesReader));
         break;
-      case StacksMessageType.LengthPrefixedString:
+      case StacksWireType.LengthPrefixedString:
         l.push(deserializeLPStringBytes(bytesReader));
         break;
-      case StacksMessageType.MemoString:
+      case StacksWireType.MemoString:
         l.push(deserializeMemoStringBytes(bytesReader));
         break;
-      case StacksMessageType.Asset:
+      case StacksWireType.Asset:
         l.push(deserializeAssetBytes(bytesReader));
         break;
-      case StacksMessageType.PostCondition:
+      case StacksWireType.PostCondition:
         l.push(deserializePostConditionBytes(bytesReader));
         break;
-      case StacksMessageType.PublicKey:
+      case StacksWireType.PublicKey:
         l.push(deserializePublicKeyBytes(bytesReader));
         break;
-      case StacksMessageType.TransactionAuthField:
+      case StacksWireType.TransactionAuthField:
         l.push(deserializeTransactionAuthFieldBytes(bytesReader));
         break;
     }
@@ -515,7 +515,7 @@ export function deserializePostConditionBytes(serialized: Uint8Array | BytesRead
       });
       amount = BigInt(`0x${bytesToHex(bytesReader.readBytes(8))}`);
       return {
-        type: StacksMessageType.PostCondition,
+        type: StacksWireType.PostCondition,
         conditionType: PostConditionType.STX,
         principal,
         conditionCode,
@@ -528,7 +528,7 @@ export function deserializePostConditionBytes(serialized: Uint8Array | BytesRead
       });
       amount = BigInt(`0x${bytesToHex(bytesReader.readBytes(8))}`);
       return {
-        type: StacksMessageType.PostCondition,
+        type: StacksWireType.PostCondition,
         conditionType: PostConditionType.Fungible,
         principal,
         conditionCode,
@@ -542,7 +542,7 @@ export function deserializePostConditionBytes(serialized: Uint8Array | BytesRead
         throw new DeserializationError(`Could not read ${n} as FungibleConditionCode`);
       });
       return {
-        type: StacksMessageType.PostCondition,
+        type: StacksWireType.PostCondition,
         conditionType: PostConditionType.NonFungible,
         principal,
         conditionCode,

--- a/packages/transactions/tests/builder.test.ts
+++ b/packages/transactions/tests/builder.test.ts
@@ -89,7 +89,7 @@ import {
   PayloadType,
   PostConditionMode,
   PubKeyEncoding,
-  StacksMessageType,
+  StacksWireType,
   TxRejectedReason,
 } from '../src/constants';
 import { makeRandomPrivKey } from '../src/keys';
@@ -2386,7 +2386,7 @@ describe('multi-sig', () => {
       expect(parsed.auth.spendingCondition.signaturesRequired).toBe(required);
 
       const signatures = parsed.auth.spendingCondition.fields
-        .filter(f => f.contents.type === StacksMessageType.MessageSignature)
+        .filter(f => f.contents.type === StacksWireType.MessageSignature)
         .map(s => s.contents.data);
       expect(signatures.length).toBe(signing.length);
 
@@ -2400,7 +2400,7 @@ describe('multi-sig', () => {
       expect(Array.from(signingSigs)).toEqual(expect.arrayContaining(signatures));
 
       const appendedKeys = parsed.auth.spendingCondition.fields.filter(
-        f => f.contents.type === StacksMessageType.PublicKey
+        f => f.contents.type === StacksWireType.PublicKey
       );
       expect(appendedKeys.length).toBe(signers.length - signing.length);
 
@@ -2451,7 +2451,7 @@ describe('multi-sig', () => {
         const signerPublicKey = privateKeyToPublic(signerKey);
         const fieldIdx = tx.auth.spendingCondition.fields.findIndex(field => {
           return (
-            field.contents.type === StacksMessageType.PublicKey &&
+            field.contents.type === StacksWireType.PublicKey &&
             bytesToHex(field.contents.data) === signerPublicKey
           );
         });

--- a/packages/transactions/tests/keys.test.ts
+++ b/packages/transactions/tests/keys.test.ts
@@ -17,7 +17,7 @@ import { AddressVersion, TransactionVersion } from '@stacks/network';
 import { ec as EC } from 'elliptic';
 import {
   PubKeyEncoding,
-  StacksMessageType,
+  StacksWireType,
   compressPublicKey,
   createStacksPublicKey,
   encodeStructuredData,
@@ -61,7 +61,7 @@ test('Stacks public key and private keys', () => {
   const pubKey = createStacksPublicKey(privateKeyToPublic(privKey));
   expect(publicKeyToHex(pubKey.data)).toBe(pubKeyString);
 
-  const deserialized = serializeDeserialize(pubKey, StacksMessageType.PublicKey);
+  const deserialized = serializeDeserialize(pubKey, StacksWireType.PublicKey);
   expect(bytesToHex(deserialized.data)).toBe(pubKeyString);
 
   expect(privateKeyToPublic(privKey)).toBe(pubKeyString);

--- a/packages/transactions/tests/macros.ts
+++ b/packages/transactions/tests/macros.ts
@@ -1,12 +1,12 @@
-import { StacksMessage, serializeStacksMessageBytes, deserializeStacksMessage } from '../src/types';
+import { StacksWire, serializeStacksWireBytes, deserializeStacksWireBytes } from '../src/types';
 import { BytesReader } from '../src/bytesReader';
-import { StacksMessageType } from '../src/constants';
+import { StacksWireType } from '../src/constants';
 
-export function serializeDeserialize<V extends StacksMessage, T extends StacksMessageType>(
+export function serializeDeserialize<V extends StacksWire, T extends StacksWireType>(
   value: V,
   type: T
 ): V {
-  const serialized = serializeStacksMessageBytes(value);
+  const serialized = serializeStacksWireBytes(value);
   const byteReader = new BytesReader(serialized);
-  return deserializeStacksMessage(byteReader, type) as V;
+  return deserializeStacksWireBytes(byteReader, type) as V;
 }

--- a/packages/transactions/tests/payload.test.ts
+++ b/packages/transactions/tests/payload.test.ts
@@ -7,7 +7,7 @@ import {
   standardPrincipalCV,
   trueCV,
 } from '../src/clarity';
-import { ClarityVersion, StacksMessageType } from '../src/constants';
+import { ClarityVersion, StacksWireType } from '../src/constants';
 import {
   CoinbasePayload,
   CoinbasePayloadToAltRecipient,
@@ -35,7 +35,7 @@ test('STX token transfer payload serialization and deserialization', () => {
 
   const deserialized = serializeDeserialize(
     payload,
-    StacksMessageType.Payload
+    StacksWireType.Payload
   ) as TokenTransferPayload;
   expect(deserialized.payloadType).toBe(payload.payloadType);
   expect(deserialized.recipient).toEqual(recipient);
@@ -53,7 +53,7 @@ test('STX token transfer payload (to contract addr)  serialization and deseriali
 
   const deserialized = serializeDeserialize(
     payload,
-    StacksMessageType.Payload
+    StacksWireType.Payload
   ) as TokenTransferPayload;
   expect(deserialized.payloadType).toBe(payload.payloadType);
   expect(deserialized.recipient).toEqual(recipient);
@@ -68,7 +68,7 @@ test('STX token transfer payload (with contract principal string) serialization 
 
   const deserialized = serializeDeserialize(
     payload,
-    StacksMessageType.Payload
+    StacksWireType.Payload
   ) as TokenTransferPayload;
   expect(deserialized.payloadType).toBe(payload.payloadType);
   expect(principalToString(deserialized.recipient)).toEqual(recipient);
@@ -83,7 +83,7 @@ test('STX token transfer payload (with address principal string) serialization a
 
   const deserialized = serializeDeserialize(
     payload,
-    StacksMessageType.Payload
+    StacksWireType.Payload
   ) as TokenTransferPayload;
   expect(deserialized.payloadType).toBe(payload.payloadType);
   expect(principalToString(deserialized.recipient)).toEqual(recipient);
@@ -98,10 +98,7 @@ test('Contract call payload serialization and deserialization', () => {
 
   const payload = createContractCallPayload(contractAddress, contractName, functionName, args);
 
-  const deserialized = serializeDeserialize(
-    payload,
-    StacksMessageType.Payload
-  ) as ContractCallPayload;
+  const deserialized = serializeDeserialize(payload, StacksWireType.Payload) as ContractCallPayload;
   expect(deserialized).toEqual(payload);
 });
 
@@ -122,7 +119,7 @@ test('Smart contract payload serialization and deserialization', () => {
 
   const deserialized = serializeDeserialize(
     payload,
-    StacksMessageType.Payload
+    StacksWireType.Payload
   ) as SmartContractPayload;
   expect(deserialized.contractName.content).toBe(contractName);
   expect(deserialized.codeBody.content).toBe(codeBody);
@@ -145,7 +142,7 @@ test('Versioned smart contract payload serialization and deserialization', () =>
 
   const deserialized = serializeDeserialize(
     payload,
-    StacksMessageType.Payload
+    StacksWireType.Payload
   ) as VersionedSmartContractPayload;
   expect(deserialized.clarityVersion).toBe(2);
   expect(deserialized.contractName.content).toBe(contractName);
@@ -157,7 +154,7 @@ test('Coinbase payload serialization and deserialization', () => {
 
   const payload = createCoinbasePayload(coinbaseBuffer);
 
-  const deserialized = serializeDeserialize(payload, StacksMessageType.Payload) as CoinbasePayload;
+  const deserialized = serializeDeserialize(payload, StacksWireType.Payload) as CoinbasePayload;
   expect(deserialized.coinbaseBytes).toEqual(coinbaseBuffer);
 });
 
@@ -169,7 +166,7 @@ test('Coinbase to standard principal recipient payload serialization and deseria
 
   const deserialized = serializeDeserialize(
     payload,
-    StacksMessageType.Payload
+    StacksWireType.Payload
   ) as CoinbasePayloadToAltRecipient;
   expect(deserialized.coinbaseBytes).toEqual(coinbaseBuffer);
   expect(deserialized.recipient).toEqual(standardRecipient);
@@ -186,7 +183,7 @@ test('Coinbase to contract principal recipient payload serialization and deseria
 
   const deserialized = serializeDeserialize(
     payload,
-    StacksMessageType.Payload
+    StacksWireType.Payload
   ) as CoinbasePayloadToAltRecipient;
   expect(deserialized.coinbaseBytes).toEqual(coinbaseBuffer);
   expect(deserialized.recipient).toEqual(contractRecipient);
@@ -211,10 +208,7 @@ test('serialize/deserialize tenure change payload', () => {
     publicKeyHash
   );
 
-  const deserialized = serializeDeserialize(
-    payload,
-    StacksMessageType.Payload
-  ) as TenureChangePayload;
+  const deserialized = serializeDeserialize(payload, StacksWireType.Payload) as TenureChangePayload;
   expect(deserialized).toEqual(payload);
 });
 

--- a/packages/transactions/tests/postcondition.test.ts
+++ b/packages/transactions/tests/postcondition.test.ts
@@ -19,7 +19,7 @@ import {
   PostConditionType,
   FungibleConditionCode,
   NonFungibleConditionCode,
-  StacksMessageType,
+  StacksWireType,
   PostConditionPrincipalId,
 } from '../src/constants';
 
@@ -41,7 +41,7 @@ test('STX post condition serialization and deserialization', () => {
 
   const deserialized = serializeDeserialize(
     postCondition,
-    StacksMessageType.PostCondition
+    StacksWireType.PostCondition
   ) as STXPostCondition;
   expect(deserialized.conditionType).toBe(postConditionType);
   expect(deserialized.principal.prefix).toBe(PostConditionPrincipalId.Standard);
@@ -68,7 +68,7 @@ test('Fungible post condition serialization and deserialization', () => {
 
   const deserialized = serializeDeserialize(
     postCondition,
-    StacksMessageType.PostCondition
+    StacksWireType.PostCondition
   ) as FungiblePostCondition;
   expect(deserialized.conditionType).toBe(postConditionType);
   expect(deserialized.principal.prefix).toBe(PostConditionPrincipalId.Standard);
@@ -105,7 +105,7 @@ test('Non-fungible post condition serialization and deserialization', () => {
 
   const deserialized = serializeDeserialize(
     postCondition,
-    StacksMessageType.PostCondition
+    StacksWireType.PostCondition
   ) as NonFungiblePostCondition;
   expect(deserialized.conditionType).toBe(postConditionType);
   expect(deserialized.principal.prefix).toBe(PostConditionPrincipalId.Contract);
@@ -141,7 +141,7 @@ test('Non-fungible post condition with string IDs serialization and deserializat
 
   const deserialized = serializeDeserialize(
     postCondition,
-    StacksMessageType.PostCondition
+    StacksWireType.PostCondition
   ) as NonFungiblePostCondition;
   expect(deserialized.conditionType).toBe(postConditionType);
   expect(deserialized.principal.prefix).toBe(PostConditionPrincipalId.Contract);

--- a/packages/transactions/tests/types.test.ts
+++ b/packages/transactions/tests/types.test.ts
@@ -1,6 +1,6 @@
 import {
   createLPList,
-  serializeStacksMessageBytes,
+  serializeStacksWireBytes,
   deserializeLPListBytes,
   addressFromHashMode,
   LengthPrefixedList,
@@ -14,7 +14,7 @@ import {
   createAsset,
 } from '../src/postcondition-types';
 import { Address, addressToString } from '../src/common';
-import { AddressHashMode, StacksMessageType } from '../src/constants';
+import { AddressHashMode, StacksWireType } from '../src/constants';
 
 import { serializeDeserialize } from './macros';
 import { BytesReader } from '../src/bytesReader';
@@ -26,7 +26,7 @@ test('Length prefixed strings serialization and deserialization', () => {
   const lpString = createLPString(testString);
   const deserialized = serializeDeserialize(
     lpString,
-    StacksMessageType.LengthPrefixedString
+    StacksWireType.LengthPrefixedString
   ) as LengthPrefixedString;
   expect(deserialized.content).toBe(testString);
 
@@ -48,10 +48,10 @@ test('Length prefixed list serialization and deserialization', () => {
     l.push(addressList[index]);
   }
   const lpList: LengthPrefixedList = createLPList(l);
-  const serialized = serializeStacksMessageBytes(lpList);
+  const serialized = serializeStacksWireBytes(lpList);
 
   const bytesReader = new BytesReader(serialized);
-  const deserialized = deserializeLPListBytes(bytesReader, StacksMessageType.Address);
+  const deserialized = deserializeLPListBytes(bytesReader, StacksWireType.Address);
 
   expect(deserialized.values.length).toBe(addressList.length);
 
@@ -135,7 +135,7 @@ test('C32 address hash mode - testnet P2WSH', () => {
 test('C32check addresses serialization and deserialization', () => {
   const c32AddressString = 'SP9YX31TK12T0EZKWP3GZXX8AM37JDQHAWM7VBTH';
   const addr = createAddress(c32AddressString);
-  const deserialized = serializeDeserialize(addr, StacksMessageType.Address) as Address;
+  const deserialized = serializeDeserialize(addr, StacksWireType.Address) as Address;
   expect(addressToString(deserialized)).toBe(c32AddressString);
 });
 
@@ -144,7 +144,7 @@ test('Asset info serialization and deserialization', () => {
   const assetContractName = 'contract_name';
   const assetName = 'asset_name';
   const info = createAsset(assetAddress, assetContractName, assetName);
-  const deserialized = serializeDeserialize(info, StacksMessageType.Asset) as Asset;
+  const deserialized = serializeDeserialize(info, StacksWireType.Asset) as Asset;
   expect(addressToString(deserialized.address)).toBe(assetAddress);
   expect(deserialized.contractName.content).toBe(assetContractName);
   expect(deserialized.assetName.content).toBe(assetName);


### PR DESCRIPTION
> This PR was published to npm with the version `6.14.1-pr.41+fcb23c4b`
> e.g. `npm install @stacks/common@6.14.1-pr.41+fcb23c4b --save-exact`<!-- Sticky Header Marker -->

- refactoring to avoid confusion between "message" and wire-formats for serialization