### PR TITLE
feat: add clarity3 in clarityversion enum

### DIFF
--- a/packages/transactions/src/constants.ts
+++ b/packages/transactions/src/constants.ts
@@ -68,6 +68,7 @@ export enum PayloadType {
 export enum ClarityVersion {
   Clarity1 = 1,
   Clarity2 = 2,
+  Clarity3 = 3,
 }
 
 /**


### PR DESCRIPTION
> This PR was published to npm with the version `6.16.1`
> e.g. `npm install @stacks/common@6.16.1 --save-exact`<!-- Sticky Header Marker -->

Clarity 3