### PR TITLE
refactor!: Make StacksTransaction.serialize() return a hex-string instead of bytes

### DIFF
--- a/.github/MIGRATION.md
+++ b/.github/MIGRATION.md
@@ -32,7 +32,7 @@
 
 - The `@stacks/network` `new StacksNetwork()` objects were removed. Instead `@stacks/network` now exports the objects `STACKS_MAINNET`, `STACKS_TESNET`, and `STACKS_DEVNET`, which are static (and shouldn't be changed for most use-cases). [Read more...](#stacks-network)
 - The `ClarityType` enum was replaced by a readable version. The previous (wire format compatible) enum is still available as `ClarityWireType`. [Read more...](#clarity-representation)
-- The `serializeXyz` methods were changed to return `string` (hex-encoded) instead of `Uint8Array`. Compatible `serializeXzyBytes` methods were added to ease the migration. [Read more...](#serialize-methods)
+- `StacksTransaction.serialize` and other `serializeXyz` methods were changed to return `string` (hex-encoded) instead of `Uint8Array`. Compatible `serializeXzyBytes` methods were added to ease the migration. [Read more...](#serialize-methods)
 - The `AssetInfo` type was renamed to `Asset` for accuracy. The `Asset` helper methods were also renamed to to remove the `Info` suffix. [Read more...](#asset-helper-methods)
 - Remove legacy CLI methods. [Read more...](#cli)
 - Disable legacy `triplesec` mnemonic encryption support. [Read more...](#triplesec)
@@ -162,9 +162,13 @@ For `bigint` values, the type of the `value` property is a now `string`, for bet
 
 ### `serialize` methods
 
-Existing methods now use hex-encoded strings instead of `Uint8Array`s.
+Existing methods now take or return **hex-encoded strings** _instead_ of `Uint8Array`s.
+
+> If you were already converting returned bytes to hex-strings in your code, you can now skip the conversion step — hex-strings are the new default.
+
 For easier migrating, renaming the following methods is possible to keep the previous behavior:
 
+- `StacksTransaction.serialize` → `StacksTransaction.serializeBytes`
 - `serializeCV` → `serializeCVBytes`
 - `serializeAddress` → `serializeAddressBytes`
 - `deserializeAddress` → `deserializeAddressBytes`

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -723,7 +723,7 @@ async function sendTokens(network: CLINetworkAdapter, args: string[]): Promise<s
   }
 
   if (txOnly) {
-    return Promise.resolve(bytesToHex(tx.serialize()));
+    return Promise.resolve(tx.serialize());
   }
 
   return broadcastTransaction({ transaction: tx, api })
@@ -782,7 +782,7 @@ async function contractDeploy(network: CLINetworkAdapter, args: string[]): Promi
   }
 
   if (txOnly) {
-    return Promise.resolve(bytesToHex(tx.serialize()));
+    return Promise.resolve(tx.serialize());
   }
 
   return broadcastTransaction({ transaction: tx })
@@ -868,7 +868,7 @@ async function contractFunctionCall(network: CLINetworkAdapter, args: string[]):
       }
 
       if (txOnly) {
-        return Promise.resolve(bytesToHex(tx.serialize()));
+        return Promise.resolve(tx.serialize());
       }
 
       return broadcastTransaction({ transaction: tx, api })

--- a/packages/transactions/src/fetch.ts
+++ b/packages/transactions/src/fetch.ts
@@ -50,7 +50,7 @@ export async function broadcastTransaction({
   /** Optional attachment in bytes or encoded as a hex string */
   attachment?: Uint8Array | string;
 } & ApiParam): Promise<TxBroadcastResult> {
-  const tx = bytesToHex(txOpt.serialize());
+  const tx = txOpt.serialize();
   const attachment = attachOpt
     ? typeof attachOpt === 'string'
       ? attachOpt
@@ -165,7 +165,7 @@ export async function estimateTransfer({
   }
 
   const feeRateResult = await response.text();
-  const txBytes = BigInt(Math.ceil(txOpt.serialize().byteLength));
+  const txBytes = BigInt(Math.ceil(txOpt.serializeBytes().byteLength));
   const feeRate = BigInt(feeRateResult);
   return feeRate * txBytes;
 }

--- a/packages/transactions/src/transaction.ts
+++ b/packages/transactions/src/transaction.ts
@@ -1,4 +1,5 @@
 import {
+  Hex,
   IntegerType,
   PrivateKey,
   bytesToHex,
@@ -178,7 +179,7 @@ export class StacksTransaction {
   }
 
   txid(): string {
-    const serialized = this.serialize();
+    const serialized = this.serializeBytes();
     return txidFromData(serialized);
   }
 
@@ -221,7 +222,35 @@ export class StacksTransaction {
     this.auth = setSponsorNonce(this.auth, nonce);
   }
 
-  serialize(): Uint8Array {
+  /**
+   * Serialize a transaction to a hex string (byte representation)
+   *
+   * @returns A hex string of the serialized transaction
+   * @example
+   * ```ts
+   * import { makeSTXTokenTransfer } from '@stacks/transactions';
+   *
+   * const transaction = makeSTXTokenTransfer({ ... });
+   * const hex = transaction.serialize();
+   * ```
+   */
+  serialize(): Hex {
+    return bytesToHex(this.serializeBytes());
+  }
+
+  /**
+   * Serialize a transaction to bytes
+   *
+   * @returns A Uint8Array of the serialized transaction
+   * @example
+   * ```ts
+   * import { makeSTXTokenTransfer } from '@stacks/transactions';
+   *
+   * const transaction = makeSTXTokenTransfer({ ... });
+   * const bytes = transaction.serializeBytes();
+   * ```
+   */
+  serializeBytes(): Uint8Array {
     if (this.version === undefined) {
       throw new SerializationError('"version" is undefined');
     }
@@ -333,33 +362,51 @@ export function estimateTransactionByteLength(transaction: StacksTransaction): n
       (multiSigSpendingCondition.signaturesRequired - existingSignatures) *
       (RECOVERABLE_ECDSA_SIG_LENGTH_BYTES + 1);
 
-    return transaction.serialize().byteLength + totalSignatureLength;
+    return transaction.serializeBytes().byteLength + totalSignatureLength;
   } else {
     // Single-sig transaction
     // Signature space already allocated by empty message signature
-    return transaction.serialize().byteLength;
+    return transaction.serializeBytes().byteLength;
   }
 }
 
 /**
  * Alias for `transaction.serialize()`
  *
- * Serializes a transaction to bytes.
+ * Serializes a transaction to a hex string.
  *
  * @example
  * ```ts
  * import { makeSTXTokenTransfer, serializeTransaction } from '@stacks/transactions';
  *
  * const transaction = makeSTXTokenTransfer({ ... });
- * const bytes = serializeTransaction(transaction);
+ * const hex = serializeTransaction(transaction);
  * ```
  */
-export function serializeTransaction(transaction: StacksTransaction): Uint8Array {
-  // todo: refactor to hex instead of bytes for `next` release
+export function serializeTransaction(transaction: StacksTransaction): Hex {
   return transaction.serialize();
 }
 
 /**
+ * Alias for `transaction.serializeBytes()`
+ *
+ * Serializes a transaction to bytes.
+ *
+ * @example
+ * ```ts
+ * import { makeSTXTokenTransfer, serializeTransactionBytes } from '@stacks/transactions';
+ *
+ * const transaction = makeSTXTokenTransfer({ ... });
+ * const bytes = serializeTransactionBytes(transaction);
+ * ```
+ */
+export function serializeTransactionBytes(transaction: StacksTransaction): Uint8Array {
+  return transaction.serializeBytes();
+}
+
+/**
+ * Alias for `transaction.serialize()`
+ *
  * Serializes a transaction to a hex string.
  *
  * @example
@@ -371,5 +418,5 @@ export function serializeTransaction(transaction: StacksTransaction): Uint8Array
  * ```
  */
 export function transactionToHex(transaction: StacksTransaction): string {
-  return bytesToHex(transaction.serialize());
+  return transaction.serialize();
 }

--- a/packages/transactions/tests/builder.test.ts
+++ b/packages/transactions/tests/builder.test.ts
@@ -170,7 +170,7 @@ test('Make STX token transfer with set tx fee', async () => {
   });
   expect(() => transaction.verifyOrigin()).not.toThrow();
 
-  const serialized = bytesToHex(transaction.serialize());
+  const serialized = transaction.serialize();
 
   const tx =
     '0000000001040015c31b8c1c11c515e244b75806bac48d1399c77500000000000000000000000000000000' +
@@ -229,7 +229,7 @@ test('Make STX token transfer with fee estimate', async () => {
   expect(() => transaction.verifyOrigin()).not.toThrow();
   expect(transaction.auth.spendingCondition?.fee?.toString()).toEqual('180');
 
-  const serialized = bytesToHex(transaction.serialize());
+  const serialized = transaction.serialize();
   const tx =
     '0000000001040015c31b8c1c11c515e244b75806bac48d1399c775000000000000000000000000000000b4' +
     '0001e5ac1152f6018fbfded102268b22086666150823d0ae57f4023bde058a7ff0b279076db25b358b8833' +
@@ -261,7 +261,7 @@ test('Make STX token transfer with testnet', async () => {
   });
   expect(() => transaction.verifyOrigin()).not.toThrow();
 
-  const serialized = bytesToHex(transaction.serialize());
+  const serialized = transaction.serialize();
   const tx =
     '8080000000040015c31b8c1c11c515e244b75806bac48d1399c77500000000000000000000000000000000' +
     '00014199f63f7e010141a36a4624d032758f54e08ff03b24ed2667463eb405b4d81505631b32a1f13b5737' +
@@ -284,7 +284,7 @@ test('Make STX token transfer with testnet string name', async () => {
   });
   expect(() => transaction.verifyOrigin()).not.toThrow();
 
-  const serialized = bytesToHex(transaction.serialize());
+  const serialized = transaction.serialize();
   const tx =
     '8080000000040015c31b8c1c11c515e244b75806bac48d1399c77500000000000000000000000000000000' +
     '00014199f63f7e010141a36a4624d032758f54e08ff03b24ed2667463eb405b4d81505631b32a1f13b5737' +
@@ -333,7 +333,7 @@ test("STX token transfers don't take post conditions", async () => {
     postConditions,
   } as SignedTokenTransferOptions);
 
-  const serialized = transaction.serialize();
+  const serialized = transaction.serializeBytes();
 
   const bytesReader = new BytesReader(serialized);
   const deserializedTx = deserializeTransaction(bytesReader);
@@ -388,9 +388,9 @@ test('Make Multi-Sig STX token transfer', async () => {
     '030200000000000516df0ba3e79792be7be5e50a370289accfc8c9e03200000000002625a074657374206d' +
     '656d6f00000000000000000000000000000000000000000000000000';
 
-  expect(bytesToHex(serializedTx)).toBe(tx);
+  expect(serializedTx).toBe(tx);
 
-  const bytesReader = new BytesReader(serializedTx);
+  const bytesReader = new BytesReader(hexToBytes(serializedTx));
   const deserializedTx = deserializeTransaction(bytesReader);
 
   expect(deserializedTx.auth.authType).toBe(authType);
@@ -415,7 +415,7 @@ test('Make Multi-Sig STX token transfer', async () => {
     '0000000000516df0ba3e79792be7be5e50a370289accfc8c9e03200000000002625a074657374206d656d6f' +
     '00000000000000000000000000000000000000000000000000';
 
-  expect(bytesToHex(serializedSignedTx)).toBe(signedTx);
+  expect(serializedSignedTx).toBe(signedTx);
 });
 
 test('Should deserialize partially signed multi-Sig STX token transfer', async () => {
@@ -454,9 +454,9 @@ test('Should deserialize partially signed multi-Sig STX token transfer', async (
     '000000000002030200000000000516df0ba3e79792be7be5e50a370289accfc8c9e03200000000002625a0' +
     '74657374206d656d6f00000000000000000000000000000000000000000000000000';
 
-  expect(bytesToHex(serializedTx)).toBe(tx);
+  expect(serializedTx).toBe(tx);
 
-  const bytesReader = new BytesReader(serializedTx);
+  const bytesReader = new BytesReader(hexToBytes(serializedTx));
 
   // Partially signed or unsigned multi-sig tx can be serialized and deserialized without exception (Incorrect number of signatures)
   // Should be able to deserializeTransaction with missing signatures.
@@ -468,7 +468,7 @@ test('Should deserialize partially signed multi-Sig STX token transfer', async (
   signer.signOrigin(privKeys[1]);
   signer.appendOrigin(pubKeys[2]);
 
-  const fullySignedTransaction = transaction.serialize();
+  const fullySignedTransaction = transaction.serializeBytes();
   const bytesReaderSignedTx = new BytesReader(fullySignedTransaction);
 
   // Should deserialize fully signed multi sig transaction
@@ -573,7 +573,7 @@ test('Make Multi-Sig STX token transfer with two transaction signers', async () 
     '000000000002030200000000000516df0ba3e79792be7be5e50a370289accfc8c9e03200000000002625a0' +
     '74657374206d656d6f00000000000000000000000000000000000000000000000000';
 
-  expect(bytesToHex(serializedTxUnsigned)).toBe(tx);
+  expect(serializedTxUnsigned).toBe(tx);
 
   // obtain first auth field and sign once
   const signer = new TransactionSigner(transaction);
@@ -588,7 +588,7 @@ test('Make Multi-Sig STX token transfer with two transaction signers', async () 
   signer.signOrigin(privKeys[0]);
 
   // serialize
-  const partiallySignedSerialized = transaction.serialize();
+  const partiallySignedSerialized = transaction.serializeBytes();
 
   // deserialize
   const bytesReader2 = new BytesReader(partiallySignedSerialized);
@@ -616,7 +616,7 @@ test('Make Multi-Sig STX token transfer with two transaction signers', async () 
   signer2.signOrigin(privKeys[1]);
   signer2.appendOrigin(pubKeys[2]);
 
-  const serializedTx = transaction.serialize();
+  const serializedTx = transaction.serializeBytes();
 
   const bytesReader = new BytesReader(serializedTx);
   const deserializedTx = deserializeTransaction(bytesReader);
@@ -649,7 +649,7 @@ test('Make Multi-Sig STX token transfer with two transaction signers', async () 
     '0000000000516df0ba3e79792be7be5e50a370289accfc8c9e03200000000002625a074657374206d656d6f' +
     '00000000000000000000000000000000000000000000000000';
 
-  expect(bytesToHex(serializedSignedTx)).toBe(signedTx);
+  expect(serializedSignedTx).toBe(signedTx);
 });
 
 test('addSignature to an unsigned transaction', async () => {
@@ -700,7 +700,7 @@ test('Make versioned smart contract deploy', async () => {
   });
   expect(() => transaction.verifyOrigin()).not.toThrow();
 
-  const serialized = bytesToHex(transaction.serialize());
+  const serialized = transaction.serialize();
 
   const tx =
     '80800000000400e6c05355e0c990ffad19a5e9bda394a9c50034290000000000000000000000000000000000009172c9841e763c32e827c177491f5228956e6ef1071043be898bfdd694bf3e680309b0666e8fec013a8a453573a8bd707152c9f21aa6f2d5e57c407af672b6f00302000000000602086b762d73746f72650000015628646566696e652d6d61702073746f72652028286b657920286275666620333229292920282876616c7565202862756666203332292929290a0a28646566696e652d7075626c696320286765742d76616c756520286b65792028627566662033322929290a20202020286d6174636820286d61702d6765743f2073746f72652028286b6579206b65792929290a2020202020202020656e74727920286f6b20286765742076616c756520656e74727929290a20202020202020202865727220302929290a0a28646566696e652d7075626c696320287365742d76616c756520286b65792028627566662033322929202876616c75652028627566662033322929290a2020202028626567696e0a2020202020202020286d61702d7365742073746f72652028286b6579206b6579292920282876616c75652076616c75652929290a2020202020202020286f6b2027747275652929290a';
@@ -725,7 +725,7 @@ test('Make smart contract deploy (defaults to versioned smart contract, as of 2.
   });
   expect(() => transaction.verifyOrigin()).not.toThrow();
 
-  const serialized = bytesToHex(transaction.serialize());
+  const serialized = transaction.serialize();
 
   const tx =
     '80800000000400e6c05355e0c990ffad19a5e9bda394a9c50034290000000000000000000000000000000000009172c9841e763c32e827c177491f5228956e6ef1071043be898bfdd694bf3e680309b0666e8fec013a8a453573a8bd707152c9f21aa6f2d5e57c407af672b6f00302000000000602086b762d73746f72650000015628646566696e652d6d61702073746f72652028286b657920286275666620333229292920282876616c7565202862756666203332292929290a0a28646566696e652d7075626c696320286765742d76616c756520286b65792028627566662033322929290a20202020286d6174636820286d61702d6765743f2073746f72652028286b6579206b65792929290a2020202020202020656e74727920286f6b20286765742076616c756520656e74727929290a20202020202020202865727220302929290a0a28646566696e652d7075626c696320287365742d76616c756520286b65792028627566662033322929202876616c75652028627566662033322929290a2020202028626567696e0a2020202020202020286d61702d7365742073746f72652028286b6579206b6579292920282876616c75652076616c75652929290a2020202020202020286f6b2027747275652929290a';
@@ -744,7 +744,7 @@ test('Make smart contract deploy with network string name (defaults to versioned
   });
   expect(() => transaction.verifyOrigin()).not.toThrow();
 
-  const serialized = bytesToHex(transaction.serialize());
+  const serialized = transaction.serialize();
 
   const tx =
     '80800000000400e6c05355e0c990ffad19a5e9bda394a9c50034290000000000000000000000000000000000009172c9841e763c32e827c177491f5228956e6ef1071043be898bfdd694bf3e680309b0666e8fec013a8a453573a8bd707152c9f21aa6f2d5e57c407af672b6f00302000000000602086b762d73746f72650000015628646566696e652d6d61702073746f72652028286b657920286275666620333229292920282876616c7565202862756666203332292929290a0a28646566696e652d7075626c696320286765742d76616c756520286b65792028627566662033322929290a20202020286d6174636820286d61702d6765743f2073746f72652028286b6579206b65792929290a2020202020202020656e74727920286f6b20286765742076616c756520656e74727929290a20202020202020202865727220302929290a0a28646566696e652d7075626c696320287365742d76616c756520286b65792028627566662033322929202876616c75652028627566662033322929290a2020202028626567696e0a2020202020202020286d61702d7365742073746f72652028286b6579206b6579292920282876616c75652076616c75652929290a2020202020202020286f6b2027747275652929290a';
@@ -770,7 +770,7 @@ test('Make smart contract deploy unsigned', async () => {
     network: STACKS_TESTNET,
   });
 
-  const serializedTx = transaction.serialize();
+  const serializedTx = transaction.serializeBytes();
 
   const bytesReader = new BytesReader(serializedTx);
   const deserializedTx = deserializeTransaction(bytesReader);
@@ -831,7 +831,7 @@ test('Make smart contract deploy signed', async () => {
   });
   expect(() => transaction.verifyOrigin()).not.toThrow();
 
-  const serializedTx = transaction.serialize();
+  const serializedTx = transaction.serializeBytes();
 
   const bytesReader = new BytesReader(serializedTx);
   const deserializedTx = deserializeTransaction(bytesReader);
@@ -863,7 +863,7 @@ test('Make contract-call', async () => {
   });
   expect(() => transaction.verifyOrigin()).not.toThrow();
 
-  const serialized = bytesToHex(transaction.serialize());
+  const serialized = transaction.serialize();
 
   const tx =
     '80800000000400e6c05355e0c990ffad19a5e9bda394a9c500342900000000000000010000000000000000' +
@@ -887,7 +887,7 @@ test('Make contract-call with network string', async () => {
   });
   expect(() => transaction.verifyOrigin()).not.toThrow();
 
-  const serialized = bytesToHex(transaction.serialize());
+  const serialized = transaction.serialize();
 
   const tx =
     '80800000000400e6c05355e0c990ffad19a5e9bda394a9c500342900000000000000010000000000000000' +
@@ -958,7 +958,7 @@ test('Make contract-call with post conditions', async () => {
   });
   expect(() => transaction.verifyOrigin()).not.toThrow();
 
-  const serialized = bytesToHex(transaction.serialize());
+  const serialized = transaction.serialize();
 
   const tx =
     '80800000000400e6c05355e0c990ffad19a5e9bda394a9c500342900000000000000010000000000000000' +
@@ -1002,7 +1002,7 @@ test('Make contract-call with post condition allow mode', async () => {
   });
   expect(() => transaction.verifyOrigin()).not.toThrow();
 
-  const serialized = bytesToHex(transaction.serialize());
+  const serialized = transaction.serialize();
 
   const tx =
     '80800000000400e6c05355e0c990ffad19a5e9bda394a9c50034290000000000000001000000000000000' +
@@ -1101,7 +1101,7 @@ test('Estimate transaction transfer fee', async () => {
     memo,
   });
 
-  const serialized = transaction.serialize();
+  const serialized = transaction.serializeBytes();
   const transactionByteLength = serialized.byteLength;
 
   const mockedResponse = JSON.stringify({
@@ -1247,7 +1247,7 @@ test('Single-sig transaction byte length must include signature', async () => {
   });
 
   // Due to empty message signature space will be allocated for signature
-  expect(unsignedTransaction.serialize().byteLength).toEqual(
+  expect(unsignedTransaction.serializeBytes().byteLength).toEqual(
     estimateTransactionByteLength(unsignedTransaction)
   );
 
@@ -1255,7 +1255,7 @@ test('Single-sig transaction byte length must include signature', async () => {
   // Now sign the transaction and verify the byteLength after adding signature
   signer.signOrigin(privateKey);
 
-  const finalSerializedTx = signer.transaction.serialize();
+  const finalSerializedTx = signer.transaction.serializeBytes();
 
   // Byte length will remains the same after signing due to pre allocated space by empty message signature
   expect(finalSerializedTx.byteLength).toEqual(estimateTransactionByteLength(signer.transaction));
@@ -1298,7 +1298,7 @@ test('Multi-sig transaction byte length must include the required signatures', a
   // Total length without signatures
   const unsignedByteLength = 120;
 
-  const serializedTx = transaction.serialize();
+  const serializedTx = transaction.serializeBytes();
   // Unsigned transaction byte length without signatures
   expect(serializedTx.byteLength).toEqual(unsignedByteLength);
 
@@ -1323,7 +1323,7 @@ test('Multi-sig transaction byte length must include the required signatures', a
   // Should calculate correct length if transaction is completely signed
   expect(estimateTransactionByteLength(signer.transaction)).toEqual(expectedFinalLength);
 
-  const finalSerializedTx = signer.transaction.serialize();
+  const finalSerializedTx = signer.transaction.serializeBytes();
   // Validate expectedFinalLength is correct
   expect(finalSerializedTx.byteLength).toEqual(expectedFinalLength);
 
@@ -1391,7 +1391,7 @@ test('Make sponsored STX token transfer', async () => {
     sponsored: true,
   });
 
-  const preSponsorSerialized = bytesToHex(transaction.serialize());
+  const preSponsorSerialized = transaction.serialize();
   const preSponsorTx =
     '0000000001050015c31b8c1c11c515e244b75806bac48d1399c77500000000000000020000000000000032' +
     '000012f0e0f7eec8657e814bdcde9352920dd9416dd757f1ada573ef268cc93001fd76db462508ffd90dec' +
@@ -1410,7 +1410,7 @@ test('Make sponsored STX token transfer', async () => {
   };
 
   const sponsorSignedTx = await sponsorTransaction(sponsorOptions);
-  const sponsorSignedTxSerialized = sponsorSignedTx.serialize();
+  const sponsorSignedTxSerialized = sponsorSignedTx.serializeBytes();
 
   const bytesReader = new BytesReader(sponsorSignedTxSerialized);
   const deserializedSponsorTx = deserializeTransaction(bytesReader);
@@ -1554,7 +1554,7 @@ test('Make sponsored STX token transfer with sponsor fee estimate', async () => 
   expect(fetchMock.mock.calls.length).toEqual(1);
   expect(fetchMock.mock.calls[0][0]).toEqual(`${api.url}${TRANSACTION_FEE_ESTIMATE_PATH}`);
 
-  const sponsorSignedTxSerialized = sponsorSignedTx.serialize();
+  const sponsorSignedTxSerialized = sponsorSignedTx.serializeBytes();
 
   const bytesReader = new BytesReader(sponsorSignedTxSerialized);
   const deserializedSponsorTx = deserializeTransaction(bytesReader);
@@ -1609,7 +1609,7 @@ test('Make sponsored STX token transfer with set tx fee', async () => {
 
   const sponsorSignedTx = await sponsorTransaction(sponsorOptions);
 
-  const sponsorSignedTxSerialized = sponsorSignedTx.serialize();
+  const sponsorSignedTxSerialized = sponsorSignedTx.serializeBytes();
 
   const bytesReader = new BytesReader(sponsorSignedTxSerialized);
   const deserializedSponsorTx = deserializeTransaction(bytesReader);
@@ -1665,7 +1665,7 @@ test('Make sponsored contract deploy with sponsor fee estimate', async () => {
 
   expect(fetchMock.mock.calls.length).toEqual(0);
 
-  const sponsorSignedTxSerialized = sponsorSignedTx.serialize();
+  const sponsorSignedTxSerialized = sponsorSignedTx.serializeBytes();
 
   const bytesReader = new BytesReader(sponsorSignedTxSerialized);
   const deserializedSponsorTx = deserializeTransaction(bytesReader);
@@ -1729,7 +1729,7 @@ test('Make sponsored contract call with sponsor nonce fetch', async () => {
     `${HIRO_TESTNET_URL}${ACCOUNT_PATH}/${sponsorAddress}?proof=0`
   );
 
-  const sponsorSignedTxSerialized = sponsorSignedTx.serialize();
+  const sponsorSignedTxSerialized = sponsorSignedTx.serializeBytes();
 
   const bytesReader = new BytesReader(sponsorSignedTxSerialized);
   const deserializedSponsorTx = deserializeTransaction(bytesReader);
@@ -1775,7 +1775,7 @@ test('Transaction broadcast success', async () => {
   expect(fetchMock.mock.calls.length).toEqual(1);
   expect(fetchMock.mock.calls[0][0]).toEqual(`${api.url}${BROADCAST_PATH}`);
   expect(fetchMock.mock.calls[0][1]?.body).toEqual(
-    JSON.stringify({ tx: bytesToHex(transaction.serialize()) })
+    JSON.stringify({ tx: bytesToHex(transaction.serializeBytes()) })
   );
   expect(response as TxBroadcastResultOk).toEqual({ txid });
 });
@@ -1798,9 +1798,7 @@ test('Transaction broadcast success with string network name', async () => {
 
   expect(fetchMock.mock.calls.length).toEqual(1);
   expect(fetchMock.mock.calls[0][0]).toEqual(`${HIRO_MAINNET_URL}${BROADCAST_PATH}`);
-  expect(fetchMock.mock.calls[0][1]?.body).toEqual(
-    JSON.stringify({ tx: bytesToHex(transaction.serialize()) })
-  );
+  expect(fetchMock.mock.calls[0][1]?.body).toEqual(JSON.stringify({ tx: transaction.serialize() }));
   expect(response as TxBroadcastResultOk).toEqual({ txid });
 });
 
@@ -1822,9 +1820,7 @@ test('Transaction broadcast success with network detection', async () => {
 
   expect(fetchMock.mock.calls.length).toEqual(1);
   expect(fetchMock.mock.calls[0][0]).toEqual(`${HIRO_TESTNET_URL}${BROADCAST_PATH}`);
-  expect(fetchMock.mock.calls[0][1]?.body).toEqual(
-    JSON.stringify({ tx: bytesToHex(transaction.serialize()) })
-  );
+  expect(fetchMock.mock.calls[0][1]?.body).toEqual(JSON.stringify({ tx: transaction.serialize() }));
   expect(response as TxBroadcastResultOk).toEqual({ txid });
 });
 
@@ -1855,7 +1851,7 @@ test('Transaction broadcast with attachment', async () => {
   expect(fetchMock.mock.calls[0][0]).toEqual(`${HIRO_MAINNET_URL}${BROADCAST_PATH}`);
   expect(fetchMock.mock.calls[0][1]?.body).toEqual(
     JSON.stringify({
-      tx: bytesToHex(transaction.serialize()),
+      tx: transaction.serialize(),
       attachment,
     })
   );
@@ -2247,7 +2243,7 @@ describe('serialize/deserialize tenure change', () => {
       '808000000004000f873150e9790e305b701aa8c7b3bcff9e31a5f9000000000000000000000000000000000001d367da530b92f4984f537f0b903c330eb5158262afa08d67cbbdea6c8e2ecae06008248ac147fc34101d3cc207b1b3e386e0f53732b5548bd5abe1570c2271340302000000000755c9861be5cff984a20ce6d99d4aa65941412889bdc665094136429b84f8c2ee00000001000000000000000000000000000000000000000000000000000279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f817980000000000000000000000000000000000000000000000000000000000000000';
     const transaction = deserializeTransaction(txBytes);
 
-    expect(bytesToHex(transaction.serialize())).toEqual(txBytes);
+    expect(transaction.serialize()).toEqual(txBytes);
   });
 
   test('deserialize/serialize tenure change transaction', () => {
@@ -2256,7 +2252,7 @@ describe('serialize/deserialize tenure change', () => {
       '808000000004001dc27eba0247f8cc9575e7d45e50a0bc7e72427d000000000000001d000000000000000000011dc72b6dfd9b36e414a2709e3b01eb5bbdd158f9bc77cd2ca6c3c8b0c803613e2189f6dacf709b34e8182e99d3a1af15812b75e59357d9c255c772695998665f010200000000076f2ff2c4517ab683bf2d588727f09603cc3e9328b9c500e21a939ead57c0560af8a3a132bd7d56566f2ff2c4517ab683bf2d588727f09603cc3e932828dcefb98f6b221eef731cabec7538314441c1e0ff06b44c22085d41aae447c1000000010014ff3cb19986645fd7e71282ad9fea07d540a60e';
     const transaction = deserializeTransaction(txBytes);
 
-    expect(bytesToHex(transaction.serialize())).toEqual(txBytes);
+    expect(transaction.serialize()).toEqual(txBytes);
   });
 });
 
@@ -2272,7 +2268,7 @@ test.each([
 ])('deserialize/serialize nakamoto coinbase transaction', txBytes => {
   const transaction = deserializeTransaction(txBytes);
 
-  expect(bytesToHex(transaction.serialize())).toEqual(txBytes);
+  expect(bytesToHex(transaction.serializeBytes())).toEqual(txBytes);
 });
 
 describe('multi-sig', () => {
@@ -2406,7 +2402,7 @@ describe('multi-sig', () => {
 
       // random byte changes
       for (let i = 0; i < 100; i++) {
-        const bytes = Array.from(tx.serialize());
+        const bytes = Array.from(tx.serializeBytes());
         const randomIdx = Math.floor(Math.random() * bytes.length);
         bytes[randomIdx] ^= 1;
         expect(() => deserializeTransaction(Uint8Array.from(bytes)).verifyOrigin()).toThrow();

--- a/packages/transactions/tests/transaction.test.ts
+++ b/packages/transactions/tests/transaction.test.ts
@@ -87,16 +87,14 @@ test('STX token transfer transaction serialization and deserialization', () => {
 
   transaction.verifyOrigin();
 
-  const serialized = transaction.serialize();
+  const serialized = transaction.serializeBytes();
   const deserialized = deserializeTransaction(new BytesReader(serialized));
 
   const serializedHexString = bytesToHex(serialized);
-  expect(bytesToHex(deserializeTransaction(serializedHexString).serialize())).toEqual(
-    bytesToHex(serialized)
-  );
+  expect(deserializeTransaction(serializedHexString).serialize()).toEqual(bytesToHex(serialized));
 
   const serializedHexStringPrefixed = '0x' + serializedHexString;
-  expect(bytesToHex(deserializeTransaction(serializedHexStringPrefixed).serialize())).toEqual(
+  expect(deserializeTransaction(serializedHexStringPrefixed).serialize()).toEqual(
     bytesToHex(serialized)
   );
 
@@ -165,14 +163,14 @@ test('STX token transfer transaction fee setting', () => {
 
   transaction.verifyOrigin();
 
-  const serialized = transaction.serialize();
+  const serialized = transaction.serializeBytes();
   const deserialized = deserializeTransaction(new BytesReader(serialized));
   expect(deserialized.auth.spendingCondition!.fee!.toString()).toBe(fee.toString());
 
   const setFee = 123;
   transaction.setFee(setFee);
 
-  const postSetFeeSerialized = transaction.serialize();
+  const postSetFeeSerialized = transaction.serializeBytes();
   const postSetFeeDeserialized = deserializeTransaction(new BytesReader(postSetFeeSerialized));
   expect(postSetFeeDeserialized.version).toBe(transactionVersion);
   expect(postSetFeeDeserialized.chainId).toBe(chainId);
@@ -247,7 +245,7 @@ test('STX token transfer transaction multi-sig serialization and deserialization
 
   transaction.verifyOrigin();
 
-  const serialized = transaction.serialize();
+  const serialized = transaction.serializeBytes();
   const deserialized = deserializeTransaction(new BytesReader(serialized));
   expect(deserialized.version).toBe(transactionVersion);
   expect(deserialized.chainId).toBe(chainId);
@@ -316,7 +314,7 @@ test('STX token transfer transaction multi-sig uncompressed keys serialization a
   expect(() => transaction.verifyOrigin()).toThrow(expectedError);
 
   const serialized = transaction.serialize();
-  expect(() => deserializeTransaction(new BytesReader(serialized))).toThrow(expectedError);
+  expect(() => deserializeTransaction(serialized)).toThrow(expectedError);
 });
 
 test('Sponsored STX token transfer transaction serialization and deserialization', () => {
@@ -362,7 +360,7 @@ test('Sponsored STX token transfer transaction serialization and deserialization
   transaction.verifyOrigin();
 
   const serialized = transaction.serialize();
-  const deserialized = deserializeTransaction(new BytesReader(serialized));
+  const deserialized = deserializeTransaction(serialized);
   expect(deserialized.version).toBe(transactionVersion);
   expect(deserialized.chainId).toBe(chainId);
   expect(deserialized.auth.authType).toBe(authType);
@@ -440,6 +438,6 @@ describe(serializeTransaction.name, () => {
   });
 
   test(transactionToHex.name, () => {
-    expect(transactionToHex(tx)).toEqual(bytesToHex(serializeTransaction(tx)));
+    expect(transactionToHex(tx)).toEqual(serializeTransaction(tx));
   });
 });


### PR DESCRIPTION
> This PR was published to npm with the version `6.14.1-pr.42+0f50711f`
> e.g. `npm install @stacks/common@6.14.1-pr.42+0f50711f --save-exact`<!-- Sticky Header Marker -->

- Make StacksTransaction.serialize() return a hex-string instead of bytes