### PR TITLE
feat: Add STX unit helpers

### DIFF
--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -321,6 +321,7 @@ export function intToBytes(value: IntegerType, signed: boolean, byteLength: numb
   return bigIntToBytes(intToBigInt(value, signed), byteLength);
 }
 
+//todo: add default param to `signed` (should only be needed in rare use-cases, not typical users) `next`
 export function intToBigInt(value: IntegerType, signed: boolean): bigint {
   let parsedValue = value;
 

--- a/packages/transactions/src/units.ts
+++ b/packages/transactions/src/units.ts
@@ -1,0 +1,27 @@
+export const MICROSTX_IN_STX = 1_000_000;
+
+/**
+ * Convert μSTX (micro-STX) to STX denomination.
+ * `1 STX = 1,000,000 μSTX`
+ *
+ * @example
+ * ```ts
+ * microStxToStx(1000000n); // 1n
+ * ```
+ */
+export function microStxToStx(amountInMicroStx: number): number {
+  return amountInMicroStx / MICROSTX_IN_STX;
+}
+
+/**
+ * Convert STX to μSTX (micro-STX) denomination.
+ * `1 STX = 1,000,000 μSTX`
+ *
+ * @example
+ * ```ts
+ * stxToMicroStx(1); // 1000000
+ * ```
+ */
+export function stxToMicroStx(amountInStx: number): number {
+  return amountInStx * MICROSTX_IN_STX;
+}

--- a/packages/transactions/tests/units.test.ts
+++ b/packages/transactions/tests/units.test.ts
@@ -1,0 +1,21 @@
+import { microStxToStx, stxToMicroStx } from '../src/units';
+
+test(stxToMicroStx.name, () => {
+  expect(stxToMicroStx(1)).toBe(1000000);
+  expect(stxToMicroStx(1.23)).toBe(1230000);
+  expect(stxToMicroStx(0.000001)).toBe(1);
+
+  expect(stxToMicroStx(-1)).toBe(-1000000);
+  expect(stxToMicroStx(-2.34)).toBe(-2340000);
+  expect(stxToMicroStx(-0.000001)).toBe(-1);
+});
+
+test(microStxToStx.name, () => {
+  expect(microStxToStx(1000000)).toBe(1);
+  expect(microStxToStx(1230000)).toBe(1.23);
+  expect(microStxToStx(1)).toBe(0.000001);
+
+  expect(microStxToStx(-1000000)).toBe(-1);
+  expect(microStxToStx(-2340000)).toBe(-2.34);
+  expect(microStxToStx(-1)).toBe(-0.000001);
+});


### PR DESCRIPTION
> This PR was published to npm with the version `6.14.1-pr.53+91f0bd20`
> e.g. `npm install @stacks/common@6.14.1-pr.53+91f0bd20 --save-exact`<!-- Sticky Header Marker -->

- Add unit helpers based on old `stx-utils` https://github.com/stacks-network/stacks-utils/blob/master/src/units.js