### PR TITLE
fix: Allow .appendOrigin to be used with unwrapped public key

### DIFF
--- a/packages/transactions/tests/builder.test.ts
+++ b/packages/transactions/tests/builder.test.ts
@@ -2578,7 +2578,7 @@ describe('multi-sig', () => {
       signer.signOrigin(signers.get(pub)!);
     }
 
-    signer.appendOrigin(createStacksPublicKey(missingSigner!));
+    signer.appendOrigin(missingSigner!);
 
     expect(() => tx.verifyOrigin()).not.toThrow();
   });


### PR DESCRIPTION
> This PR was published to npm with the version `6.14.1-pr.49+4ce5ba90`
> e.g. `npm install @stacks/common@6.14.1-pr.49+4ce5ba90 --save-exact`<!-- Sticky Header Marker -->

Allow .appendOrigin to be used with raw public key