### PR TITLE
feat: Add `Address` namespace

### DIFF
--- a/packages/transactions/src/index.ts
+++ b/packages/transactions/src/index.ts
@@ -25,6 +25,8 @@ export * from './utils';
 export * from './address';
 export * from './wire';
 
+export * from './namespaces';
+
 /**
  * ### `Cl.` Clarity Value Namespace
  * The `Cl` namespace is provided as a convenience to build/parse Clarity Value objects.

--- a/packages/transactions/src/keys.ts
+++ b/packages/transactions/src/keys.ts
@@ -226,6 +226,23 @@ export function signMessageHashRsv({
 }
 
 /**
+ * Convert a private key to a single-sig address.
+ * @returns A Stacks address string (encoded with c32check)
+ * @example
+ * ```
+ * const address = privateKeyToAddress("73a2f291df5a8ce3ceb668a25ac7af45639513af7596d710ddf59f64f484fd2801");
+ * // SP10J81WVGVB3M4PHQN4Q4G0R8586TBJH948RESDR
+ * ```
+ */
+export function privateKeyToAddress(
+  privateKey: PrivateKey,
+  network?: StacksNetworkName | StacksNetwork
+): string {
+  const publicKey = privateKeyToPublic(privateKey);
+  return publicKeyToAddressSingleSig(publicKey, network);
+}
+
+/**
  * Convert a public key to an address.
  * @returns A Stacks address string (encoded with c32check)
  * @example Public key to address

--- a/packages/transactions/src/namespaces/address.ts
+++ b/packages/transactions/src/namespaces/address.ts
@@ -1,0 +1,108 @@
+import { c32address, c32addressDecode } from 'c32check';
+import { AddressVersion } from '../constants';
+import { privateKeyToAddress, publicKeyToAddressSingleSig } from '../keys';
+import { AddressString, ContractIdString } from '../types';
+
+const C32 = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+
+export type AddressRepr = { hash160: string; contractName?: string } & (
+  | {
+      version: AddressVersion;
+      versionChar: string;
+    }
+  | {
+      version: AddressVersion;
+    }
+  | {
+      versionChar: string;
+    }
+);
+
+/**
+ * Parse a C32 Stacks address string to an address object.
+ * @param address - The address string to parse.
+ * @example
+ * ```ts
+ * import { Address } from '@stacks/transactions';
+ *
+ * const address = Address.parse('SP000000000000000000002Q6VF78');
+ * // { version: 22, versionChar: 'P', hash160: '0000000000000000000000000000000000000000' }
+ *
+ * const address = Address.parse('ST000000000000000000002AMW42H.pox');
+ * // { version: 22, versionChar: 'P', hash160: '0000000000000000000000000000000000000000', contractName: 'pox' }
+ * ```
+ */
+export function parse(
+  address:
+    | AddressString
+    // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
+    | ContractIdString
+): AddressRepr {
+  const [addr, contractName] = address.split('.');
+  const parsed = c32addressDecode(addr);
+  return {
+    version: parsed[0],
+    versionChar: C32[parsed[0]],
+    hash160: parsed[1],
+    contractName: contractName,
+  };
+}
+
+/**
+ * Stringify an address to the C32 address format.
+ * @param address - The address object to stringify.
+ * @example
+ * ```ts
+ * import { Address } from '@stacks/transactions';
+ *
+ * const address = Address.stringify({ version: 22, hash160: '0000000000000000000000000000000000000000' });
+ * console.log(address); // 'SP000000000000000000002Q6VF78'
+ *
+ * const address = Address.stringify({ versionChar: 'P', hash160: '0000000000000000000000000000000000000000' });
+ * console.log(address); // 'SP000000000000000000002Q6VF78'
+ * ```
+ */
+export function stringify(address: AddressRepr): string {
+  const version =
+    'version' in address ? address.version : C32.indexOf(address.versionChar.toUpperCase());
+  const addr = c32address(version, address.hash160);
+
+  if (address.contractName) return `${addr}.${address.contractName}`;
+  return addr;
+}
+
+/**
+ * Convert a private key to a single-sig C32 Stacks address.
+ * @param privateKey - The private key to convert.
+ * @returns The address string.
+ *
+ * @example
+ * ```ts
+ * import { Address } from '@stacks/transactions';
+ *
+ * const address = Address.fromPrivateKey('73a2f291df5a8ce3ceb668a25ac7af45639513af7596d710ddf59f64f484fd2801');
+ * // 'SP10J81WVGVB3M4PHQN4Q4G0R8586TBJH948RESDR'
+ *
+ * const address = Address.fromPrivateKey('73a2f291df5a8ce3ceb668a25ac7af45639513af7596d710ddf59f64f484fd2801', 'testnet');
+ * // 'ST10J81WVGVB3M4PHQN4Q4G0R8586TBJH94CGRESQ'
+ * ```
+ */
+export const fromPrivateKey = privateKeyToAddress;
+
+/**
+ * Convert a public key to a single-sig C32 Stacks address.
+ * @param publicKey - The public key to convert.
+ * @returns The address string.
+ *
+ * @example
+ * ```ts
+ * import { Address } from '@stacks/transactions';
+ *
+ * const address = Address.fromPublicKey('0316e35d38b52d4886e40065e4952a49535ce914e02294be58e252d1998f129b19');
+ * // 'SP10J81WVGVB3M4PHQN4Q4G0R8586TBJH948RESDR'
+ *
+ * const address = Address.fromPublicKey('0316e35d38b52d4886e40065e4952a49535ce914e02294be58e252d1998f129b19', 'testnet');
+ * // 'ST10J81WVGVB3M4PHQN4Q4G0R8586TBJH94CGRESQ'
+ * ```
+ */
+export const fromPublicKey = publicKeyToAddressSingleSig;

--- a/packages/transactions/src/namespaces/index.ts
+++ b/packages/transactions/src/namespaces/index.ts
@@ -1,0 +1,1 @@
+export * as Address from './address';

--- a/packages/transactions/tests/keys.test.ts
+++ b/packages/transactions/tests/keys.test.ts
@@ -13,7 +13,7 @@ import {
   signatureRsvToVrs,
   utf8ToBytes,
 } from '@stacks/common';
-import { AddressVersion, TransactionVersion } from '@stacks/network';
+import { AddressVersion, STACKS_TESTNET, TransactionVersion } from '@stacks/network';
 import { ec as EC } from 'elliptic';
 import {
   PubKeyEncoding,
@@ -24,6 +24,7 @@ import {
   getAddressFromPrivateKey,
   getAddressFromPublicKey,
   makeRandomPrivKey,
+  privateKeyToAddress,
   privateKeyToHex,
   privateKeyToPublic,
   publicKeyFromSignatureRsv,
@@ -328,5 +329,17 @@ describe(publicKeyToAddress.name, () => {
     const publicKey = '03ef788b3830c00abe8f64f62dc32fc863bc0b2cafeb073b6c8e1c7657d9c2c3ab';
     const address = publicKeyToAddress(AddressVersion.MainnetSingleSig, publicKey);
     expect(address).toBe('SPAW66WC3G8WA5F28JVNG1NTRJ6H76E7EN5H6QQD');
+  });
+});
+
+describe(privateKeyToAddress.name, () => {
+  it('should return the correct single-sig address', () => {
+    const privateKey = '73a2f291df5a8ce3ceb668a25ac7af45639513af7596d710ddf59f64f484fd2801';
+
+    const address = privateKeyToAddress(privateKey);
+    expect(address).toBe('SP10J81WVGVB3M4PHQN4Q4G0R8586TBJH948RESDR');
+
+    const addressTestnet = privateKeyToAddress(privateKey, STACKS_TESTNET);
+    expect(addressTestnet).toBe('ST10J81WVGVB3M4PHQN4Q4G0R8586TBJH94CGRESQ');
   });
 });

--- a/packages/transactions/tests/namespaces/address.test.ts
+++ b/packages/transactions/tests/namespaces/address.test.ts
@@ -1,0 +1,85 @@
+import { Address } from '../../src';
+
+describe('Address Namespace', () => {
+  describe(Address.parse, () => {
+    it('should parse addresses correctly', () => {
+      const address = Address.parse('SP000000000000000000002Q6VF78');
+      expect(address).toEqual({ version: 22, versionChar: 'P', hash160: '0'.repeat(40) });
+
+      const addressWithVersionChar = Address.parse('SP000000000000000000002Q6VF78');
+      expect(addressWithVersionChar).toEqual({
+        version: 22,
+        versionChar: 'P',
+        hash160: '0'.repeat(40),
+      });
+
+      const addressWithContractId = Address.parse('ST000000000000000000002AMW42H.pox');
+      expect(addressWithContractId).toEqual({
+        version: 26,
+        versionChar: 'T',
+        hash160: '0'.repeat(40),
+        contractName: 'pox',
+      });
+    });
+
+    it('should throw an error for invalid addresses', () => {
+      expect(() => Address.parse('invalid')).toThrow('Invalid c32 address: must start with "S"');
+    });
+
+    it('should throw an error for checksum mismatches', () => {
+      expect(() => Address.parse('ST000BLABLA')).toThrow(
+        'Invalid c32check string: checksum mismatch'
+      );
+    });
+  });
+
+  describe(Address.stringify, () => {
+    it('should return the correct address', () => {
+      const addressWithVersion = Address.stringify({ version: 22, hash160: '0'.repeat(40) });
+      expect(addressWithVersion).toBe('SP000000000000000000002Q6VF78');
+
+      const addressWithVersionChar = Address.stringify({
+        versionChar: 'P',
+        hash160: '0'.repeat(40),
+      });
+      expect(addressWithVersionChar).toBe('SP000000000000000000002Q6VF78');
+
+      const addressWithContractId = Address.stringify({
+        versionChar: 'T',
+        hash160: '0'.repeat(40),
+        contractName: 'pox',
+      });
+      expect(addressWithContractId).toBe('ST000000000000000000002AMW42H.pox');
+    });
+  });
+
+  describe(Address.fromPrivateKey, () => {
+    it('should return the correct address', () => {
+      const address = Address.fromPrivateKey(
+        '73a2f291df5a8ce3ceb668a25ac7af45639513af7596d710ddf59f64f484fd2801'
+      );
+      expect(address).toBe('SP10J81WVGVB3M4PHQN4Q4G0R8586TBJH948RESDR');
+
+      const addressTestnet = Address.fromPrivateKey(
+        '73a2f291df5a8ce3ceb668a25ac7af45639513af7596d710ddf59f64f484fd2801',
+        'testnet'
+      );
+      expect(addressTestnet).toBe('ST10J81WVGVB3M4PHQN4Q4G0R8586TBJH94CGRESQ');
+    });
+  });
+
+  describe(Address.fromPublicKey, () => {
+    it('should return the correct address', () => {
+      const address = Address.fromPublicKey(
+        '0316e35d38b52d4886e40065e4952a49535ce914e02294be58e252d1998f129b19'
+      );
+      expect(address).toBe('SP10J81WVGVB3M4PHQN4Q4G0R8586TBJH948RESDR');
+
+      const addressTestnet = Address.fromPublicKey(
+        '0316e35d38b52d4886e40065e4952a49535ce914e02294be58e252d1998f129b19',
+        'testnet'
+      );
+      expect(addressTestnet).toBe('ST10J81WVGVB3M4PHQN4Q4G0R8586TBJH94CGRESQ');
+    });
+  });
+});

--- a/packages/transactions/tests/namespaces/address.ts
+++ b/packages/transactions/tests/namespaces/address.ts
@@ -1,0 +1,25 @@
+import { Address } from '../../src';
+
+describe('Address', () => {
+  describe(Address.parse, () => {});
+
+  describe(Address.stringify, () => {
+    it('should return the correct address', () => {
+      const addressWithVersion = Address.stringify({ version: 22, hash160: '0'.repeat(40) });
+      expect(addressWithVersion).toBe('SP000000000000000000002Q6VF78');
+
+      const addressWithVersionChar = Address.stringify({
+        versionChar: 'P',
+        hash160: '0'.repeat(40),
+      });
+      expect(addressWithVersionChar).toBe('SP000000000000000000002Q6VF78');
+
+      const addressWithContractId = Address.stringify({
+        versionChar: 'T',
+        hash160: '0'.repeat(40),
+        contractName: 'pox',
+      });
+      expect(addressWithContractId).toBe('ST000000000000000000002Q6VF78.pox');
+    });
+  });
+});


### PR DESCRIPTION
> This PR was published to npm with the version `6.14.1-pr.54+9ac757b2`
> e.g. `npm install @stacks/common@6.14.1-pr.54+9ac757b2 --save-exact`<!-- Sticky Header Marker -->

_Similar to `Cl` I'm trying to add more "namespace" objects._

- Adds missing `privateKeyToAddress` translation helper (and test)
- Adds `Address` namespace file with:
  - `.parse`
  - `.stringify`
  - `.fromPrivateKey`
  - `.fromPublicKey`

Example DX
```ts
import { Address } from '@stacks/transactions';

const { version, hash160 } = Address.parse("SP000BKJAF12");

const addressStr = Address.stringify({ versionChar: 'T', hash160: "deadbeef" });

const addressStr = Address.fromPrivateKey("7869ae87ae7901");

const addressStr = Address.fromPublicKey("03cb15c5c1b7869ae87ae79");
```

