### PR TITLE
refactor!: Rename more types to use "Wire" suffix

### DIFF
--- a/.github/MIGRATION.md
+++ b/.github/MIGRATION.md
@@ -198,7 +198,7 @@ For easier migrating, renaming the following methods is possible to keep the pre
 The following interfaces and methods were renamed:
 
 - `AssetInfo` → `Asset`
-- `StacksMessageType.AssetInfo` → `StacksMessageType.Asset`
+- `StacksWireType.AssetInfo` → `StacksWireType.Asset`
 - `createAssetInfo` → `createAsset`
 - `parseAssetInfoString` → `parseAssetString`
 
@@ -221,6 +221,29 @@ This is only used for advanced serialization use-cases internally and should not
 - `StacksMessageType` → `StacksWireType`
 - `serializeStacksMessage` → `serializeStacksWireBytes`
 - `deserializeStacksMessage` → `deserializeStacksWireBytes`
+
+More types were renamed to indicate use for serialization to _wire-format_:
+
+- `MessageSignature` → `MessageSignatureWire`
+- `StacksPublicKey` → `PublicKeyWire`
+- `TransactionAuthField` → `TransactionAuthFieldWire`
+- `Asset` → `AssetWire`
+- `Address` → `AddressWire`
+- `PostCondition` → `PostConditionWire`
+- `PostConditionPrincipal` → `PostConditionPrincipalWire`
+- `STXPostCondition` → `STXPostConditionWire`
+- `FungiblePostCondition` → `FungiblePostConditionWire`
+- `NonFungiblePostCondition` → `NonFungiblePostConditionWire`
+- `LengthPrefixedString` → `LengthPrefixedStringWire`
+- `CoinbasePayload` → `CoinbasePayloadWire`
+- `PoisonPayload` → `PoisonPayloadWire`
+- `SmartContractPayload` → `SmartContractPayloadWire`
+- `TokenTransferPayload` → `TokenTransferPayloadWire`
+- `VersionedSmartContractPayload` → `VersionedSmartContractPayloadWire`
+- `NakamotoCoinbasePayload` → `NakamotoCoinbasePayloadWire`
+- `TenureChangePayload` → `TenureChangePayloadWire`
+- `StandardPrincipal` → `StandardPrincipalWire`
+- `ContractPrincipal` → `ContractPrincipalWire`
 
 ## Stacks.js (&lt;=4.x.x) → (5.x.x)
 

--- a/packages/bns/src/index.ts
+++ b/packages/bns/src/index.ts
@@ -5,7 +5,7 @@ import {
   ClarityValue,
   FungibleConditionCode,
   NonFungibleConditionCode,
-  PostCondition,
+  PostConditionWire,
   ResponseErrorCV,
   StacksTransaction,
   UnsignedContractCallOptions,
@@ -60,7 +60,7 @@ export interface BnsContractCallOptions {
   functionArgs: ClarityValue[];
   publicKey: string;
   network: StacksNetwork;
-  postConditions?: PostCondition[];
+  postConditions?: PostConditionWire[];
 }
 
 async function makeBnsContractCall(options: BnsContractCallOptions): Promise<StacksTransaction> {

--- a/packages/transactions/src/builders.ts
+++ b/packages/transactions/src/builders.ts
@@ -43,12 +43,12 @@ import {
   createSTXPostCondition,
 } from './postcondition';
 import {
-  Asset,
   AssetString,
-  FungiblePostCondition,
-  NonFungiblePostCondition,
-  PostCondition,
-  STXPostCondition,
+  AssetWire,
+  FungiblePostConditionWire,
+  NonFungiblePostConditionWire,
+  PostConditionWire,
+  STXPostConditionWire,
   createAddress,
   createContractPrincipal,
   createStandardPrincipal,
@@ -268,7 +268,7 @@ export interface BaseContractDeployOptions {
    * transfered assets */
   postConditionMode?: PostConditionMode;
   /** a list of post conditions to add to the transaction */
-  postConditions?: PostCondition[];
+  postConditions?: PostConditionWire[];
   /** set to true if another account is sponsoring the transaction (covering the transaction fee) */
   sponsored?: boolean;
 }
@@ -390,7 +390,7 @@ export async function makeUnsignedContractDeploy(
     ? createSponsoredAuth(spendingCondition)
     : createStandardAuth(spendingCondition);
 
-  const postConditions: PostCondition[] = [];
+  const postConditions: PostConditionWire[] = [];
   if (options.postConditions && options.postConditions.length > 0) {
     options.postConditions.forEach(postCondition => {
       postConditions.push(postCondition);
@@ -444,7 +444,7 @@ export interface ContractCallOptions {
    * transfered assets */
   postConditionMode?: PostConditionMode;
   /** a list of post conditions to add to the transaction */
-  postConditions?: PostCondition[];
+  postConditions?: PostConditionWire[];
   /** set to true to validate that the supplied function args match those specified in
    * the published contract */
   validateWithAbi?: boolean | ClarityAbi;
@@ -547,7 +547,7 @@ export async function makeUnsignedContractCall(
     ? createSponsoredAuth(spendingCondition)
     : createStandardAuth(spendingCondition);
 
-  const postConditions: PostCondition[] = [];
+  const postConditions: PostConditionWire[] = [];
   if (options.postConditions && options.postConditions.length > 0) {
     options.postConditions.forEach(postCondition => {
       postConditions.push(postCondition);
@@ -632,7 +632,7 @@ export function makeStandardSTXPostCondition(
   address: string,
   conditionCode: FungibleConditionCode,
   amount: IntegerType
-): STXPostCondition {
+): STXPostConditionWire {
   return createSTXPostCondition(createStandardPrincipal(address), conditionCode, amount);
 }
 
@@ -646,14 +646,14 @@ export function makeStandardSTXPostCondition(
  * @param conditionCode - the condition code
  * @param amount - the amount of STX tokens (denoted in micro-STX)
  *
- * @return {STXPostCondition}
+ * @return {STXPostConditionWire}
  */
 export function makeContractSTXPostCondition(
   address: string,
   contractName: string,
   conditionCode: FungibleConditionCode,
   amount: IntegerType
-): STXPostCondition {
+): STXPostConditionWire {
   return createSTXPostCondition(
     createContractPrincipal(address, contractName),
     conditionCode,
@@ -675,8 +675,8 @@ export function makeStandardFungiblePostCondition(
   address: string,
   conditionCode: FungibleConditionCode,
   amount: IntegerType,
-  asset: AssetString | Asset
-): FungiblePostCondition {
+  asset: AssetString | AssetWire
+): FungiblePostConditionWire {
   return createFungiblePostCondition(
     createStandardPrincipal(address),
     conditionCode,
@@ -701,8 +701,8 @@ export function makeContractFungiblePostCondition(
   contractName: string,
   conditionCode: FungibleConditionCode,
   amount: IntegerType,
-  asset: AssetString | Asset
-): FungiblePostCondition {
+  asset: AssetString | AssetWire
+): FungiblePostConditionWire {
   return createFungiblePostCondition(
     createContractPrincipal(address, contractName),
     conditionCode,
@@ -718,17 +718,17 @@ export function makeContractFungiblePostCondition(
  *
  * @param {String} address - the c32check address
  * @param {FungibleConditionCode} conditionCode - the condition code
- * @param {Asset} asset - asset info describing the non-fungible token
+ * @param {AssetWire} asset - asset info describing the non-fungible token
  * @param {ClarityValue} assetId - asset identifier of the nft instance (typically a uint/buffer/string)
  *
- * @return {NonFungiblePostCondition}
+ * @return {NonFungiblePostConditionWire}
  */
 export function makeStandardNonFungiblePostCondition(
   address: string,
   conditionCode: NonFungibleConditionCode,
-  asset: AssetString | Asset,
+  asset: AssetString | AssetWire,
   assetId: ClarityValue
-): NonFungiblePostCondition {
+): NonFungiblePostConditionWire {
   return createNonFungiblePostCondition(
     createStandardPrincipal(address),
     conditionCode,
@@ -745,18 +745,18 @@ export function makeStandardNonFungiblePostCondition(
  * @param {String} address - the c32check address
  * @param {String} contractName - the name of the contract
  * @param {FungibleConditionCode} conditionCode - the condition code
- * @param {Asset} asset - asset info describing the non-fungible token
+ * @param {AssetWire} asset - asset info describing the non-fungible token
  * @param {ClarityValue} assetId - asset identifier of the nft instance (typically a uint/buffer/string)
  *
- * @return {NonFungiblePostCondition}
+ * @return {NonFungiblePostConditionWire}
  */
 export function makeContractNonFungiblePostCondition(
   address: string,
   contractName: string,
   conditionCode: NonFungibleConditionCode,
-  asset: AssetString | Asset,
+  asset: AssetString | AssetWire,
   assetId: ClarityValue
-): NonFungiblePostCondition {
+): NonFungiblePostConditionWire {
   return createNonFungiblePostCondition(
     createContractPrincipal(address, contractName),
     conditionCode,

--- a/packages/transactions/src/clarity/types.ts
+++ b/packages/transactions/src/clarity/types.ts
@@ -1,5 +1,5 @@
-import { Address } from '../common';
-import { LengthPrefixedString } from '../postcondition-types';
+import { AddressWire } from '../common';
+import { LengthPrefixedStringWire } from '../postcondition-types';
 import { ClarityValue } from './clarityValue';
 import { ClarityType } from './constants';
 
@@ -48,13 +48,13 @@ export type PrincipalCV = StandardPrincipalCV | ContractPrincipalCV;
 
 export interface StandardPrincipalCV {
   readonly type: ClarityType.PrincipalStandard;
-  readonly address: Address;
+  readonly address: AddressWire;
 }
 
 export interface ContractPrincipalCV {
   readonly type: ClarityType.PrincipalContract;
-  readonly address: Address;
-  readonly contractName: LengthPrefixedString;
+  readonly address: AddressWire;
+  readonly contractName: LengthPrefixedStringWire;
 }
 
 export type ResponseCV = ResponseErrorCV | ResponseOkCV;

--- a/packages/transactions/src/clarity/values/principalCV.ts
+++ b/packages/transactions/src/clarity/values/principalCV.ts
@@ -1,6 +1,6 @@
 import { utf8ToBytes } from '@stacks/common';
-import { Address, addressToString } from '../../common';
-import { LengthPrefixedString, createAddress, createLPString } from '../../postcondition-types';
+import { AddressWire, addressToString } from '../../common';
+import { LengthPrefixedStringWire, createAddress, createLPString } from '../../postcondition-types';
 import { ClarityType } from '../constants';
 import { ContractPrincipalCV, PrincipalCV, StandardPrincipalCV } from '../types';
 
@@ -68,7 +68,7 @@ export function standardPrincipalCV(addressString: string): StandardPrincipalCV 
  * @see
  * {@link https://github.com/hirosystems/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
-export function standardPrincipalCVFromAddress(address: Address): StandardPrincipalCV {
+export function standardPrincipalCVFromAddress(address: AddressWire): StandardPrincipalCV {
   return { type: ClarityType.PrincipalStandard, address };
 }
 
@@ -117,8 +117,8 @@ export function contractPrincipalCV(
  * {@link https://github.com/hirosystems/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 export function contractPrincipalCVFromAddress(
-  address: Address,
-  contractName: LengthPrefixedString
+  address: AddressWire,
+  contractName: LengthPrefixedStringWire
 ): ContractPrincipalCV {
   if (utf8ToBytes(contractName.content).byteLength >= 128) {
     throw new Error('Contract name must be less than 128 bytes');

--- a/packages/transactions/src/common.ts
+++ b/packages/transactions/src/common.ts
@@ -9,18 +9,18 @@ import { c32address } from 'c32check';
 import { hexToBytes } from '@stacks/common';
 import { TransactionVersion } from '@stacks/network';
 
-export interface Address {
+export interface AddressWire {
   readonly type: StacksWireType.Address;
   readonly version: AddressVersion;
   readonly hash160: string;
 }
 
-export interface MessageSignature {
+export interface MessageSignatureWire {
   readonly type: StacksWireType.MessageSignature;
   data: string;
 }
 
-export function createMessageSignature(signature: string): MessageSignature {
+export function createMessageSignature(signature: string): MessageSignatureWire {
   const length = hexToBytes(signature).byteLength;
   if (length != RECOVERABLE_ECDSA_SIG_LENGTH_BYTES) {
     throw Error('Invalid signature');
@@ -73,10 +73,10 @@ export function addressHashModeToVersion(
   }
 }
 
-export function addressFromVersionHash(version: AddressVersion, hash: string): Address {
+export function addressFromVersionHash(version: AddressVersion, hash: string): AddressWire {
   return { type: StacksWireType.Address, version, hash160: hash };
 }
 
-export function addressToString(address: Address): string {
+export function addressToString(address: AddressWire): string {
   return c32address(address.version, address.hash160);
 }

--- a/packages/transactions/src/index.ts
+++ b/packages/transactions/src/index.ts
@@ -58,13 +58,13 @@ export * from './constants';
 export * from './contract-abi';
 export * from './keys';
 export {
-  CoinbasePayload,
+  CoinbasePayloadWire,
   CoinbasePayloadToAltRecipient,
   ContractCallPayload,
-  PoisonPayload,
-  SmartContractPayload,
-  TokenTransferPayload,
-  VersionedSmartContractPayload,
+  PoisonPayloadWire,
+  SmartContractPayloadWire,
+  TokenTransferPayloadWire,
+  VersionedSmartContractPayloadWire,
   isCoinbasePayload,
   isContractCallPayload,
   isPoisonPayload,

--- a/packages/transactions/src/keys.ts
+++ b/packages/transactions/src/keys.ts
@@ -36,7 +36,7 @@ import {
   addressHashModeToVersion,
   addressToString,
   createMessageSignature,
-  MessageSignature,
+  MessageSignatureWire,
 } from './common';
 import {
   AddressHashMode,
@@ -46,7 +46,7 @@ import {
   StacksWireType,
   UNCOMPRESSED_PUBKEY_LENGTH_BYTES,
 } from './constants';
-import { StructuredDataSignature } from './message-types';
+import { StructuredDataSignatureWire } from './message-types';
 import { hash160, hashP2PKH } from './utils';
 
 /**
@@ -62,7 +62,7 @@ utils.hmacSha256Sync = (key: Uint8Array, ...msgs: Uint8Array[]) => {
   return h.digest();
 };
 
-export interface StacksPublicKey {
+export interface PublicKeyWire {
   readonly type: StacksWireType.PublicKey;
   readonly data: Uint8Array;
 }
@@ -91,7 +91,7 @@ export function getAddressFromPublicKey(
   return addrString;
 }
 
-export function createStacksPublicKey(publicKey: PublicKey): StacksPublicKey {
+export function createStacksPublicKey(publicKey: PublicKey): PublicKeyWire {
   publicKey = typeof publicKey === 'string' ? hexToBytes(publicKey) : publicKey;
   return {
     type: StacksWireType.PublicKey,
@@ -101,7 +101,7 @@ export function createStacksPublicKey(publicKey: PublicKey): StacksPublicKey {
 
 export function publicKeyFromSignatureVrs(
   messageHash: string,
-  messageSignature: MessageSignature | StructuredDataSignature,
+  messageSignature: MessageSignatureWire | StructuredDataSignatureWire,
   pubKeyEncoding = PubKeyEncoding.Compressed
 ): string {
   const parsedSignature = parseRecoverableSignatureVrs(messageSignature.data);
@@ -113,7 +113,7 @@ export function publicKeyFromSignatureVrs(
 
 export function publicKeyFromSignatureRsv(
   messageHash: string,
-  messageSignature: MessageSignature | StructuredDataSignature,
+  messageSignature: MessageSignatureWire | StructuredDataSignatureWire,
   pubKeyEncoding = PubKeyEncoding.Compressed
 ): string {
   return publicKeyFromSignatureVrs(
@@ -137,11 +137,11 @@ export function publicKeyIsCompressed(publicKey: PublicKey): boolean {
   return !publicKeyToHex(publicKey).startsWith('04');
 }
 
-export function serializePublicKey(key: StacksPublicKey): string {
+export function serializePublicKey(key: PublicKeyWire): string {
   return bytesToHex(serializePublicKeyBytes(key));
 }
 /** @ignore */
-export function serializePublicKeyBytes(key: StacksPublicKey): Uint8Array {
+export function serializePublicKeyBytes(key: PublicKeyWire): Uint8Array {
   return key.data.slice();
 }
 
@@ -165,11 +165,11 @@ export function uncompressPublicKey(publicKey: PublicKey): string {
   return Point.fromHex(publicKeyToHex(publicKey)).toHex(false);
 }
 
-export function deserializePublicKey(serialized: string): StacksPublicKey {
+export function deserializePublicKey(serialized: string): PublicKeyWire {
   return deserializePublicKeyBytes(hexToBytes(serialized));
 }
 /** @ignore */
-export function deserializePublicKeyBytes(serialized: Uint8Array | BytesReader): StacksPublicKey {
+export function deserializePublicKeyBytes(serialized: Uint8Array | BytesReader): PublicKeyWire {
   const bytesReader = isInstance(serialized, BytesReader)
     ? serialized
     : new BytesReader(serialized);
@@ -188,7 +188,7 @@ export function makeRandomPrivKey(): string {
  * @deprecated The Clarity compatible {@link signMessageHashRsv} is preferred, but differs in signature format
  * @returns A recoverable signature (in VRS order)
  */
-export function signWithKey(privateKey: PrivateKey, messageHash: string): MessageSignature {
+export function signWithKey(privateKey: PrivateKey, messageHash: string): MessageSignatureWire {
   privateKey = privateKeyToBytes(privateKey);
   const [rawSignature, recoveryId] = signSync(messageHash, privateKey.slice(0, 32), {
     canonical: true,
@@ -213,7 +213,7 @@ export function signMessageHashRsv({
 }: {
   messageHash: string;
   privateKey: PrivateKey;
-}): MessageSignature {
+}): MessageSignatureWire {
   const messageSignature = signWithKey(privateKey, messageHash);
   return { ...messageSignature, data: signatureVrsToRsv(messageSignature.data) };
 }

--- a/packages/transactions/src/message-types.ts
+++ b/packages/transactions/src/message-types.ts
@@ -2,7 +2,8 @@
 // needed now to fix a circular dependency issue in structuredDataSignature
 import { StacksWireType } from './constants';
 
-export interface StructuredDataSignature {
+/** @deprecated  */
+export interface StructuredDataSignatureWire {
   readonly type: StacksWireType.StructuredDataSignature;
   data: string;
 }

--- a/packages/transactions/src/payload.ts
+++ b/packages/transactions/src/payload.ts
@@ -20,7 +20,7 @@ import {
   serializeCVBytes,
   someCV,
 } from './clarity/';
-import { Address } from './common';
+import { AddressWire } from './common';
 import {
   ClarityVersion,
   COINBASE_BYTES_LENGTH,
@@ -28,69 +28,72 @@ import {
   StacksWireType,
   VRF_PROOF_BYTES_LENGTH,
 } from './constants';
-import { createAddress, createLPString, LengthPrefixedString } from './postcondition-types';
+import { createAddress, createLPString, LengthPrefixedStringWire } from './postcondition-types';
 import {
   codeBodyString,
   createMemoString,
   deserializeAddressBytes,
   deserializeLPStringBytes,
   deserializeMemoStringBytes,
-  MemoString,
+  MemoStringWire,
   serializeStacksWireBytes,
 } from './types';
 import { PrincipalCV } from './clarity/types';
 
-export type Payload =
-  | TokenTransferPayload
+export type PayloadWire =
+  | TokenTransferPayloadWire
   | ContractCallPayload
-  | SmartContractPayload
-  | VersionedSmartContractPayload
-  | PoisonPayload
-  | CoinbasePayload
+  | SmartContractPayloadWire
+  | VersionedSmartContractPayloadWire
+  | PoisonPayloadWire
+  | CoinbasePayloadWire
   | CoinbasePayloadToAltRecipient
-  | NakamotoCoinbasePayload
-  | TenureChangePayload;
+  | NakamotoCoinbasePayloadWire
+  | TenureChangePayloadWire;
 
-export function isTokenTransferPayload(p: Payload): p is TokenTransferPayload {
+export function isTokenTransferPayload(p: PayloadWire): p is TokenTransferPayloadWire {
   return p.payloadType === PayloadType.TokenTransfer;
 }
-export function isContractCallPayload(p: Payload): p is ContractCallPayload {
+export function isContractCallPayload(p: PayloadWire): p is ContractCallPayload {
   return p.payloadType === PayloadType.ContractCall;
 }
-export function isSmartContractPayload(p: Payload): p is SmartContractPayload {
+export function isSmartContractPayload(p: PayloadWire): p is SmartContractPayloadWire {
   return p.payloadType === PayloadType.SmartContract;
 }
-export function isPoisonPayload(p: Payload): p is PoisonPayload {
+export function isPoisonPayload(p: PayloadWire): p is PoisonPayloadWire {
   return p.payloadType === PayloadType.PoisonMicroblock;
 }
-export function isCoinbasePayload(p: Payload): p is CoinbasePayload {
+export function isCoinbasePayload(p: PayloadWire): p is CoinbasePayloadWire {
   return p.payloadType === PayloadType.Coinbase;
 }
 
-export interface TokenTransferPayload {
+export interface TokenTransferPayloadWire {
   readonly type: StacksWireType.Payload;
   readonly payloadType: PayloadType.TokenTransfer;
   readonly recipient: PrincipalCV;
   readonly amount: bigint;
-  readonly memo: MemoString;
+  readonly memo: MemoStringWire;
 }
 
 export type PayloadInput =
-  | (TokenTransferPayload | (Omit<TokenTransferPayload, 'amount'> & { amount: IntegerType }))
+  | (
+      | TokenTransferPayloadWire
+      | (Omit<TokenTransferPayloadWire, 'amount'> & { amount: IntegerType })
+    )
   | ContractCallPayload
-  | SmartContractPayload
-  | VersionedSmartContractPayload
-  | PoisonPayload
-  | CoinbasePayload
+  | SmartContractPayloadWire
+  | VersionedSmartContractPayloadWire
+  | PoisonPayloadWire
+  | CoinbasePayloadWire
   | CoinbasePayloadToAltRecipient
-  | NakamotoCoinbasePayload
-  | TenureChangePayload;
+  | NakamotoCoinbasePayloadWire
+  | TenureChangePayloadWire;
 
 export function createTokenTransferPayload(
   recipient: string | PrincipalCV,
   amount: IntegerType,
-  memo?: string | MemoString
-): TokenTransferPayload {
+  memo?: string | MemoStringWire
+): TokenTransferPayloadWire {
   if (typeof recipient === 'string') {
     recipient = principalCV(recipient);
   }
@@ -110,16 +113,16 @@ export function createTokenTransferPayload(
 export interface ContractCallPayload {
   readonly type: StacksWireType.Payload;
   readonly payloadType: PayloadType.ContractCall;
-  readonly contractAddress: Address;
-  readonly contractName: LengthPrefixedString;
-  readonly functionName: LengthPrefixedString;
+  readonly contractAddress: AddressWire;
+  readonly contractName: LengthPrefixedStringWire;
+  readonly functionName: LengthPrefixedStringWire;
   readonly functionArgs: ClarityValue[];
 }
 
 export function createContractCallPayload(
-  contractAddress: string | Address,
-  contractName: string | LengthPrefixedString,
-  functionName: string | LengthPrefixedString,
+  contractAddress: string | AddressWire,
+  contractName: string | LengthPrefixedStringWire,
+  functionName: string | LengthPrefixedStringWire,
   functionArgs: ClarityValue[]
 ): ContractCallPayload {
   if (typeof contractAddress === 'string') {
@@ -142,26 +145,26 @@ export function createContractCallPayload(
   };
 }
 
-export interface SmartContractPayload {
+export interface SmartContractPayloadWire {
   readonly type: StacksWireType.Payload;
   readonly payloadType: PayloadType.SmartContract;
-  readonly contractName: LengthPrefixedString;
-  readonly codeBody: LengthPrefixedString;
+  readonly contractName: LengthPrefixedStringWire;
+  readonly codeBody: LengthPrefixedStringWire;
 }
 
-export interface VersionedSmartContractPayload {
+export interface VersionedSmartContractPayloadWire {
   readonly type: StacksWireType.Payload;
   readonly payloadType: PayloadType.VersionedSmartContract;
   readonly clarityVersion: ClarityVersion;
-  readonly contractName: LengthPrefixedString;
-  readonly codeBody: LengthPrefixedString;
+  readonly contractName: LengthPrefixedStringWire;
+  readonly codeBody: LengthPrefixedStringWire;
 }
 
 export function createSmartContractPayload(
-  contractName: string | LengthPrefixedString,
-  codeBody: string | LengthPrefixedString,
+  contractName: string | LengthPrefixedStringWire,
+  codeBody: string | LengthPrefixedStringWire,
   clarityVersion?: ClarityVersion
-): SmartContractPayload | VersionedSmartContractPayload {
+): SmartContractPayloadWire | VersionedSmartContractPayloadWire {
   if (typeof contractName === 'string') {
     contractName = createLPString(contractName);
   }
@@ -186,16 +189,16 @@ export function createSmartContractPayload(
   };
 }
 
-export interface PoisonPayload {
+export interface PoisonPayloadWire {
   readonly type: StacksWireType.Payload;
   readonly payloadType: PayloadType.PoisonMicroblock;
 }
 
-export function createPoisonPayload(): PoisonPayload {
+export function createPoisonPayload(): PoisonPayloadWire {
   return { type: StacksWireType.Payload, payloadType: PayloadType.PoisonMicroblock };
 }
 
-export interface CoinbasePayload {
+export interface CoinbasePayloadWire {
   readonly type: StacksWireType.Payload;
   readonly payloadType: PayloadType.Coinbase;
   readonly coinbaseBytes: Uint8Array;
@@ -211,7 +214,7 @@ export interface CoinbasePayloadToAltRecipient {
 export function createCoinbasePayload(
   coinbaseBytes: Uint8Array,
   altRecipient?: PrincipalCV
-): CoinbasePayload | CoinbasePayloadToAltRecipient {
+): CoinbasePayloadWire | CoinbasePayloadToAltRecipient {
   if (coinbaseBytes.byteLength != COINBASE_BYTES_LENGTH) {
     throw Error(`Coinbase buffer size must be ${COINBASE_BYTES_LENGTH} bytes`);
   }
@@ -231,7 +234,7 @@ export function createCoinbasePayload(
   };
 }
 
-export interface NakamotoCoinbasePayload {
+export interface NakamotoCoinbasePayloadWire {
   readonly type: StacksWireType.Payload;
   readonly payloadType: PayloadType.NakamotoCoinbase;
   readonly coinbaseBytes: Uint8Array;
@@ -243,7 +246,7 @@ export function createNakamotoCoinbasePayload(
   coinbaseBytes: Uint8Array,
   recipient: OptionalCV<PrincipalCV>,
   vrfProof: Uint8Array
-): NakamotoCoinbasePayload {
+): NakamotoCoinbasePayloadWire {
   if (coinbaseBytes.byteLength != COINBASE_BYTES_LENGTH) {
     throw Error(`Coinbase buffer size must be ${COINBASE_BYTES_LENGTH} bytes`);
   }
@@ -268,7 +271,7 @@ export enum TenureChangeCause {
   Extended = 1,
 }
 
-export interface TenureChangePayload {
+export interface TenureChangePayloadWire {
   readonly type: StacksWireType.Payload;
   readonly payloadType: PayloadType.TenureChange;
   /**
@@ -307,7 +310,7 @@ export function createTenureChangePayload(
   previousTenureBlocks: number,
   cause: TenureChangeCause,
   publicKeyHash: string
-): TenureChangePayload {
+): TenureChangePayloadWire {
   return {
     type: StacksWireType.Payload,
     payloadType: PayloadType.TenureChange,
@@ -384,11 +387,11 @@ export function serializePayloadBytes(payload: PayloadInput): Uint8Array {
   return concatArray(bytesArray);
 }
 
-export function deserializePayload(serialized: string): Payload {
+export function deserializePayload(serialized: string): PayloadWire {
   return deserializePayloadBytes(hexToBytes(serialized));
 }
 /** @ignore */
-export function deserializePayloadBytes(serialized: Uint8Array | BytesReader): Payload {
+export function deserializePayloadBytes(serialized: Uint8Array | BytesReader): PayloadWire {
   const bytesReader = isInstance(serialized, BytesReader)
     ? serialized
     : new BytesReader(serialized);

--- a/packages/transactions/src/pc.ts
+++ b/packages/transactions/src/pc.ts
@@ -12,7 +12,7 @@ import { FungibleConditionCode, NonFungibleConditionCode } from './constants';
 import {
   AssetString,
   ContractIdString,
-  NonFungiblePostCondition,
+  NonFungiblePostConditionWire,
   createAsset,
 } from './postcondition-types';
 import { AddressString } from './types';
@@ -254,7 +254,7 @@ class PartialPcNftWithCode {
    * @param assetName - The name of the NFT asset. Formatted as `<contract-address>.<contract-name>::<token-name>`.
    * @param assetId - The asset identifier of the NFT. A Clarity value defining the single NFT instance.
    */
-  nft(assetName: AssetString, assetId: ClarityValue): NonFungiblePostCondition;
+  nft(assetName: AssetString, assetId: ClarityValue): NonFungiblePostConditionWire;
   /**
    * ### Non-Fungible Token Post Condition
    * @param contractId - The contract identifier of the NFT. Formatted as `<contract-address>.<contract-name>`.
@@ -265,8 +265,8 @@ class PartialPcNftWithCode {
     contractId: ContractIdString,
     tokenName: string,
     assetId: ClarityValue
-  ): NonFungiblePostCondition;
-  nft(...args: [any, any] | [any, any, any]): NonFungiblePostCondition {
+  ): NonFungiblePostConditionWire;
+  nft(...args: [any, any] | [any, any, any]): NonFungiblePostConditionWire {
     const { contractAddress, contractName, tokenName, assetId } = getNftArgs(
       ...(args as [any, any, any])
     );

--- a/packages/transactions/src/postcondition.ts
+++ b/packages/transactions/src/postcondition.ts
@@ -7,21 +7,21 @@ import {
   StacksWireType,
 } from './constants';
 import {
-  Asset,
   AssetString,
-  FungiblePostCondition,
-  NonFungiblePostCondition,
-  PostConditionPrincipal,
-  STXPostCondition,
+  AssetWire,
+  FungiblePostConditionWire,
+  NonFungiblePostConditionWire,
+  PostConditionPrincipalWire,
+  STXPostConditionWire,
   parseAssetString,
   parsePrincipalString,
 } from './postcondition-types';
 
 export function createSTXPostCondition(
-  principal: string | PostConditionPrincipal,
+  principal: string | PostConditionPrincipalWire,
   conditionCode: FungibleConditionCode,
   amount: IntegerType
-): STXPostCondition {
+): STXPostConditionWire {
   if (typeof principal === 'string') {
     principal = parsePrincipalString(principal);
   }
@@ -36,11 +36,11 @@ export function createSTXPostCondition(
 }
 
 export function createFungiblePostCondition(
-  principal: string | PostConditionPrincipal,
+  principal: string | PostConditionPrincipalWire,
   conditionCode: FungibleConditionCode,
   amount: IntegerType,
-  asset: AssetString | Asset
-): FungiblePostCondition {
+  asset: AssetString | AssetWire
+): FungiblePostConditionWire {
   if (typeof principal === 'string') {
     principal = parsePrincipalString(principal);
   }
@@ -59,11 +59,11 @@ export function createFungiblePostCondition(
 }
 
 export function createNonFungiblePostCondition(
-  principal: string | PostConditionPrincipal,
+  principal: string | PostConditionPrincipalWire,
   conditionCode: NonFungibleConditionCode,
-  asset: AssetString | Asset,
+  asset: AssetString | AssetWire,
   assetName: ClarityValue
-): NonFungiblePostCondition {
+): NonFungiblePostConditionWire {
   if (typeof principal === 'string') {
     principal = parsePrincipalString(principal);
   }

--- a/packages/transactions/src/signature.ts
+++ b/packages/transactions/src/signature.ts
@@ -1,10 +1,10 @@
 import { bytesToHex, concatArray, hexToBytes, isInstance } from '@stacks/common';
 import { BytesReader } from './bytesReader';
-import { MessageSignature, createMessageSignature } from './common';
+import { MessageSignatureWire, createMessageSignature } from './common';
 import { PubKeyEncoding, RECOVERABLE_ECDSA_SIG_LENGTH_BYTES, StacksWireType } from './constants';
 import { DeserializationError } from './errors';
 import {
-  StacksPublicKey,
+  PublicKeyWire,
   compressPublicKey,
   createStacksPublicKey,
   deserializePublicKeyBytes,
@@ -18,21 +18,21 @@ export enum AuthFieldType {
   SignatureUncompressed = 0x03,
 }
 
-export interface TransactionAuthField {
+export interface TransactionAuthFieldWire {
   type: StacksWireType.TransactionAuthField;
   pubKeyEncoding: PubKeyEncoding;
-  contents: TransactionAuthFieldContents;
+  contents: TransactionAuthFieldContentsWire;
 }
 
-export type TransactionAuthFieldContents = StacksPublicKey | MessageSignature;
+export type TransactionAuthFieldContentsWire = PublicKeyWire | MessageSignatureWire;
 
-export function deserializeMessageSignature(serialized: string): MessageSignature {
+export function deserializeMessageSignature(serialized: string): MessageSignatureWire {
   return deserializeMessageSignatureBytes(hexToBytes(serialized));
 }
 /** @ignore */
 export function deserializeMessageSignatureBytes(
   serialized: Uint8Array | BytesReader
-): MessageSignature {
+): MessageSignatureWire {
   const bytesReader = isInstance(serialized, BytesReader)
     ? serialized
     : new BytesReader(serialized);
@@ -43,16 +43,16 @@ export function deserializeMessageSignatureBytes(
 
 // todo: `next` refactor to match wire format more precisely eg https://github.com/jbencin/sips/blob/sip-02x-non-sequential-multisig-transactions/sips/sip-02x/sip-02x-non-sequential-multisig-transactions.md
 //  "A spending authorization field is encoded as follows:" ...
-export interface TransactionAuthField {
+export interface TransactionAuthFieldWire {
   type: StacksWireType.TransactionAuthField;
   pubKeyEncoding: PubKeyEncoding;
-  contents: TransactionAuthFieldContents;
+  contents: TransactionAuthFieldContentsWire;
 }
 
 export function createTransactionAuthField(
   pubKeyEncoding: PubKeyEncoding,
-  contents: TransactionAuthFieldContents
-): TransactionAuthField {
+  contents: TransactionAuthFieldContentsWire
+): TransactionAuthFieldWire {
   return {
     pubKeyEncoding,
     type: StacksWireType.TransactionAuthField,
@@ -60,13 +60,13 @@ export function createTransactionAuthField(
   };
 }
 
-export function deserializeTransactionAuthField(serialized: string): TransactionAuthField {
+export function deserializeTransactionAuthField(serialized: string): TransactionAuthFieldWire {
   return deserializeTransactionAuthFieldBytes(hexToBytes(serialized));
 }
 /** @ignore */
 export function deserializeTransactionAuthFieldBytes(
   serialized: Uint8Array | BytesReader
-): TransactionAuthField {
+): TransactionAuthFieldWire {
   const bytesReader = isInstance(serialized, BytesReader)
     ? serialized
     : new BytesReader(serialized);
@@ -100,19 +100,19 @@ export function deserializeTransactionAuthFieldBytes(
   }
 }
 
-export function serializeMessageSignature(messageSignature: MessageSignature): string {
+export function serializeMessageSignature(messageSignature: MessageSignatureWire): string {
   return bytesToHex(serializeMessageSignatureBytes(messageSignature));
 }
 /** @ignore */
-export function serializeMessageSignatureBytes(messageSignature: MessageSignature): Uint8Array {
+export function serializeMessageSignatureBytes(messageSignature: MessageSignatureWire): Uint8Array {
   return hexToBytes(messageSignature.data);
 }
 
-export function serializeTransactionAuthField(field: TransactionAuthField): string {
+export function serializeTransactionAuthField(field: TransactionAuthFieldWire): string {
   return bytesToHex(serializeTransactionAuthFieldBytes(field));
 }
 /** @ignore */
-export function serializeTransactionAuthFieldBytes(field: TransactionAuthField): Uint8Array {
+export function serializeTransactionAuthFieldBytes(field: TransactionAuthFieldWire): Uint8Array {
   const bytesArray = [];
 
   switch (field.contents.type) {

--- a/packages/transactions/src/signer.ts
+++ b/packages/transactions/src/signer.ts
@@ -8,7 +8,7 @@ import {
 } from './authorization';
 import { AddressHashMode, AuthType, PubKeyEncoding, StacksWireType } from './constants';
 import { SigningError } from './errors';
-import { StacksPublicKey } from './keys';
+import { PublicKeyWire } from './keys';
 import { StacksTransaction } from './transaction';
 import { cloneDeep } from './utils';
 
@@ -116,7 +116,7 @@ export class TransactionSigner {
     }
   }
 
-  appendOrigin(publicKey: StacksPublicKey) {
+  appendOrigin(publicKey: PublicKeyWire) {
     if (this.checkOverlap && this.originDone) {
       throw Error('Cannot append public key to origin after sponsor key');
     }

--- a/packages/transactions/src/structuredDataSignature.ts
+++ b/packages/transactions/src/structuredDataSignature.ts
@@ -2,8 +2,8 @@ import { sha256 } from '@noble/hashes/sha256';
 import { PrivateKey, bytesToHex, concatBytes, utf8ToBytes } from '@stacks/common';
 import { ClarityType, ClarityValue, serializeCVBytes } from './clarity';
 import { StacksWireType } from './constants';
-import { StructuredDataSignature } from './message-types';
 import { signMessageHashRsv } from './keys';
+import { StructuredDataSignatureWire } from './message-types';
 
 // Refer to SIP018 https://github.com/stacksgov/sips/
 // > asciiToBytes('SIP018')
@@ -79,7 +79,7 @@ export function signStructuredData({
   message: ClarityValue;
   domain: ClarityValue;
   privateKey: PrivateKey;
-}): StructuredDataSignature {
+}): StructuredDataSignatureWire {
   const structuredDataHash: string = bytesToHex(sha256(encodeStructuredData({ message, domain })));
 
   const { data } = signMessageHashRsv({

--- a/packages/transactions/src/transaction.ts
+++ b/packages/transactions/src/transaction.ts
@@ -44,8 +44,13 @@ import {
   anchorModeFrom,
 } from './constants';
 import { SerializationError, SigningError } from './errors';
-import { StacksPublicKey, privateKeyIsCompressed, publicKeyIsCompressed } from './keys';
-import { Payload, PayloadInput, deserializePayloadBytes, serializePayloadBytes } from './payload';
+import { PublicKeyWire, privateKeyIsCompressed, publicKeyIsCompressed } from './keys';
+import {
+  PayloadWire,
+  PayloadInput,
+  deserializePayloadBytes,
+  serializePayloadBytes,
+} from './payload';
 import { createTransactionAuthField } from './signature';
 import {
   LengthPrefixedList,
@@ -60,7 +65,7 @@ export class StacksTransaction {
   chainId: ChainId;
   auth: Authorization;
   anchorMode: AnchorMode;
-  payload: Payload;
+  payload: PayloadWire;
   postConditionMode: PostConditionMode;
   postConditions: LengthPrefixedList;
 
@@ -132,7 +137,7 @@ export class StacksTransaction {
     }
   }
 
-  appendPubkey(publicKey: StacksPublicKey) {
+  appendPubkey(publicKey: PublicKeyWire) {
     const cond = this.auth.spendingCondition;
     if (cond && !isSingleSig(cond)) {
       const compressed = publicKeyIsCompressed(publicKey.data);

--- a/packages/transactions/tests/builder.test.ts
+++ b/packages/transactions/tests/builder.test.ts
@@ -94,7 +94,7 @@ import {
 } from '../src/constants';
 import { makeRandomPrivKey } from '../src/keys';
 import {
-  TokenTransferPayload,
+  TokenTransferPayloadWire,
   createTokenTransferPayload,
   serializePayloadBytes,
 } from '../src/payload';
@@ -401,7 +401,7 @@ test('Make Multi-Sig STX token transfer', async () => {
   expect(deserializedTx.auth.spendingCondition!.signer).toEqual(
     'a23ea89d6529ac48ac766f720e480beec7f19273'
   );
-  const deserializedPayload = deserializedTx.payload as TokenTransferPayload;
+  const deserializedPayload = deserializedTx.payload as TokenTransferPayloadWire;
   expect(deserializedPayload.amount.toString()).toBe(amount.toString());
 
   const serializedSignedTx = serializedTx;
@@ -482,7 +482,7 @@ test('Should deserialize partially signed multi-Sig STX token transfer', async (
   expect(deserializedTx.auth.spendingCondition!.signer).toEqual(
     'a23ea89d6529ac48ac766f720e480beec7f19273'
   );
-  const deserializedPayload = deserializedTx.payload as TokenTransferPayload;
+  const deserializedPayload = deserializedTx.payload as TokenTransferPayloadWire;
   expect(deserializedPayload.amount.toString()).toBe(amount.toString());
 
   const signedTx =
@@ -630,7 +630,7 @@ test('Make Multi-Sig STX token transfer with two transaction signers', async () 
   expect(deserializedTx.auth.spendingCondition!.signer).toEqual(
     'a23ea89d6529ac48ac766f720e480beec7f19273'
   );
-  const deserializedPayload = deserializedTx.payload as TokenTransferPayload;
+  const deserializedPayload = deserializedTx.payload as TokenTransferPayloadWire;
   expect(deserializedPayload.amount.toString()).toBe(amount.toString());
 
   const spendingCondition = deserializedTx.auth.spendingCondition as MultiSigSpendingCondition;
@@ -1486,7 +1486,7 @@ test('Make sponsored STX token transfer', async () => {
     signerSpendingCondition.signature.type.toString()
   );
 
-  const deserializedPayload = deserializedSponsorTx.payload as TokenTransferPayload;
+  const deserializedPayload = deserializedSponsorTx.payload as TokenTransferPayloadWire;
   expect(deserializedPayload.amount.toString()).toBe(amount.toString());
 });
 
@@ -1572,7 +1572,7 @@ test('Make sponsored STX token transfer with sponsor fee estimate', async () => 
   expect(deserializedSponsorSpendingCondition.nonce!.toString()).toBe(sponsorNonce.toString());
   expect(deserializedSponsorSpendingCondition.fee!.toString()).toBe('1');
 
-  const deserializedPayload = deserializedSponsorTx.payload as TokenTransferPayload;
+  const deserializedPayload = deserializedSponsorTx.payload as TokenTransferPayloadWire;
   expect(deserializedPayload.amount.toString()).toBe(amount.toString());
 });
 
@@ -1624,7 +1624,7 @@ test('Make sponsored STX token transfer with set tx fee', async () => {
   expect(deserializedSponsorSpendingCondition.nonce!.toString()).toBe(sponsorNonce.toString());
   expect(deserializedSponsorSpendingCondition.fee!.toString()).toBe(sponsorFee.toString());
 
-  const deserializedPayload = deserializedSponsorTx.payload as TokenTransferPayload;
+  const deserializedPayload = deserializedSponsorTx.payload as TokenTransferPayloadWire;
   expect(deserializedPayload.amount.toString()).toBe(amount.toString());
 });
 

--- a/packages/transactions/tests/payload.test.ts
+++ b/packages/transactions/tests/payload.test.ts
@@ -9,14 +9,14 @@ import {
 } from '../src/clarity';
 import { ClarityVersion, StacksWireType } from '../src/constants';
 import {
-  CoinbasePayload,
+  CoinbasePayloadWire,
   CoinbasePayloadToAltRecipient,
   ContractCallPayload,
-  SmartContractPayload,
+  SmartContractPayloadWire,
   TenureChangeCause,
-  TenureChangePayload,
-  TokenTransferPayload,
-  VersionedSmartContractPayload,
+  TenureChangePayloadWire,
+  TokenTransferPayloadWire,
+  VersionedSmartContractPayloadWire,
   createCoinbasePayload,
   createContractCallPayload,
   createSmartContractPayload,
@@ -36,7 +36,7 @@ test('STX token transfer payload serialization and deserialization', () => {
   const deserialized = serializeDeserialize(
     payload,
     StacksWireType.Payload
-  ) as TokenTransferPayload;
+  ) as TokenTransferPayloadWire;
   expect(deserialized.payloadType).toBe(payload.payloadType);
   expect(deserialized.recipient).toEqual(recipient);
   expect(deserialized.amount.toString()).toBe(amount.toString());
@@ -54,7 +54,7 @@ test('STX token transfer payload (to contract addr)  serialization and deseriali
   const deserialized = serializeDeserialize(
     payload,
     StacksWireType.Payload
-  ) as TokenTransferPayload;
+  ) as TokenTransferPayloadWire;
   expect(deserialized.payloadType).toBe(payload.payloadType);
   expect(deserialized.recipient).toEqual(recipient);
   expect(deserialized.amount.toString()).toBe(amount.toString());
@@ -69,7 +69,7 @@ test('STX token transfer payload (with contract principal string) serialization 
   const deserialized = serializeDeserialize(
     payload,
     StacksWireType.Payload
-  ) as TokenTransferPayload;
+  ) as TokenTransferPayloadWire;
   expect(deserialized.payloadType).toBe(payload.payloadType);
   expect(principalToString(deserialized.recipient)).toEqual(recipient);
   expect(deserialized.amount.toString()).toBe(amount.toString());
@@ -84,7 +84,7 @@ test('STX token transfer payload (with address principal string) serialization a
   const deserialized = serializeDeserialize(
     payload,
     StacksWireType.Payload
-  ) as TokenTransferPayload;
+  ) as TokenTransferPayloadWire;
   expect(deserialized.payloadType).toBe(payload.payloadType);
   expect(principalToString(deserialized.recipient)).toEqual(recipient);
   expect(deserialized.amount.toString()).toBe(amount.toString());
@@ -120,7 +120,7 @@ test('Smart contract payload serialization and deserialization', () => {
   const deserialized = serializeDeserialize(
     payload,
     StacksWireType.Payload
-  ) as SmartContractPayload;
+  ) as SmartContractPayloadWire;
   expect(deserialized.contractName.content).toBe(contractName);
   expect(deserialized.codeBody.content).toBe(codeBody);
 });
@@ -143,7 +143,7 @@ test('Versioned smart contract payload serialization and deserialization', () =>
   const deserialized = serializeDeserialize(
     payload,
     StacksWireType.Payload
-  ) as VersionedSmartContractPayload;
+  ) as VersionedSmartContractPayloadWire;
   expect(deserialized.clarityVersion).toBe(2);
   expect(deserialized.contractName.content).toBe(contractName);
   expect(deserialized.codeBody.content).toBe(codeBody);
@@ -154,7 +154,7 @@ test('Coinbase payload serialization and deserialization', () => {
 
   const payload = createCoinbasePayload(coinbaseBuffer);
 
-  const deserialized = serializeDeserialize(payload, StacksWireType.Payload) as CoinbasePayload;
+  const deserialized = serializeDeserialize(payload, StacksWireType.Payload) as CoinbasePayloadWire;
   expect(deserialized.coinbaseBytes).toEqual(coinbaseBuffer);
 });
 
@@ -208,7 +208,10 @@ test('serialize/deserialize tenure change payload', () => {
     publicKeyHash
   );
 
-  const deserialized = serializeDeserialize(payload, StacksWireType.Payload) as TenureChangePayload;
+  const deserialized = serializeDeserialize(
+    payload,
+    StacksWireType.Payload
+  ) as TenureChangePayloadWire;
   expect(deserialized).toEqual(payload);
 });
 

--- a/packages/transactions/tests/postcondition.test.ts
+++ b/packages/transactions/tests/postcondition.test.ts
@@ -5,13 +5,13 @@ import {
 } from '../src/postcondition';
 
 import {
-  STXPostCondition,
-  FungiblePostCondition,
-  NonFungiblePostCondition,
+  STXPostConditionWire,
+  FungiblePostConditionWire,
+  NonFungiblePostConditionWire,
   createAsset,
   createStandardPrincipal,
   createContractPrincipal,
-  ContractPrincipal,
+  ContractPrincipalWire,
 } from '../src/postcondition-types';
 import { addressToString } from '../src/common';
 
@@ -42,7 +42,7 @@ test('STX post condition serialization and deserialization', () => {
   const deserialized = serializeDeserialize(
     postCondition,
     StacksWireType.PostCondition
-  ) as STXPostCondition;
+  ) as STXPostConditionWire;
   expect(deserialized.conditionType).toBe(postConditionType);
   expect(deserialized.principal.prefix).toBe(PostConditionPrincipalId.Standard);
   expect(addressToString(deserialized.principal.address)).toBe(address);
@@ -69,7 +69,7 @@ test('Fungible post condition serialization and deserialization', () => {
   const deserialized = serializeDeserialize(
     postCondition,
     StacksWireType.PostCondition
-  ) as FungiblePostCondition;
+  ) as FungiblePostConditionWire;
   expect(deserialized.conditionType).toBe(postConditionType);
   expect(deserialized.principal.prefix).toBe(PostConditionPrincipalId.Standard);
   expect(addressToString(deserialized.principal.address)).toBe(address);
@@ -106,11 +106,11 @@ test('Non-fungible post condition serialization and deserialization', () => {
   const deserialized = serializeDeserialize(
     postCondition,
     StacksWireType.PostCondition
-  ) as NonFungiblePostCondition;
+  ) as NonFungiblePostConditionWire;
   expect(deserialized.conditionType).toBe(postConditionType);
   expect(deserialized.principal.prefix).toBe(PostConditionPrincipalId.Contract);
   expect(addressToString(deserialized.principal.address)).toBe(address);
-  expect((deserialized.principal as ContractPrincipal).contractName.content).toBe(contractName);
+  expect((deserialized.principal as ContractPrincipalWire).contractName.content).toBe(contractName);
   expect(deserialized.conditionCode).toBe(conditionCode);
   expect(addressToString(deserialized.asset.address)).toBe(assetAddress);
   expect(deserialized.asset.contractName.content).toBe(assetContractName);
@@ -142,11 +142,11 @@ test('Non-fungible post condition with string IDs serialization and deserializat
   const deserialized = serializeDeserialize(
     postCondition,
     StacksWireType.PostCondition
-  ) as NonFungiblePostCondition;
+  ) as NonFungiblePostConditionWire;
   expect(deserialized.conditionType).toBe(postConditionType);
   expect(deserialized.principal.prefix).toBe(PostConditionPrincipalId.Contract);
   expect(addressToString(deserialized.principal.address)).toBe(address);
-  expect((deserialized.principal as ContractPrincipal).contractName.content).toBe(contractName);
+  expect((deserialized.principal as ContractPrincipalWire).contractName.content).toBe(contractName);
   expect(deserialized.conditionCode).toBe(conditionCode);
   expect(addressToString(deserialized.asset.address)).toBe(assetAddress);
   expect(deserialized.asset.contractName.content).toBe(assetContractName);

--- a/packages/transactions/tests/transaction.test.ts
+++ b/packages/transactions/tests/transaction.test.ts
@@ -27,11 +27,11 @@ import {
 } from '../src/keys';
 import {
   CoinbasePayloadToAltRecipient,
-  TokenTransferPayload,
+  TokenTransferPayloadWire,
   createTokenTransferPayload,
 } from '../src/payload';
 import { createSTXPostCondition } from '../src/postcondition';
-import { STXPostCondition, createStandardPrincipal } from '../src/postcondition-types';
+import { STXPostConditionWire, createStandardPrincipal } from '../src/postcondition-types';
 import { TransactionSigner } from '../src/signer';
 import {
   StacksTransaction,
@@ -110,12 +110,12 @@ test('STX token transfer transaction serialization and deserialization', () => {
   expect(deserialized.postConditionMode).toBe(postConditionMode);
   expect(deserialized.postConditions.values.length).toBe(1);
 
-  const deserializedPostCondition = deserialized.postConditions.values[0] as STXPostCondition;
+  const deserializedPostCondition = deserialized.postConditions.values[0] as STXPostConditionWire;
   expect(deserializedPostCondition.principal.address).toStrictEqual(recipient.address);
   expect(deserializedPostCondition.conditionCode).toBe(FungibleConditionCode.GreaterEqual);
   expect(deserializedPostCondition.amount.toString()).toBe('0');
 
-  const deserializedPayload = deserialized.payload as TokenTransferPayload;
+  const deserializedPayload = deserialized.payload as TokenTransferPayloadWire;
   expect(deserializedPayload.recipient).toEqual(recipientCV);
   expect(deserializedPayload.amount.toString()).toBe(amount.toString());
 });
@@ -185,12 +185,12 @@ test('STX token transfer transaction fee setting', () => {
   expect(postSetFeeDeserialized.postConditions.values.length).toBe(1);
 
   const deserializedPostCondition = postSetFeeDeserialized.postConditions
-    .values[0] as STXPostCondition;
+    .values[0] as STXPostConditionWire;
   expect(deserializedPostCondition.principal.address).toStrictEqual(recipient.address);
   expect(deserializedPostCondition.conditionCode).toBe(FungibleConditionCode.GreaterEqual);
   expect(deserializedPostCondition.amount.toString()).toBe('0');
 
-  const deserializedPayload = postSetFeeDeserialized.payload as TokenTransferPayload;
+  const deserializedPayload = postSetFeeDeserialized.payload as TokenTransferPayloadWire;
   expect(deserializedPayload.recipient).toEqual(recipientCV);
   expect(deserializedPayload.amount.toString()).toBe(amount.toString());
 });
@@ -259,7 +259,7 @@ test('STX token transfer transaction multi-sig serialization and deserialization
   expect(deserialized.postConditionMode).toBe(PostConditionMode.Deny);
   expect(deserialized.postConditions.values.length).toBe(0);
 
-  const deserializedPayload = deserialized.payload as TokenTransferPayload;
+  const deserializedPayload = deserialized.payload as TokenTransferPayloadWire;
   expect(deserializedPayload.recipient).toEqual(recipientCV);
   expect(deserializedPayload.amount.toString()).toBe(amount.toString());
 });
@@ -379,7 +379,7 @@ test('Sponsored STX token transfer transaction serialization and deserialization
   expect(deserialized.anchorMode).toBe(anchorMode);
   expect(deserialized.postConditionMode).toBe(postConditionMode);
 
-  const deserializedPayload = deserialized.payload as TokenTransferPayload;
+  const deserializedPayload = deserialized.payload as TokenTransferPayloadWire;
   expect(deserializedPayload.recipient).toEqual(recipientCV);
   expect(deserializedPayload.amount.toString()).toBe(amount.toString());
 });

--- a/packages/transactions/tests/types.test.ts
+++ b/packages/transactions/tests/types.test.ts
@@ -7,13 +7,13 @@ import {
   addressFromPublicKeys,
 } from '../src/types';
 import {
-  LengthPrefixedString,
-  Asset,
+  LengthPrefixedStringWire,
+  AssetWire,
   createLPString,
   createAddress,
   createAsset,
 } from '../src/postcondition-types';
-import { Address, addressToString } from '../src/common';
+import { AddressWire, addressToString } from '../src/common';
 import { AddressHashMode, StacksWireType } from '../src/constants';
 
 import { serializeDeserialize } from './macros';
@@ -27,7 +27,7 @@ test('Length prefixed strings serialization and deserialization', () => {
   const deserialized = serializeDeserialize(
     lpString,
     StacksWireType.LengthPrefixedString
-  ) as LengthPrefixedString;
+  ) as LengthPrefixedStringWire;
   expect(deserialized.content).toBe(testString);
 
   const longTestString = 'a'.repeat(129);
@@ -135,7 +135,7 @@ test('C32 address hash mode - testnet P2WSH', () => {
 test('C32check addresses serialization and deserialization', () => {
   const c32AddressString = 'SP9YX31TK12T0EZKWP3GZXX8AM37JDQHAWM7VBTH';
   const addr = createAddress(c32AddressString);
-  const deserialized = serializeDeserialize(addr, StacksWireType.Address) as Address;
+  const deserialized = serializeDeserialize(addr, StacksWireType.Address) as AddressWire;
   expect(addressToString(deserialized)).toBe(c32AddressString);
 });
 
@@ -144,7 +144,7 @@ test('Asset info serialization and deserialization', () => {
   const assetContractName = 'contract_name';
   const assetName = 'asset_name';
   const info = createAsset(assetAddress, assetContractName, assetName);
-  const deserialized = serializeDeserialize(info, StacksWireType.Asset) as Asset;
+  const deserialized = serializeDeserialize(info, StacksWireType.Asset) as AssetWire;
   expect(addressToString(deserialized.address)).toBe(assetAddress);
   expect(deserialized.contractName.content).toBe(assetContractName);
   expect(deserialized.assetName.content).toBe(assetName);


### PR DESCRIPTION
> This PR was published to npm with the version `6.14.1-pr.43+5f1cb1b7`
> e.g. `npm install @stacks/common@6.14.1-pr.43+5f1cb1b7 --save-exact`<!-- Sticky Header Marker -->

- Renames more internals to have the `Wire` suffix (maybe not the best name, but should indicate wire-format / serialization representation)
- _Just_ renames, no logic change

I would like to do this to open more naming options for things developers will actually use. Ideally the Wire suffix isn't seen by most users, so next steps would also reduce this type in function signatures of helpers (reducing more wrapper types that are unnecessarily typed for most use-cases)