### PR TITLE
feat!: Update post-condition representation to humand readable types

### DIFF
--- a/.github/MIGRATION.md
+++ b/.github/MIGRATION.md
@@ -7,6 +7,7 @@
   - [StacksNodeApi](#stacksnodeapi)
   - [StacksNetwork to StacksNodeApi](#stacksnetwork-to-stacksnodeapi)
   - [Clarity Representation](#clarity-representation)
+  - [Post-conditions](#post-conditions)
   - [`serialize` methods](#serialize-methods)
   - [Asset Helper Methods](#asset-helper-methods)
   - [CLI](#cli)
@@ -31,7 +32,8 @@
 ### Breaking Changes
 
 - The `@stacks/network` `new StacksNetwork()` objects were removed. Instead `@stacks/network` now exports the objects `STACKS_MAINNET`, `STACKS_TESNET`, and `STACKS_DEVNET`, which are static (and shouldn't be changed for most use-cases). [Read more...](#stacks-network)
-- The `ClarityType` enum was replaced by a readable version. The previous (wire format compatible) enum is still available as `ClarityWireType`. [Read more...](#clarity-representation)
+- The `ClarityType` enum was replaced by a human-readable version. The previous (wire format compatible) enum is still available as `ClarityWireType`. [Read more...](#clarity-representation)
+- The previous post-conditions types and `create..` methods were replaced with a human-readable representation. [Read more...](#post-conditions)
 - `StacksTransaction.serialize` and other `serializeXyz` methods were changed to return `string` (hex-encoded) instead of `Uint8Array`. Compatible `serializeXzyBytes` methods were added to ease the migration. [Read more...](#serialize-methods)
 - The `AssetInfo` type was renamed to `Asset` for accuracy. The `Asset` helper methods were also renamed to to remove the `Info` suffix. [Read more...](#asset-helper-methods)
 - Remove legacy CLI methods. [Read more...](#cli)
@@ -158,6 +160,41 @@ For `bigint` values, the type of the `value` property is a now `string`, for bet
 -  list: [ ... ],
 +  value: [ ... ],
 }
+```
+
+### Post-conditions
+
+The old `PostCondition` type was renamed to `PostConditionWire`.
+A new human-readable `PostCondition` type was introduced in its place.
+
+Below is an example of the new `PostCondition` types.
+
+```ts
+// STX post-condition
+const stxPostCondition: StxPostCondition = {
+  type: 'stx-postcondition',
+  address: 'SP2JXKMSH007NPYAQHKJPQMAQYAD90NQGTVJVQ02B',
+  condition: 'gte',
+  amount: '100',
+};
+
+// Fungible token post-condition
+const ftPostCondition: FungiblePostCondition = {
+  type: 'ft-postcondition',
+  address: 'SP2JXKMSH007NPYAQHKJPQMAQYAD90NQGTVJVQ02B',
+  condition: 'eq',
+  amount: '100',
+  asset: 'SP3D6PV2ACBPEKYJTCMH7HEN02KP87QSP8KTEH335.my-ft-token::my-token',
+};
+
+// Non-fungible token post-condition
+const nftPostCondition: NonFungiblePostCondition = {
+  type: 'nft-postcondition',
+  address: 'SP2JXKMSH007NPYAQHKJPQMAQYAD90NQGTVJVQ02B',
+  condition: 'sent',
+  asset: 'SP3D6PV2ACBPEKYJTCMH7HEN02KP87QSP8KTEH335.my-nft::my-asset',
+  assetId: Cl.uint(602),
+};
 ```
 
 ### `serialize` methods

--- a/packages/bns/tests/bns.test.ts
+++ b/packages/bns/tests/bns.test.ts
@@ -1,16 +1,13 @@
 import { utf8ToBytes } from '@stacks/common';
 import { STACKS_TESTNET } from '@stacks/network';
 import {
-  FungibleConditionCode,
-  NonFungibleConditionCode,
+  NonFungiblePostCondition,
+  StxPostCondition,
   bufferCV,
   bufferCVFromString,
-  createNonFungiblePostCondition,
-  createSTXPostCondition,
   falseCV,
   hash160,
   noneCV,
-  parseAssetString,
   publicKeyToAddress,
   responseErrorCV,
   responseOkCV,
@@ -317,11 +314,12 @@ test('preorderNamespace', async () => {
   });
 
   const bnsFunctionName = 'namespace-preorder';
-  const burnSTXPostCondition = createSTXPostCondition(
-    publicKeyToAddress(network.addressVersion.singleSig, publicKey),
-    FungibleConditionCode.Equal,
-    stxToBurn
-  );
+  const burnSTXPostCondition: StxPostCondition = {
+    type: 'stx-postcondition',
+    address: publicKeyToAddress(network.addressVersion.singleSig, publicKey),
+    condition: 'eq',
+    amount: stxToBurn,
+  };
   const expectedBNSContractCallOptions = {
     contractAddress: STACKS_TESTNET.bootAddress,
     contractName: BNS_CONTRACT_NAME,
@@ -537,11 +535,12 @@ test('preorderName', async () => {
   });
 
   const bnsFunctionName = 'name-preorder';
-  const burnSTXPostCondition = createSTXPostCondition(
-    publicKeyToAddress(network.addressVersion.singleSig, publicKey),
-    FungibleConditionCode.Equal,
-    stxToBurn
-  );
+  const burnSTXPostCondition: StxPostCondition = {
+    type: 'stx-postcondition',
+    address: publicKeyToAddress(network.addressVersion.singleSig, publicKey),
+    condition: 'eq',
+    amount: stxToBurn,
+  };
   const expectedBNSContractCallOptions = {
     contractAddress: STACKS_TESTNET.bootAddress,
     contractName: BNS_CONTRACT_NAME,
@@ -680,24 +679,26 @@ test('transferName', async () => {
   const bnsFunctionName = 'name-transfer';
 
   const { namespace, name } = decodeFQN(fullyQualifiedName);
-  const nameTransferPostConditionOne = createNonFungiblePostCondition(
-    publicKeyToAddress(network.addressVersion.singleSig, publicKey),
-    NonFungibleConditionCode.Sends,
-    parseAssetString(`${network.bootAddress}.bns::names`),
-    tupleCV({
+  const nameTransferPostConditionOne: NonFungiblePostCondition = {
+    type: 'nft-postcondition',
+    address: publicKeyToAddress(network.addressVersion.singleSig, publicKey),
+    condition: 'sent',
+    asset: `${network.bootAddress}.bns::names`,
+    assetId: tupleCV({
       name: bufferCVFromString(name),
       namespace: bufferCVFromString(namespace),
-    })
-  );
-  const nameTransferPostConditionTwo = createNonFungiblePostCondition(
-    newOwnerAddress,
-    NonFungibleConditionCode.DoesNotSend,
-    parseAssetString(`${network.bootAddress}.bns::names`),
-    tupleCV({
+    }),
+  };
+  const nameTransferPostConditionTwo: NonFungiblePostCondition = {
+    type: 'nft-postcondition',
+    address: newOwnerAddress,
+    condition: 'not-sent',
+    asset: `${network.bootAddress}.bns::names`,
+    assetId: tupleCV({
       name: bufferCVFromString(name),
       namespace: bufferCVFromString(namespace),
-    })
-  );
+    }),
+  };
   const expectedBNSContractCallOptions = {
     contractAddress: STACKS_TESTNET.bootAddress,
     contractName: BNS_CONTRACT_NAME,
@@ -747,24 +748,26 @@ test('transferName optionalArguments', async () => {
   const bnsFunctionName = 'name-transfer';
 
   const { namespace, name } = decodeFQN(fullyQualifiedName);
-  const nameTransferPostConditionOne = createNonFungiblePostCondition(
-    publicKeyToAddress(network.addressVersion.singleSig, publicKey),
-    NonFungibleConditionCode.Sends,
-    parseAssetString(`${network.bootAddress}.bns::names`),
-    tupleCV({
+  const nameTransferPostConditionOne: NonFungiblePostCondition = {
+    type: 'nft-postcondition',
+    address: publicKeyToAddress(network.addressVersion.singleSig, publicKey),
+    condition: 'sent',
+    asset: `${network.bootAddress}.bns::names`,
+    assetId: tupleCV({
       name: bufferCVFromString(name),
       namespace: bufferCVFromString(namespace),
-    })
-  );
-  const nameTransferPostConditionTwo = createNonFungiblePostCondition(
-    newOwnerAddress,
-    NonFungibleConditionCode.DoesNotSend,
-    parseAssetString(`${network.bootAddress}.bns::names`),
-    tupleCV({
+    }),
+  };
+  const nameTransferPostConditionTwo: NonFungiblePostCondition = {
+    type: 'nft-postcondition',
+    address: newOwnerAddress,
+    condition: 'not-sent',
+    asset: `${network.bootAddress}.bns::names`,
+    assetId: tupleCV({
       name: bufferCVFromString(name),
       namespace: bufferCVFromString(namespace),
-    })
-  );
+    }),
+  };
   const expectedBNSContractCallOptions = {
     contractAddress: STACKS_TESTNET.bootAddress,
     contractName: BNS_CONTRACT_NAME,
@@ -852,11 +855,12 @@ test('renewName', async () => {
   const bnsFunctionName = 'name-renewal';
 
   const { namespace, name } = decodeFQN(fullyQualifiedName);
-  const burnSTXPostCondition = createSTXPostCondition(
-    publicKeyToAddress(network.addressVersion.singleSig, publicKey),
-    FungibleConditionCode.Equal,
-    stxToBurn
-  );
+  const burnSTXPostCondition: StxPostCondition = {
+    type: 'stx-postcondition',
+    address: publicKeyToAddress(network.addressVersion.singleSig, publicKey),
+    condition: 'eq',
+    amount: stxToBurn,
+  };
   const expectedBNSContractCallOptions = {
     contractAddress: STACKS_TESTNET.bootAddress,
     contractName: BNS_CONTRACT_NAME,
@@ -907,11 +911,12 @@ test('renewName optionalArguments', async () => {
   const bnsFunctionName = 'name-renewal';
 
   const { namespace, name } = decodeFQN(fullyQualifiedName);
-  const burnSTXPostCondition = createSTXPostCondition(
-    publicKeyToAddress(network.addressVersion.singleSig, publicKey),
-    FungibleConditionCode.Equal,
-    stxToBurn
-  );
+  const burnSTXPostCondition: StxPostCondition = {
+    type: 'stx-postcondition',
+    address: publicKeyToAddress(network.addressVersion.singleSig, publicKey),
+    condition: 'eq',
+    amount: stxToBurn,
+  };
   const expectedBNSContractCallOptions = {
     contractAddress: STACKS_TESTNET.bootAddress,
     contractName: BNS_CONTRACT_NAME,

--- a/packages/stacking/src/index.ts
+++ b/packages/stacking/src/index.ts
@@ -40,7 +40,6 @@ import {
   makeContractCall,
   noneCV,
   principalCV,
-  principalToString,
   someCV,
   stringAsciiCV,
   uintCV,
@@ -434,10 +433,14 @@ export class StackingClient {
 
     return unwrapMap(result as OptionalCV<TupleCV>, tuple => ({
       pox_address: {
-        version: ((tuple.data['pox-addr'] as TupleCV).data['version'] as BufferCV).buffer,
-        hashbytes: ((tuple.data['pox-addr'] as TupleCV).data['hashbytes'] as BufferCV).buffer,
+        version: hexToBytes(
+          ((tuple.value['pox-addr'] as TupleCV).value['version'] as BufferCV).value
+        ),
+        hashbytes: hexToBytes(
+          ((tuple.value['pox-addr'] as TupleCV).value['hashbytes'] as BufferCV).value
+        ),
       },
-      total_ustx: (tuple.data['total-ustx'] as UIntCV).value,
+      total_ustx: BigInt((tuple.value['total-ustx'] as UIntCV).value),
     }));
   }
 
@@ -1388,11 +1391,11 @@ export class StackingClient {
       if (responseCV.type === ClarityType.OptionalSome) {
         const someCV = responseCV;
         const tupleCV: TupleCV = someCV.value as TupleCV;
-        const poxAddress: TupleCV = tupleCV.data['pox-addr'] as TupleCV;
-        const firstRewardCycle: UIntCV = tupleCV.data['first-reward-cycle'] as UIntCV;
-        const lockPeriod: UIntCV = tupleCV.data['lock-period'] as UIntCV;
-        const version: BufferCV = poxAddress.data['version'] as BufferCV;
-        const hashbytes: BufferCV = poxAddress.data['hashbytes'] as BufferCV;
+        const poxAddress: TupleCV = tupleCV.value['pox-addr'] as TupleCV;
+        const firstRewardCycle: UIntCV = tupleCV.value['first-reward-cycle'] as UIntCV;
+        const lockPeriod: UIntCV = tupleCV.value['lock-period'] as UIntCV;
+        const version: BufferCV = poxAddress.value['version'] as BufferCV;
+        const hashbytes: BufferCV = poxAddress.value['hashbytes'] as BufferCV;
 
         return {
           stacked: true,
@@ -1401,8 +1404,8 @@ export class StackingClient {
             lock_period: Number(lockPeriod.value),
             unlock_height: account.unlock_height,
             pox_address: {
-              version: version.buffer,
-              hashbytes: hashbytes.buffer,
+              version: hexToBytes(version.value),
+              hashbytes: hexToBytes(hashbytes.value),
             },
           },
         };
@@ -1436,20 +1439,20 @@ export class StackingClient {
     }).then((responseCV: ClarityValue) => {
       if (responseCV.type === ClarityType.OptionalSome) {
         const tupleCV = responseCV.value as TupleCV;
-        const amountMicroStx = tupleCV.data['amount-ustx'] as UIntCV;
-        const delegatedTo = tupleCV.data['delegated-to'] as PrincipalCV;
+        const amountMicroStx = tupleCV.value['amount-ustx'] as UIntCV;
+        const delegatedTo = tupleCV.value['delegated-to'] as PrincipalCV;
 
-        const poxAddress = unwrapMap(tupleCV.data['pox-addr'] as OptionalCV<TupleCV>, tuple => ({
-          version: (tuple.data['version'] as BufferCV).buffer[0],
-          hashbytes: (tuple.data['hashbytes'] as BufferCV).buffer,
+        const poxAddress = unwrapMap(tupleCV.value['pox-addr'] as OptionalCV<TupleCV>, tuple => ({
+          version: hexToBytes((tuple.value['version'] as BufferCV).value)[0],
+          hashbytes: hexToBytes((tuple.value['hashbytes'] as BufferCV).value),
         }));
-        const untilBurnBlockHeight = unwrap(tupleCV.data['until-burn-ht'] as OptionalCV<UIntCV>);
+        const untilBurnBlockHeight = unwrap(tupleCV.value['until-burn-ht'] as OptionalCV<UIntCV>);
 
         return {
           delegated: true,
           details: {
             amount_micro_stx: BigInt(amountMicroStx.value),
-            delegated_to: principalToString(delegatedTo),
+            delegated_to: delegatedTo.value,
             pox_address: poxAddress,
             until_burn_ht: untilBurnBlockHeight ? Number(untilBurnBlockHeight.value) : undefined,
           },

--- a/packages/stacking/src/utils.ts
+++ b/packages/stacking/src/utils.ts
@@ -1,6 +1,6 @@
 import { sha256 } from '@noble/hashes/sha256';
 import { bech32, bech32m } from '@scure/base';
-import { IntegerType, PrivateKey, bigIntToBytes } from '@stacks/common';
+import { IntegerType, PrivateKey, bigIntToBytes, hexToBytes } from '@stacks/common';
 import {
   base58CheckDecode,
   base58CheckEncode,
@@ -142,26 +142,29 @@ export function decodeBtcAddress(btcAddress: string): {
   }
 }
 
-export function extractPoxAddressFromClarityValue(poxAddrClarityValue: ClarityValue) {
+export function extractPoxAddressFromClarityValue(poxAddrClarityValue: ClarityValue): {
+  version: number;
+  hashBytes: Uint8Array;
+} {
   const clarityValue = poxAddrClarityValue as TupleCV;
-  if (clarityValue.type !== ClarityType.Tuple || !clarityValue.data) {
+  if (clarityValue.type !== ClarityType.Tuple || !clarityValue.value) {
     throw new Error('Invalid argument, expected ClarityValue to be a TupleCV');
   }
-  if (!('version' in clarityValue.data) || !('hashbytes' in clarityValue.data)) {
+  if (!('version' in clarityValue.value) || !('hashbytes' in clarityValue.value)) {
     throw new Error(
       'Invalid argument, expected Clarity tuple value to contain `version` and `hashbytes` keys'
     );
   }
-  const versionCV = clarityValue.data['version'] as BufferCV;
-  const hashBytesCV = clarityValue.data['hashbytes'] as BufferCV;
+  const versionCV = clarityValue.value['version'] as BufferCV;
+  const hashBytesCV = clarityValue.value['hashbytes'] as BufferCV;
   if (versionCV.type !== ClarityType.Buffer || hashBytesCV.type !== ClarityType.Buffer) {
     throw new Error(
       'Invalid argument, expected Clarity tuple value to contain `version` and `hashbytes` buffers'
     );
   }
   return {
-    version: versionCV.buffer[0],
-    hashBytes: hashBytesCV.buffer,
+    version: hexToBytes(versionCV.value)[0],
+    hashBytes: hexToBytes(hashBytesCV.value),
   };
 }
 

--- a/packages/stacking/tests/stacking.test.ts
+++ b/packages/stacking/tests/stacking.test.ts
@@ -1110,14 +1110,14 @@ test('pox address to btc address', () => {
   vectors.forEach(item => {
     const clarityValue: TupleCV = {
       type: ClarityType.Tuple,
-      data: {
+      value: {
         version: {
           type: ClarityType.Buffer,
-          buffer: new Uint8Array([item.version]),
+          value: bytesToHex(new Uint8Array([item.version])),
         },
         hashbytes: {
           type: ClarityType.Buffer,
-          buffer: item.hashBytes,
+          value: bytesToHex(item.hashBytes),
         },
       },
     };

--- a/packages/stacking/tests/utils.test.ts
+++ b/packages/stacking/tests/utils.test.ts
@@ -72,10 +72,10 @@ test.each(BTC_ADDRESS_CASES)(
     expect(decoded.data).toHaveLength(expectedLength);
 
     const tuple = poxAddressToTuple(address);
-    expect(tuple.data['version'].buffer).toHaveLength(1);
-    expect(tuple.data['version'].buffer[0]).toBe(expectedVersion);
-    expect(tuple.data['hashbytes'].buffer).toEqual(hexToBytes(expectedHash));
-    expect(tuple.data['hashbytes'].buffer).toHaveLength(expectedLength);
+    expect(hexToBytes(tuple.value['version'].value)).toHaveLength(1);
+    expect(hexToBytes(tuple.value['version'].value)[0]).toBe(expectedVersion);
+    expect(tuple.value['hashbytes'].value).toEqual(expectedHash);
+    expect(hexToBytes(tuple.value['hashbytes'].value)).toHaveLength(expectedLength);
   }
 );
 

--- a/packages/transactions/src/clarity/clarityValue.ts
+++ b/packages/transactions/src/clarity/clarityValue.ts
@@ -15,10 +15,9 @@ import {
   SomeCV,
   TrueCV,
   FalseCV,
-  principalToString,
 } from '.';
 import { ClarityType } from './constants';
-import { asciiToBytes, bytesToAscii, bytesToHex, utf8ToBytes } from '@stacks/common';
+import { asciiToBytes, bytesToAscii, hexToBytes, utf8ToBytes } from '@stacks/common';
 
 export type ClarityValue =
   | BooleanCV
@@ -48,12 +47,12 @@ export function cvToString(val: ClarityValue, encoding: 'tryAscii' | 'hex' = 'he
       return `u${val.value.toString()}`;
     case ClarityType.Buffer:
       if (encoding === 'tryAscii') {
-        const str = bytesToAscii(val.buffer);
+        const str = bytesToAscii(hexToBytes(val.value));
         if (/[ -~]/.test(str)) {
           return JSON.stringify(str);
         }
       }
-      return `0x${bytesToHex(val.buffer)}`;
+      return `0x${val.value}`;
     case ClarityType.OptionalNone:
       return 'none';
     case ClarityType.OptionalSome:
@@ -64,17 +63,17 @@ export function cvToString(val: ClarityValue, encoding: 'tryAscii' | 'hex' = 'he
       return `(ok ${cvToString(val.value, encoding)})`;
     case ClarityType.PrincipalStandard:
     case ClarityType.PrincipalContract:
-      return principalToString(val);
+      return val.value;
     case ClarityType.List:
-      return `(list ${val.list.map(v => cvToString(v, encoding)).join(' ')})`;
+      return `(list ${val.value.map(v => cvToString(v, encoding)).join(' ')})`;
     case ClarityType.Tuple:
-      return `(tuple ${Object.keys(val.data)
-        .map(key => `(${key} ${cvToString(val.data[key], encoding)})`)
+      return `(tuple ${Object.keys(val.value)
+        .map(key => `(${key} ${cvToString(val.value[key], encoding)})`)
         .join(' ')})`;
     case ClarityType.StringASCII:
-      return `"${val.data}"`;
+      return `"${val.value}"`;
     case ClarityType.StringUTF8:
-      return `u"${val.data}"`;
+      return `u"${val.value}"`;
   }
 }
 
@@ -96,7 +95,7 @@ export function cvToValue(val: ClarityValue, strictJsonCompat: boolean = false):
       }
       return val.value;
     case ClarityType.Buffer:
-      return `0x${bytesToHex(val.buffer)}`;
+      return `0x${val.value}`;
     case ClarityType.OptionalNone:
       return null;
     case ClarityType.OptionalSome:
@@ -107,19 +106,19 @@ export function cvToValue(val: ClarityValue, strictJsonCompat: boolean = false):
       return cvToJSON(val.value);
     case ClarityType.PrincipalStandard:
     case ClarityType.PrincipalContract:
-      return principalToString(val);
+      return val.value;
     case ClarityType.List:
-      return val.list.map(v => cvToJSON(v));
+      return val.value.map(v => cvToJSON(v));
     case ClarityType.Tuple:
       const result: { [key: string]: any } = {};
-      Object.keys(val.data).forEach(key => {
-        result[key] = cvToJSON(val.data[key]);
+      Object.keys(val.value).forEach(key => {
+        result[key] = cvToJSON(val.value[key]);
       });
       return result;
     case ClarityType.StringASCII:
-      return val.data;
+      return val.value;
     case ClarityType.StringUTF8:
-      return val.data;
+      return val.value;
   }
 }
 
@@ -144,7 +143,7 @@ export function getCVTypeString(val: ClarityValue): string {
     case ClarityType.UInt:
       return 'uint';
     case ClarityType.Buffer:
-      return `(buff ${val.buffer.length})`;
+      return `(buff ${Math.ceil(val.value.length / 2)})`;
     case ClarityType.OptionalNone:
       return '(optional none)';
     case ClarityType.OptionalSome:
@@ -157,17 +156,17 @@ export function getCVTypeString(val: ClarityValue): string {
     case ClarityType.PrincipalContract:
       return 'principal';
     case ClarityType.List:
-      return `(list ${val.list.length} ${
-        val.list.length ? getCVTypeString(val.list[0]) : 'UnknownType'
+      return `(list ${val.value.length} ${
+        val.value.length ? getCVTypeString(val.value[0]) : 'UnknownType'
       })`;
     case ClarityType.Tuple:
-      return `(tuple ${Object.keys(val.data)
-        .map(key => `(${key} ${getCVTypeString(val.data[key])})`)
+      return `(tuple ${Object.keys(val.value)
+        .map(key => `(${key} ${getCVTypeString(val.value[key])})`)
         .join(' ')})`;
     case ClarityType.StringASCII:
-      return `(string-ascii ${asciiToBytes(val.data).length})`;
+      return `(string-ascii ${asciiToBytes(val.value).length})`;
     case ClarityType.StringUTF8:
-      return `(string-utf8 ${utf8ToBytes(val.data).length})`;
+      return `(string-utf8 ${utf8ToBytes(val.value).length})`;
   }
 }
 

--- a/packages/transactions/src/clarity/parser.ts
+++ b/packages/transactions/src/clarity/parser.ts
@@ -236,7 +236,7 @@ function clTuple(): Combinator {
         ],
         ([k, v]) => Cl.tuple({ [k as string]: v as ClarityValue })
       ),
-      c => Cl.tuple(Object.assign({}, ...c.map(t => (t as TupleCV).data))),
+      c => Cl.tuple(Object.assign({}, ...c.map(t => (t as TupleCV).value))),
       regex(/\s*\,\s*/)
     ),
     regex(/\}/),
@@ -261,7 +261,7 @@ function clTuple(): Combinator {
             ([k, v]) => Cl.tuple({ [k as string]: v as ClarityValue })
           )
         ),
-        c => Cl.tuple(Object.assign({}, ...c.map(t => (t as TupleCV).data))),
+        c => Cl.tuple(Object.assign({}, ...c.map(t => (t as TupleCV).value))),
         whitespace()
       ),
     ])

--- a/packages/transactions/src/clarity/prettyPrint.ts
+++ b/packages/transactions/src/clarity/prettyPrint.ts
@@ -6,8 +6,7 @@
   `Cl.tuple({ id: u1 })` => { id: u1 }
 */
 
-import { bytesToHex } from '@stacks/common';
-import { ClarityType, ClarityValue, ListCV, TupleCV, principalToString } from '.';
+import { ClarityType, ClarityValue, ListCV, TupleCV } from '.';
 
 function formatSpace(space: number, depth: number, end = false) {
   if (!space) return ' ';
@@ -29,12 +28,12 @@ function formatSpace(space: number, depth: number, end = false) {
  * ```
  */
 function formatList(cv: ListCV, space: number, depth = 1): string {
-  if (cv.list.length === 0) return '(list)';
+  if (cv.value.length === 0) return '(list)';
 
   const spaceBefore = formatSpace(space, depth, false);
   const endSpace = space ? formatSpace(space, depth, true) : '';
 
-  const items = cv.list.map(v => prettyPrintWithDepth(v, space, depth)).join(spaceBefore);
+  const items = cv.value.map(v => prettyPrintWithDepth(v, space, depth)).join(spaceBefore);
 
   return `(list${spaceBefore}${items}${endSpace})`;
 }
@@ -56,10 +55,10 @@ function formatList(cv: ListCV, space: number, depth = 1): string {
  * ```
  */
 function formatTuple(cv: TupleCV, space: number, depth = 1): string {
-  if (Object.keys(cv.data).length === 0) return '{}';
+  if (Object.keys(cv.value).length === 0) return '{}';
 
   const items: string[] = [];
-  for (const [key, value] of Object.entries(cv.data)) {
+  for (const [key, value] of Object.entries(cv.value)) {
     items.push(`${key}: ${prettyPrintWithDepth(value, space, depth)}`);
   }
 
@@ -81,13 +80,13 @@ function prettyPrintWithDepth(cv: ClarityValue, space = 0, depth: number): strin
   if (cv.type === ClarityType.Int) return cv.value.toString();
   if (cv.type === ClarityType.UInt) return `u${cv.value.toString()}`;
 
-  if (cv.type === ClarityType.StringASCII) return `"${cv.data}"`;
-  if (cv.type === ClarityType.StringUTF8) return `u"${cv.data}"`;
+  if (cv.type === ClarityType.StringASCII) return `"${cv.value}"`;
+  if (cv.type === ClarityType.StringUTF8) return `u"${cv.value}"`;
 
-  if (cv.type === ClarityType.PrincipalContract) return `'${principalToString(cv)}`;
-  if (cv.type === ClarityType.PrincipalStandard) return `'${principalToString(cv)}`;
+  if (cv.type === ClarityType.PrincipalContract) return `'${cv.value}`;
+  if (cv.type === ClarityType.PrincipalStandard) return `'${cv.value}`;
 
-  if (cv.type === ClarityType.Buffer) return `0x${bytesToHex(cv.buffer)}`;
+  if (cv.type === ClarityType.Buffer) return `0x${cv.value}`;
 
   if (cv.type === ClarityType.OptionalNone) return 'none';
   if (cv.type === ClarityType.OptionalSome)

--- a/packages/transactions/src/clarity/types.ts
+++ b/packages/transactions/src/clarity/types.ts
@@ -1,5 +1,4 @@
-import { AddressWire } from '../common';
-import { LengthPrefixedStringWire } from '../postcondition-types';
+import { ContractIdString } from '../types';
 import { ClarityValue } from './clarityValue';
 import { ClarityType } from './constants';
 
@@ -15,22 +14,22 @@ export interface FalseCV {
 
 export interface BufferCV {
   readonly type: ClarityType.Buffer;
-  readonly buffer: Uint8Array;
+  readonly value: string;
 }
 
 export interface IntCV {
   readonly type: ClarityType.Int;
-  readonly value: bigint;
+  readonly value: bigint | number | string;
 }
 
 export interface UIntCV {
   readonly type: ClarityType.UInt;
-  readonly value: bigint;
+  readonly value: bigint | number | string;
 }
 
 export interface ListCV<T extends ClarityValue = ClarityValue> {
   type: ClarityType.List;
-  list: T[];
+  value: T[];
 }
 
 export type OptionalCV<T extends ClarityValue = ClarityValue> = NoneCV | SomeCV<T>;
@@ -48,13 +47,12 @@ export type PrincipalCV = StandardPrincipalCV | ContractPrincipalCV;
 
 export interface StandardPrincipalCV {
   readonly type: ClarityType.PrincipalStandard;
-  readonly address: AddressWire;
+  readonly value: string;
 }
 
 export interface ContractPrincipalCV {
   readonly type: ClarityType.PrincipalContract;
-  readonly address: AddressWire;
-  readonly contractName: LengthPrefixedStringWire;
+  readonly value: ContractIdString;
 }
 
 export type ResponseCV = ResponseErrorCV | ResponseOkCV;
@@ -71,17 +69,17 @@ export interface ResponseOkCV<T extends ClarityValue = ClarityValue> {
 
 export interface StringAsciiCV {
   readonly type: ClarityType.StringASCII;
-  readonly data: string;
+  readonly value: string;
 }
 
 export interface StringUtf8CV {
   readonly type: ClarityType.StringUTF8;
-  readonly data: string;
+  readonly value: string;
 }
 
 export type TupleData<T extends ClarityValue = ClarityValue> = { [key: string]: T };
 
 export interface TupleCV<T extends TupleData = TupleData> {
   type: ClarityType.Tuple;
-  data: T;
+  value: T;
 }

--- a/packages/transactions/src/clarity/values/bufferCV.ts
+++ b/packages/transactions/src/clarity/values/bufferCV.ts
@@ -1,4 +1,4 @@
-import { utf8ToBytes } from '@stacks/common';
+import { bytesToHex, utf8ToBytes } from '@stacks/common';
 import { ClarityType } from '../constants';
 import { BufferCV } from '../types';
 
@@ -29,7 +29,7 @@ export const bufferCV = (buffer: Uint8Array): BufferCV => {
     throw new Error('Cannot construct clarity buffer that is greater than 1MB');
   }
 
-  return { type: ClarityType.Buffer, buffer };
+  return { type: ClarityType.Buffer, value: bytesToHex(buffer) };
 };
 
 /**

--- a/packages/transactions/src/clarity/values/listCV.ts
+++ b/packages/transactions/src/clarity/values/listCV.ts
@@ -21,5 +21,5 @@ import { ListCV } from '../types';
  * {@link https://github.com/hirosystems/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 export function listCV<T extends ClarityValue = ClarityValue>(values: T[]): ListCV<T> {
-  return { type: ClarityType.List, list: values };
+  return { type: ClarityType.List, value: values };
 }

--- a/packages/transactions/src/clarity/values/stringCV.ts
+++ b/packages/transactions/src/clarity/values/stringCV.ts
@@ -21,7 +21,7 @@ import { StringAsciiCV, StringUtf8CV } from '../types';
  * {@link https://github.com/hirosystems/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 export const stringAsciiCV = (data: string): StringAsciiCV => {
-  return { type: ClarityType.StringASCII, data };
+  return { type: ClarityType.StringASCII, value: data };
 };
 
 /**
@@ -44,7 +44,7 @@ export const stringAsciiCV = (data: string): StringAsciiCV => {
  * {@link https://github.com/hirosystems/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 export const stringUtf8CV = (data: string): StringUtf8CV => {
-  return { type: ClarityType.StringUTF8, data };
+  return { type: ClarityType.StringUTF8, value: data };
 };
 
 /**

--- a/packages/transactions/src/clarity/values/tupleCV.ts
+++ b/packages/transactions/src/clarity/values/tupleCV.ts
@@ -34,5 +34,5 @@ export function tupleCV<T extends ClarityValue = ClarityValue>(
     }
   }
 
-  return { type: ClarityType.Tuple, data };
+  return { type: ClarityType.Tuple, value: data };
 }

--- a/packages/transactions/src/contract-abi.ts
+++ b/packages/transactions/src/contract-abi.ts
@@ -300,17 +300,17 @@ function matchType(cv: ClarityValue, abiType: ClarityAbiType): boolean {
     case ClarityType.Buffer:
       return (
         union.id === ClarityAbiTypeId.ClarityAbiTypeBuffer &&
-        union.type.buffer.length >= cv.buffer.length
+        union.type.buffer.length >= Math.ceil(cv.value.length / 2)
       );
     case ClarityType.StringASCII:
       return (
         union.id === ClarityAbiTypeId.ClarityAbiTypeStringAscii &&
-        union.type['string-ascii'].length >= cv.data.length
+        union.type['string-ascii'].length >= cv.value.length
       );
     case ClarityType.StringUTF8:
       return (
         union.id === ClarityAbiTypeId.ClarityAbiTypeStringUtf8 &&
-        union.type['string-utf8'].length >= cv.data.length
+        union.type['string-utf8'].length >= cv.value.length
       );
     case ClarityType.OptionalNone:
       return (
@@ -342,12 +342,12 @@ function matchType(cv: ClarityValue, abiType: ClarityAbiType): boolean {
     case ClarityType.List:
       return (
         union.id == ClarityAbiTypeId.ClarityAbiTypeList &&
-        union.type.list.length >= cv.list.length &&
-        cv.list.every(val => matchType(val, union.type.list.type))
+        union.type.list.length >= cv.value.length &&
+        cv.value.every(val => matchType(val, union.type.list.type))
       );
     case ClarityType.Tuple:
       if (union.id == ClarityAbiTypeId.ClarityAbiTypeTuple) {
-        const tuple = cloneDeep(cv.data);
+        const tuple = cloneDeep(cv.value);
         for (let i = 0; i < union.type.tuple.length; i++) {
           const abiTupleEntry = union.type.tuple[i];
           const key = abiTupleEntry.name;

--- a/packages/transactions/src/index.ts
+++ b/packages/transactions/src/index.ts
@@ -90,11 +90,7 @@ export {
  * ```
  */
 export * as Pc from './pc';
-export {
-  createFungiblePostCondition,
-  createNonFungiblePostCondition,
-  createSTXPostCondition,
-} from './postcondition';
+export * from './postcondition';
 export * from './postcondition-types';
 export * from './signature';
 export * from './signer';

--- a/packages/transactions/src/structuredDataSignature.ts
+++ b/packages/transactions/src/structuredDataSignature.ts
@@ -18,12 +18,12 @@ const hash256BytesLength = 32;
 function isDomain(value: ClarityValue): boolean {
   if (value.type !== ClarityType.Tuple) return false;
   // Check that the tuple has at least 'name', 'version' and 'chain-id'
-  if (!['name', 'version', 'chain-id'].every(key => key in value.data)) return false;
+  if (!['name', 'version', 'chain-id'].every(key => key in value.value)) return false;
   // Check each key is of the right type
-  if (!['name', 'version'].every(key => value.data[key].type === ClarityType.StringASCII))
+  if (!['name', 'version'].every(key => value.value[key].type === ClarityType.StringASCII))
     return false;
 
-  if (value.data['chain-id'].type !== ClarityType.UInt) return false;
+  if (value.value['chain-id'].type !== ClarityType.UInt) return false;
   return true;
 }
 
@@ -86,6 +86,7 @@ export function signStructuredData({
     messageHash: structuredDataHash,
     privateKey,
   });
+  // todo: `next` reduce wrapped signature type
   return {
     data,
     type: StacksWireType.StructuredDataSignature,

--- a/packages/transactions/src/types.ts
+++ b/packages/transactions/src/types.ts
@@ -66,7 +66,17 @@ import {
  */
 export type AddressString = string;
 
-/** @ignore */
+/**
+ * A contract identifier string given as `<address>.<contract-name>`
+ */
+export type ContractIdString = `${string}.${string}`;
+
+/**
+ * An asset name string given as `<contract-id>::<token-name>` aka `<contract-address>.<contract-name>::<token-name>`
+ */
+export type AssetString = `${ContractIdString}::${string}`;
+
+/** @internal */
 export type StacksWire =
   | AddressWire
   | PostConditionPrincipalWire
@@ -80,11 +90,11 @@ export type StacksWire =
   | TransactionAuthFieldWire
   | MessageSignatureWire;
 
-/** @ignore */
+/** @internal */
 export function serializeStacksWire(wire: StacksWire): string {
   return bytesToHex(serializeStacksWireBytes(wire));
 }
-/** @ignore */
+/** @internal */
 export function serializeStacksWireBytes(wire: StacksWire): Uint8Array {
   switch (wire.type) {
     case StacksWireType.Address:
@@ -112,7 +122,7 @@ export function serializeStacksWireBytes(wire: StacksWire): Uint8Array {
   }
 }
 
-/** @ignore */
+/** @internal */
 export function deserializeStacksWireBytes(
   bytesReader: BytesReader,
   type: StacksWireType,
@@ -214,7 +224,7 @@ export function addressFromPublicKeys(
 export function serializeAddress(address: AddressWire): string {
   return bytesToHex(serializeAddressBytes(address));
 }
-/** @ignore */
+/** @internal */
 export function serializeAddressBytes(address: AddressWire): Uint8Array {
   const bytesArray = [];
   bytesArray.push(hexToBytes(intToHex(address.version, 1)));
@@ -225,7 +235,7 @@ export function serializeAddressBytes(address: AddressWire): Uint8Array {
 export function deserializeAddress(serialized: string): AddressWire {
   return deserializeAddressBytes(hexToBytes(serialized));
 }
-/** @ignore */
+/** @internal */
 export function deserializeAddressBytes(serialized: Uint8Array | BytesReader): AddressWire {
   const bytesReader = isInstance(serialized, BytesReader)
     ? serialized
@@ -239,7 +249,7 @@ export function deserializeAddressBytes(serialized: Uint8Array | BytesReader): A
 export function serializePrincipal(principal: PostConditionPrincipalWire): string {
   return bytesToHex(serializePrincipalBytes(principal));
 }
-/** @ignore */
+/** @internal */
 export function serializePrincipalBytes(principal: PostConditionPrincipalWire): Uint8Array {
   const bytesArray = [];
   bytesArray.push(principal.prefix);
@@ -253,7 +263,7 @@ export function serializePrincipalBytes(principal: PostConditionPrincipalWire): 
 export function deserializePrincipal(serialized: string): PostConditionPrincipalWire {
   return deserializePrincipalBytes(hexToBytes(serialized));
 }
-/** @ignore */
+/** @internal */
 export function deserializePrincipalBytes(
   serialized: Uint8Array | BytesReader
 ): PostConditionPrincipalWire {
@@ -279,7 +289,7 @@ export function deserializePrincipalBytes(
 export function serializeLPString(lps: LengthPrefixedStringWire): string {
   return bytesToHex(serializeLPStringBytes(lps));
 }
-/** @ignore */
+/** @internal */
 export function serializeLPStringBytes(lps: LengthPrefixedStringWire): Uint8Array {
   const bytesArray = [];
   const contentBytes = utf8ToBytes(lps.content);
@@ -296,7 +306,7 @@ export function deserializeLPString(
 ): LengthPrefixedStringWire {
   return deserializeLPStringBytes(hexToBytes(serialized), prefixBytes, maxLength);
 }
-/** @ignore */
+/** @internal */
 export function deserializeLPStringBytes(
   serialized: Uint8Array | BytesReader,
   prefixBytes?: number,
@@ -330,7 +340,7 @@ export function createMemoString(content: string): MemoStringWire {
 export function serializeMemoString(memoString: MemoStringWire): string {
   return bytesToHex(serializeMemoStringBytes(memoString));
 }
-/** @ignore */
+/** @internal */
 export function serializeMemoStringBytes(memoString: MemoStringWire): Uint8Array {
   const bytesArray = [];
   const contentBytes = utf8ToBytes(memoString.content);
@@ -342,7 +352,7 @@ export function serializeMemoStringBytes(memoString: MemoStringWire): Uint8Array
 export function deserializeMemoString(serialized: string): MemoStringWire {
   return deserializeMemoStringBytes(hexToBytes(serialized));
 }
-/** @ignore */
+/** @internal */
 export function deserializeMemoStringBytes(serialized: Uint8Array | BytesReader): MemoStringWire {
   const bytesReader = isInstance(serialized, BytesReader)
     ? serialized
@@ -355,7 +365,7 @@ export function deserializeMemoStringBytes(serialized: Uint8Array | BytesReader)
 export function serializeAsset(info: AssetWire): string {
   return bytesToHex(serializeAssetBytes(info));
 }
-/** @ignore */
+/** @internal */
 export function serializeAssetBytes(info: AssetWire): Uint8Array {
   const bytesArray = [];
   bytesArray.push(serializeAddressBytes(info.address));
@@ -367,7 +377,7 @@ export function serializeAssetBytes(info: AssetWire): Uint8Array {
 export function deserializeAsset(serialized: string): AssetWire {
   return deserializeAssetBytes(hexToBytes(serialized));
 }
-/** @ignore */
+/** @internal */
 export function deserializeAssetBytes(serialized: Uint8Array | BytesReader): AssetWire {
   const bytesReader = isInstance(serialized, BytesReader)
     ? serialized
@@ -400,7 +410,7 @@ export function createLPList<T extends StacksWire>(
 export function serializeLPList(lpList: LengthPrefixedList): string {
   return bytesToHex(serializeLPListBytes(lpList));
 }
-/** @ignore */
+/** @internal */
 export function serializeLPListBytes(lpList: LengthPrefixedList): Uint8Array {
   const list = lpList.values;
   const bytesArray = [];
@@ -419,7 +429,7 @@ export function deserializeLPList(
 ): LengthPrefixedList {
   return deserializeLPListBytes(hexToBytes(serialized), type, lengthPrefixBytes);
 }
-/** @ignore */
+/** @internal */
 export function deserializeLPListBytes(
   serialized: Uint8Array | BytesReader,
   type: StacksWireType,
@@ -462,7 +472,7 @@ export function deserializeLPListBytes(
 export function serializePostCondition(postCondition: PostConditionWire): string {
   return bytesToHex(serializePostConditionBytes(postCondition));
 }
-/** @ignore */
+/** @internal */
 export function serializePostConditionBytes(postCondition: PostConditionWire): Uint8Array {
   const bytesArray = [];
   bytesArray.push(postCondition.conditionType);
@@ -497,7 +507,7 @@ export function serializePostConditionBytes(postCondition: PostConditionWire): U
 export function deserializePostCondition(serialized: string): PostConditionWire {
   return deserializePostConditionBytes(hexToBytes(serialized));
 }
-/** @ignore */
+/** @internal */
 export function deserializePostConditionBytes(
   serialized: Uint8Array | BytesReader
 ): PostConditionWire {

--- a/packages/transactions/src/utils.ts
+++ b/packages/transactions/src/utils.ts
@@ -14,6 +14,7 @@ import { c32addressDecode } from 'c32check';
 import lodashCloneDeep from 'lodash.clonedeep';
 import { ClarityValue, deserializeCV, serializeCV } from './clarity';
 import { StacksNetwork, deriveDefaultUrl, StacksNetworkName } from '@stacks/network';
+import { ContractIdString } from './types';
 
 // Export verify as utility method for signature verification
 export { verify as verifySignature } from '@noble/secp256k1';
@@ -37,7 +38,7 @@ export const rightPadHexToLength = (hexString: string, length: number): string =
 export const exceedsMaxLengthBytes = (string: string, maxLengthBytes: number): boolean =>
   string ? utf8ToBytes(string).length > maxLengthBytes : false;
 
-/** @ignore */
+/** @internal */
 export function cloneDeep<T>(obj: T): T {
   return lodashCloneDeep(obj);
 }
@@ -66,14 +67,14 @@ export const txidFromBytes = txidFromData;
 
 // Internally, the Stacks blockchain encodes address the same as Bitcoin
 // single-sig address (p2pkh)
-/** @ignore */
+/** @internal */
 export const hashP2PKH = (input: Uint8Array): string => {
   return bytesToHex(hash160(input));
 };
 
 // Internally, the Stacks blockchain encodes address the same as Bitcoin
 // single-sig address over p2sh (p2h-p2wpkh)
-/** @ignore */
+/** @internal */
 export const hashP2WPKH = (input: Uint8Array): string => {
   const keyHash = hash160(input);
   const redeemScript = concatBytes(new Uint8Array([0]), new Uint8Array([keyHash.length]), keyHash);
@@ -83,7 +84,7 @@ export const hashP2WPKH = (input: Uint8Array): string => {
 
 // Internally, the Stacks blockchain encodes address the same as Bitcoin
 // multi-sig address (p2sh)
-/** @ignore */
+/** @internal */
 export const hashP2SH = (numSigs: number, pubKeys: Uint8Array[]): string => {
   if (numSigs > 15 || pubKeys.length > 15) {
     throw Error('P2SH multisig address can only contain up to 15 public keys');
@@ -110,7 +111,7 @@ export const hashP2SH = (numSigs: number, pubKeys: Uint8Array[]): string => {
 
 // Internally, the Stacks blockchain encodes address the same as Bitcoin
 // multisig address over p2sh (p2sh-p2wsh)
-/** @ignore */
+/** @internal */
 export const hashP2WSH = (numSigs: number, pubKeys: Uint8Array[]): string => {
   if (numSigs > 15 || pubKeys.length > 15) {
     throw Error('P2WSH multisig address can only contain up to 15 public keys');
@@ -203,7 +204,7 @@ export const validateStacksAddress = (address: string): boolean => {
   }
 };
 
-/** @ignore */
+/** @internal */
 export const defaultApiFromNetwork = (
   network: StacksNetworkName | StacksNetwork,
   override?: ApiOpts
@@ -217,3 +218,10 @@ export const defaultApiFromNetwork = (
     override
   );
 };
+
+/** @internal */
+export function parseContractId(contractId: ContractIdString) {
+  const [address, name] = contractId.split('.');
+  if (!address || !name) throw new Error(`Invalid contract identifier: ${contractId}`);
+  return [address, name];
+}

--- a/packages/transactions/tests/payload.test.ts
+++ b/packages/transactions/tests/payload.test.ts
@@ -1,12 +1,6 @@
 import { bytesToHex, utf8ToBytes } from '@stacks/common';
 import { randomBytes } from '../src';
-import {
-  contractPrincipalCV,
-  falseCV,
-  principalToString,
-  standardPrincipalCV,
-  trueCV,
-} from '../src/clarity';
+import { contractPrincipalCV, falseCV, standardPrincipalCV, trueCV } from '../src/clarity';
 import { ClarityVersion, StacksWireType } from '../src/constants';
 import {
   CoinbasePayloadWire,
@@ -71,7 +65,7 @@ test('STX token transfer payload (with contract principal string) serialization 
     StacksWireType.Payload
   ) as TokenTransferPayloadWire;
   expect(deserialized.payloadType).toBe(payload.payloadType);
-  expect(principalToString(deserialized.recipient)).toEqual(recipient);
+  expect(deserialized.recipient.value).toEqual(recipient);
   expect(deserialized.amount.toString()).toBe(amount.toString());
 });
 
@@ -86,7 +80,7 @@ test('STX token transfer payload (with address principal string) serialization a
     StacksWireType.Payload
   ) as TokenTransferPayloadWire;
   expect(deserialized.payloadType).toBe(payload.payloadType);
-  expect(principalToString(deserialized.recipient)).toEqual(recipient);
+  expect(deserialized.recipient.value).toEqual(recipient);
   expect(deserialized.amount.toString()).toBe(amount.toString());
 });
 

--- a/packages/transactions/tests/pc.test.ts
+++ b/packages/transactions/tests/pc.test.ts
@@ -1,14 +1,8 @@
 import {
-  createAsset,
-  FungibleConditionCode,
-  makeContractFungiblePostCondition,
-  makeContractNonFungiblePostCondition,
-  makeContractSTXPostCondition,
-  makeStandardFungiblePostCondition,
-  makeStandardNonFungiblePostCondition,
-  makeStandardSTXPostCondition,
-  NonFungibleConditionCode,
+  FungiblePostCondition,
+  NonFungiblePostCondition,
   Pc,
+  StxPostCondition,
   uintCV,
 } from '../src';
 
@@ -94,51 +88,56 @@ describe('pc -- post condition builder', () => {
     describe('stx post condition', () => {
       test('100 ustx', () => {
         const pc = Pc.principal(STANDARD_ADDRESS).willSendEq(100).ustx();
-        const postCondition = makeStandardSTXPostCondition(
-          STANDARD_ADDRESS,
-          FungibleConditionCode.Equal,
-          100
-        );
+        const postCondition: StxPostCondition = {
+          type: 'stx-postcondition',
+          address: STANDARD_ADDRESS,
+          condition: 'eq',
+          amount: '100',
+        };
         expect(pc).toEqual(postCondition);
       });
 
       test('lte 100 ustx', () => {
-        const pc = Pc.principal(STANDARD_ADDRESS).willSendLt(100).ustx();
-        const postCondition = makeStandardSTXPostCondition(
-          STANDARD_ADDRESS,
-          FungibleConditionCode.Less,
-          100
-        );
+        const pc = Pc.principal(STANDARD_ADDRESS).willSendLte(100).ustx();
+        const postCondition: StxPostCondition = {
+          type: 'stx-postcondition',
+          address: STANDARD_ADDRESS,
+          condition: 'lte',
+          amount: '100',
+        };
         expect(pc).toEqual(postCondition);
       });
 
       test('lt 100 ustx', () => {
         const pc = Pc.principal(STANDARD_ADDRESS).willSendLt(100).ustx();
-        const postCondition = makeStandardSTXPostCondition(
-          STANDARD_ADDRESS,
-          FungibleConditionCode.Less,
-          100
-        );
+        const postCondition: StxPostCondition = {
+          type: 'stx-postcondition',
+          address: STANDARD_ADDRESS,
+          condition: 'lt',
+          amount: '100',
+        };
         expect(pc).toEqual(postCondition);
       });
 
       test('gte 100 ustx', () => {
         const pc = Pc.principal(STANDARD_ADDRESS).willSendGte(100).ustx();
-        const postCondition = makeStandardSTXPostCondition(
-          STANDARD_ADDRESS,
-          FungibleConditionCode.GreaterEqual,
-          100
-        );
+        const postCondition: StxPostCondition = {
+          type: 'stx-postcondition',
+          address: STANDARD_ADDRESS,
+          condition: 'gte',
+          amount: '100',
+        };
         expect(pc).toEqual(postCondition);
       });
 
       test('gt 100 ustx', () => {
         const pc = Pc.principal(STANDARD_ADDRESS).willSendGt(100).ustx();
-        const postCondition = makeStandardSTXPostCondition(
-          STANDARD_ADDRESS,
-          FungibleConditionCode.Greater,
-          100
-        );
+        const postCondition: StxPostCondition = {
+          type: 'stx-postcondition',
+          address: STANDARD_ADDRESS,
+          condition: 'gt',
+          amount: '100',
+        };
         expect(pc).toEqual(postCondition);
       });
     });
@@ -148,12 +147,13 @@ describe('pc -- post condition builder', () => {
         const pc = Pc.principal(STANDARD_ADDRESS)
           .willSendEq(100)
           .ft(`${FT_CONTRACT_ADDRESS}.${FT_CONTRACT_NAME}`, FT_ASSET_NAME);
-        const postCondition = makeStandardFungiblePostCondition(
-          STANDARD_ADDRESS,
-          FungibleConditionCode.Equal,
-          100,
-          createAsset(FT_CONTRACT_ADDRESS, FT_CONTRACT_NAME, FT_ASSET_NAME)
-        );
+        const postCondition = {
+          type: 'ft-postcondition',
+          address: STANDARD_ADDRESS,
+          condition: 'eq',
+          amount: '100',
+          asset: `${FT_CONTRACT_ADDRESS}.${FT_CONTRACT_NAME}::${FT_ASSET_NAME}`,
+        } as FungiblePostCondition;
         expect(pc).toEqual(postCondition);
       });
 
@@ -161,12 +161,13 @@ describe('pc -- post condition builder', () => {
         const pc = Pc.principal(STANDARD_ADDRESS)
           .willSendLt(100)
           .ft(`${FT_CONTRACT_ADDRESS}.${FT_CONTRACT_NAME}`, FT_ASSET_NAME);
-        const postCondition = makeStandardFungiblePostCondition(
-          STANDARD_ADDRESS,
-          FungibleConditionCode.Less,
-          100,
-          createAsset(FT_CONTRACT_ADDRESS, FT_CONTRACT_NAME, FT_ASSET_NAME)
-        );
+        const postCondition = {
+          type: 'ft-postcondition',
+          address: STANDARD_ADDRESS,
+          condition: 'lt',
+          amount: '100',
+          asset: `${FT_CONTRACT_ADDRESS}.${FT_CONTRACT_NAME}::${FT_ASSET_NAME}`,
+        } as FungiblePostCondition;
         expect(pc).toEqual(postCondition);
       });
 
@@ -174,12 +175,13 @@ describe('pc -- post condition builder', () => {
         const pc = Pc.principal(STANDARD_ADDRESS)
           .willSendLt(100)
           .ft(`${FT_CONTRACT_ADDRESS}.${FT_CONTRACT_NAME}`, FT_ASSET_NAME);
-        const postCondition = makeStandardFungiblePostCondition(
-          STANDARD_ADDRESS,
-          FungibleConditionCode.Less,
-          100,
-          createAsset(FT_CONTRACT_ADDRESS, FT_CONTRACT_NAME, FT_ASSET_NAME)
-        );
+        const postCondition = {
+          type: 'ft-postcondition',
+          address: STANDARD_ADDRESS,
+          condition: 'lt',
+          amount: '100',
+          asset: `${FT_CONTRACT_ADDRESS}.${FT_CONTRACT_NAME}::${FT_ASSET_NAME}`,
+        } as FungiblePostCondition;
         expect(pc).toEqual(postCondition);
       });
 
@@ -187,12 +189,13 @@ describe('pc -- post condition builder', () => {
         const pc = Pc.principal(STANDARD_ADDRESS)
           .willSendGte(100)
           .ft(`${FT_CONTRACT_ADDRESS}.${FT_CONTRACT_NAME}`, FT_ASSET_NAME);
-        const postCondition = makeStandardFungiblePostCondition(
-          STANDARD_ADDRESS,
-          FungibleConditionCode.GreaterEqual,
-          100,
-          createAsset(FT_CONTRACT_ADDRESS, FT_CONTRACT_NAME, FT_ASSET_NAME)
-        );
+        const postCondition = {
+          type: 'ft-postcondition',
+          address: STANDARD_ADDRESS,
+          condition: 'gte',
+          amount: '100',
+          asset: `${FT_CONTRACT_ADDRESS}.${FT_CONTRACT_NAME}::${FT_ASSET_NAME}`,
+        } as FungiblePostCondition;
         expect(pc).toEqual(postCondition);
       });
 
@@ -200,12 +203,13 @@ describe('pc -- post condition builder', () => {
         const pc = Pc.principal(STANDARD_ADDRESS)
           .willSendGt(100)
           .ft(`${FT_CONTRACT_ADDRESS}.${FT_CONTRACT_NAME}`, FT_ASSET_NAME);
-        const postCondition = makeStandardFungiblePostCondition(
-          STANDARD_ADDRESS,
-          FungibleConditionCode.Greater,
-          100,
-          createAsset(FT_CONTRACT_ADDRESS, FT_CONTRACT_NAME, FT_ASSET_NAME)
-        );
+        const postCondition = {
+          type: 'ft-postcondition',
+          address: STANDARD_ADDRESS,
+          condition: 'gt',
+          amount: '100',
+          asset: `${FT_CONTRACT_ADDRESS}.${FT_CONTRACT_NAME}::${FT_ASSET_NAME}`,
+        } as FungiblePostCondition;
         expect(pc).toEqual(postCondition);
       });
     });
@@ -215,12 +219,13 @@ describe('pc -- post condition builder', () => {
         const pc = Pc.principal(STANDARD_ADDRESS)
           .willSendAsset()
           .nft(`${NFT_CONTRACT_ADDRESS}.${NFT_CONTRACT_NAME}`, NFT_TOKEN_NAME, NFT_ASSET_ID);
-        const postCondition = makeStandardNonFungiblePostCondition(
-          STANDARD_ADDRESS,
-          NonFungibleConditionCode.Sends,
-          createAsset(NFT_CONTRACT_ADDRESS, NFT_CONTRACT_NAME, NFT_TOKEN_NAME),
-          NFT_ASSET_ID
-        );
+        const postCondition = {
+          type: 'nft-postcondition',
+          address: STANDARD_ADDRESS,
+          condition: 'sent',
+          asset: `${NFT_CONTRACT_ADDRESS}.${NFT_CONTRACT_NAME}::${NFT_TOKEN_NAME}`,
+          assetId: NFT_ASSET_ID,
+        } as NonFungiblePostCondition;
         expect(pc).toEqual(postCondition);
       });
 
@@ -228,12 +233,13 @@ describe('pc -- post condition builder', () => {
         const pc = Pc.principal(STANDARD_ADDRESS)
           .willNotSendAsset()
           .nft(`${NFT_CONTRACT_ADDRESS}.${NFT_CONTRACT_NAME}`, NFT_TOKEN_NAME, NFT_ASSET_ID);
-        const postCondition = makeStandardNonFungiblePostCondition(
-          STANDARD_ADDRESS,
-          NonFungibleConditionCode.DoesNotSend,
-          createAsset(NFT_CONTRACT_ADDRESS, NFT_CONTRACT_NAME, NFT_TOKEN_NAME),
-          NFT_ASSET_ID
-        );
+        const postCondition = {
+          type: 'nft-postcondition',
+          address: STANDARD_ADDRESS,
+          condition: 'not-sent',
+          asset: `${NFT_CONTRACT_ADDRESS}.${NFT_CONTRACT_NAME}::${NFT_TOKEN_NAME}`,
+          assetId: NFT_ASSET_ID,
+        } as NonFungiblePostCondition;
         expect(pc).toEqual(postCondition);
       });
     });
@@ -243,56 +249,56 @@ describe('pc -- post condition builder', () => {
     describe('stx post condition', () => {
       test('100 ustx', () => {
         const pc = Pc.principal(`${CONTRACT_ADDRESS}.${CONTRACT_NAME}`).willSendEq(100).ustx();
-        const postCondition = makeContractSTXPostCondition(
-          CONTRACT_ADDRESS,
-          CONTRACT_NAME,
-          FungibleConditionCode.Equal,
-          100
-        );
+        const postCondition: StxPostCondition = {
+          type: 'stx-postcondition',
+          address: `${CONTRACT_ADDRESS}.${CONTRACT_NAME}`,
+          condition: 'eq',
+          amount: '100',
+        };
         expect(pc).toEqual(postCondition);
       });
 
       test('lte 100 ustx', () => {
         const pc = Pc.principal(`${CONTRACT_ADDRESS}.${CONTRACT_NAME}`).willSendLt(100).ustx();
-        const postCondition = makeContractSTXPostCondition(
-          CONTRACT_ADDRESS,
-          CONTRACT_NAME,
-          FungibleConditionCode.Less,
-          100
-        );
+        const postCondition: StxPostCondition = {
+          type: 'stx-postcondition',
+          address: `${CONTRACT_ADDRESS}.${CONTRACT_NAME}`,
+          condition: 'lt',
+          amount: '100',
+        };
         expect(pc).toEqual(postCondition);
       });
 
       test('lt 100 ustx', () => {
         const pc = Pc.principal(`${CONTRACT_ADDRESS}.${CONTRACT_NAME}`).willSendLt(100).ustx();
-        const postCondition = makeContractSTXPostCondition(
-          CONTRACT_ADDRESS,
-          CONTRACT_NAME,
-          FungibleConditionCode.Less,
-          100
-        );
+        const postCondition: StxPostCondition = {
+          type: 'stx-postcondition',
+          address: `${CONTRACT_ADDRESS}.${CONTRACT_NAME}`,
+          condition: 'lt',
+          amount: '100',
+        };
         expect(pc).toEqual(postCondition);
       });
 
       test('gte 100 ustx', () => {
         const pc = Pc.principal(`${CONTRACT_ADDRESS}.${CONTRACT_NAME}`).willSendGte(100).ustx();
-        const postCondition = makeContractSTXPostCondition(
-          CONTRACT_ADDRESS,
-          CONTRACT_NAME,
-          FungibleConditionCode.GreaterEqual,
-          100
-        );
+        const postCondition: StxPostCondition = {
+          type: 'stx-postcondition',
+          address: `${CONTRACT_ADDRESS}.${CONTRACT_NAME}`,
+          condition: 'gte',
+          amount: '100',
+        };
         expect(pc).toEqual(postCondition);
       });
 
       test('gt 100 ustx', () => {
         const pc = Pc.principal(`${CONTRACT_ADDRESS}.${CONTRACT_NAME}`).willSendGt(100).ustx();
-        const postCondition = makeContractSTXPostCondition(
-          CONTRACT_ADDRESS,
-          CONTRACT_NAME,
-          FungibleConditionCode.Greater,
-          100
-        );
+        const postCondition: StxPostCondition = {
+          type: 'stx-postcondition',
+          address: `${CONTRACT_ADDRESS}.${CONTRACT_NAME}`,
+          condition: 'gt',
+          amount: '100',
+        };
         expect(pc).toEqual(postCondition);
       });
     });
@@ -302,13 +308,13 @@ describe('pc -- post condition builder', () => {
         const pc = Pc.principal(`${CONTRACT_ADDRESS}.${CONTRACT_NAME}`)
           .willSendEq(100)
           .ft(`${FT_CONTRACT_ADDRESS}.${FT_CONTRACT_NAME}`, FT_ASSET_NAME);
-        const postCondition = makeContractFungiblePostCondition(
-          CONTRACT_ADDRESS,
-          CONTRACT_NAME,
-          FungibleConditionCode.Equal,
-          100,
-          createAsset(FT_CONTRACT_ADDRESS, FT_CONTRACT_NAME, FT_ASSET_NAME)
-        );
+        const postCondition = {
+          type: 'ft-postcondition',
+          address: `${CONTRACT_ADDRESS}.${CONTRACT_NAME}`,
+          condition: 'eq',
+          amount: '100',
+          asset: `${FT_CONTRACT_ADDRESS}.${FT_CONTRACT_NAME}::${FT_ASSET_NAME}`,
+        } as FungiblePostCondition;
         expect(pc).toEqual(postCondition);
       });
 
@@ -316,13 +322,13 @@ describe('pc -- post condition builder', () => {
         const pc = Pc.principal(`${CONTRACT_ADDRESS}.${CONTRACT_NAME}`)
           .willSendLt(100)
           .ft(`${FT_CONTRACT_ADDRESS}.${FT_CONTRACT_NAME}`, FT_ASSET_NAME);
-        const postCondition = makeContractFungiblePostCondition(
-          CONTRACT_ADDRESS,
-          CONTRACT_NAME,
-          FungibleConditionCode.Less,
-          100,
-          createAsset(FT_CONTRACT_ADDRESS, FT_CONTRACT_NAME, FT_ASSET_NAME)
-        );
+        const postCondition = {
+          type: 'ft-postcondition',
+          address: `${CONTRACT_ADDRESS}.${CONTRACT_NAME}`,
+          condition: 'lt',
+          amount: '100',
+          asset: `${FT_CONTRACT_ADDRESS}.${FT_CONTRACT_NAME}::${FT_ASSET_NAME}`,
+        } as FungiblePostCondition;
         expect(pc).toEqual(postCondition);
       });
 
@@ -330,13 +336,13 @@ describe('pc -- post condition builder', () => {
         const pc = Pc.principal(`${CONTRACT_ADDRESS}.${CONTRACT_NAME}`)
           .willSendLt(100)
           .ft(`${FT_CONTRACT_ADDRESS}.${FT_CONTRACT_NAME}`, FT_ASSET_NAME);
-        const postCondition = makeContractFungiblePostCondition(
-          CONTRACT_ADDRESS,
-          CONTRACT_NAME,
-          FungibleConditionCode.Less,
-          100,
-          createAsset(FT_CONTRACT_ADDRESS, FT_CONTRACT_NAME, FT_ASSET_NAME)
-        );
+        const postCondition = {
+          type: 'ft-postcondition',
+          address: `${CONTRACT_ADDRESS}.${CONTRACT_NAME}`,
+          condition: 'lt',
+          amount: '100',
+          asset: `${FT_CONTRACT_ADDRESS}.${FT_CONTRACT_NAME}::${FT_ASSET_NAME}`,
+        } as FungiblePostCondition;
         expect(pc).toEqual(postCondition);
       });
 
@@ -344,13 +350,13 @@ describe('pc -- post condition builder', () => {
         const pc = Pc.principal(`${CONTRACT_ADDRESS}.${CONTRACT_NAME}`)
           .willSendGte(100)
           .ft(`${FT_CONTRACT_ADDRESS}.${FT_CONTRACT_NAME}`, FT_ASSET_NAME);
-        const postCondition = makeContractFungiblePostCondition(
-          CONTRACT_ADDRESS,
-          CONTRACT_NAME,
-          FungibleConditionCode.GreaterEqual,
-          100,
-          createAsset(FT_CONTRACT_ADDRESS, FT_CONTRACT_NAME, FT_ASSET_NAME)
-        );
+        const postCondition = {
+          type: 'ft-postcondition',
+          address: `${CONTRACT_ADDRESS}.${CONTRACT_NAME}`,
+          condition: 'gte',
+          amount: '100',
+          asset: `${FT_CONTRACT_ADDRESS}.${FT_CONTRACT_NAME}::${FT_ASSET_NAME}`,
+        } as FungiblePostCondition;
         expect(pc).toEqual(postCondition);
       });
 
@@ -358,13 +364,13 @@ describe('pc -- post condition builder', () => {
         const pc = Pc.principal(`${CONTRACT_ADDRESS}.${CONTRACT_NAME}`)
           .willSendGt(100)
           .ft(`${FT_CONTRACT_ADDRESS}.${FT_CONTRACT_NAME}`, FT_ASSET_NAME);
-        const postCondition = makeContractFungiblePostCondition(
-          CONTRACT_ADDRESS,
-          CONTRACT_NAME,
-          FungibleConditionCode.Greater,
-          100,
-          createAsset(FT_CONTRACT_ADDRESS, FT_CONTRACT_NAME, FT_ASSET_NAME)
-        );
+        const postCondition = {
+          type: 'ft-postcondition',
+          address: `${CONTRACT_ADDRESS}.${CONTRACT_NAME}`,
+          condition: 'gt',
+          amount: '100',
+          asset: `${FT_CONTRACT_ADDRESS}.${FT_CONTRACT_NAME}::${FT_ASSET_NAME}`,
+        } as FungiblePostCondition;
         expect(pc).toEqual(postCondition);
       });
     });
@@ -374,13 +380,13 @@ describe('pc -- post condition builder', () => {
         const pc = Pc.principal(`${CONTRACT_ADDRESS}.${CONTRACT_NAME}`)
           .willSendAsset()
           .nft(`${NFT_CONTRACT_ADDRESS}.${NFT_CONTRACT_NAME}`, NFT_TOKEN_NAME, NFT_ASSET_ID);
-        const postCondition = makeContractNonFungiblePostCondition(
-          CONTRACT_ADDRESS,
-          CONTRACT_NAME,
-          NonFungibleConditionCode.Sends,
-          createAsset(NFT_CONTRACT_ADDRESS, NFT_CONTRACT_NAME, NFT_TOKEN_NAME),
-          NFT_ASSET_ID
-        );
+        const postCondition = {
+          type: 'nft-postcondition',
+          address: `${CONTRACT_ADDRESS}.${CONTRACT_NAME}`,
+          condition: 'sent',
+          asset: `${NFT_CONTRACT_ADDRESS}.${NFT_CONTRACT_NAME}::${NFT_TOKEN_NAME}`,
+          assetId: NFT_ASSET_ID,
+        } as NonFungiblePostCondition;
         expect(pc).toEqual(postCondition);
       });
 
@@ -388,13 +394,13 @@ describe('pc -- post condition builder', () => {
         const pc = Pc.principal(`${CONTRACT_ADDRESS}.${CONTRACT_NAME}`)
           .willNotSendAsset()
           .nft(`${NFT_CONTRACT_ADDRESS}.${NFT_CONTRACT_NAME}`, NFT_TOKEN_NAME, NFT_ASSET_ID);
-        const postCondition = makeContractNonFungiblePostCondition(
-          CONTRACT_ADDRESS,
-          CONTRACT_NAME,
-          NonFungibleConditionCode.DoesNotSend,
-          createAsset(NFT_CONTRACT_ADDRESS, NFT_CONTRACT_NAME, NFT_TOKEN_NAME),
-          NFT_ASSET_ID
-        );
+        const postCondition = {
+          type: 'nft-postcondition',
+          address: `${CONTRACT_ADDRESS}.${CONTRACT_NAME}`,
+          condition: 'not-sent',
+          asset: `${NFT_CONTRACT_ADDRESS}.${NFT_CONTRACT_NAME}::${NFT_TOKEN_NAME}`,
+          assetId: NFT_ASSET_ID,
+        } as NonFungiblePostCondition;
         expect(pc).toEqual(postCondition);
       });
     });

--- a/packages/transactions/tests/transaction.test.ts
+++ b/packages/transactions/tests/transaction.test.ts
@@ -30,7 +30,6 @@ import {
   TokenTransferPayloadWire,
   createTokenTransferPayload,
 } from '../src/payload';
-import { createSTXPostCondition } from '../src/postcondition';
 import { STXPostConditionWire, createStandardPrincipal } from '../src/postcondition-types';
 import { TransactionSigner } from '../src/signer';
 import {
@@ -40,6 +39,8 @@ import {
   transactionToHex,
 } from '../src/transaction';
 import { createLPList } from '../src/types';
+import { postConditionToWire } from '../src/postcondition';
+import { Pc } from '../src';
 
 beforeEach(() => {
   fetchMock.resetMocks();
@@ -69,7 +70,12 @@ test('STX token transfer transaction serialization and deserialization', () => {
   const authType = AuthType.Standard;
   const authorization = createStandardAuth(spendingCondition);
 
-  const postCondition = createSTXPostCondition(recipient, FungibleConditionCode.GreaterEqual, 0);
+  const postCondition = postConditionToWire({
+    type: 'stx-postcondition',
+    address,
+    condition: 'gte',
+    amount: 0,
+  });
 
   const postConditions = createLPList([postCondition]);
   const transaction = new StacksTransaction(
@@ -144,7 +150,7 @@ test('STX token transfer transaction fee setting', () => {
   const authType = AuthType.Standard;
   const authorization = createStandardAuth(spendingCondition);
 
-  const postCondition = createSTXPostCondition(recipient, FungibleConditionCode.GreaterEqual, 0);
+  const postCondition = postConditionToWire(Pc.principal(address).willSendGte(0).ustx());
 
   const postConditions = createLPList([postCondition]);
 


### PR DESCRIPTION
- update post-condition representations for [SIP](https://github.com/stacksgov/sips/pull/166)

---

**Example** Post-conditions should now be human-readable and serializable. This is a breaking change.

```ts
const condition = {
  type: 'stx-postcondition',
  address: 'SP...123',
  condition: 'eq',
  amount: 10000
}
```