### PR TITLE
feat!: Rename networking/fetch methods to include `fetch` prefix

### DIFF
--- a/.github/MIGRATION.md
+++ b/.github/MIGRATION.md
@@ -4,6 +4,7 @@
   - [Breaking Changes](#breaking-changes)
   - [Stacks Network](#stacks-network)
     - [Impacts](#impacts)
+  - [Fetch Methods](#fetch-methods)
   - [StacksNodeApi](#stacksnodeapi)
   - [StacksNetwork to StacksNodeApi](#stacksnetwork-to-stacksnodeapi)
   - [Clarity Representation](#clarity-representation)
@@ -32,6 +33,7 @@
 ### Breaking Changes
 
 - The `@stacks/network` `new StacksNetwork()` objects were removed. Instead `@stacks/network` now exports the objects `STACKS_MAINNET`, `STACKS_TESNET`, and `STACKS_DEVNET`, which are static (and shouldn't be changed for most use-cases). [Read more...](#stacks-network)
+- Most `fetch` (aka networking) methods were renamed to indicate they send HTTP requests. The new methods are named `fetchXyz` and are compatible with the old `Xyz` interfaces. [Read more...](#fetch-methods)
 - The `ClarityType` enum was replaced by a human-readable version. The previous (wire format compatible) enum is still available as `ClarityWireType`. [Read more...](#clarity-representation)
 - The previous post-conditions types and `create..` methods were replaced with a human-readable representation. [Read more...](#post-conditions)
 - `StacksTransaction.serialize` and other `serializeXyz` methods were changed to return `string` (hex-encoded) instead of `Uint8Array`. Compatible `serializeXzyBytes` methods were added to ease the migration. [Read more...](#serialize-methods)
@@ -61,6 +63,21 @@ import { STACKS_DEVNET } from '@stacks/network';
 
 - @stacks/bns: `BnsContractAddress` was removed, since `.bootAddress` is now a part of the network objects.
 - @stacks/transactions: `AddressVersion` was moved to `@stacks/network`.
+
+### Fetch Methods
+
+The following methods were renamed:
+
+- `estimateFee` → `fetchFeeEstimate`
+- `estimateTransfer` → `fetchFeeEstimateTransfer`
+- `estimateTransaction` → `fetchFeeEstimateTransaction`
+- `getAbi` → `fetchAbi`
+- `getNonce` → `fetchNonce`
+- `getContractMapEntry` → `fetchContractMapEntry`
+- `callReadOnlyFunction` → `fetchCallReadOnlyFunction`
+
+`broadcastTransaction` wasn't renamed to highlight the uniqueness of the method.
+Namely, the node/API it is sent to will "broadcast" the transaction to the mempool.
 
 ### StacksNodeApi
 

--- a/packages/api/src/api.ts
+++ b/packages/api/src/api.ts
@@ -20,9 +20,9 @@ import {
   StacksTransaction,
   TxBroadcastResult,
   broadcastTransaction,
-  estimateTransaction,
-  getAbi,
-  getNonce,
+  fetchAbi,
+  fetchFeeEstimateTransaction,
+  fetchNonce,
 } from '@stacks/transactions';
 import {
   BaseErrorResponse,
@@ -79,7 +79,7 @@ export class StacksNodeApi {
    * @return A promise that resolves to a bigint of the next nonce
    */
   getNonce = async (address: string): Promise<bigint> => {
-    return getNonce({ address, api: this });
+    return fetchNonce({ address, api: this });
   };
 
   /**
@@ -94,7 +94,7 @@ export class StacksNodeApi {
     payload: Hex,
     estimatedLength?: number
   ): Promise<[FeeEstimation, FeeEstimation, FeeEstimation]> => {
-    return estimateTransaction({ payload, estimatedLength, api: this });
+    return fetchFeeEstimateTransaction({ payload, estimatedLength, api: this });
   };
 
   /**
@@ -103,7 +103,7 @@ export class StacksNodeApi {
    */
   getAbi = async (contract: ContractIdString): Promise<ClarityAbi> => {
     const [contractAddress, contractName] = contract.split('.');
-    return getAbi({ contractAddress, contractName, api: this });
+    return fetchAbi({ contractAddress, contractName, api: this });
   };
 
   /** Get stacks node info */

--- a/packages/bns/src/index.ts
+++ b/packages/bns/src/index.ts
@@ -11,8 +11,8 @@ import {
   UnsignedContractCallOptions,
   bufferCV,
   bufferCVFromString,
-  callReadOnlyFunction,
   cvToString,
+  fetchCallReadOnlyFunction,
   getAddressFromPrivateKey,
   getCVTypeString,
   hash160,
@@ -85,7 +85,7 @@ export interface BnsReadOnlyOptions {
 async function callReadOnlyBnsFunction(
   options: BnsReadOnlyOptions & ApiParam
 ): Promise<ClarityValue> {
-  return callReadOnlyFunction({
+  return fetchCallReadOnlyFunction({
     contractAddress: options.network.bootAddress,
     contractName: BNS_CONTRACT_NAME,
     functionName: options.functionName,

--- a/packages/bns/tests/bns.test.ts
+++ b/packages/bns/tests/bns.test.ts
@@ -32,14 +32,14 @@ test('canRegisterName true', async () => {
   const trueFunctionCallResponse = responseOkCV(trueCV());
   const notRandomAddress = 'SPF0324DSC4K505TP6A8C7GAK4R95E38TGNZP7RE';
 
-  const callReadOnlyFunction = jest.fn().mockResolvedValue(trueFunctionCallResponse);
+  const fetchCallReadOnlyFunction = jest.fn().mockResolvedValue(trueFunctionCallResponse);
   const getAddressFromPrivateKey = jest.fn().mockReturnValue(notRandomAddress);
 
   const network = STACKS_TESTNET;
 
   jest.mock('@stacks/transactions', () => ({
     ...jest.requireActual('@stacks/transactions'),
-    callReadOnlyFunction,
+    fetchCallReadOnlyFunction,
     getAddressFromPrivateKey,
   }));
 
@@ -61,8 +61,8 @@ test('canRegisterName true', async () => {
   };
 
   expect(result).toEqual(true);
-  expect(callReadOnlyFunction).toHaveBeenCalledTimes(1);
-  expect(callReadOnlyFunction).toHaveBeenCalledWith(expectedReadOnlyFunctionCallOptions);
+  expect(fetchCallReadOnlyFunction).toHaveBeenCalledTimes(1);
+  expect(fetchCallReadOnlyFunction).toHaveBeenCalledWith(expectedReadOnlyFunctionCallOptions);
 });
 
 test('canRegisterName false', async () => {
@@ -71,14 +71,14 @@ test('canRegisterName false', async () => {
   const falseFunctionCallResponse = responseOkCV(falseCV());
   const notRandomAddress = 'SPF0324DSC4K505TP6A8C7GAK4R95E38TGNZP7RE';
 
-  const callReadOnlyFunction = jest.fn().mockResolvedValue(falseFunctionCallResponse);
+  const fetchCallReadOnlyFunction = jest.fn().mockResolvedValue(falseFunctionCallResponse);
   const getAddressFromPrivateKey = jest.fn().mockReturnValue(notRandomAddress);
 
   const network = STACKS_TESTNET;
 
   jest.mock('@stacks/transactions', () => ({
     ...jest.requireActual('@stacks/transactions'),
-    callReadOnlyFunction,
+    fetchCallReadOnlyFunction,
     getAddressFromPrivateKey,
   }));
 
@@ -100,8 +100,8 @@ test('canRegisterName false', async () => {
   };
 
   expect(result).toEqual(false);
-  expect(callReadOnlyFunction).toHaveBeenCalledTimes(1);
-  expect(callReadOnlyFunction).toHaveBeenCalledWith(expectedReadOnlyFunctionCallOptions);
+  expect(fetchCallReadOnlyFunction).toHaveBeenCalledTimes(1);
+  expect(fetchCallReadOnlyFunction).toHaveBeenCalledWith(expectedReadOnlyFunctionCallOptions);
 });
 
 test('canRegisterName error', async () => {
@@ -110,14 +110,14 @@ test('canRegisterName error', async () => {
   const errorFunctionCallResponse = responseErrorCV(bufferCV(utf8ToBytes('error')));
   const notRandomAddress = 'SPF0324DSC4K505TP6A8C7GAK4R95E38TGNZP7RE';
 
-  const callReadOnlyFunction = jest.fn().mockResolvedValue(errorFunctionCallResponse);
+  const fetchCallReadOnlyFunction = jest.fn().mockResolvedValue(errorFunctionCallResponse);
   const getAddressFromPrivateKey = jest.fn().mockReturnValue(notRandomAddress);
 
   const network = STACKS_TESTNET;
 
   jest.mock('@stacks/transactions', () => ({
     ...jest.requireActual('@stacks/transactions'),
-    callReadOnlyFunction,
+    fetchCallReadOnlyFunction,
     getAddressFromPrivateKey,
   }));
 
@@ -139,8 +139,8 @@ test('canRegisterName error', async () => {
   };
 
   expect(result).toEqual(false);
-  expect(callReadOnlyFunction).toHaveBeenCalledTimes(1);
-  expect(callReadOnlyFunction).toHaveBeenCalledWith(expectedReadOnlyFunctionCallOptions);
+  expect(fetchCallReadOnlyFunction).toHaveBeenCalledTimes(1);
+  expect(fetchCallReadOnlyFunction).toHaveBeenCalledWith(expectedReadOnlyFunctionCallOptions);
 });
 
 test('getNamespacePrice', async () => {
@@ -149,14 +149,14 @@ test('getNamespacePrice', async () => {
   const address = 'SPF0324DSC4K505TP6A8C7GAK4R95E38TGNZP7RE';
 
   const namespacePriceResponse = responseOkCV(uintCV(10));
-  const callReadOnlyFunction = jest.fn().mockResolvedValue(namespacePriceResponse);
+  const fetchCallReadOnlyFunction = jest.fn().mockResolvedValue(namespacePriceResponse);
   const getAddressFromPrivateKey = jest.fn().mockReturnValue(address);
 
   const network = STACKS_TESTNET;
 
   jest.mock('@stacks/transactions', () => ({
     ...jest.requireActual('@stacks/transactions'),
-    callReadOnlyFunction,
+    fetchCallReadOnlyFunction,
     getAddressFromPrivateKey,
   }));
 
@@ -175,8 +175,8 @@ test('getNamespacePrice', async () => {
   };
 
   expect(result.toString()).toEqual('10');
-  expect(callReadOnlyFunction).toHaveBeenCalledTimes(1);
-  expect(callReadOnlyFunction).toHaveBeenCalledWith(expectedReadOnlyFunctionCallOptions);
+  expect(fetchCallReadOnlyFunction).toHaveBeenCalledTimes(1);
+  expect(fetchCallReadOnlyFunction).toHaveBeenCalledWith(expectedReadOnlyFunctionCallOptions);
 });
 
 test('getNamespacePrice error', async () => {
@@ -185,14 +185,14 @@ test('getNamespacePrice error', async () => {
   const address = 'SPF0324DSC4K505TP6A8C7GAK4R95E38TGNZP7RE';
 
   const errorResponse = responseErrorCV(uintCV(1001));
-  const callReadOnlyFunction = jest.fn().mockResolvedValue(errorResponse);
+  const fetchCallReadOnlyFunction = jest.fn().mockResolvedValue(errorResponse);
   const getAddressFromPrivateKey = jest.fn().mockReturnValue(address);
 
   const network = STACKS_TESTNET;
 
   jest.mock('@stacks/transactions', () => ({
     ...jest.requireActual('@stacks/transactions'),
-    callReadOnlyFunction,
+    fetchCallReadOnlyFunction,
     getAddressFromPrivateKey,
   }));
 
@@ -210,8 +210,8 @@ test('getNamespacePrice error', async () => {
   };
 
   await expect(getNamespacePrice({ namespace, network })).rejects.toEqual(new Error('u1001'));
-  expect(callReadOnlyFunction).toHaveBeenCalledTimes(1);
-  expect(callReadOnlyFunction).toHaveBeenCalledWith(expectedReadOnlyFunctionCallOptions);
+  expect(fetchCallReadOnlyFunction).toHaveBeenCalledTimes(1);
+  expect(fetchCallReadOnlyFunction).toHaveBeenCalledWith(expectedReadOnlyFunctionCallOptions);
 });
 
 test('getNamePrice', async () => {
@@ -222,14 +222,14 @@ test('getNamePrice', async () => {
   const address = 'SPF0324DSC4K505TP6A8C7GAK4R95E38TGNZP7RE';
 
   const namePriceResponse = responseOkCV(uintCV(10));
-  const callReadOnlyFunction = jest.fn().mockResolvedValue(namePriceResponse);
+  const fetchCallReadOnlyFunction = jest.fn().mockResolvedValue(namePriceResponse);
   const getAddressFromPrivateKey = jest.fn().mockReturnValue(address);
 
   const network = STACKS_TESTNET;
 
   jest.mock('@stacks/transactions', () => ({
     ...jest.requireActual('@stacks/transactions'),
-    callReadOnlyFunction,
+    fetchCallReadOnlyFunction,
     getAddressFromPrivateKey,
   }));
 
@@ -248,8 +248,8 @@ test('getNamePrice', async () => {
   };
 
   expect(result.toString()).toEqual('10');
-  expect(callReadOnlyFunction).toHaveBeenCalledTimes(1);
-  expect(callReadOnlyFunction).toHaveBeenCalledWith(expectedReadOnlyFunctionCallOptions);
+  expect(fetchCallReadOnlyFunction).toHaveBeenCalledTimes(1);
+  expect(fetchCallReadOnlyFunction).toHaveBeenCalledWith(expectedReadOnlyFunctionCallOptions);
 });
 
 test('getNamePrice error', async () => {
@@ -260,14 +260,14 @@ test('getNamePrice error', async () => {
   const address = 'SPF0324DSC4K505TP6A8C7GAK4R95E38TGNZP7RE';
 
   const namePriceResponse = responseErrorCV(uintCV(2001));
-  const callReadOnlyFunction = jest.fn().mockResolvedValue(namePriceResponse);
+  const fetchCallReadOnlyFunction = jest.fn().mockResolvedValue(namePriceResponse);
   const getAddressFromPrivateKey = jest.fn().mockReturnValue(address);
 
   const network = STACKS_TESTNET;
 
   jest.mock('@stacks/transactions', () => ({
     ...jest.requireActual('@stacks/transactions'),
-    callReadOnlyFunction,
+    fetchCallReadOnlyFunction,
     getAddressFromPrivateKey,
   }));
 
@@ -285,8 +285,8 @@ test('getNamePrice error', async () => {
   };
 
   await expect(getNamePrice({ fullyQualifiedName, network })).rejects.toEqual(new Error('u2001'));
-  expect(callReadOnlyFunction).toHaveBeenCalledTimes(1);
-  expect(callReadOnlyFunction).toHaveBeenCalledWith(expectedReadOnlyFunctionCallOptions);
+  expect(fetchCallReadOnlyFunction).toHaveBeenCalledTimes(1);
+  expect(fetchCallReadOnlyFunction).toHaveBeenCalledWith(expectedReadOnlyFunctionCallOptions);
 });
 
 test('preorderNamespace', async () => {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -6,17 +6,17 @@ import { bytesToHex, HIRO_MAINNET_URL, HIRO_TESTNET_URL } from '@stacks/common';
 import {
   ACCOUNT_PATH,
   broadcastTransaction,
-  callReadOnlyFunction,
   Cl,
   ClarityAbi,
   ClarityValue,
   ContractCallPayload,
   cvToJSON,
   cvToString,
-  estimateTransaction,
   estimateTransactionByteLength,
-  estimateTransfer,
-  getAbi,
+  fetchAbi,
+  fetchCallReadOnlyFunction,
+  fetchFeeEstimateTransaction,
+  fetchFeeEstimateTransfer,
   getAddressFromPrivateKey,
   makeContractCall,
   makeContractDeploy,
@@ -717,7 +717,7 @@ async function sendTokens(network: CLINetworkAdapter, args: string[]): Promise<s
   const tx: StacksTransaction = await makeSTXTokenTransfer(options);
 
   if (estimateOnly) {
-    return estimateTransfer({ transaction: tx, api }).then(cost => {
+    return fetchFeeEstimateTransfer({ transaction: tx, api }).then(cost => {
       return cost.toString(10);
     });
   }
@@ -775,7 +775,7 @@ async function contractDeploy(network: CLINetworkAdapter, args: string[]): Promi
   const tx = await makeContractDeploy(options);
 
   if (estimateOnly) {
-    return estimateTransaction({
+    return fetchFeeEstimateTransaction({
       payload: serializePayload(tx.payload),
       estimatedLength: estimateTransactionByteLength(tx),
     }).then(costs => costs[1].fee.toString(10));
@@ -825,7 +825,7 @@ async function contractFunctionCall(network: CLINetworkAdapter, args: string[]):
   let abiArgs: ClarityFunctionArg[];
   let functionArgs: ClarityValue[] = [];
 
-  return getAbi({ contractAddress, contractName, api })
+  return fetchAbi({ contractAddress, contractName, api })
     .then(responseAbi => {
       abi = responseAbi;
       const filtered = abi.functions.filter(fn => fn.name === functionName);
@@ -861,7 +861,7 @@ async function contractFunctionCall(network: CLINetworkAdapter, args: string[]):
       }
 
       if (estimateOnly) {
-        return estimateTransaction({
+        return fetchFeeEstimateTransaction({
           payload: serializePayload(tx.payload),
           estimatedLength: estimateTransactionByteLength(tx),
         }).then(costs => costs[1].fee.toString(10));
@@ -911,7 +911,7 @@ async function readOnlyContractFunctionCall(
   let abiArgs: ClarityFunctionArg[];
   let functionArgs: ClarityValue[] = [];
 
-  return getAbi({ contractAddress, contractName, api })
+  return fetchAbi({ contractAddress, contractName, api })
     .then(responseAbi => {
       abi = responseAbi;
       const filtered = abi.functions.filter(fn => fn.name === functionName);
@@ -935,7 +935,7 @@ async function readOnlyContractFunctionCall(
         network: api.network,
       };
 
-      return callReadOnlyFunction(options);
+      return fetchCallReadOnlyFunction(options);
     })
     .then(returnValue => {
       return cvToString(returnValue);

--- a/packages/stacking/src/index.ts
+++ b/packages/stacking/src/index.ts
@@ -34,8 +34,8 @@ import {
   UIntCV,
   broadcastTransaction,
   bufferCV,
-  callReadOnlyFunction,
   cvToString,
+  fetchCallReadOnlyFunction,
   getFee,
   makeContractCall,
   noneCV,
@@ -422,7 +422,7 @@ export class StackingClient {
   /** Get PoX address from reward set by index (if it exists) */
   async getRewardSet(options: RewardSetOptions): Promise<RewardSetInfo | undefined> {
     const [contractAddress, contractName] = this.parseContractId(options?.contractId);
-    const result = await callReadOnlyFunction({
+    const result = await fetchCallReadOnlyFunction({
       api: this.api,
       senderAddress: this.address,
       contractAddress,
@@ -533,7 +533,7 @@ export class StackingClient {
         const address = poxAddressToTuple(poxAddress);
         const [contractAddress, contractName] = this.parseContractId(poxInfo.contract_id);
 
-        return callReadOnlyFunction({
+        return fetchCallReadOnlyFunction({
           api: this.api,
           contractName,
           contractAddress,
@@ -1380,7 +1380,7 @@ export class StackingClient {
     const account = await this.getAccountStatus();
     const functionName = 'get-stacker-info';
 
-    return callReadOnlyFunction({
+    return fetchCallReadOnlyFunction({
       contractAddress,
       contractName,
       functionName,
@@ -1429,7 +1429,7 @@ export class StackingClient {
     const [contractAddress, contractName] = this.parseContractId(poxInfo.contract_id);
     const functionName = 'get-delegation-info';
 
-    return callReadOnlyFunction({
+    return fetchCallReadOnlyFunction({
       contractAddress,
       contractName,
       functionName,
@@ -1509,7 +1509,7 @@ export class StackingClient {
       uintCV(authId),
     ];
 
-    return callReadOnlyFunction({
+    return fetchCallReadOnlyFunction({
       contractAddress,
       contractName,
       functionName,

--- a/packages/stacking/tests/stacking-2.4.test.ts
+++ b/packages/stacking/tests/stacking-2.4.test.ts
@@ -1,7 +1,5 @@
 import { StacksNodeApi } from '@stacks/api';
 import { hexToBytes } from '@stacks/common';
-import { STACKS_MAINNET, STACKS_TESTNET } from '@stacks/network';
-import { ContractCallPayload, deserializeTransaction, getNonce } from '@stacks/transactions';
 import {
   MOCK_EMPTY_ACCOUNT,
   MOCK_FULL_ACCOUNT,
@@ -14,6 +12,8 @@ import {
   waitForCycle,
   waitForTx,
 } from '@stacks/internal';
+import { STACKS_MAINNET, STACKS_TESTNET } from '@stacks/network';
+import { ContractCallPayload, deserializeTransaction, fetchNonce } from '@stacks/transactions';
 import { StackingClient, decodeBtcAddress } from '../src';
 import { PoxOperationPeriod } from '../src/constants';
 import { BTC_ADDRESS_CASES } from './utils.test';
@@ -697,7 +697,7 @@ describe('delegated stacking', () => {
     poxInfo = await clientPool.getPoxInfo();
 
     // Manual nonce setting is required for multiple transactions in the same block
-    let noncePool = await getNonce({ address: poolAddress, api });
+    let noncePool = await fetchNonce({ address: poolAddress, api });
 
     // Pool stacks for stacker A
     const stackAPool = await clientPool.delegateStackStx({
@@ -847,7 +847,7 @@ describe('delegated stacking', () => {
     poxInfo = await clientPool.getPoxInfo();
 
     // Manual nonce setting is required for multiple transactions in the same block
-    let noncePool = await getNonce({ address: poolAddress, api });
+    let noncePool = await fetchNonce({ address: poolAddress, api });
 
     // Pool stacks for stacker A (stacks all 3/4)
     const stackAPool = await clientPool.delegateStackStx({

--- a/packages/stacking/tests/stacking.test.ts
+++ b/packages/stacking/tests/stacking.test.ts
@@ -200,11 +200,11 @@ test('check stacking eligibility true', async () => {
   const network = STACKS_TESTNET;
 
   const functionCallResponse = responseOkCV(trueCV());
-  const callReadOnlyFunction = jest.fn().mockResolvedValue(functionCallResponse);
+  const fetchCallReadOnlyFunction = jest.fn().mockResolvedValue(functionCallResponse);
 
   jest.mock('@stacks/transactions', () => ({
     ...jest.requireActual('@stacks/transactions'),
-    callReadOnlyFunction,
+    fetchCallReadOnlyFunction,
   }));
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const { StackingClient } = require('../src'); // needed for jest.mock module
@@ -241,11 +241,11 @@ test('check stacking eligibility false bad cycles', async () => {
 
   const expectedErrorString = StackingErrors[StackingErrors.ERR_STACKING_INVALID_LOCK_PERIOD];
   const functionCallResponse = responseErrorCV(intCV(2));
-  const callReadOnlyFunction = jest.fn().mockResolvedValue(functionCallResponse);
+  const fetchCallReadOnlyFunction = jest.fn().mockResolvedValue(functionCallResponse);
 
   jest.mock('@stacks/transactions', () => ({
     ...jest.requireActual('@stacks/transactions'),
-    callReadOnlyFunction,
+    fetchCallReadOnlyFunction,
   }));
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const { StackingClient } = require('../src'); // needed for jest.mock module
@@ -786,11 +786,11 @@ test('get stacking status', async () => {
     })
   );
 
-  const callReadOnlyFunction = jest.fn().mockResolvedValue(functionCallResponse);
+  const fetchCallReadOnlyFunction = jest.fn().mockResolvedValue(functionCallResponse);
 
   jest.mock('@stacks/transactions', () => ({
     ...jest.requireActual('@stacks/transactions'),
-    callReadOnlyFunction,
+    fetchCallReadOnlyFunction,
   }));
 
   fetchMock.mockResponse(request => {
@@ -823,8 +823,8 @@ test('get stacking status', async () => {
     api: client.api,
   };
 
-  expect(callReadOnlyFunction).toHaveBeenCalledTimes(1);
-  expect(callReadOnlyFunction).toHaveBeenCalledWith(expectedReadOnlyFunctionCallOptions);
+  expect(fetchCallReadOnlyFunction).toHaveBeenCalledTimes(1);
+  expect(fetchCallReadOnlyFunction).toHaveBeenCalledWith(expectedReadOnlyFunctionCallOptions);
 
   expect(stackingStatus.stacked).toEqual(true);
   expect(stackingStatus.details.first_reward_cycle).toEqual(firstRewardCycle);

--- a/packages/transactions/src/builders.ts
+++ b/packages/transactions/src/builders.ts
@@ -28,7 +28,7 @@ import {
   SingleSigHashMode,
 } from './constants';
 import { ClarityAbi, validateContractCall } from './contract-abi';
-import { estimateFee, getAbi, getNonce } from './fetch';
+import { fetchFeeEstimate, fetchAbi, fetchNonce } from './fetch';
 import { createStacksPublicKey, privateKeyToPublic, publicKeyToAddress } from './keys';
 import { postConditionToWire } from './postcondition';
 import { PostCondition } from './postcondition-types';
@@ -182,14 +182,14 @@ export async function makeUnsignedSTXTokenTransfer(
   );
 
   if (txOptions.fee == null) {
-    const fee = await estimateFee({ transaction, api: options.api });
+    const fee = await fetchFeeEstimate({ transaction, api: options.api });
     transaction.setFee(fee);
   }
 
   if (txOptions.nonce == null) {
     const addressVersion = network.addressVersion.singleSig;
     const address = c32address(addressVersion, transaction.auth.spendingCondition!.signer);
-    const txNonce = await getNonce({ address, api: options.api });
+    const txNonce = await fetchNonce({ address, api: options.api });
     transaction.setNonce(txNonce);
   }
 
@@ -396,14 +396,14 @@ export async function makeUnsignedContractDeploy(
   );
 
   if (txOptions.fee === undefined || txOptions.fee === null) {
-    const fee = await estimateFee({ transaction, api: options.api });
+    const fee = await fetchFeeEstimate({ transaction, api: options.api });
     transaction.setFee(fee);
   }
 
   if (txOptions.nonce === undefined || txOptions.nonce === null) {
     const addressVersion = network.addressVersion.singleSig;
     const address = c32address(addressVersion, transaction.auth.spendingCondition!.signer);
-    const txNonce = await getNonce({ address, api: options.api });
+    const txNonce = await fetchNonce({ address, api: options.api });
     transaction.setNonce(txNonce);
   }
 
@@ -483,7 +483,7 @@ export async function makeUnsignedContractCall(
     let abi: ClarityAbi;
     if (typeof options.validateWithAbi === 'boolean') {
       if (options?.network) {
-        abi = await getAbi({ ...options });
+        abi = await fetchAbi({ ...options });
       } else {
         throw new Error('Network option must be provided in order to validate with ABI');
       }
@@ -550,14 +550,14 @@ export async function makeUnsignedContractCall(
   );
 
   if (txOptions.fee === undefined || txOptions.fee === null) {
-    const fee = await estimateFee({ transaction, api: options.api });
+    const fee = await fetchFeeEstimate({ transaction, api: options.api });
     transaction.setFee(fee);
   }
 
   if (txOptions.nonce === undefined || txOptions.nonce === null) {
     const addressVersion = network.addressVersion.singleSig;
     const address = c32address(addressVersion, transaction.auth.spendingCondition!.signer);
-    const txNonce = await getNonce({ address, api: options.api });
+    const txNonce = await fetchNonce({ address, api: options.api });
     transaction.setNonce(txNonce);
   }
 
@@ -660,7 +660,7 @@ export async function sponsorTransaction(
       case PayloadType.SmartContract:
       case PayloadType.VersionedSmartContract:
       case PayloadType.ContractCall:
-        txFee = BigInt(await estimateFee({ ...options }));
+        txFee = BigInt(await fetchFeeEstimate({ ...options }));
         break;
       default:
         throw new Error(
@@ -676,7 +676,7 @@ export async function sponsorTransaction(
   if (sponsorOptions.sponsorNonce == null) {
     const addressVersion = network.addressVersion.singleSig;
     const address = publicKeyToAddress(addressVersion, sponsorPubKey);
-    const sponsorNonce = await getNonce({ address, api: options.api });
+    const sponsorNonce = await fetchNonce({ address, api: options.api });
     options.sponsorNonce = sponsorNonce;
   }
 

--- a/packages/transactions/src/fetch.ts
+++ b/packages/transactions/src/fetch.ts
@@ -100,7 +100,7 @@ async function _getNonceApi({
  * @param opts.api - Optional API info (`.url` & `.fetch`) used for fetch call
  * @return A promise that resolves to an integer
  */
-export async function getNonce({
+export async function fetchNonce({
   address,
   api: apiOpt,
 }: {
@@ -128,7 +128,7 @@ export async function getNonce({
 }
 
 /**
- * @deprecated Use the new {@link estimateTransaction} function instead.
+ * @deprecated Use the new {@link fetchFeeEstimateTransaction} function instead.
  *
  * Estimate the total transaction fee in microstacks for a token transfer
  *
@@ -137,7 +137,7 @@ export async function getNonce({
  * @param opts.api - Optional API info (`.url` & `.fetch`) used for fetch call
  * @return A promise that resolves to number of microstacks per byte
  */
-export async function estimateTransfer({
+export async function fetchFeeEstimateTransfer({
   transaction: txOpt,
   api: apiOpt,
 }: {
@@ -178,7 +178,7 @@ export async function estimateTransfer({
  * @param opts.api - Optional API info (`.url` & `.fetch`) used for fetch call
  * @return A promise that resolves to FeeEstimate
  */
-export async function estimateTransaction({
+export async function fetchFeeEstimateTransaction({
   payload,
   estimatedLength,
   api: apiOpt,
@@ -217,13 +217,13 @@ export async function estimateTransaction({
 }
 
 /**
- * Estimates the fee using {@link estimateTransaction}, but retries to estimate
- * with {@link estimateTransfer} as a fallback if does not get an estimation due
+ * Estimates the fee using {@link fetchFeeEstimateTransaction}, but retries to estimate
+ * with {@link fetchFeeEstimateTransfer} as a fallback if does not get an estimation due
  * to the {@link NoEstimateAvailableError} error.
  * @param opts.transaction - The transaction to estimate fees for
  * @param opts.api - Optional API info (`.url` & `.fetch`) used for fetch call
  */
-export async function estimateFee({
+export async function fetchFeeEstimate({
   transaction: txOpt,
   api: apiOpt,
 }: {
@@ -241,7 +241,7 @@ export async function estimateFee({
   try {
     const estimatedLength = estimateTransactionByteLength(txOpt);
     return (
-      await estimateTransaction({
+      await fetchFeeEstimateTransaction({
         payload: bytesToHex(serializePayloadBytes(txOpt.payload)),
         estimatedLength,
         api,
@@ -249,7 +249,7 @@ export async function estimateFee({
     )[1].fee;
   } catch (error) {
     if (!(error instanceof NoEstimateAvailableError)) throw error;
-    return await estimateTransfer({ transaction: txOpt, api });
+    return await fetchFeeEstimateTransfer({ transaction: txOpt, api });
   }
 }
 
@@ -260,7 +260,7 @@ export async function estimateFee({
  * @param opts.api - Optional API info (`.url` & `.fetch`) used for fetch call
  * @returns A promise that resolves to a ClarityAbi if the operation succeeds
  */
-export async function getAbi({
+export async function fetchAbi({
   contractAddress: address,
   contractName: name,
   api: apiOpt,
@@ -294,7 +294,7 @@ export async function getAbi({
  * @return Returns an object with a status bool (okay) and a result string that
  * is a serialized clarity value in hex format.
  */
-export async function callReadOnlyFunction({
+export async function fetchCallReadOnlyFunction({
   contractName,
   contractAddress,
   functionName,
@@ -347,7 +347,7 @@ export async function callReadOnlyFunction({
  * @returns Promise that resolves to a ClarityValue if the operation succeeds.
  * Resolves to NoneCV if the map does not contain the given key, if the map does not exist, or if the contract prinicipal does not exist
  */
-export async function getContractMapEntry<T extends ClarityValue = ClarityValue>({
+export async function fetchContractMapEntry<T extends ClarityValue = ClarityValue>({
   contractAddress,
   contractName,
   mapName,


### PR DESCRIPTION
> This PR was published to npm with the version `6.14.1-pr.50+348b9395`
> e.g. `npm install @stacks/common@6.14.1-pr.50+348b9395 --save-exact`<!-- Sticky Header Marker -->

- Rename "fetch" methods for better discoverability