### PR TITLE
refactor: add internal package for reusing test and other helpers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4300,6 +4300,10 @@
         "eslint-plugin-unused-imports": ">=3"
       }
     },
+    "node_modules/@stacks/internal": {
+      "resolved": "packages/internal",
+      "link": true
+    },
     "node_modules/@stacks/network": {
       "resolved": "packages/network",
       "link": true
@@ -13171,6 +13175,8 @@
     },
     "node_modules/jest-fetch-mock": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz",
+      "integrity": "sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -22425,6 +22431,146 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "packages/internal": {
+      "name": "@stacks/internal",
+      "devDependencies": {
+        "@stacks/api": "^6.9.0",
+        "@stacks/blockchain-api-client": "^7.12.0",
+        "@stacks/network": "^6.16.0",
+        "jest-fetch-mock": "^3.0.3"
+      }
+    },
+    "packages/internal/node_modules/@stacks/blockchain-api-client": {
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/@stacks/blockchain-api-client/-/blockchain-api-client-7.12.0.tgz",
+      "integrity": "sha512-N0Pxc8ZK0FQe4CtabDvs2oj2+9E0nrcCt3A3bx8QgZUWS7DPtIaqX3gK6aDSu0k8kD/v5lQQyVrISbNDAeygqQ==",
+      "dev": true,
+      "license": "GPL-3.0",
+      "dependencies": {
+        "@stacks/stacks-blockchain-api-types": "*",
+        "@types/ws": "7.4.7",
+        "cross-fetch": "3.1.5",
+        "eventemitter3": "4.0.7",
+        "jsonrpc-lite": "2.2.0",
+        "socket.io-client": "4.7.3",
+        "ws": "8.16.0"
+      }
+    },
+    "packages/internal/node_modules/cross-fetch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "2.6.7"
+      }
+    },
+    "packages/internal/node_modules/engine.io-client": {
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.4.tgz",
+      "integrity": "sha512-GeZeeRjpD2qf49cZQ0Wvh/8NJNfeXkXXcoGh+F77oEAgo9gUHwT1fCRxSNU+YEEaysOJTnsFHmM5oAcPy4ntvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1",
+        "xmlhttprequest-ssl": "~2.0.0"
+      }
+    },
+    "packages/internal/node_modules/engine.io-client/node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "packages/internal/node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "packages/internal/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "packages/internal/node_modules/socket.io-client": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.7.3.tgz",
+      "integrity": "sha512-nU+ywttCyBitXIl9Xe0RSEfek4LneYkJxCeNnKCuhwoH4jGXO1ipIUw/VA/+Vvv2G1MTym11fzFC0SxkrcfXDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.2",
+        "engine.io-client": "~6.5.2",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "packages/internal/node_modules/ws": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
+      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "packages/network": {
       "name": "@stacks/network",
       "version": "6.16.0",
@@ -22501,6 +22647,7 @@
       },
       "devDependencies": {
         "@stacks/blockchain-api-client": "^7.3.0",
+        "@stacks/internal": "file:../internal",
         "jest-fetch-mock": "^3.0.3",
         "process": "^0.11.10",
         "rimraf": "^3.0.2",
@@ -22508,7 +22655,9 @@
       }
     },
     "packages/stacking/node_modules/@stacks/blockchain-api-client": {
-      "version": "7.3.0",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/@stacks/blockchain-api-client/-/blockchain-api-client-7.12.0.tgz",
+      "integrity": "sha512-N0Pxc8ZK0FQe4CtabDvs2oj2+9E0nrcCt3A3bx8QgZUWS7DPtIaqX3gK6aDSu0k8kD/v5lQQyVrISbNDAeygqQ==",
       "dev": true,
       "license": "GPL-3.0",
       "dependencies": {
@@ -22517,8 +22666,8 @@
         "cross-fetch": "3.1.5",
         "eventemitter3": "4.0.7",
         "jsonrpc-lite": "2.2.0",
-        "socket.io-client": "4.6.1",
-        "ws": "7.5.6"
+        "socket.io-client": "4.7.3",
+        "ws": "8.16.0"
       }
     },
     "packages/stacking/node_modules/@stacks/stacks-blockchain-api-types": {
@@ -22534,19 +22683,23 @@
       }
     },
     "packages/stacking/node_modules/engine.io-client": {
-      "version": "6.4.0",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.4.tgz",
+      "integrity": "sha512-GeZeeRjpD2qf49cZQ0Wvh/8NJNfeXkXXcoGh+F77oEAgo9gUHwT1fCRxSNU+YEEaysOJTnsFHmM5oAcPy4ntvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1",
-        "engine.io-parser": "~5.0.3",
-        "ws": "~8.11.0",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1",
         "xmlhttprequest-ssl": "~2.0.0"
       }
     },
     "packages/stacking/node_modules/engine.io-client/node_modules/ws": {
-      "version": "8.11.0",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -22554,7 +22707,7 @@
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -22563,6 +22716,16 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "packages/stacking/node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "packages/stacking/node_modules/node-fetch": {
@@ -22599,29 +22762,33 @@
       }
     },
     "packages/stacking/node_modules/socket.io-client": {
-      "version": "4.6.1",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.7.3.tgz",
+      "integrity": "sha512-nU+ywttCyBitXIl9Xe0RSEfek4LneYkJxCeNnKCuhwoH4jGXO1ipIUw/VA/+Vvv2G1MTym11fzFC0SxkrcfXDw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.2",
-        "engine.io-client": "~6.4.0",
-        "socket.io-parser": "~4.2.1"
+        "engine.io-client": "~6.5.2",
+        "socket.io-parser": "~4.2.4"
       },
       "engines": {
         "node": ">=10.0.0"
       }
     },
     "packages/stacking/node_modules/ws": {
-      "version": "7.5.6",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
+      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8.3.0"
+        "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -1,0 +1,15 @@
+{
+  "private": true,
+  "name": "@stacks/internal",
+  "scripts": {
+    "start": "tsc -b tsconfig.build.json --watch --verbose",
+    "typecheck": "tsc --noEmit",
+    "typecheck:watch": "npm run typecheck -- --watch"
+  },
+  "devDependencies": {
+    "@stacks/api": "^6.9.0",
+    "@stacks/blockchain-api-client": "^7.12.0",
+    "@stacks/network": "^6.16.0",
+    "jest-fetch-mock": "^3.0.3"
+  }
+}

--- a/packages/internal/src/apiMockingHelpers.ts
+++ b/packages/internal/src/apiMockingHelpers.ts
@@ -1,7 +1,7 @@
 import { Configuration, TransactionsApi } from '@stacks/blockchain-api-client';
 import { STACKS_TESTNET } from '@stacks/network';
 import { MockResponseInitFunction } from 'jest-fetch-mock';
-import { StackingClient } from '../src';
+import { StackingClient } from '../../stacking/src';
 import { StacksNodeApi } from '@stacks/api';
 
 // NOTES
@@ -93,7 +93,7 @@ export async function waitForTx(txId: string, apiUrl = 'http://localhost:3999') 
 export async function waitForBlock(burnBlockId: number, client?: StackingClient) {
   if (isMocking()) return;
 
-  const api = new StacksNodeApi({ url: 'http://localhost:3999' });
+  const api = { url: 'http://localhost:3999' };
   client = client ?? new StackingClient({ address: '', network: STACKS_TESTNET, api });
 
   let current: number;

--- a/packages/internal/src/index.ts
+++ b/packages/internal/src/index.ts
@@ -1,0 +1,1 @@
+export * from './apiMockingHelpers';

--- a/packages/internal/tsconfig.build.json
+++ b/packages/internal/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo",
+    "composite": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/internal/tsconfig.json
+++ b/packages/internal/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*", "tests/**/*"],
+  "typedocOptions": {
+    "entryPoints": ["src/index.ts"]
+  }
+}

--- a/packages/stacking/package.json
+++ b/packages/stacking/package.json
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "@stacks/blockchain-api-client": "^7.3.0",
+    "@stacks/internal": "file:../internal",
     "jest-fetch-mock": "^3.0.3",
     "process": "^0.11.10",
     "rimraf": "^3.0.2",

--- a/packages/stacking/tests/stacking-2.4.test.ts
+++ b/packages/stacking/tests/stacking-2.4.test.ts
@@ -1,23 +1,22 @@
+import { StacksNodeApi } from '@stacks/api';
 import { hexToBytes } from '@stacks/common';
 import { STACKS_MAINNET, STACKS_TESTNET } from '@stacks/network';
 import { ContractCallPayload, deserializeTransaction, getNonce } from '@stacks/transactions';
-
-import { decodeBtcAddress, StackingClient } from '../src';
-import { PoxOperationPeriod } from '../src/constants';
 import {
-  getFetchMockBroadcast,
   MOCK_EMPTY_ACCOUNT,
   MOCK_FULL_ACCOUNT,
   MOCK_POX_3_REGTEST,
-  setApiMocks,
   V2_POX_INTERFACE_POX_3,
   V2_POX_MAINNET_POX_2,
+  getFetchMockBroadcast,
+  setApiMocks,
   waitForBlock,
   waitForCycle,
   waitForTx,
-} from './apiMockingHelpers';
+} from '@stacks/internal';
+import { StackingClient, decodeBtcAddress } from '../src';
+import { PoxOperationPeriod } from '../src/constants';
 import { BTC_ADDRESS_CASES } from './utils.test';
-import { StacksNodeApi } from '@stacks/api';
 
 const API_URL = 'http://localhost:3999'; // default regtest url
 

--- a/packages/stacking/tests/stacking-2.5.test.ts
+++ b/packages/stacking/tests/stacking-2.5.test.ts
@@ -1,8 +1,8 @@
 import { getPublicKeyFromPrivate, publicKeyToBtcAddress } from '@stacks/encryption';
-import { makeRandomPrivKey } from '@stacks/transactions';
-import { StackingClient } from '../src';
-import { V2_POX_REGTEST_POX_4, setApiMocks } from './apiMockingHelpers';
 import { STACKS_MOCKNET } from '@stacks/network/src';
+import { makeRandomPrivKey } from '@stacks/transactions';
+import { V2_POX_REGTEST_POX_4, setApiMocks } from '../../internal/src';
+import { StackingClient } from '../src';
 
 beforeEach(() => {
   jest.resetModules();

--- a/packages/stacking/tests/stacking.test.ts
+++ b/packages/stacking/tests/stacking.test.ts
@@ -22,6 +22,7 @@ import {
   validateContractCall,
 } from '@stacks/transactions';
 import fetchMock from 'jest-fetch-mock';
+import { V2_POX_REGTEST_POX_3, setApiMocks } from '../../internal/src';
 import { StackingClient } from '../src';
 import { PoXAddressVersion, StackingErrors } from '../src/constants';
 import {
@@ -31,7 +32,6 @@ import {
   signPox4SignatureHash,
   verifyPox4SignatureHash,
 } from '../src/utils';
-import { V2_POX_REGTEST_POX_3, setApiMocks } from './apiMockingHelpers';
 
 const poxInfo = {
   contract_id: 'ST000000000000000000002AMW42H.pox-3',

--- a/packages/stacking/tsconfig.build.json
+++ b/packages/stacking/tsconfig.build.json
@@ -18,6 +18,9 @@
       "path": "../encryption/tsconfig.build.json"
     },
     {
+      "path": "../internal/tsconfig.build.json"
+    },
+    {
       "path": "../network/tsconfig.build.json"
     },
     {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
       "@stacks/cli": ["packages/cli/src"],
       "@stacks/common": ["packages/common/src"],
       "@stacks/encryption": ["packages/encryption/src"],
+      "@stacks/internal": ["packages/internal/src"],
       "@stacks/network": ["packages/network/src"],
       "@stacks/profile": ["packages/profile/src"],
       "@stacks/stacking": ["packages/stacking/src"],


### PR DESCRIPTION
> This PR was published to npm with the version `6.14.1-pr.47+e28933de`
> e.g. `npm install @stacks/common@6.14.1-pr.47+e28933de --save-exact`<!-- Sticky Header Marker -->

- add new `internal` private package for re-using helpers accross the monorepo which don't need to be exported/shipped