### PR TITLE
feat: Reduce wrapping of types for public key appending

### DIFF
--- a/packages/transactions/src/builders.ts
+++ b/packages/transactions/src/builders.ts
@@ -730,8 +730,7 @@ function mutatingSignAppendMultiSig(
       signer.signOrigin(signerKey);
     } else {
       // or append the public key (which did not sign here)
-      // todo: remove wrapper type here as well `next`
-      signer.appendOrigin(createStacksPublicKey(publicKey));
+      signer.appendOrigin(publicKey);
     }
   }
 }


### PR DESCRIPTION
> This PR was published to npm with the version `6.14.1-pr.59+761f0c92`
> e.g. `npm install @stacks/common@6.14.1-pr.59+761f0c92 --save-exact`<!-- Sticky Header Marker -->

- Reducing "wrapper" types, so developers can use raw types instead