### PR TITLE
feat: Add serialization helpers for transaction

### DIFF
--- a/packages/transactions/src/transaction.ts
+++ b/packages/transactions/src/transaction.ts
@@ -293,3 +293,36 @@ export function deserializeTransaction(tx: string | Uint8Array | BytesReader) {
     chainId
   );
 }
+
+/**
+ * Alias for `transaction.serialize()`
+ *
+ * Serializes a transaction to bytes.
+ *
+ * @example
+ * ```ts
+ * import { makeSTXTokenTransfer, serializeTransaction } from '@stacks/transactions';
+ *
+ * const transaction = makeSTXTokenTransfer({ ... });
+ * const bytes = serializeTransaction(transaction);
+ * ```
+ */
+export function serializeTransaction(transaction: StacksTransaction): Uint8Array {
+  // todo: refactor to hex instead of bytes for `next` release
+  return transaction.serialize();
+}
+
+/**
+ * Serializes a transaction to a hex string.
+ *
+ * @example
+ * ```ts
+ * import { makeSTXTokenTransfer, transactionToHex } from '@stacks/transactions';
+ *
+ * const transaction = makeSTXTokenTransfer({ ... });
+ * const hex = transactionToHex(transaction);
+ * ```
+ */
+export function transactionToHex(transaction: StacksTransaction): string {
+  return bytesToHex(transaction.serialize());
+}

--- a/packages/transactions/tests/transaction.test.ts
+++ b/packages/transactions/tests/transaction.test.ts
@@ -1,4 +1,9 @@
-import { deserializeTransaction, StacksTransaction } from '../src/transaction';
+import {
+  deserializeTransaction,
+  serializeTransaction,
+  StacksTransaction,
+  transactionToHex,
+} from '../src/transaction';
 
 import {
   createMultiSigSpendingCondition,
@@ -434,4 +439,18 @@ test('Coinbase pay to alt contract principal recipient deserialization', () => {
     'bd1a9e1d60ca29fc630633170f396f5b6b85c9620bd16d63384ebc5a01a1829b'
   );
   expect(deserializedTx.version).toBe(TransactionVersion.Testnet);
+});
+
+describe(serializeTransaction.name, () => {
+  const serializedTx =
+    '0x8080000000040055a0a92720d20398211cd4c7663d65d018efcc1f00000000000000030000000000000000010118da31f542913e8c56961b87ee4794924e655a28a2034e37ef4823eeddf074747285bd6efdfbd84eecdf62cffa7c1864e683c688f4c105f4db7429066735b4e2010200000000050000000000000000000000000000000000000000000000000000000000000000061aba27f99e007c7f605a8305e318c1abde3cd220ac0b68656c6c6f5f776f726c64';
+  const tx = deserializeTransaction(serializedTx);
+
+  test('alias of .serialize', () => {
+    expect(tx.serialize()).toEqual(serializeTransaction(tx));
+  });
+
+  test(transactionToHex.name, () => {
+    expect(transactionToHex(tx)).toEqual(bytesToHex(serializeTransaction(tx)));
+  });
 });


### PR DESCRIPTION
> This PR was published to npm with the version `6.15.0`
> e.g. `npm install @stacks/common@6.15.0 --save-exact`<!-- Sticky Header Marker -->

- implements a part of  #1633
- adds aliases and helpers for more consistent tx serialization