### PR TITLE
refactor!: Remove wrapper type for message signatures

### DIFF
--- a/.github/MIGRATION.md
+++ b/.github/MIGRATION.md
@@ -5,6 +5,7 @@
   - [Stacks Network](#stacks-network)
     - [Impacts](#impacts)
   - [Fetch Methods](#fetch-methods)
+  - [Reducing Wrapper Types](#reducing-wrapper-types)
   - [StacksNodeApi](#stacksnodeapi)
   - [StacksNetwork to StacksNodeApi](#stacksnetwork-to-stacksnodeapi)
   - [Clarity Representation](#clarity-representation)
@@ -36,6 +37,7 @@
 
 - The `@stacks/network` `new StacksNetwork()` objects were removed. Instead `@stacks/network` now exports the objects `STACKS_MAINNET`, `STACKS_TESNET`, and `STACKS_DEVNET`, which are static (and shouldn't be changed for most use-cases). [Read more...](#stacks-network)
 - Most `fetch` (aka networking) methods were renamed to indicate they send HTTP requests. The new methods are named `fetchXyz` and are compatible with the old `Xyz` interfaces. [Read more...](#fetch-methods)
+- Reducing wrapper types, which create annoyances for the developer, rather than being able to use values directly. [Read more...](#reducing-wrapper-types)
 - The `ClarityType` enum was replaced by a human-readable version. The previous (wire format compatible) enum is still available as `ClarityWireType`. [Read more...](#clarity-representation)
 - The previous post-conditions types and `create..` methods were replaced with a human-readable representation. [Read more...](#post-conditions)
 - `StacksTransaction.serialize` and other `serializeXyz` methods were changed to return `string` (hex-encoded) instead of `Uint8Array`. Compatible `serializeXzyBytes` methods were added to ease the migration. [Read more...](#serialize-methods)
@@ -82,6 +84,15 @@ The following methods were renamed:
 
 `broadcastTransaction` wasn't renamed to highlight the uniqueness of the method.
 Namely, the node/API it is sent to will "broadcast" the transaction to the mempool.
+
+### Reducing Wrapper Types
+
+With this release we are aiming to reduce unnecessary "wrapper" types, which are used in the internals of the codebase, but shouldn't be pushed onto the user/developer.
+
+This breaks the signatures of many functions:
+
+- `signMessageHashRsv`, `signWithKey` now return the message signature as a `string` directly.
+- `nextSignature`, `nextVerification`, `publicKeyFromSignatureVrs`, `publicKeyFromSignatureRsv` now take in the message signature as a `string`.
 
 ### StacksNodeApi
 

--- a/packages/bns/src/index.ts
+++ b/packages/bns/src/index.ts
@@ -1,4 +1,4 @@
-import { ApiParam, IntegerType, intToBigInt, utf8ToBytes } from '@stacks/common';
+import { ApiParam, IntegerType, PublicKey, intToBigInt, utf8ToBytes } from '@stacks/common';
 import { StacksNetwork } from '@stacks/network';
 import {
   ClarityType,
@@ -55,7 +55,7 @@ export interface PriceFunction {
 export interface BnsContractCallOptions {
   functionName: string;
   functionArgs: ClarityValue[];
-  publicKey: string;
+  publicKey: PublicKey;
   network: StacksNetwork;
   postConditions?: PostCondition[];
 }
@@ -480,7 +480,7 @@ export interface PreorderNameOptions {
   /** amount of STX to burn for the registration */
   stxToBurn: IntegerType;
   /** the private key to sign the transaction */
-  publicKey: string;
+  publicKey: PublicKey;
   /** the Stacks blockchain network to use */
   network: StacksNetwork;
 }
@@ -541,7 +541,7 @@ export interface RegisterNameOptions {
   fullyQualifiedName: string;
   salt: string;
   zonefile: string;
-  publicKey: string;
+  publicKey: PublicKey;
   network: StacksNetwork;
 }
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,7 +15,9 @@
     "prepublishOnly": "npm run test && NODE_ENV=production npm run build",
     "start": "tsc -b tsconfig.build.json --watch --verbose",
     "test": "jest",
-    "test:watch": "jest --watch --coverage=false"
+    "test:watch": "jest --watch --coverage=false",
+    "typecheck": "tsc --noEmit",
+    "typecheck:watch": "npm run typecheck -- --watch"
   },
   "dependencies": {
     "@scure/bip32": "1.1.3",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -435,7 +435,7 @@ async function migrateSubdomains(network: CLINetworkAdapter, args: string[]): Pr
       const sig = signWithKey(account.dataPrivateKey, hash);
 
       // https://docs.stacks.co/build-apps/references/bns#subdomain-lifecycle
-      subDomainOp.signature = sig.data;
+      subDomainOp.signature = sig;
 
       payload.subdomains_list.push(subDomainOp);
     }

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -420,7 +420,7 @@ describe('Subdomain Migration', () => {
     const hash = crypto.createHash('sha256').update(textToSign).digest('hex');
     const sig = signWithKey(privateKey, hash);
 
-    subDomainOp.signature = sig.data; // Assign signature to subDomainOp
+    subDomainOp.signature = sig; // Assign signature to subDomainOp
 
     // Verify that the generated signature is valid
     const pubKey = publicKeyFromSignatureVrs(hash, sig);

--- a/packages/stacking/src/utils.ts
+++ b/packages/stacking/src/utils.ts
@@ -438,7 +438,7 @@ export function signPox4SignatureHash({
   return signStructuredData({
     ...pox4SignatureMessage({ topic, poxAddress, rewardCycle, period, network, maxAmount, authId }),
     privateKey,
-  }).data;
+  });
 }
 
 /**

--- a/packages/transactions/src/signer.ts
+++ b/packages/transactions/src/signer.ts
@@ -50,7 +50,7 @@ export class TransactionSigner {
           spendingCondition.fee,
           spendingCondition.nonce,
           PubKeyEncoding.Compressed, // always compressed for multisig
-          signature
+          signature.data
         );
 
         if (!isNonSequentialMultiSig(spendingCondition.hashMode)) {

--- a/packages/transactions/src/structuredDataSignature.ts
+++ b/packages/transactions/src/structuredDataSignature.ts
@@ -2,7 +2,6 @@ import { sha256 } from '@noble/hashes/sha256';
 import { PrivateKey, bytesToHex, concatBytes, utf8ToBytes } from '@stacks/common';
 import { ClarityType, ClarityValue, serializeCVBytes } from './clarity';
 import { signMessageHashRsv } from './keys';
-import { StacksWireType, StructuredDataSignatureWire } from './wire';
 
 // Refer to SIP018 https://github.com/stacksgov/sips/
 // > asciiToBytes('SIP018')
@@ -78,16 +77,11 @@ export function signStructuredData({
   message: ClarityValue;
   domain: ClarityValue;
   privateKey: PrivateKey;
-}): StructuredDataSignatureWire {
-  const structuredDataHash: string = bytesToHex(sha256(encodeStructuredData({ message, domain })));
+}): string {
+  const structuredDataHash = bytesToHex(sha256(encodeStructuredData({ message, domain })));
 
-  const { data } = signMessageHashRsv({
+  return signMessageHashRsv({
     messageHash: structuredDataHash,
     privateKey,
   });
-  // todo: `next` reduce wrapped signature type
-  return {
-    data,
-    type: StacksWireType.StructuredDataSignature,
-  };
 }

--- a/packages/transactions/src/transaction.ts
+++ b/packages/transactions/src/transaction.ts
@@ -53,6 +53,7 @@ import {
   PublicKeyWire,
   StacksWireType,
   createLPList,
+  createMessageSignature,
   createTransactionAuthField,
   deserializeLPListBytes,
   deserializePayloadBytes,
@@ -188,13 +189,13 @@ export class StacksTransaction {
       privateKey
     );
     if (isSingleSig(condition)) {
-      condition.signature = nextSig;
+      condition.signature = createMessageSignature(nextSig);
     } else {
       const compressed = privateKeyIsCompressed(privateKey);
       condition.fields.push(
         createTransactionAuthField(
           compressed ? PubKeyEncoding.Compressed : PubKeyEncoding.Uncompressed,
-          nextSig
+          createMessageSignature(nextSig)
         )
       );
     }

--- a/packages/transactions/tests/authorization.test.ts
+++ b/packages/transactions/tests/authorization.test.ts
@@ -22,7 +22,7 @@ test('ECDSA recoverable signature', () => {
     '019901d8b1d67a7b853dc473d0609508ab2519ec370eabfef460aa0fd9234660' +
     '787970968562da9de8b024a7f36f946b2fdcbf39b2f59247267a9d72730f19276b';
   const messageSignature = signWithKey(privKey, messagetoSign);
-  expect(messageSignature.data).toBe(correctSignature);
+  expect(messageSignature).toBe(correctSignature);
 });
 
 test('Single spending condition serialization and deserialization', () => {

--- a/packages/transactions/tests/builder.test.ts
+++ b/packages/transactions/tests/builder.test.ts
@@ -578,7 +578,7 @@ test('Make Multi-Sig STX token transfer with two transaction signers', async () 
   const compressed1 = privKeys[0].endsWith('01');
   const field1 = createTransactionAuthField(
     compressed1 ? PubKeyEncoding.Compressed : PubKeyEncoding.Uncompressed,
-    sig1
+    createMessageSignature(sig1)
   );
   signer.signOrigin(privKeys[0]);
 
@@ -599,7 +599,7 @@ test('Make Multi-Sig STX token transfer with two transaction signers', async () 
   const compressed2 = privKeys[1].endsWith('01');
   const field2 = createTransactionAuthField(
     compressed2 ? PubKeyEncoding.Compressed : PubKeyEncoding.Uncompressed,
-    sig2
+    createMessageSignature(sig2)
   );
 
   const compressedPub = publicKeyIsCompressed(pubKeys[2].data);
@@ -2396,9 +2396,7 @@ describe('multi-sig', () => {
 
       const signingSigs = new Set(
         // deduplicate
-        signing.map(
-          sk => nextSignature(tx.signBegin(), tx.auth.authType, 1_000n, 2n, sk).nextSig.data
-        )
+        signing.map(sk => nextSignature(tx.signBegin(), tx.auth.authType, 1_000n, 2n, sk).nextSig)
       );
       expect(signingSigs.size).toBe(signatures.length);
       expect(Array.from(signingSigs)).toEqual(expect.arrayContaining(signatures));
@@ -2463,7 +2461,7 @@ describe('multi-sig', () => {
           hexToBytes(signerKey).byteLength === PRIVATE_KEY_COMPRESSED_LENGTH
             ? PubKeyEncoding.Compressed
             : PubKeyEncoding.Uncompressed,
-          nextSig
+          createMessageSignature(nextSig)
         );
 
         serialized = transactionToHex(tx);

--- a/packages/transactions/tests/keys.test.ts
+++ b/packages/transactions/tests/keys.test.ts
@@ -118,7 +118,7 @@ test('signWithKey', () => {
   expect(messageHash).toBe(expectedMessageHash);
 
   const signature = signWithKey(privateKey, messageHash);
-  expect(signature.data).toBe(expectedSignatureVrs);
+  expect(signature).toBe(expectedSignatureVrs);
 });
 
 test('signMessageHashRsv', () => {
@@ -139,7 +139,7 @@ test('signMessageHashRsv', () => {
   expect(messageHash).toBe(expectedMessageHash);
 
   const signature = signMessageHashRsv({ privateKey, messageHash });
-  expect(signature.data).toBe(expectedSignatureRsv);
+  expect(signature).toBe(expectedSignatureRsv);
 });
 
 test('noble sign message', () => {
@@ -152,7 +152,7 @@ test('noble sign message', () => {
   const messageHash = bytesToHex(sha256('greetings from noble'));
   expect(messageHash).toBe(expectedMessageHash);
 
-  const signatureRsv = signMessageHashRsv({ privateKey, messageHash }).data;
+  const signatureRsv = signMessageHashRsv({ privateKey, messageHash });
   const signatureVrs = signatureRsvToVrs(signatureRsv);
 
   const { r: signatureR, s: signatureS } = parseRecoverableSignatureVrs(signatureVrs);

--- a/packages/transactions/tests/structuredDataSignature.test.ts
+++ b/packages/transactions/tests/structuredDataSignature.test.ts
@@ -229,10 +229,10 @@ describe('SIP018 test vectors', () => {
       domain,
       privateKey,
     });
-    expect(computedSignature.data).toEqual(expectedSignature);
+    expect(computedSignature).toEqual(expectedSignature);
     // Verify signature
     const isSignatureVerified = verifyMessageSignatureRsv({
-      signature: computedSignature.data,
+      signature: computedSignature,
       message: hexToBytes(messageHash),
       publicKey,
     });
@@ -260,11 +260,11 @@ test('verifyMessageSignature works for both legacy/current and future message si
   const publicKey = publicKeyFromSignatureRsv(encodedMessageHash, signature);
   const publicKeyAlt = publicKeyFromSignatureRsv(encodedMessageHashAlt, signatureAlt);
 
-  expect(verifyMessageSignatureRsv({ message, signature: signature.data, publicKey })).toBe(true);
+  expect(verifyMessageSignatureRsv({ message, signature, publicKey })).toBe(true);
   expect(
     verifyMessageSignatureRsv({
       message,
-      signature: signatureAlt.data,
+      signature: signatureAlt,
       publicKey: publicKeyAlt,
     })
   ).toBe(true);


### PR DESCRIPTION
> This PR was published to npm with the version `6.14.1-pr.61+4b7fd662`
> e.g. `npm install @stacks/common@6.14.1-pr.61+4b7fd662 --save-exact`<!-- Sticky Header Marker -->

- Prefer direct `string` instead of message signature wrapper type
- Add `PublicKey` super type where TS complained