### PR TITLE
fix: Generate compressed private keys by default

### DIFF
--- a/.github/MIGRATION.md
+++ b/.github/MIGRATION.md
@@ -322,6 +322,7 @@ This likely was a misunderstood and unused feature.
 ### Advanced: Refactorings
 
 - `AddressHashMode`: The `Serialize` prefixes were removed for brevity.
+- `makeRandomPrivKey` was renamed to `randomPrivateKey` and now returns a compressed private key.
 
 ## Stacks.js (&lt;=4.x.x) → (5.x.x)
 

--- a/packages/transactions/src/keys.ts
+++ b/packages/transactions/src/keys.ts
@@ -172,9 +172,20 @@ export function uncompressPublicKey(publicKey: PublicKey): string {
   return Point.fromHex(publicKeyToHex(publicKey)).toHex(false);
 }
 
-// todo: double-check for deduplication, rename!
-export function makeRandomPrivKey(): string {
-  return bytesToHex(utils.randomPrivateKey());
+/** @deprecated Use {@link randomPrivateKey} instead */
+export const makeRandomPrivKey = randomPrivateKey;
+
+/**
+ * Generate a random private key (compressed)
+ *
+ * @example
+ * ```ts
+ * const privateKey = randomPrivateKey();
+ * // 'f5a31c1268a1e37d4edaa05c7d11183c5fbfdcdc48aae36ea4d8cd5cb709932801'
+ * ```
+ */
+export function randomPrivateKey(): string {
+  return compressPrivateKey(utils.randomPrivateKey());
 }
 
 /**

--- a/packages/transactions/tests/keys.test.ts
+++ b/packages/transactions/tests/keys.test.ts
@@ -68,8 +68,8 @@ test('Stacks public key and private keys', () => {
 
   expect(privateKeyToPublic(privKey)).toBe(pubKeyString);
 
-  const randomKey = makeRandomPrivKey(); // defaults to uncompressed (i.e. no 01 suffix)
-  expect(privateKeyToHex(randomKey).length).toEqual(64);
+  const randomKey = makeRandomPrivKey(); // defaults to compressed (i.e. with 01 suffix)
+  expect(privateKeyToHex(randomKey).length).toEqual(66);
 
   expect(getAddressFromPrivateKey(privKey)).toBe('SPZG6BAY4JVR9RNAB1HY92B7Q208ZYY4HZEA9PX5');
   expect(getAddressFromPrivateKey(hexToBytes(privKey))).toBe(


### PR DESCRIPTION
> This PR was published to npm with the version `6.14.1-pr.64+bbe6c9a4`
> e.g. `npm install @stacks/common@6.14.1-pr.64+bbe6c9a4 --save-exact`<!-- Sticky Header Marker -->

- switch to compressed private keys by default