### PR TITLE
refactor: Add renamed `randomSeedPhrase` method

### DIFF
--- a/.github/MIGRATION.md
+++ b/.github/MIGRATION.md
@@ -323,6 +323,7 @@ This likely was a misunderstood and unused feature.
 
 - `AddressHashMode`: The `Serialize` prefixes were removed for brevity.
 - `makeRandomPrivKey` was renamed to `randomPrivateKey` and now returns a compressed private key.
+- `generateSecretKey` was renamed to `randomSeedPhrase`.
 
 ## Stacks.js (&lt;=4.x.x) → (5.x.x)
 

--- a/packages/wallet-sdk/src/generate.ts
+++ b/packages/wallet-sdk/src/generate.ts
@@ -19,13 +19,24 @@ import { bytesToHex } from '@stacks/common';
 
 export type AllowedKeyEntropyBits = 128 | 256;
 
-export const generateSecretKey = (entropy: AllowedKeyEntropyBits = 256) => {
-  const secretKey = generateMnemonic(wordlist, entropy);
-  return secretKey;
-};
+/**
+ * Generate a random 12 or 24 word mnemonic phrase.
+ *
+ * @example
+ * ```ts
+ * const phrase = randomSeedPhrase();
+ * // "warrior volume sport ... figure cake since"
+ * ```
+ */
+export function randomSeedPhrase(entropy: AllowedKeyEntropyBits = 256): string {
+  return generateMnemonic(wordlist, entropy);
+}
+
+/** @deprecated Use {@link randomSeedPhrase} instead */
+export const generateSecretKey = randomSeedPhrase;
 
 /**
- * Generate a new [[Wallet]].
+ * Generate a new {@link Wallet}.
  * @param secretKey A 12 or 24 word mnemonic phrase. Must be a valid bip39 mnemonic.
  * @param password A password used to encrypt the wallet
  */


### PR DESCRIPTION
> This PR was published to npm with the version `6.14.1-pr.65+64be49f7`
> e.g. `npm install @stacks/common@6.14.1-pr.65+64be49f7 --save-exact`<!-- Sticky Header Marker -->

- add rename/overload with better naming