### PR TITLE
fix: update multi-sig signer state

### DIFF
--- a/packages/transactions/tests/builder.test.ts
+++ b/packages/transactions/tests/builder.test.ts
@@ -412,7 +412,9 @@ test('Make Multi-Sig STX token transfer', async () => {
     anchorMode: AnchorMode.Any,
   });
   const signer = new TransactionSigner(transaction);
+  expect(signer.sigHash).toBe(transaction.signBegin());
   signer.signOrigin(privKeys[0]);
+  expect(signer.sigHash).not.toBe(transaction.signBegin());
   signer.signOrigin(privKeys[1]);
   signer.appendOrigin(pubKeys[2]);
   expect(() => transaction.verifyOrigin()).not.toThrow();
@@ -2629,11 +2631,17 @@ describe('multi-sig', () => {
       const signer = new TransactionSigner(tx);
 
       // sign in reverse order
+      expect(signer.sigHash).toBe(tx.signBegin());
       signer.signOrigin(createStacksPrivateKey(pk3));
+      expect(signer.sigHash).toBe(tx.signBegin());
       signer.signOrigin(createStacksPrivateKey(pk2));
+      expect(signer.sigHash).toBe(tx.signBegin());
       signer.appendOrigin(getPublicKey(createStacksPrivateKey(pk1)));
+      expect(signer.sigHash).toBe(tx.signBegin());
 
       if (isSingleSig(tx.auth.spendingCondition)) throw 'type error';
+
+      expect(signer.sigHash).toBe(tx.signBegin()); // sighash doesn't change for non-sequential multisig
 
       // todo: a `finalize` method would be nice to do this for us
       // we'll manually need to fix the order (for now)


### PR DESCRIPTION
> This PR was published to npm with the version `6.16.0`
> e.g. `npm install @stacks/common@6.16.0 --save-exact`<!-- Sticky Header Marker -->

- minor update to the multi sig changes (signer sighash was not correct in all states) 