### PR TITLE
refactor: Remove Serialize prefix from enum keys

### DIFF
--- a/.github/MIGRATION.md
+++ b/.github/MIGRATION.md
@@ -15,6 +15,7 @@
   - [Triplesec](#triplesec)
   - [Advanced: WireType](#advanced-wiretype)
   - [Advanced: Signed BigInt](#advanced-signed-bigint)
+  - [Advanced: Refactorings](#advanced-refactorings)
 - [Stacks.js (\<=4.x.x) → (5.x.x)](#stacksjs-4xx--5xx)
   - [Breaking Changes](#breaking-changes-1)
     - [Buffer to Uint8Array](#buffer-to-uint8array)
@@ -43,6 +44,7 @@
 - Disable legacy `triplesec` mnemonic encryption support. [Read more...](#triplesec)
 - **Advanced:** Rename `MessageType` and related concepts to `WireType`. [Read more...](#advanced-wiretype)
 - **Advanced:** Removes two's complement compatibilty from `intToBigInt` parser method. [Read more...](#advanced-signed-bigint)
+- **Advanced:** Refactorings and less visible updates. [Read more...](#advanced-refactorings)
 
 ### Stacks Network
 
@@ -305,6 +307,10 @@ More types were renamed to indicate use for serialization to _wire-format_:
 
 The `intToBigInt` method no longer supports two's complement signed integers and removed the `signed` boolean parameter.
 This likely was a misunderstood and unused feature.
+
+### Advanced: Refactorings
+
+- `AddressHashMode`: The `Serialize` prefixes were removed for brevity.
 
 ## Stacks.js (&lt;=4.x.x) → (5.x.x)
 

--- a/packages/transactions/src/address.ts
+++ b/packages/transactions/src/address.ts
@@ -17,7 +17,7 @@ export function addressHashModeToVersion(
 ): AddressVersion {
   network = networkFrom(network ?? STACKS_MAINNET);
   switch (hashMode) {
-    case AddressHashMode.SerializeP2PKH:
+    case AddressHashMode.P2PKH:
       switch (network.transactionVersion) {
         case TransactionVersion.Mainnet:
           return AddressVersion.MainnetSingleSig;
@@ -28,11 +28,11 @@ export function addressHashModeToVersion(
             `Unexpected transactionVersion ${network.transactionVersion} for hashMode ${hashMode}`
           );
       }
-    case AddressHashMode.SerializeP2SH:
-    case AddressHashMode.SerializeP2SHNonSequential:
-    case AddressHashMode.SerializeP2WPKH:
-    case AddressHashMode.SerializeP2WSH:
-    case AddressHashMode.SerializeP2WSHNonSequential:
+    case AddressHashMode.P2SH:
+    case AddressHashMode.P2SHNonSequential:
+    case AddressHashMode.P2WPKH:
+    case AddressHashMode.P2WSH:
+    case AddressHashMode.P2WSHNonSequential:
       switch (network.transactionVersion) {
         case TransactionVersion.Mainnet:
           return AddressVersion.MainnetMultiSig;

--- a/packages/transactions/src/authorization.ts
+++ b/packages/transactions/src/authorization.ts
@@ -99,7 +99,7 @@ export function createSpendingCondition(
 ) {
   if ('publicKey' in options) {
     return createSingleSigSpendingCondition(
-      AddressHashMode.SerializeP2PKH,
+      AddressHashMode.P2PKH,
       options.publicKey,
       options.nonce,
       options.fee
@@ -107,7 +107,7 @@ export function createSpendingCondition(
   }
   // multi-sig
   return createMultiSigSpendingCondition(
-    AddressHashMode.SerializeP2SH,
+    AddressHashMode.P2SH,
     options.numSignatures,
     options.publicKeys,
     options.nonce,
@@ -178,14 +178,14 @@ export function isSingleSig(
 
 /** @internal */
 export function isSequentialMultiSig(hashMode: AddressHashMode): boolean {
-  return hashMode === AddressHashMode.SerializeP2SH || hashMode === AddressHashMode.SerializeP2WSH;
+  return hashMode === AddressHashMode.P2SH || hashMode === AddressHashMode.P2WSH;
 }
 
 /** @internal */
 export function isNonSequentialMultiSig(hashMode: AddressHashMode): boolean {
   return (
-    hashMode === AddressHashMode.SerializeP2SHNonSequential ||
-    hashMode === AddressHashMode.SerializeP2WSHNonSequential
+    hashMode === AddressHashMode.P2SHNonSequential ||
+    hashMode === AddressHashMode.P2WSHNonSequential
   );
 }
 
@@ -252,7 +252,7 @@ export function deserializeSingleSigSpendingCondition(
   const keyEncoding = bytesReader.readUInt8Enum(PubKeyEncoding, n => {
     throw new DeserializationError(`Could not parse ${n} as PubKeyEncoding`);
   });
-  if (hashMode === AddressHashMode.SerializeP2WPKH && keyEncoding != PubKeyEncoding.Compressed) {
+  if (hashMode === AddressHashMode.P2WPKH && keyEncoding != PubKeyEncoding.Compressed) {
     throw new DeserializationError(
       'Failed to parse singlesig spending condition: incomaptible hash mode and key encoding'
     );
@@ -304,8 +304,7 @@ export function deserializeMultiSigSpendingCondition(
 
   if (
     haveUncompressed &&
-    (hashMode === AddressHashMode.SerializeP2WSH ||
-      hashMode === AddressHashMode.SerializeP2WSHNonSequential)
+    (hashMode === AddressHashMode.P2WSH || hashMode === AddressHashMode.P2WSHNonSequential)
   ) {
     throw new VerificationError('Uncompressed keys are not allowed in this hash mode');
   }
@@ -332,7 +331,7 @@ export function deserializeSpendingCondition(bytesReader: BytesReader): Spending
     throw new DeserializationError(`Could not parse ${n} as AddressHashMode`);
   });
 
-  if (hashMode === AddressHashMode.SerializeP2PKH || hashMode === AddressHashMode.SerializeP2WPKH) {
+  if (hashMode === AddressHashMode.P2PKH || hashMode === AddressHashMode.P2WPKH) {
     return deserializeSingleSigSpendingCondition(hashMode, bytesReader);
   } else {
     return deserializeMultiSigSpendingCondition(hashMode, bytesReader);
@@ -436,12 +435,7 @@ export function nextVerification(
 }
 
 function newInitialSigHash(): SpendingCondition {
-  const spendingCondition = createSingleSigSpendingCondition(
-    AddressHashMode.SerializeP2PKH,
-    '',
-    0,
-    0
-  );
+  const spendingCondition = createSingleSigSpendingCondition(AddressHashMode.P2PKH, '', 0, 0);
   spendingCondition.signer = createEmptyAddress().hash160;
   spendingCondition.keyEncoding = PubKeyEncoding.Compressed;
   spendingCondition.signature = emptyMessageSignature();
@@ -537,8 +531,8 @@ function verifyMultiSig(
 
   if (
     haveUncompressed &&
-    (condition.hashMode === AddressHashMode.SerializeP2WSH ||
-      condition.hashMode === AddressHashMode.SerializeP2WSHNonSequential)
+    (condition.hashMode === AddressHashMode.P2WSH ||
+      condition.hashMode === AddressHashMode.P2WSHNonSequential)
   )
     throw new VerificationError('Uncompressed keys are not allowed in this hash mode');
 
@@ -585,7 +579,7 @@ export function createSponsoredAuth(
     spendingCondition,
     sponsorSpendingCondition: sponsorSpendingCondition
       ? sponsorSpendingCondition
-      : createSingleSigSpendingCondition(AddressHashMode.SerializeP2PKH, '0'.repeat(66), 0, 0),
+      : createSingleSigSpendingCondition(AddressHashMode.P2PKH, '0'.repeat(66), 0, 0),
   };
 }
 

--- a/packages/transactions/src/builders.ts
+++ b/packages/transactions/src/builders.ts
@@ -138,7 +138,7 @@ export async function makeUnsignedSTXTokenTransfer(
   if ('publicKey' in options) {
     // single-sig
     spendingCondition = createSingleSigSpendingCondition(
-      AddressHashMode.SerializeP2PKH,
+      AddressHashMode.P2PKH,
       options.publicKey,
       options.nonce,
       options.fee
@@ -146,8 +146,8 @@ export async function makeUnsignedSTXTokenTransfer(
   } else {
     // multi-sig
     const hashMode = options.useNonSequentialMultiSig
-      ? AddressHashMode.SerializeP2SHNonSequential
-      : AddressHashMode.SerializeP2SH;
+      ? AddressHashMode.P2SHNonSequential
+      : AddressHashMode.P2SH;
 
     const publicKeys = options.address
       ? sortPublicKeysForAddress(
@@ -344,7 +344,7 @@ export async function makeUnsignedContractDeploy(
   if ('publicKey' in options) {
     // single-sig
     spendingCondition = createSingleSigSpendingCondition(
-      AddressHashMode.SerializeP2PKH,
+      AddressHashMode.P2PKH,
       options.publicKey,
       options.nonce,
       options.fee
@@ -352,8 +352,8 @@ export async function makeUnsignedContractDeploy(
   } else {
     // multi-sig
     const hashMode = options.useNonSequentialMultiSig
-      ? AddressHashMode.SerializeP2SHNonSequential
-      : AddressHashMode.SerializeP2SH;
+      ? AddressHashMode.P2SHNonSequential
+      : AddressHashMode.P2SH;
 
     const publicKeys = options.address
       ? sortPublicKeysForAddress(
@@ -501,7 +501,7 @@ export async function makeUnsignedContractCall(
   if ('publicKey' in options) {
     // single-sig
     spendingCondition = createSingleSigSpendingCondition(
-      AddressHashMode.SerializeP2PKH,
+      AddressHashMode.P2PKH,
       options.publicKey,
       options.nonce,
       options.fee
@@ -509,8 +509,8 @@ export async function makeUnsignedContractCall(
   } else {
     // multi-sig
     const hashMode = options.useNonSequentialMultiSig
-      ? AddressHashMode.SerializeP2SHNonSequential
-      : AddressHashMode.SerializeP2SH;
+      ? AddressHashMode.P2SHNonSequential
+      : AddressHashMode.P2SH;
 
     const publicKeys = options.address
       ? sortPublicKeysForAddress(
@@ -643,7 +643,7 @@ export async function sponsorTransaction(
   const defaultOptions = {
     fee: 0 as IntegerType,
     sponsorNonce: 0 as IntegerType,
-    sponsorAddressHashmode: AddressHashMode.SerializeP2PKH as SingleSigHashMode,
+    sponsorAddressHashmode: AddressHashMode.P2PKH as SingleSigHashMode,
     network: defaultNetwork,
   };
 

--- a/packages/transactions/src/constants.ts
+++ b/packages/transactions/src/constants.ts
@@ -120,28 +120,27 @@ export enum AuthType {
  */
 export enum AddressHashMode {
   /** `SingleSigHashMode` — hash160(public-key), same as bitcoin's p2pkh */
-  SerializeP2PKH = 0x00,
+  P2PKH = 0x00,
   /** Legacy `MultiSigHashMode` — hash160(multisig-redeem-script), same as bitcoin's multisig p2sh */
-  SerializeP2SH = 0x01,
+  P2SH = 0x01,
   /** `SingleSigHashMode` — hash160(segwit-program-00(p2pkh)), same as bitcoin's p2sh-p2wpkh */
-  SerializeP2WPKH = 0x02,
+  P2WPKH = 0x02,
   /** Legacy `MultiSigHashMode` — hash160(segwit-program-00(public-keys)), same as bitcoin's p2sh-p2wsh */
-  SerializeP2WSH = 0x03,
+  P2WSH = 0x03,
   /** Non-Sequential `MultiSigHashMode` — hash160(multisig-redeem-script), same as bitcoin's multisig p2sh */
-  SerializeP2SHNonSequential = 0x05,
+  P2SHNonSequential = 0x05,
   /** Non-Sequential `MultiSigHashMode` — hash160(segwit-program-00(public-keys)), same as bitcoin's p2sh-p2wsh */
-  SerializeP2WSHNonSequential = 0x07,
+  P2WSHNonSequential = 0x07,
 
-  // todo: `next` rename to remove the `Serialize` prefix?
-  // todo: `next` rename to remove `NonSequential` and add `Legacy` to sequential mutlisig
+  // todo: once live, rename to remove `NonSequential` and add `Legacy` to sequential mutlisig
 }
 
-export type SingleSigHashMode = AddressHashMode.SerializeP2PKH | AddressHashMode.SerializeP2WPKH;
+export type SingleSigHashMode = AddressHashMode.P2PKH | AddressHashMode.P2WPKH;
 export type MultiSigHashMode =
-  | AddressHashMode.SerializeP2SH
-  | AddressHashMode.SerializeP2WSH
-  | AddressHashMode.SerializeP2SHNonSequential
-  | AddressHashMode.SerializeP2WSHNonSequential;
+  | AddressHashMode.P2SH
+  | AddressHashMode.P2WSH
+  | AddressHashMode.P2SHNonSequential
+  | AddressHashMode.P2WSHNonSequential;
 
 // re-export for backwards compatibility
 export { AddressVersion } from '@stacks/network';

--- a/packages/transactions/src/keys.ts
+++ b/packages/transactions/src/keys.ts
@@ -67,7 +67,7 @@ export function getAddressFromPublicKey(
 ): string {
   network = networkFrom(network ?? STACKS_MAINNET);
   publicKey = typeof publicKey === 'string' ? hexToBytes(publicKey) : publicKey;
-  const addrVer = addressHashModeToVersion(AddressHashMode.SerializeP2PKH, network);
+  const addrVer = addressHashModeToVersion(AddressHashMode.P2PKH, network);
   const addr = addressFromVersionHash(addrVer, hashP2PKH(publicKey));
   const addrString = addressToString(addr);
   return addrString;

--- a/packages/transactions/src/signer.ts
+++ b/packages/transactions/src/signer.ts
@@ -93,8 +93,8 @@ export class TransactionSigner {
 
     const spendingCondition = this.transaction.auth.spendingCondition;
     if (
-      spendingCondition.hashMode === AddressHashMode.SerializeP2SH ||
-      spendingCondition.hashMode === AddressHashMode.SerializeP2WSH
+      spendingCondition.hashMode === AddressHashMode.P2SH ||
+      spendingCondition.hashMode === AddressHashMode.P2WSH
     ) {
       // only check oversign on legacy multisig modes
       if (

--- a/packages/transactions/src/transaction.ts
+++ b/packages/transactions/src/transaction.ts
@@ -368,7 +368,7 @@ export function deriveNetworkFromTx(transaction: StacksTransaction) {
 export function estimateTransactionByteLength(transaction: StacksTransaction): number {
   const hashMode = transaction.auth.spendingCondition.hashMode;
   // List of Multi-sig transaction hash modes
-  const multiSigHashModes = [AddressHashMode.SerializeP2SH, AddressHashMode.SerializeP2WSH];
+  const multiSigHashModes = [AddressHashMode.P2SH, AddressHashMode.P2WSH];
 
   // Check if its a Multi-sig transaction
   if (multiSigHashModes.includes(hashMode)) {

--- a/packages/transactions/src/wire/helpers.ts
+++ b/packages/transactions/src/wire/helpers.ts
@@ -31,16 +31,16 @@ export function addressFromPublicKeys(
     throw Error('Invalid number of public keys');
   }
 
-  if (hashMode === AddressHashMode.SerializeP2PKH || hashMode === AddressHashMode.SerializeP2WPKH) {
+  if (hashMode === AddressHashMode.P2PKH || hashMode === AddressHashMode.P2WPKH) {
     if (publicKeys.length !== 1 || numSigs !== 1) {
       throw Error('Invalid number of public keys or signatures');
     }
   }
 
   if (
-    hashMode === AddressHashMode.SerializeP2WPKH ||
-    hashMode === AddressHashMode.SerializeP2WSH ||
-    hashMode === AddressHashMode.SerializeP2WSHNonSequential
+    hashMode === AddressHashMode.P2WPKH ||
+    hashMode === AddressHashMode.P2WSH ||
+    hashMode === AddressHashMode.P2WSHNonSequential
   ) {
     if (!publicKeys.map(p => p.data).every(publicKeyIsCompressed)) {
       throw Error('Public keys must be compressed for segwit');
@@ -48,18 +48,18 @@ export function addressFromPublicKeys(
   }
 
   switch (hashMode) {
-    case AddressHashMode.SerializeP2PKH:
+    case AddressHashMode.P2PKH:
       return addressFromVersionHash(version, hashP2PKH(publicKeys[0].data));
-    case AddressHashMode.SerializeP2WPKH:
+    case AddressHashMode.P2WPKH:
       return addressFromVersionHash(version, hashP2WPKH(publicKeys[0].data));
-    case AddressHashMode.SerializeP2SH:
-    case AddressHashMode.SerializeP2SHNonSequential:
+    case AddressHashMode.P2SH:
+    case AddressHashMode.P2SHNonSequential:
       return addressFromVersionHash(
         version,
         hashP2SH(numSigs, publicKeys.map(serializePublicKeyBytes))
       );
-    case AddressHashMode.SerializeP2WSH:
-    case AddressHashMode.SerializeP2WSHNonSequential:
+    case AddressHashMode.P2WSH:
+    case AddressHashMode.P2WSHNonSequential:
       return addressFromVersionHash(
         version,
         hashP2WSH(numSigs, publicKeys.map(serializePublicKeyBytes))

--- a/packages/transactions/tests/authorization.test.ts
+++ b/packages/transactions/tests/authorization.test.ts
@@ -26,7 +26,7 @@ test('ECDSA recoverable signature', () => {
 });
 
 test('Single spending condition serialization and deserialization', () => {
-  const addressHashMode = AddressHashMode.SerializeP2PKH;
+  const addressHashMode = AddressHashMode.P2PKH;
   const nonce = 0;
   const fee = 0;
   const pubKey = '03ef788b3830c00abe8f64f62dc32fc863bc0b2cafeb073b6c8e1c7657d9c2c3ab';
@@ -45,7 +45,7 @@ test('Single spending condition serialization and deserialization', () => {
 });
 
 test('Single sig spending condition uncompressed', () => {
-  const addressHashMode = AddressHashMode.SerializeP2PKH;
+  const addressHashMode = AddressHashMode.P2PKH;
   const nonce = 123;
   const fee = 456;
   const pubKey = '';
@@ -61,7 +61,7 @@ test('Single sig spending condition uncompressed', () => {
   // prettier-ignore
   const spendingConditionBytesHex = [
     // address hash mode
-    AddressHashMode.SerializeP2PKH,
+    AddressHashMode.P2PKH,
     // signer
     0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
     0x11, 0x11, 0x11, 0x11, 0x11,
@@ -84,7 +84,7 @@ test('Single sig spending condition uncompressed', () => {
 });
 
 test('Multi sig spending condition uncompressed', () => {
-  const addressHashMode = AddressHashMode.SerializeP2SH;
+  const addressHashMode = AddressHashMode.P2SH;
   const nonce = 123;
   const fee = 456;
   const pubKey = '02'.repeat(33);
@@ -110,7 +110,7 @@ test('Multi sig spending condition uncompressed', () => {
   // prettier-ignore
   const spendingConditionBytesHex = [
     // address hash mode
-    AddressHashMode.SerializeP2SH,
+    AddressHashMode.P2SH,
     // signer
     0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
     0x11, 0x11, 0x11, 0x11, 0x11,
@@ -142,7 +142,7 @@ test('Multi sig spending condition uncompressed', () => {
 
 // auth.rs: tx_stacks_spending_condition_p2sh() (compressed multisig)
 test('Multi sig P2SH spending condition compressed', () => {
-  const addressHashMode = AddressHashMode.SerializeP2SH;
+  const addressHashMode = AddressHashMode.P2SH;
   const nonce = 456;
   const fee = 567;
   const pubKey = '03ef2340518b5867b23598a9cf74611f8b98064f7d55cdb8c107c67b5efcbc5c77';
@@ -169,7 +169,7 @@ test('Multi sig P2SH spending condition compressed', () => {
   // prettier-ignore
   const spendingConditionBytesHex = [
     // address hash mode
-    AddressHashMode.SerializeP2SH,
+    AddressHashMode.P2SH,
     // signer
     0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
     0x11, 0x11, 0x11, 0x11, 0x11,
@@ -209,7 +209,7 @@ test('Multi sig P2SH spending condition compressed', () => {
 
 // auth.rs: tx_stacks_spending_condition_p2wsh()
 test('Multi sig P2WSH spending condition compressed', () => {
-  const addressHashMode = AddressHashMode.SerializeP2WSH;
+  const addressHashMode = AddressHashMode.P2WSH;
   const nonce = 456;
   const fee = 567;
   const pubKey = '03ef2340518b5867b23598a9cf74611f8b98064f7d55cdb8c107c67b5efcbc5c77';
@@ -236,7 +236,7 @@ test('Multi sig P2WSH spending condition compressed', () => {
   // prettier-ignore
   const spendingConditionBytesHex = [
     // address hash mode
-    AddressHashMode.SerializeP2WSH,
+    AddressHashMode.P2WSH,
     // signer
     0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
     0x11, 0x11, 0x11, 0x11, 0x11,
@@ -287,18 +287,18 @@ test('Spending conditions', () => {
     '04ef2340518b5867b23598a9cf74611f8b98064f7d55cdb8c107c67b5efcbc5c771f112f919b00a6c6c5f51f7c63e1762fe9fac9b66ec75a053db7f51f4a52712b';
   const pubKeyCompressed = '03ef2340518b5867b23598a9cf74611f8b98064f7d55cdb8c107c67b5efcbc5c77';
 
-  const sp1 = createSingleSigSpendingCondition(AddressHashMode.SerializeP2PKH, '', bn123, bn567);
+  const sp1 = createSingleSigSpendingCondition(AddressHashMode.P2PKH, '', bn123, bn567);
   sp1.signer = signer;
   sp1.keyEncoding = PubKeyEncoding.Uncompressed;
   sp1.signature = signatureFF;
 
-  const sp2 = createSingleSigSpendingCondition(AddressHashMode.SerializeP2PKH, '', bn345, bn567);
+  const sp2 = createSingleSigSpendingCondition(AddressHashMode.P2PKH, '', bn345, bn567);
   sp2.signer = signer;
   sp2.keyEncoding = PubKeyEncoding.Compressed;
   sp2.signature = signatureFF;
 
   const sp3 = createMultiSigSpendingCondition(
-    AddressHashMode.SerializeP2SH,
+    AddressHashMode.P2SH,
     2,
     [pubKeyUncompressed, pubKeyUncompressed, pubKeyUncompressed],
     bn123,
@@ -310,7 +310,7 @@ test('Spending conditions', () => {
   );
 
   const sp4 = createMultiSigSpendingCondition(
-    AddressHashMode.SerializeP2SH,
+    AddressHashMode.P2SH,
     2,
     [pubKeyCompressed, pubKeyCompressed, pubKeyCompressed],
     bn123,
@@ -321,13 +321,13 @@ test('Spending conditions', () => {
     createTransactionAuthField(PubKeyEncoding.Compressed, sig)
   );
 
-  const sp5 = createSingleSigSpendingCondition(AddressHashMode.SerializeP2WPKH, '', bn345, bn567);
+  const sp5 = createSingleSigSpendingCondition(AddressHashMode.P2WPKH, '', bn345, bn567);
   sp5.signer = signer;
   sp5.keyEncoding = PubKeyEncoding.Compressed;
   sp5.signature = signatureFE;
 
   const sp6 = createMultiSigSpendingCondition(
-    AddressHashMode.SerializeP2WSH,
+    AddressHashMode.P2WSH,
     2,
     [pubKeyCompressed, pubKeyCompressed, pubKeyCompressed],
     bn456,
@@ -403,7 +403,7 @@ test('Invalid spending conditions', () => {
   // prettier-ignore
   const badHashModeMultiSigBytesHex = [
     // hash mode
-    AddressHashMode.SerializeP2SH,
+    AddressHashMode.P2SH,
     // signer
     0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
     0x11,
@@ -432,7 +432,7 @@ test('Invalid spending conditions', () => {
   // prettier-ignore
   const badHashModeSinglesigBytesParseable = [
     // hash mode
-    AddressHashMode.SerializeP2PKH,
+    AddressHashMode.P2PKH,
     // signer
     0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
     0x11,
@@ -469,7 +469,7 @@ test('Invalid spending conditions', () => {
   // prettier-ignore
   const badPublicKeyCountBytes = [
     // hash mode
-    AddressHashMode.SerializeP2SH,
+    AddressHashMode.P2SH,
     // signer
     0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
     0x11,
@@ -509,7 +509,7 @@ test('Invalid spending conditions', () => {
   // prettier-ignore
   const badPublicKeyCountBytes2 = [
     // hash mode
-    AddressHashMode.SerializeP2SH,
+    AddressHashMode.P2SH,
     // signer
     0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
     0x11,
@@ -562,7 +562,7 @@ test('Invalid spending conditions', () => {
   // hashing mode doesn't allow uncompressed keys
   const signatureFF = createMessageSignature('ff'.repeat(65));
   const badP2WpkhUncompressedSP = createSingleSigSpendingCondition(
-    AddressHashMode.SerializeP2WPKH,
+    AddressHashMode.P2WPKH,
     '',
     123,
     567
@@ -574,7 +574,7 @@ test('Invalid spending conditions', () => {
   // prettier-ignore
   const badP2WpkhUncompressedBytes = [
     // hash mode
-    AddressHashMode.SerializeP2WPKH,
+    AddressHashMode.P2WPKH,
     // signer
     0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
     0x11,
@@ -605,12 +605,7 @@ test('Invalid spending conditions', () => {
 // auth.rs: tx_stacks_spending_condition_p2pkh()
 test('Single sig P2PKH spending condition', () => {
   // p2pkh
-  const spP2PkhUncompressed = createSingleSigSpendingCondition(
-    AddressHashMode.SerializeP2PKH,
-    '',
-    123,
-    456
-  );
+  const spP2PkhUncompressed = createSingleSigSpendingCondition(AddressHashMode.P2PKH, '', 123, 456);
   spP2PkhUncompressed.keyEncoding = PubKeyEncoding.Uncompressed;
 
   const signature = createMessageSignature('ff'.repeat(65));
@@ -620,7 +615,7 @@ test('Single sig P2PKH spending condition', () => {
   // prettier-ignore
   const spendingConditionP2PkhUncompressedBytes = [
     // address hash mode
-    AddressHashMode.SerializeP2PKH,
+    AddressHashMode.P2PKH,
     // signer
     0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
     0x11, 0x11, 0x11, 0x11, 0x11,
@@ -638,12 +633,7 @@ test('Single sig P2PKH spending condition', () => {
     0xff, 0xff, 0xff, 0xff, 0xff
   ];
 
-  const spP2PkhCompressed = createSingleSigSpendingCondition(
-    AddressHashMode.SerializeP2PKH,
-    '',
-    345,
-    456
-  );
+  const spP2PkhCompressed = createSingleSigSpendingCondition(AddressHashMode.P2PKH, '', 345, 456);
   spP2PkhCompressed.keyEncoding = PubKeyEncoding.Compressed;
 
   spP2PkhCompressed.signature = createMessageSignature('fe'.repeat(65));
@@ -653,7 +643,7 @@ test('Single sig P2PKH spending condition', () => {
 
   const spendingConditionP2PkhCompressedBytes = [
     // hash mode
-    AddressHashMode.SerializeP2PKH,
+    AddressHashMode.P2PKH,
     // signer
     0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
     0x11, 0x11,
@@ -691,12 +681,7 @@ test('Single sig P2PKH spending condition', () => {
 // auth.rs: tx_stacks_spending_condition_p2wpkh()
 test('Single sig P2WPKH spending condition', () => {
   // P2WPKH
-  const spP2WPKHCompressed = createSingleSigSpendingCondition(
-    AddressHashMode.SerializeP2WPKH,
-    '',
-    345,
-    567
-  );
+  const spP2WPKHCompressed = createSingleSigSpendingCondition(AddressHashMode.P2WPKH, '', 345, 567);
   spP2WPKHCompressed.keyEncoding = PubKeyEncoding.Compressed;
 
   const signature = createMessageSignature('fe'.repeat(65));
@@ -706,7 +691,7 @@ test('Single sig P2WPKH spending condition', () => {
   // prettier-ignore
   const spendingConditionP2WpkhCompressedBytes = [
     // hash mode
-    AddressHashMode.SerializeP2WPKH,
+    AddressHashMode.P2WPKH,
     // signer
     0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
     0x11, 0x11,

--- a/packages/transactions/tests/builder.test.ts
+++ b/packages/transactions/tests/builder.test.ts
@@ -345,7 +345,7 @@ test('Make Multi-Sig STX token transfer', async () => {
   const memo = 'test memo';
 
   const authType = AuthType.Standard;
-  const addressHashMode = AddressHashMode.SerializeP2SH;
+  const addressHashMode = AddressHashMode.P2SH;
 
   const privKeys = [
     '6d430bb91222408e7706c9001cfaeb91b08c2be6d5ac95779ab52c6b431950e001',
@@ -421,7 +421,7 @@ test('Should deserialize partially signed multi-Sig STX token transfer', async (
   const memo = 'test memo';
 
   const authType = AuthType.Standard;
-  const addressHashMode = AddressHashMode.SerializeP2SH;
+  const addressHashMode = AddressHashMode.P2SH;
 
   const privKeys = [
     '6d430bb91222408e7706c9001cfaeb91b08c2be6d5ac95779ab52c6b431950e001',
@@ -540,7 +540,7 @@ test('Make Multi-Sig STX token transfer with two transaction signers', async () 
   const memo = 'test memo';
 
   const authType = AuthType.Standard;
-  const addressHashMode = AddressHashMode.SerializeP2SH;
+  const addressHashMode = AddressHashMode.P2SH;
 
   const privKeys = [
     '6d430bb91222408e7706c9001cfaeb91b08c2be6d5ac95779ab52c6b431950e001',
@@ -755,7 +755,7 @@ test('Make smart contract deploy unsigned', async () => {
   const nonce = 0;
 
   const authType = AuthType.Standard;
-  const addressHashMode = AddressHashMode.SerializeP2PKH;
+  const addressHashMode = AddressHashMode.P2PKH;
   const transaction = await makeUnsignedContractDeploy({
     contractName,
     codeBody,
@@ -815,7 +815,7 @@ test('Make smart contract deploy signed', async () => {
   const nonce = 0;
 
   const authType = AuthType.Standard;
-  const addressHashMode = AddressHashMode.SerializeP2PKH;
+  const addressHashMode = AddressHashMode.P2PKH;
   const transaction = await makeContractDeploy({
     contractName,
     codeBody,
@@ -1385,7 +1385,7 @@ test('Make sponsored STX token transfer', async () => {
   const sponsorNonce = 55;
 
   const authType = AuthType.Sponsored;
-  const addressHashMode = AddressHashMode.SerializeP2PKH;
+  const addressHashMode = AddressHashMode.P2PKH;
 
   const transaction = await makeSTXTokenTransfer({
     recipient,
@@ -1509,7 +1509,7 @@ test('Make sponsored STX token transfer with sponsor fee estimate', async () => 
   const sponsorNonce = 55;
 
   const authType = AuthType.Sponsored;
-  const addressHashMode = AddressHashMode.SerializeP2PKH;
+  const addressHashMode = AddressHashMode.P2PKH;
 
   const transaction = await makeSTXTokenTransfer({
     recipient,
@@ -1648,7 +1648,7 @@ test('Make sponsored contract deploy with sponsor fee estimate', async () => {
   const sponsorFee = 4000;
 
   const authType = AuthType.Sponsored;
-  const addressHashMode = AddressHashMode.SerializeP2PKH;
+  const addressHashMode = AddressHashMode.P2PKH;
 
   const transaction = await makeContractDeploy({
     contractName,
@@ -1705,7 +1705,7 @@ test('Make sponsored contract call with sponsor nonce fetch', async () => {
   const sponsorNonce = 55;
 
   const authType = AuthType.Sponsored;
-  const addressHashMode = AddressHashMode.SerializeP2PKH;
+  const addressHashMode = AddressHashMode.P2PKH;
 
   const transaction = await makeContractCall({
     contractAddress,
@@ -2592,14 +2592,14 @@ describe('multi-sig', () => {
 
     const address = addressFromPublicKeys(
       0 as any, // only used for hash, so version doesn't matter
-      AddressHashMode.SerializeP2SHNonSequential,
+      AddressHashMode.P2SHNonSequential,
       2,
       publicKeys.map(createStacksPublicKey)
     );
 
     const addressSorted = addressFromPublicKeys(
       0 as any, // only used for hash, so version doesn't matter
-      AddressHashMode.SerializeP2SHNonSequential,
+      AddressHashMode.P2SHNonSequential,
       2,
       publicKeys.slice().sort().map(createStacksPublicKey)
     );

--- a/packages/transactions/tests/transaction.test.ts
+++ b/packages/transactions/tests/transaction.test.ts
@@ -59,7 +59,7 @@ test('STX token transfer transaction serialization and deserialization', () => {
 
   const payload = createTokenTransferPayload(recipientCV, amount, memo);
 
-  const addressHashMode = AddressHashMode.SerializeP2PKH;
+  const addressHashMode = AddressHashMode.P2PKH;
   const nonce = 0;
   const fee = 0;
   const pubKey = '03ef788b3830c00abe8f64f62dc32fc863bc0b2cafeb073b6c8e1c7657d9c2c3ab';
@@ -140,7 +140,7 @@ test('STX token transfer transaction fee setting', () => {
 
   const payload = createTokenTransferPayload(recipientCV, amount, memo);
 
-  const addressHashMode = AddressHashMode.SerializeP2PKH;
+  const addressHashMode = AddressHashMode.P2PKH;
   const nonce = 0;
   const fee = 0;
   const pubKey = '03ef788b3830c00abe8f64f62dc32fc863bc0b2cafeb073b6c8e1c7657d9c2c3ab';
@@ -202,7 +202,7 @@ test('STX token transfer transaction fee setting', () => {
 });
 
 test('STX token transfer transaction multi-sig serialization and deserialization', () => {
-  const addressHashMode = AddressHashMode.SerializeP2SH;
+  const addressHashMode = AddressHashMode.P2SH;
   const nonce = 0;
   const fee = 0;
 
@@ -284,17 +284,17 @@ test('STX token transfer transaction multi-sig uncompressed keys serialization a
   const pubKeyStrings = pubKeys.map(serializePublicKeyBytes).map(publicKeyToHex);
 
   expect(() =>
-    createMultiSigSpendingCondition(AddressHashMode.SerializeP2WSH, 2, pubKeyStrings, nonce, fee)
+    createMultiSigSpendingCondition(AddressHashMode.P2WSH, 2, pubKeyStrings, nonce, fee)
   ).toThrowError('Public keys must be compressed for segwit');
 
   const spendingCondition = createMultiSigSpendingCondition(
-    AddressHashMode.SerializeP2SH, // will be replaced in the next step
+    AddressHashMode.P2SH, // will be replaced in the next step
     2,
     pubKeyStrings,
     nonce,
     fee
   );
-  spendingCondition.hashMode = AddressHashMode.SerializeP2WSH;
+  spendingCondition.hashMode = AddressHashMode.P2WSH;
 
   const originAuth = createStandardAuth(spendingCondition);
   const originAddress = originAuth.spendingCondition?.signer;
@@ -338,7 +338,7 @@ test('Sponsored STX token transfer transaction serialization and deserialization
 
   const payload = createTokenTransferPayload(recipientCV, amount, memo);
 
-  const addressHashMode = AddressHashMode.SerializeP2PKH;
+  const addressHashMode = AddressHashMode.P2PKH;
   const nonce = 0;
   const sponsorNonce = 123;
   const fee = 0;

--- a/packages/transactions/tests/types.test.ts
+++ b/packages/transactions/tests/types.test.ts
@@ -63,7 +63,7 @@ test('Length prefixed list serialization and deserialization', () => {
 test('C32 address hash mode - testnet P2PKH', () => {
   const address = addressToString(
     addressFromHashMode(
-      AddressHashMode.SerializeP2PKH,
+      AddressHashMode.P2PKH,
       STACKS_TESTNET,
       'c22d24fec5d06e539c551e732a5ba88997761ba0'
     )
@@ -75,7 +75,7 @@ test('C32 address hash mode - testnet P2PKH', () => {
 test('C32 address hash mode - mainnet P2PKH', () => {
   const address = addressToString(
     addressFromHashMode(
-      AddressHashMode.SerializeP2PKH,
+      AddressHashMode.P2PKH,
       STACKS_MAINNET,
       'b976e9f5d6181e40bed7fa589142dfcf2fb28d8e'
     )
@@ -87,7 +87,7 @@ test('C32 address hash mode - mainnet P2PKH', () => {
 test('C32 address hash mode - mainnet P2SH', () => {
   const address = addressToString(
     addressFromHashMode(
-      AddressHashMode.SerializeP2SH,
+      AddressHashMode.P2SH,
       STACKS_MAINNET,
       '55011fc38a7e12f7d00496aef7a1c4b6dfeba81b'
     )
@@ -99,7 +99,7 @@ test('C32 address hash mode - mainnet P2SH', () => {
 test('C32 address hash mode - testnet P2SH', () => {
   const address = addressToString(
     addressFromHashMode(
-      AddressHashMode.SerializeP2SH,
+      AddressHashMode.P2SH,
       STACKS_TESTNET,
       '55011fc38a7e12f7d00496aef7a1c4b6dfeba81b'
     )
@@ -111,7 +111,7 @@ test('C32 address hash mode - testnet P2SH', () => {
 test('C32 address hash mode - mainnet P2WSH', () => {
   const address = addressToString(
     addressFromHashMode(
-      AddressHashMode.SerializeP2WSH,
+      AddressHashMode.P2WSH,
       STACKS_MAINNET,
       '55011fc38a7e12f7d00496aef7a1c4b6dfeba81b'
     )
@@ -123,7 +123,7 @@ test('C32 address hash mode - mainnet P2WSH', () => {
 test('C32 address hash mode - testnet P2WSH', () => {
   const address = addressToString(
     addressFromHashMode(
-      AddressHashMode.SerializeP2WSH,
+      AddressHashMode.P2WSH,
       STACKS_TESTNET,
       '55011fc38a7e12f7d00496aef7a1c4b6dfeba81b'
     )
@@ -199,11 +199,11 @@ test('Public keys to address hash', () => {
     let hashMode;
 
     if (!fixture.segwit) {
-      if (fixture.numRequired === 1) hashMode = AddressHashMode.SerializeP2PKH;
-      else hashMode = AddressHashMode.SerializeP2SH;
+      if (fixture.numRequired === 1) hashMode = AddressHashMode.P2PKH;
+      else hashMode = AddressHashMode.P2SH;
     } else {
-      if (fixture.numRequired === 1) hashMode = AddressHashMode.SerializeP2WPKH;
-      else hashMode = AddressHashMode.SerializeP2WSH;
+      if (fixture.numRequired === 1) hashMode = AddressHashMode.P2WPKH;
+      else hashMode = AddressHashMode.P2WSH;
     }
 
     const address = addressFromPublicKeys(


### PR DESCRIPTION
> This PR was published to npm with the version `6.14.1-pr.60+b1e02ed1`
> e.g. `npm install @stacks/common@6.14.1-pr.60+b1e02ed1 --save-exact`<!-- Sticky Header Marker -->

- remove unnecessary prefix