### PR TITLE
feat: Add non-sequential multi-sig support

### DIFF
--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -33,6 +33,7 @@ export enum PeerNetworkID {
 
 /** @ignore internal */
 export const PRIVATE_KEY_COMPRESSED_LENGTH = 33;
+// todo: `next` make length consts more consistent in naming
 
 /** @ignore internal */
 export const PRIVATE_KEY_UNCOMPRESSED_LENGTH = 32;

--- a/packages/transactions/src/authorization.ts
+++ b/packages/transactions/src/authorization.ts
@@ -273,8 +273,13 @@ export function deserializeMultiSigSpendingCondition(
   // Partially signed multi-sig tx can be serialized and deserialized without exception (Incorrect number of signatures)
   // No need to check numSigs !== signaturesRequired to throw Incorrect number of signatures error
 
-  if (haveUncompressed && hashMode === AddressHashMode.SerializeP2SH)
+  if (
+    haveUncompressed &&
+    (hashMode === AddressHashMode.SerializeP2WSH ||
+      hashMode === AddressHashMode.SerializeP2WSHNonSequential)
+  ) {
     throw new VerificationError('Uncompressed keys are not allowed in this hash mode');
+  }
 
   return {
     hashMode,
@@ -502,7 +507,11 @@ function verifyMultiSig(
   )
     throw new VerificationError('Incorrect number of signatures');
 
-  if (haveUncompressed && condition.hashMode === AddressHashMode.SerializeP2SH)
+  if (
+    haveUncompressed &&
+    (condition.hashMode === AddressHashMode.SerializeP2WSH ||
+      condition.hashMode === AddressHashMode.SerializeP2WSHNonSequential)
+  )
     throw new VerificationError('Uncompressed keys are not allowed in this hash mode');
 
   const addrBytes = addressFromPublicKeys(

--- a/packages/transactions/src/builders.ts
+++ b/packages/transactions/src/builders.ts
@@ -1738,12 +1738,14 @@ function mutatingSignAppendMultiSig(
 
   const signer = new TransactionSigner(transaction);
 
-  const pubs = sortPublicKeysForAddress(
-    publicKeys,
-    transaction.auth.spendingCondition.signaturesRequired,
-    transaction.auth.spendingCondition.hashMode,
-    address ? createAddress(address).hash160 : undefined
-  );
+  const pubs = address
+    ? sortPublicKeysForAddress(
+        publicKeys,
+        transaction.auth.spendingCondition.signaturesRequired,
+        transaction.auth.spendingCondition.hashMode,
+        createAddress(address).hash160
+      )
+    : publicKeys;
 
   // sign in order of public keys
   for (const publicKey of pubs) {
@@ -1763,10 +1765,8 @@ function sortPublicKeysForAddress(
   publicKeys: string[],
   numSigs: number,
   hashMode: MultiSigHashMode,
-  hash?: string
+  hash: string
 ): string[] {
-  if (!hash) return publicKeys;
-
   // unsorted
   const hashUnsorted = addressFromPublicKeys(
     0 as any, // only used for hash, so version doesn't matter

--- a/packages/transactions/src/builders.ts
+++ b/packages/transactions/src/builders.ts
@@ -701,7 +701,7 @@ export async function makeUnsignedSTXTokenTransfer(
       : AddressHashMode.SerializeP2SH;
 
     const publicKeys = options.address
-      ? ensureValidMultiSigPublicKeyOrder(
+      ? sortPublicKeysForAddress(
           options.publicKeys,
           options.numSignatures,
           hashMode,
@@ -966,7 +966,7 @@ export async function makeUnsignedContractDeploy(
       : AddressHashMode.SerializeP2SH;
 
     const publicKeys = options.address
-      ? ensureValidMultiSigPublicKeyOrder(
+      ? sortPublicKeysForAddress(
           options.publicKeys,
           options.numSignatures,
           hashMode,
@@ -1179,7 +1179,7 @@ export async function makeUnsignedContractCall(
       : AddressHashMode.SerializeP2SH;
 
     const publicKeys = options.address
-      ? ensureValidMultiSigPublicKeyOrder(
+      ? sortPublicKeysForAddress(
           options.publicKeys,
           options.numSignatures,
           hashMode,
@@ -1738,7 +1738,7 @@ function mutatingSignAppendMultiSig(
 
   const signer = new TransactionSigner(transaction);
 
-  const pubs = ensureValidMultiSigPublicKeyOrder(
+  const pubs = sortPublicKeysForAddress(
     publicKeys,
     transaction.auth.spendingCondition.signaturesRequired,
     transaction.auth.spendingCondition.hashMode,
@@ -1759,7 +1759,7 @@ function mutatingSignAppendMultiSig(
 }
 
 /** @internal Get the matching public-keys array for a multi-sig address */
-function ensureValidMultiSigPublicKeyOrder(
+function sortPublicKeysForAddress(
   publicKeys: string[],
   numSigs: number,
   hashMode: MultiSigHashMode,

--- a/packages/transactions/src/common.ts
+++ b/packages/transactions/src/common.ts
@@ -40,6 +40,7 @@ export function addressHashModeToVersion(
   hashMode: AddressHashMode,
   txVersion: TransactionVersion
 ): AddressVersion {
+  // todo: `next` refacto with network param
   switch (hashMode) {
     case AddressHashMode.SerializeP2PKH:
       switch (txVersion) {
@@ -53,8 +54,10 @@ export function addressHashModeToVersion(
           );
       }
     case AddressHashMode.SerializeP2SH:
+    case AddressHashMode.SerializeP2SHNonSequential:
     case AddressHashMode.SerializeP2WPKH:
     case AddressHashMode.SerializeP2WSH:
+    case AddressHashMode.SerializeP2WSHNonSequential:
       switch (txVersion) {
         case TransactionVersion.Mainnet:
           return AddressVersion.MainnetMultiSig;

--- a/packages/transactions/src/constants.ts
+++ b/packages/transactions/src/constants.ts
@@ -163,16 +163,27 @@ export enum AuthType {
 export enum AddressHashMode {
   /** `SingleSigHashMode` — hash160(public-key), same as bitcoin's p2pkh */
   SerializeP2PKH = 0x00,
-  /** `MultiSigHashMode` — hash160(multisig-redeem-script), same as bitcoin's multisig p2sh */
+  /** Legacy `MultiSigHashMode` — hash160(multisig-redeem-script), same as bitcoin's multisig p2sh */
   SerializeP2SH = 0x01,
   /** `SingleSigHashMode` — hash160(segwit-program-00(p2pkh)), same as bitcoin's p2sh-p2wpkh */
   SerializeP2WPKH = 0x02,
-  /** `MultiSigHashMode` — hash160(segwit-program-00(public-keys)), same as bitcoin's p2sh-p2wsh */
+  /** Legacy `MultiSigHashMode` — hash160(segwit-program-00(public-keys)), same as bitcoin's p2sh-p2wsh */
   SerializeP2WSH = 0x03,
+  /** Non-Sequential `MultiSigHashMode` — hash160(multisig-redeem-script), same as bitcoin's multisig p2sh */
+  SerializeP2SHNonSequential = 0x05,
+  /** Non-Sequential `MultiSigHashMode` — hash160(segwit-program-00(public-keys)), same as bitcoin's p2sh-p2wsh */
+  SerializeP2WSHNonSequential = 0x07,
+
+  // todo: `next` rename to remove the `Serialize` prefix?
+  // todo: `next` rename to remove `NonSequential` and add `Legacy` to sequential mutlisig
 }
 
 export type SingleSigHashMode = AddressHashMode.SerializeP2PKH | AddressHashMode.SerializeP2WPKH;
-export type MultiSigHashMode = AddressHashMode.SerializeP2SH | AddressHashMode.SerializeP2WSH;
+export type MultiSigHashMode =
+  | AddressHashMode.SerializeP2SH
+  | AddressHashMode.SerializeP2WSH
+  | AddressHashMode.SerializeP2SHNonSequential
+  | AddressHashMode.SerializeP2WSHNonSequential;
 
 /**
  * Address versions for identifying address types in an encoded Stacks address.

--- a/packages/transactions/src/keys.ts
+++ b/packages/transactions/src/keys.ts
@@ -140,6 +140,12 @@ export function compressPublicKey(publicKey: string | Uint8Array): StacksPublicK
   return createStacksPublicKey(compressed);
 }
 
+export function uncompressPublicKey(publicKey: string | Uint8Array): StacksPublicKey {
+  const hex = typeof publicKey === 'string' ? publicKey : bytesToHex(publicKey);
+  const compressed = Point.fromHex(hex).toHex(false);
+  return createStacksPublicKey(compressed);
+}
+
 export function deserializePublicKey(bytesReader: BytesReader): StacksPublicKey {
   const fieldId = bytesReader.readUInt8();
   const keyLength =
@@ -161,6 +167,7 @@ export function createStacksPrivateKey(key: string | Uint8Array): StacksPrivateK
 }
 
 export function makeRandomPrivKey(): StacksPrivateKey {
+  // todo: `next` default to compressed private key
   return createStacksPrivateKey(utils.randomPrivateKey());
 }
 

--- a/packages/transactions/src/utils.ts
+++ b/packages/transactions/src/utils.ts
@@ -34,6 +34,7 @@ export function cloneDeep<T>(obj: T): T {
   return lodashCloneDeep(obj);
 }
 
+// todo: remove this function and instead delete param without clone (if possible)?
 export function omit<T, K extends keyof any>(obj: T, prop: K): Omit<T, K> {
   const clone = cloneDeep(obj);
   // @ts-expect-error


### PR DESCRIPTION
> This PR was published to npm with the version `6.15.0`
> e.g. `npm install @stacks/common@6.15.0 --save-exact`<!-- Sticky Header Marker -->

- Adds non-sequential multi-sig support ✨ closes https://github.com/hirosystems/stacks.js/issues/1487

* Fixes incorrect compression check in signing algorithm
* Fixes incorrect compression in deserialization
* Fixes incorrect field order for legacy (sequential) multisig
* Cleans up opts types/interfaces for less duplication

**Related**: 
- [📓 SIP: non-sequential-multisig-transactions](https://github.com/jbencin/sips/blob/sip-02x-non-sequential-multisig-transactions/sips/sip-02x/sip-02x-non-sequential-multisig-transactions.md)
- Core PR https://github.com/stacks-network/stacks-core/pull/3710

---

Adds a `useNonSequentialMultiSig` flag to multi-sig transaction creation methods. (Along with the internals to support it)

So far this opt is marked `@experimental`, since the interface of the default could change. (And we likely want to see how the authorization type plays out on mainnet, before switching fully)

Example

```ts
      const tx = await makeSTXTokenTransfer({
        recipient: 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6',
        amount: 12_345n,
        fee: 1_000n,
        nonce: 2n,
        network: 'testnet',

        numSignatures: required,
        publicKeys: [k1, k2, k3],
        signerKeys: [k3, k1], // could sign in any order (even if serializing in between and not sharing state)

        useNonSequentialMultiSig: true, // <--- NEW OPTIONAL FLAG
      });
```

Comment

> The separate signing test really shows there is more work needed to make this easy to use for folks building a "real" multi-sig experience -- with serializing the transaction in between signatures. This could be added as a separate issue or addressed in a breaking change (there is an opportunity to clean up the TransactionSigner as well, which is intertwined with the StacksTransaction class).

> Follow up thoughts: This can probably be addressed with one mutating public method on the `StacksTransaction` called something like `.finalize()` or `.finalizeMultiSig()`, which ensures the transaction-auth-fields are in the intended order. (Might need the list of public-keys again, or can do an opinionated `.sort` first, but technically should work for legacy multi-sig as well).