### PR TITLE
fix: Consolidate `is` prefixed boolean methods

### DIFF
--- a/packages/transactions/src/wire/helpers.ts
+++ b/packages/transactions/src/wire/helpers.ts
@@ -2,10 +2,11 @@ import { TransactionVersion } from '@stacks/network';
 import { c32address } from 'c32check';
 import { addressHashModeToVersion } from '../address';
 import { AddressHashMode, AddressVersion, PayloadType } from '../constants';
-import { publicKeyIsCompressed, serializePublicKeyBytes } from '../keys';
+import { publicKeyIsCompressed } from '../keys';
 import { AssetString } from '../types';
 import { hashP2PKH, hashP2SH, hashP2WPKH, hashP2WSH } from '../utils';
 import { createAsset, createContractPrincipal, createStandardPrincipal } from './create';
+import { serializePublicKeyBytes } from './serialization';
 import {
   AddressWire,
   AssetWire,

--- a/packages/transactions/tests/transaction.test.ts
+++ b/packages/transactions/tests/transaction.test.ts
@@ -19,12 +19,7 @@ import {
   FungibleConditionCode,
   PostConditionMode,
 } from '../src/constants';
-import {
-  createStacksPublicKey,
-  privateKeyToPublic,
-  publicKeyToHex,
-  serializePublicKeyBytes,
-} from '../src/keys';
+import { createStacksPublicKey, privateKeyToPublic, publicKeyToHex } from '../src/keys';
 
 import {
   CoinbasePayloadToAltRecipient,
@@ -34,6 +29,7 @@ import {
   createLPList,
   createStandardPrincipal,
   createTokenTransferPayload,
+  serializePublicKeyBytes,
 } from '../src';
 import { postConditionToWire } from '../src/postcondition';
 import { TransactionSigner } from '../src/signer';


### PR DESCRIPTION
> This PR was published to npm with the version `6.14.1-pr.51+c5d30b34`
> e.g. `npm install @stacks/common@6.14.1-pr.51+c5d30b34 --save-exact`<!-- Sticky Header Marker -->

- move remaining `serialize/deserialize` helpers to new folder (a previous PR)
- consolidate naming of `is` prefixed functions for better discoverability
- add more docstrings