### PR TITLE
refactor: Rename api to client and undo previous StacksNodeAPI changes

### DIFF
--- a/.github/MIGRATION.md
+++ b/.github/MIGRATION.md
@@ -6,8 +6,7 @@
     - [Impacts](#impacts)
   - [Fetch Methods](#fetch-methods)
   - [Reducing Wrapper Types](#reducing-wrapper-types)
-  - [StacksNodeApi](#stacksnodeapi)
-  - [StacksNetwork to StacksNodeApi](#stacksnetwork-to-stacksnodeapi)
+  - [Stacks Network](#stacks-network-1)
   - [Clarity Representation](#clarity-representation)
   - [Post-conditions](#post-conditions)
   - [`serialize` methods](#serialize-methods)
@@ -94,20 +93,7 @@ This breaks the signatures of many functions:
 - `signMessageHashRsv`, `signWithKey` now return the message signature as a `string` directly.
 - `nextSignature`, `nextVerification`, `publicKeyFromSignatureVrs`, `publicKeyFromSignatureRsv` now take in the message signature as a `string`.
 
-### StacksNodeApi
-
-The new `StacksNodeApi` class lets you interact with a Stacks node or API.
-
-<!-- todo: will be renamed to Client in a followup PR -->
-
-```ts
-import { StacksNodeApi } from '@stacks/transactions';
-
-const api = new StacksNodeApi();
-await api.broadcastTx(txHex);
-```
-
-### StacksNetwork to StacksNodeApi
+### Stacks Network
 
 Stacks network objects are now exported by the `@stacks/common` package.
 They are used to specify network settings for other functions and don't require instantiation (like the `@stacks/network` approach did).
@@ -118,14 +104,12 @@ import { STACKS_MAINNET } from '@stacks/transactions';
 
 After importing the network object (e.g. `STACKS_MAINNET` here), you can use it in other functions like so:
 
-```ts
-// todo: update more functions, show example
-```
+<!-- todo: update more functions, show examples -->
 
-For easing the transition, the functions which depended on a network instance now accept an `api` parameter.
-The `api` parameter can be an instance of `StacksNodeApi` or any object containing a `url` and `fetch` property.
+For easing the transition, the functions which depended on a network instance now accept an `client` parameter.
+The `client` parameter can be any object containing a `baseUrl` and `fetch` property.
 
-- The `url` property should be a string containing the base URL of the Stacks node you want to use.
+- The `baseUrl` property should be a string containing the base URL of the Stacks node you want to use.
 - The `fetch` property can be any (fetch)[https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API] compatible function.
 
 The following diffs show examples of how to migrate to the new pattern.
@@ -144,7 +128,7 @@ const transaction = await makeSTXTokenTransfer({
 ```
 
 > [!NOTE]
-> String literal network names are still supported.
+> String literal network names are still supported and the recommended way to specify the network.
 
 ```diff
 const transaction = await makeSTXTokenTransfer({
@@ -155,14 +139,14 @@ const transaction = await makeSTXTokenTransfer({
 ```
 
 > [!NOTE]
-> Custom URLs and fetch functions are still supported via the `api` parameter.
+> Custom URLs and fetch functions are still supported via the `client` parameter.
 
 ```diff
 const transaction = await makeSTXTokenTransfer({
   // ...
 - network: new StacksTestnet({ url: "mynode-optional.com", fetchFn: myFetch }), // optional options
 + network: STACKS_TESTNET,
-+ api: { url: "mynode-optional.com", fetch: myFetch } // optional params
++ client: { baseUrl: "mynode-optional.com", fetch: myFetch } // optional params
 });
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22639,7 +22639,6 @@
       "dependencies": {
         "@noble/hashes": "1.1.5",
         "@scure/base": "1.1.1",
-        "@stacks/api": "file:../api",
         "@stacks/common": "^6.16.0",
         "@stacks/encryption": "^6.16.1",
         "@stacks/network": "^6.16.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22288,7 +22288,6 @@
       "dependencies": {
         "@scure/bip32": "1.1.3",
         "@scure/bip39": "1.1.0",
-        "@stacks/api": "file:../api",
         "@stacks/auth": "^6.16.1",
         "@stacks/blockchain-api-client": "4.0.1",
         "@stacks/bns": "^6.16.1",
@@ -22435,7 +22434,6 @@
     "packages/internal": {
       "name": "@stacks/internal",
       "devDependencies": {
-        "@stacks/api": "^6.9.0",
         "@stacks/blockchain-api-client": "^7.12.0",
         "@stacks/network": "^6.16.0",
         "@stacks/stacking": "^6.9.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "@stacks/api",
   "version": "6.9.0",
   "description": "Javascript library for interacting with the Stacks Blockchain Node and API.",

--- a/packages/api/tests/api.test.ts
+++ b/packages/api/tests/api.test.ts
@@ -9,6 +9,6 @@ describe('setting StacksApi URL', () => {
     { network: STACKS_DEVNET, url: DEVNET_URL },
   ])('the api class determines the correct url for each network object', ({ network, url }) => {
     const api = new StacksNodeApi({ network });
-    expect(api.url).toEqual(url);
+    expect(api.baseUrl).toEqual(url);
   });
 });

--- a/packages/auth/src/profile.ts
+++ b/packages/auth/src/profile.ts
@@ -4,7 +4,7 @@ import { resolveZoneFileToProfile } from '@stacks/profile';
 export interface ProfileLookupOptions {
   username: string;
   zoneFileLookupURL?: string;
-  api?: ClientOpts;
+  client?: ClientOpts;
 }
 
 /**
@@ -21,21 +21,21 @@ export function lookupProfile(options: ProfileLookupOptions): Promise<Record<str
     return Promise.reject(new Error('No username provided'));
   }
 
-  const api = defaultClientOpts(options.api);
+  const client = defaultClientOpts(options.client);
 
   let lookupPromise;
   if (options.zoneFileLookupURL) {
     const url = `${options.zoneFileLookupURL.replace(/\/$/, '')}/${options.username}`;
-    lookupPromise = api.fetch(url).then(response => response.json());
+    lookupPromise = client.fetch(url).then(response => response.json());
   } else {
-    lookupPromise = getNameInfo({ name: options.username, client: api });
+    lookupPromise = getNameInfo({ name: options.username, client: client });
   }
   return lookupPromise.then((responseJSON: any) => {
     if (responseJSON.hasOwnProperty('zonefile') && responseJSON.hasOwnProperty('address')) {
       return resolveZoneFileToProfile({
         zoneFile: responseJSON.zonefile,
         publicKeyOrAddress: responseJSON.address,
-        client: api,
+        client,
       });
     } else {
       throw new Error(

--- a/packages/bns/src/index.ts
+++ b/packages/bns/src/index.ts
@@ -1,4 +1,4 @@
-import { ApiParam, IntegerType, PublicKey, intToBigInt, utf8ToBytes } from '@stacks/common';
+import { ClientParam, IntegerType, PublicKey, intToBigInt, utf8ToBytes } from '@stacks/common';
 import { StacksNetwork } from '@stacks/network';
 import {
   ClarityType,
@@ -83,7 +83,7 @@ export interface BnsReadOnlyOptions {
 }
 
 async function callReadOnlyBnsFunction(
-  options: BnsReadOnlyOptions & ApiParam
+  options: BnsReadOnlyOptions & ClientParam
 ): Promise<ClarityValue> {
   return fetchCallReadOnlyFunction({
     contractAddress: options.network.bootAddress,
@@ -91,7 +91,7 @@ async function callReadOnlyBnsFunction(
     functionName: options.functionName,
     senderAddress: options.senderAddress,
     functionArgs: options.functionArgs,
-    api: options.api,
+    client: options.client,
   });
 }
 

--- a/packages/bns/tests/bns.test.ts
+++ b/packages/bns/tests/bns.test.ts
@@ -57,7 +57,7 @@ test('canRegisterName true', async () => {
       bufferCV(utf8ToBytes(fullyQualifiedName.split('.')[0])),
     ],
     senderAddress: notRandomAddress,
-    api: undefined,
+    client: undefined,
   };
 
   expect(result).toEqual(true);
@@ -96,7 +96,7 @@ test('canRegisterName false', async () => {
       bufferCV(utf8ToBytes(fullyQualifiedName.split('.')[0])),
     ],
     senderAddress: notRandomAddress,
-    api: undefined,
+    client: undefined,
   };
 
   expect(result).toEqual(false);
@@ -135,7 +135,7 @@ test('canRegisterName error', async () => {
       bufferCV(utf8ToBytes(fullyQualifiedName.split('.')[0])),
     ],
     senderAddress: notRandomAddress,
-    api: undefined,
+    client: undefined,
   };
 
   expect(result).toEqual(false);
@@ -171,7 +171,7 @@ test('getNamespacePrice', async () => {
     functionName: bnsFunctionName,
     senderAddress: address,
     functionArgs: [bufferCVFromString(namespace)],
-    api: undefined,
+    client: undefined,
   };
 
   expect(result.toString()).toEqual('10');
@@ -206,7 +206,7 @@ test('getNamespacePrice error', async () => {
     functionName: bnsFunctionName,
     senderAddress: address,
     functionArgs: [bufferCVFromString(namespace)],
-    api: undefined,
+    client: undefined,
   };
 
   await expect(getNamespacePrice({ namespace, network })).rejects.toEqual(new Error('u1001'));
@@ -244,7 +244,7 @@ test('getNamePrice', async () => {
     functionName: bnsFunctionName,
     senderAddress: address,
     functionArgs: [bufferCVFromString(namespace), bufferCVFromString(name)],
-    api: undefined,
+    client: undefined,
   };
 
   expect(result.toString()).toEqual('10');
@@ -281,7 +281,7 @@ test('getNamePrice error', async () => {
     functionName: bnsFunctionName,
     senderAddress: address,
     functionArgs: [bufferCVFromString(namespace), bufferCVFromString(name)],
-    api: undefined,
+    client: undefined,
   };
 
   await expect(getNamePrice({ fullyQualifiedName, network })).rejects.toEqual(new Error('u2001'));

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "@scure/bip32": "1.1.3",
     "@scure/bip39": "1.1.0",
-    "@stacks/api": "file:../api",
     "@stacks/auth": "^6.16.1",
     "@stacks/blockchain-api-client": "4.0.1",
     "@stacks/bns": "^6.16.1",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -91,7 +91,7 @@ import { CLI_NETWORK_OPTS, CLINetworkAdapter, getNetwork, NameInfoType } from '.
 
 import { gaiaAuth, gaiaConnect, gaiaUploadProfileAll, getGaiaAddressFromProfile } from './data';
 
-import { deriveDefaultUrl, STACKS_MAINNET, STACKS_TESTNET } from '@stacks/network';
+import { defaultUrlFromNetwork, STACKS_MAINNET, STACKS_TESTNET } from '@stacks/network';
 import {
   generateNewAccount,
   generateWallet,
@@ -359,7 +359,7 @@ async function migrateSubdomains(network: CLINetworkAdapter, args: string[]): Pr
 
     console.log(`Finding subdomains for data-key address '${dataKeyAddress}'`);
     const namesResponse = await fetch(
-      `${deriveDefaultUrl(_network)}/v1/addresses/stacks/${dataKeyAddress}`
+      `${defaultUrlFromNetwork(_network)}/v1/addresses/stacks/${dataKeyAddress}`
     );
     const namesJson = await namesResponse.json();
 
@@ -377,7 +377,7 @@ async function migrateSubdomains(network: CLINetworkAdapter, args: string[]): Pr
       // Alerts the user to any subdomains that can't be migrated to these wallet-key-derived addresses
       // Given collision with existing usernames owned by them
       const namesResponse = await fetch(
-        `${deriveDefaultUrl(_network)}/v1/addresses/stacks/${walletKeyAddress}`
+        `${defaultUrlFromNetwork(_network)}/v1/addresses/stacks/${walletKeyAddress}`
       );
       const existingNames = await namesResponse.json();
       if (existingNames.names?.includes(subdomain)) {
@@ -386,7 +386,7 @@ async function migrateSubdomains(network: CLINetworkAdapter, args: string[]): Pr
       }
 
       // Validate user owns the subdomain
-      const nameInfo = await fetch(`${deriveDefaultUrl(_network)}/v1/names/${subdomain}`);
+      const nameInfo = await fetch(`${defaultUrlFromNetwork(_network)}/v1/names/${subdomain}`);
       const nameInfoJson = await nameInfo.json();
       console.log('Subdomain Info: ', nameInfoJson);
       if (nameInfoJson.address !== dataKeyAddress) {

--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -9,9 +9,6 @@
   },
   "references": [
     {
-      "path": "../api/tsconfig.build.json"
-    },
-    {
       "path": "../auth/tsconfig.build.json"
     },
     {

--- a/packages/common/src/fetch.ts
+++ b/packages/common/src/fetch.ts
@@ -51,16 +51,19 @@ export async function fetchWrapper(input: RequestInfo, init?: RequestInit): Prom
 
 export type FetchFn = (url: string, init?: RequestInit) => Promise<Response>;
 
-/** @ignore Internally used for letting networking functions specify "API" options */
-export type ApiOpts = {
-  url?: string;
+/**
+ * @ignore Internally used for letting networking functions specify "API" options.
+ * Should be compatible with the `client`s created by the API and RPC packages.
+ */
+export type ClientOpts = {
+  baseUrl?: string;
   fetch?: FetchFn;
 };
 
 /** @ignore Internally used for letting networking functions specify "API" options */
-export type ApiParam = {
+export type ClientParam = {
   /** Optional API object (for `.url` and `.fetch`) used for API/Node, defaults to use mainnet */
-  api?: ApiOpts;
+  client?: ClientOpts;
 };
 
 export interface RequestContext {
@@ -190,11 +193,11 @@ export function createFetchFn(...args: any[]): FetchFn {
   return fetchFn;
 }
 
-/** @ignore Creates a API-like object, which can be used without circular dependencies */
-export function defaultApiLike(opts?: { url?: string; fetch?: FetchFn }) {
+/** @ignore Creates a client-like object, which can be used without circular dependencies */
+export function defaultClientOpts(opts?: { baseUrl?: string; fetch?: FetchFn }) {
   return {
     // todo: do we want network here as well?
-    url: opts?.url ?? HIRO_MAINNET_URL,
+    baseUrl: opts?.baseUrl ?? HIRO_MAINNET_URL,
     fetch: opts?.fetch ?? createFetchFn(),
   };
 }

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -7,7 +7,6 @@
     "typecheck:watch": "npm run typecheck -- --watch"
   },
   "devDependencies": {
-    "@stacks/api": "^6.9.0",
     "@stacks/stacking": "^6.9.0",
     "@stacks/blockchain-api-client": "^7.12.0",
     "@stacks/network": "^6.16.0",

--- a/packages/internal/src/apiMockingHelpers.ts
+++ b/packages/internal/src/apiMockingHelpers.ts
@@ -2,7 +2,6 @@ import { Configuration, TransactionsApi } from '@stacks/blockchain-api-client';
 import { STACKS_TESTNET } from '@stacks/network';
 import { MockResponseInitFunction } from 'jest-fetch-mock';
 import { StackingClient } from '@stacks/stacking';
-import { StacksNodeApi } from '@stacks/api';
 
 // NOTES
 // Capture traffic via the fetchWrapper
@@ -93,8 +92,13 @@ export async function waitForTx(txId: string, apiUrl = 'http://localhost:3999') 
 export async function waitForBlock(burnBlockId: number, client?: StackingClient) {
   if (isMocking()) return;
 
-  const api = { url: 'http://localhost:3999' };
-  client = client ?? new StackingClient({ address: '', network: STACKS_TESTNET, api });
+  client =
+    client ??
+    new StackingClient({
+      address: '',
+      network: STACKS_TESTNET,
+      client: { baseUrl: 'http://localhost:3999' },
+    });
 
   let current: number;
   for (let i = 1; i <= MAX_ITERATIONS; i++) {
@@ -117,8 +121,13 @@ export async function waitForBlock(burnBlockId: number, client?: StackingClient)
 export async function waitForCycle(cycleId: number, client?: StackingClient) {
   if (isMocking()) return;
 
-  const api = new StacksNodeApi({ url: 'http://localhost:3999' });
-  client = client ?? new StackingClient({ address: '', network: STACKS_TESTNET, api });
+  client =
+    client ??
+    new StackingClient({
+      address: '',
+      network: STACKS_TESTNET,
+      client: { baseUrl: 'http://localhost:3999' },
+    });
 
   let current: number;
   for (let i = 1; i <= MAX_ITERATIONS; i++) {

--- a/packages/internal/tsconfig.build.json
+++ b/packages/internal/tsconfig.build.json
@@ -9,9 +9,6 @@
   },
   "references": [
     {
-      "path": "../api/tsconfig.build.json"
-    },
-    {
       "path": "../stacking/tsconfig.build.json"
     }
   ],

--- a/packages/network/src/network.ts
+++ b/packages/network/src/network.ts
@@ -91,7 +91,7 @@ export function defaultUrlFromNetwork(network?: StacksNetwork | StacksNetworkNam
 
 /** @ignore */
 export const defaultClientOptsFromNetwork = (
-  network: StacksNetworkName | StacksNetwork,
+  network?: StacksNetworkName | StacksNetwork,
   override?: ClientOpts
 ): Required<ClientOpts> => {
   return Object.assign(

--- a/packages/network/src/network.ts
+++ b/packages/network/src/network.ts
@@ -1,4 +1,10 @@
-import { DEVNET_URL, HIRO_MAINNET_URL, HIRO_TESTNET_URL } from '@stacks/common';
+import {
+  ClientOpts,
+  DEVNET_URL,
+  HIRO_MAINNET_URL,
+  HIRO_TESTNET_URL,
+  createFetchFn,
+} from '@stacks/common';
 import { AddressVersion, ChainId, PeerNetworkId, TransactionVersion } from './constants';
 
 export interface StacksNetwork {
@@ -71,7 +77,7 @@ export function networkFrom(network: StacksNetworkName | StacksNetwork) {
 }
 
 /** @ignore */
-export function deriveDefaultUrl(network?: StacksNetwork | StacksNetworkName) {
+export function defaultUrlFromNetwork(network?: StacksNetwork | StacksNetworkName) {
   if (!network) return HIRO_MAINNET_URL; // default to mainnet if no network is given
 
   network = networkFrom(network);
@@ -82,3 +88,18 @@ export function deriveDefaultUrl(network?: StacksNetwork | StacksNetworkName) {
       ? DEVNET_URL // default to devnet if magicBytes are devnet
       : HIRO_TESTNET_URL;
 }
+
+/** @ignore */
+export const defaultClientOptsFromNetwork = (
+  network: StacksNetworkName | StacksNetwork,
+  override?: ClientOpts
+): Required<ClientOpts> => {
+  return Object.assign(
+    {},
+    {
+      baseUrl: defaultUrlFromNetwork(network),
+      fetch: createFetchFn(),
+    },
+    override
+  );
+};

--- a/packages/profile/src/profile.ts
+++ b/packages/profile/src/profile.ts
@@ -22,7 +22,7 @@ import { makeZoneFile, parseZoneFile } from 'zone-file';
 // @ts-ignore
 import * as inspector from 'schema-inspector';
 
-import { ApiParam, Logger, defaultApiLike } from '@stacks/common';
+import { ClientParam, Logger, defaultClientOpts } from '@stacks/common';
 import { PublicPersonProfile } from './types';
 
 const schemaDefinition: { [key: string]: any } = {
@@ -340,9 +340,9 @@ export function resolveZoneFileToProfile(
   opts: {
     zoneFile: any;
     publicKeyOrAddress: string;
-  } & ApiParam
+  } & ClientParam
 ): Promise<Record<string, any>> {
-  const api = defaultApiLike(opts.api);
+  const api = defaultClientOpts(opts.client);
 
   return new Promise((resolve, reject) => {
     let zoneFileJson = null;

--- a/packages/stacking/package.json
+++ b/packages/stacking/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "@noble/hashes": "1.1.5",
     "@scure/base": "1.1.1",
-    "@stacks/api": "file:../api",
     "@stacks/common": "^6.16.0",
     "@stacks/encryption": "^6.16.1",
     "@stacks/network": "^6.16.0",

--- a/packages/stacking/src/index.ts
+++ b/packages/stacking/src/index.ts
@@ -1,12 +1,11 @@
+import { ClientOpts, IntegerType, PrivateKey, hexToBytes, intToBigInt } from '@stacks/common';
 import {
-  ClientOpts,
-  IntegerType,
-  PrivateKey,
-  defaultClientOpts,
-  hexToBytes,
-  intToBigInt,
-} from '@stacks/common';
-import { ChainId, StacksNetwork, StacksNetworkName, networkFrom } from '@stacks/network';
+  ChainId,
+  StacksNetwork,
+  StacksNetworkName,
+  defaultClientOptsFromNetwork,
+  networkFrom,
+} from '@stacks/network';
 import {
   BurnchainRewardListResponse,
   BurnchainRewardSlotHolderListResponse,
@@ -342,7 +341,7 @@ export class StackingClient {
   }) {
     this.address = opts.address;
     this.network = networkFrom(opts.network);
-    this.client = defaultClientOpts(opts.client);
+    this.client = defaultClientOptsFromNetwork(this.network, opts.client);
   }
 
   get baseUrl() {
@@ -353,17 +352,17 @@ export class StackingClient {
     return this.client.fetch;
   }
 
-  /** @deprecated alias of StacksNodeApi.getCoreInfo, kept for backwards compatibility */
+  /** @deprecated Kept for backwards compatibility, may be removed in the future */
   getCoreInfo(): Promise<V2CoreInfoResponse> {
     return this.client.fetch(`${this.client.baseUrl}/v2/info`).then(res => res.json());
   }
 
-  /** @deprecated alias of StacksNodeApi.getPoxInfo, kept for backwards compatibility */
+  /** @deprecated Kept for backwards compatibility, may be removed in the future */
   getPoxInfo(): Promise<V2PoxInfoResponse> {
     return this.client.fetch(`${this.client.baseUrl}/v2/pox`).then(res => res.json());
   }
 
-  /** @deprecated alias of StacksNodeApi.getTargetBlockTime, kept for backwards compatibility */
+  /** @deprecated Kept for backwards compatibility, may be removed in the future */
   async getTargetBlockTime(): Promise<number> {
     const res = await this.client
       .fetch(`${this.client.baseUrl}/extended/v1/info/network_block_times`)

--- a/packages/stacking/tests/stacking-2.4.test.ts
+++ b/packages/stacking/tests/stacking-2.4.test.ts
@@ -1,5 +1,4 @@
-import { StacksNodeApi } from '@stacks/api';
-import { hexToBytes } from '@stacks/common';
+import { defaultClientOpts, hexToBytes } from '@stacks/common';
 import {
   MOCK_EMPTY_ACCOUNT,
   MOCK_FULL_ACCOUNT,
@@ -53,8 +52,11 @@ describe('2.4 activation', () => {
       '/v2/pox': `{"contract_id":"ST000000000000000000002AMW42H.pox-3","pox_activation_threshold_ustx":600057388429055,"first_burnchain_block_height":0,"current_burnchain_block_height":180,"prepare_phase_block_length":1,"reward_phase_block_length":4,"reward_slots":8,"rejection_fraction":3333333333333333,"total_liquid_supply_ustx":60005738842905576,"current_cycle":{"id":35,"min_threshold_ustx":1875180000000000,"stacked_ustx":1875180000000000,"is_pox_active":false},"next_cycle":{"id":36,"min_threshold_ustx":1875180000000000,"min_increment_ustx":7500717355363,"stacked_ustx":1875180000000000,"prepare_phase_start_block_height":184,"blocks_until_prepare_phase":4,"reward_phase_start_block_height":185,"blocks_until_reward_phase":5,"ustx_until_pox_rejection":8484139029839119000},"min_amount_ustx":1875180000000000,"prepare_cycle_length":1,"reward_cycle_id":35,"reward_cycle_length":5,"rejection_votes_left_required":8484139029839119000,"next_reward_cycle_in":5,"contract_versions":[{"contract_id":"ST000000000000000000002AMW42H.pox","activation_burnchain_block_height":0,"first_reward_cycle_id":0},{"contract_id":"ST000000000000000000002AMW42H.pox-2","activation_burnchain_block_height":107,"first_reward_cycle_id":22},{"contract_id":"ST000000000000000000002AMW42H.pox-3","activation_burnchain_block_height":111,"first_reward_cycle_id":23}]}`,
     });
 
-    const api = new StacksNodeApi({ url: API_URL });
-    const client = new StackingClient({ address: '', network: STACKS_TESTNET, api });
+    const client = new StackingClient({
+      address: '',
+      network: STACKS_TESTNET,
+      client: defaultClientOpts({ baseUrl: API_URL }),
+    });
 
     const poxInfo = await client.getPoxInfo();
     expect(poxInfo.contract_id).toBe('ST000000000000000000002AMW42H.pox-3');
@@ -77,8 +79,11 @@ test('in period 3, pox-3 stacking works', async () => {
   const address = 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6';
   const poxAddress = '1Xik14zRm29UsyS6DjhYg4iZeZqsDa8D3';
 
-  const api = new StacksNodeApi({ url: API_URL });
-  const client = new StackingClient({ address, network: STACKS_TESTNET, api });
+  const client = new StackingClient({
+    address,
+    network: STACKS_TESTNET,
+    client: defaultClientOpts({ baseUrl: API_URL }),
+  });
 
   setApiMocks({
     '/v2/pox': `{"contract_id":"ST000000000000000000002AMW42H.pox-3","pox_activation_threshold_ustx":600057529871055,"first_burnchain_block_height":0,"current_burnchain_block_height":217,"prepare_phase_block_length":1,"reward_phase_block_length":4,"reward_slots":8,"rejection_fraction":3333333333333333,"total_liquid_supply_ustx":60005752987105576,"current_cycle":{"id":43,"min_threshold_ustx":1875180000000000,"stacked_ustx":0,"is_pox_active":false},"next_cycle":{"id":44,"min_threshold_ustx":1875180000000000,"min_increment_ustx":7500719123388,"stacked_ustx":0,"prepare_phase_start_block_height":219,"blocks_until_prepare_phase":2,"reward_phase_start_block_height":220,"blocks_until_reward_phase":3,"ustx_until_pox_rejection":1485692420695552500},"min_amount_ustx":1875180000000000,"prepare_cycle_length":1,"reward_cycle_id":43,"reward_cycle_length":5,"rejection_votes_left_required":1485692420695552500,"next_reward_cycle_in":3,"contract_versions":[{"contract_id":"ST000000000000000000002AMW42H.pox","activation_burnchain_block_height":0,"first_reward_cycle_id":0},{"contract_id":"ST000000000000000000002AMW42H.pox-2","activation_burnchain_block_height":107,"first_reward_cycle_id":22},{"contract_id":"ST000000000000000000002AMW42H.pox-3","activation_burnchain_block_height":111,"first_reward_cycle_id":23}]}`,
@@ -122,8 +127,11 @@ describe('stacking eligibility', () => {
     const address = 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6';
     const poxAddress = '1Xik14zRm29UsyS6DjhYg4iZeZqsDa8D3';
 
-    const api = new StacksNodeApi({ url: API_URL });
-    const client = new StackingClient({ address, network: STACKS_TESTNET, api });
+    const client = new StackingClient({
+      address,
+      network: STACKS_TESTNET,
+      client: defaultClientOpts({ baseUrl: API_URL }),
+    });
 
     const cycles = 1;
     const stackingEligibility = await client.canStack({ poxAddress, cycles });
@@ -141,8 +149,11 @@ describe('stacking eligibility', () => {
     const address = 'ST162GBCTD9ESBF09XC2T63NCX6ZKS42ZPWGXZ6VH';
     const poxAddress = 'mnTdnFyjxRomWaSLp4fNGSa9Gyg9XJo4j4';
 
-    const api = new StacksNodeApi({ url: API_URL });
-    const client = new StackingClient({ address, network: STACKS_TESTNET, api });
+    const client = new StackingClient({
+      address,
+      network: STACKS_TESTNET,
+      client: defaultClientOpts({ baseUrl: API_URL }),
+    });
 
     const cycles = 1;
     const stackingEligibility = await client.canStack({ poxAddress, cycles });
@@ -162,8 +173,11 @@ describe('normal stacking', () => {
     const address = 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6';
     const poxAddress = '1Xik14zRm29UsyS6DjhYg4iZeZqsDa8D3';
 
-    const api = new StacksNodeApi({ url: API_URL });
-    const client = new StackingClient({ address, network: STACKS_TESTNET, api });
+    const client = new StackingClient({
+      address,
+      network: STACKS_TESTNET,
+      client: defaultClientOpts({ baseUrl: API_URL }),
+    });
 
     setApiMocks({
       ...MOCK_POX_3_REGTEST,
@@ -199,8 +213,11 @@ describe('normal stacking', () => {
     const address = 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6';
     const poxAddress = '1Xik14zRm29UsyS6DjhYg4iZeZqsDa8D3';
 
-    const api = new StacksNodeApi({ url: API_URL });
-    const client = new StackingClient({ address, network: STACKS_TESTNET, api });
+    const client = new StackingClient({
+      address,
+      network: STACKS_TESTNET,
+      client: defaultClientOpts({ baseUrl: API_URL }),
+    });
 
     setApiMocks({
       ...MOCK_POX_3_REGTEST,
@@ -254,8 +271,11 @@ describe('normal stacking', () => {
     const address = 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6';
     const poxAddress = '1Xik14zRm29UsyS6DjhYg4iZeZqsDa8D3';
 
-    const api = new StacksNodeApi({ url: API_URL });
-    const client = new StackingClient({ address, network: STACKS_TESTNET, api });
+    const client = new StackingClient({
+      address,
+      network: STACKS_TESTNET,
+      client: defaultClientOpts({ baseUrl: API_URL }),
+    });
 
     setApiMocks({
       ...MOCK_POX_3_REGTEST,
@@ -308,8 +328,11 @@ describe('delegated stacking', () => {
 
     const delegateTo = 'ST2MCYPWTFMD2MGR5YY695EJG0G1R4J2BTJPRGM7H';
 
-    const api = new StacksNodeApi({ url: API_URL });
-    const client = new StackingClient({ address, network: STACKS_TESTNET, api });
+    const client = new StackingClient({
+      address,
+      network: STACKS_TESTNET,
+      client: defaultClientOpts({ baseUrl: API_URL }),
+    });
 
     setApiMocks({
       ...MOCK_POX_3_REGTEST,
@@ -350,8 +373,11 @@ describe('delegated stacking', () => {
 
     const delegateTo = 'ST2MCYPWTFMD2MGR5YY695EJG0G1R4J2BTJPRGM7H';
 
-    const api = new StacksNodeApi({ url: API_URL });
-    const client = new StackingClient({ address, network: STACKS_TESTNET, api });
+    const client = new StackingClient({
+      address,
+      network: STACKS_TESTNET,
+      client: defaultClientOpts({ baseUrl: API_URL }),
+    });
 
     setApiMocks({
       ...MOCK_POX_3_REGTEST,
@@ -391,8 +417,11 @@ describe('delegated stacking', () => {
     const delegatorAddress = 'ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y';
     const delegatorPoxAddress = '1797Pp1o8A7a8X8Qs7ejXtYyw8gbecFK2b';
 
-    const api = new StacksNodeApi({ url: API_URL });
-    const client = new StackingClient({ address, network: STACKS_TESTNET, api });
+    const client = new StackingClient({
+      address,
+      network: STACKS_TESTNET,
+      client: defaultClientOpts({ baseUrl: API_URL }),
+    });
     const delegatorClient = new StackingClient({
       address: delegatorAddress,
       network: STACKS_TESTNET,
@@ -457,8 +486,11 @@ describe('delegated stacking', () => {
     const delegatorAddress = 'ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y';
     const delegatorPoxAddress = '1797Pp1o8A7a8X8Qs7ejXtYyw8gbecFK2b';
 
-    const api = new StacksNodeApi({ url: API_URL });
-    const client = new StackingClient({ address, network: STACKS_TESTNET, api });
+    const client = new StackingClient({
+      address,
+      network: STACKS_TESTNET,
+      client: defaultClientOpts({ baseUrl: API_URL }),
+    });
     const delegatorClient = new StackingClient({
       address: delegatorAddress,
       network: STACKS_TESTNET,
@@ -545,8 +577,11 @@ describe('delegated stacking', () => {
     const delegatorAddress = 'ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y';
     const delegatorPoxAddress = '1797Pp1o8A7a8X8Qs7ejXtYyw8gbecFK2b';
 
-    const api = new StacksNodeApi({ url: API_URL });
-    const client = new StackingClient({ address, network: STACKS_TESTNET, api });
+    const client = new StackingClient({
+      address,
+      network: STACKS_TESTNET,
+      client: defaultClientOpts({ baseUrl: API_URL }),
+    });
     const delegatorClient = new StackingClient({
       address: delegatorAddress,
       network: STACKS_TESTNET,
@@ -632,20 +667,32 @@ describe('delegated stacking', () => {
     // * The pool commits a total stacking amount (covering all of its stackers)
     //   * This is required for a pools pox-address to be "commited" into the reward-set
 
-    const api = new StacksNodeApi({ url: API_URL });
+    const client = defaultClientOpts({ baseUrl: API_URL });
 
     const stackerAKey = 'cb3df38053d132895220b9ce471f6b676db5b9bf0b4adefb55f2118ece2478df01';
     const stackerAAddress = 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6';
-    const clientA = new StackingClient({ address: stackerAAddress, network: STACKS_TESTNET, api });
+    const clientA = new StackingClient({
+      address: stackerAAddress,
+      network: STACKS_TESTNET,
+      client,
+    });
 
     const stackerBKey = 'c71700b07d520a8c9731e4d0f095aa6efb91e16e25fb27ce2b72e7b698f8127a01';
     const stackerBAddress = 'ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR';
-    const clientB = new StackingClient({ address: stackerBAddress, network: STACKS_TESTNET, api });
+    const clientB = new StackingClient({
+      address: stackerBAddress,
+      network: STACKS_TESTNET,
+      client,
+    });
 
     const poolPrivateKey = '21d43d2ae0da1d9d04cfcaac7d397a33733881081f0b2cd038062cf0ccbb752601';
     const poolAddress = 'ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y';
     const poolPoxAddress = '1797Pp1o8A7a8X8Qs7ejXtYyw8gbecFK2b';
-    const clientPool = new StackingClient({ address: poolAddress, network: STACKS_TESTNET, api });
+    const clientPool = new StackingClient({
+      address: poolAddress,
+      network: STACKS_TESTNET,
+      client,
+    });
 
     setApiMocks({
       ...MOCK_POX_3_REGTEST,
@@ -697,7 +744,7 @@ describe('delegated stacking', () => {
     poxInfo = await clientPool.getPoxInfo();
 
     // Manual nonce setting is required for multiple transactions in the same block
-    let noncePool = await fetchNonce({ address: poolAddress, api });
+    let noncePool = await fetchNonce({ address: poolAddress, client });
 
     // Pool stacks for stacker A
     const stackAPool = await clientPool.delegateStackStx({
@@ -785,20 +832,32 @@ describe('delegated stacking', () => {
     // * The pool realizes the mistake and increases the amount to all of its stackers' funds
     //   * This will only work if the reward cycle anchor block hasn't been reached yet!
 
-    const api = new StacksNodeApi({ url: API_URL });
+    const clientOpts = defaultClientOpts({ baseUrl: API_URL });
 
     const stackerAKey = 'cb3df38053d132895220b9ce471f6b676db5b9bf0b4adefb55f2118ece2478df01';
     const stackerAAddress = 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6';
-    const clientA = new StackingClient({ address: stackerAAddress, network: STACKS_TESTNET, api });
+    const clientA = new StackingClient({
+      address: stackerAAddress,
+      network: STACKS_TESTNET,
+      client: clientOpts,
+    });
 
     const stackerBKey = 'c71700b07d520a8c9731e4d0f095aa6efb91e16e25fb27ce2b72e7b698f8127a01';
     const stackerBAddress = 'ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR';
-    const clientB = new StackingClient({ address: stackerBAddress, network: STACKS_TESTNET, api });
+    const clientB = new StackingClient({
+      address: stackerBAddress,
+      network: STACKS_TESTNET,
+      client: clientOpts,
+    });
 
     const poolPrivateKey = '21d43d2ae0da1d9d04cfcaac7d397a33733881081f0b2cd038062cf0ccbb752601';
     const poolAddress = 'ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y';
     const poolPoxAddress = '1797Pp1o8A7a8X8Qs7ejXtYyw8gbecFK2b';
-    const clientPool = new StackingClient({ address: poolAddress, network: STACKS_TESTNET, api });
+    const clientPool = new StackingClient({
+      address: poolAddress,
+      network: STACKS_TESTNET,
+      client: clientOpts,
+    });
 
     setApiMocks({
       ...MOCK_POX_3_REGTEST,
@@ -847,7 +906,7 @@ describe('delegated stacking', () => {
     poxInfo = await clientPool.getPoxInfo();
 
     // Manual nonce setting is required for multiple transactions in the same block
-    let noncePool = await fetchNonce({ address: poolAddress, api });
+    let noncePool = await fetchNonce({ address: poolAddress, client: clientOpts });
 
     // Pool stacks for stacker A (stacks all 3/4)
     const stackAPool = await clientPool.delegateStackStx({
@@ -959,8 +1018,11 @@ describe('btc addresses', () => {
       const privateKey = 'cb3df38053d132895220b9ce471f6b676db5b9bf0b4adefb55f2118ece2478df01';
       const address = 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6';
 
-      const api = new StacksNodeApi({ url: API_URL });
-      const client = new StackingClient({ address, network: STACKS_TESTNET, api });
+      const client = new StackingClient({
+        address,
+        network: STACKS_TESTNET,
+        client: defaultClientOpts({ baseUrl: API_URL }),
+      });
 
       setApiMocks({
         ...MOCK_POX_3_REGTEST,

--- a/packages/stacking/tests/stacking-2.5.test.ts
+++ b/packages/stacking/tests/stacking-2.5.test.ts
@@ -13,7 +13,7 @@ describe('pox-4', () => {
   test('verify-signer-key-sig', async () => {
     const network = STACKS_MOCKNET;
     const address = 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6';
-    const client = new StackingClient({ address, network, api: { url: 'localhost:3999' } });
+    const client = new StackingClient({ address, network, client: { baseUrl: 'localhost:3999' } });
 
     const signerPrivateKey = makeRandomPrivKey();
     const signerKey = getPublicKeyFromPrivate(signerPrivateKey);

--- a/packages/stacking/tests/stacking.test.ts
+++ b/packages/stacking/tests/stacking.test.ts
@@ -1,8 +1,14 @@
 import { sha256 } from '@noble/hashes/sha256';
-import { StacksNodeApi } from '@stacks/api';
-import { HIRO_TESTNET_URL, bigIntToBytes, bytesToHex, hexToBytes } from '@stacks/common';
+import {
+  HIRO_TESTNET_URL,
+  bigIntToBytes,
+  bytesToHex,
+  defaultClientOpts,
+  hexToBytes,
+} from '@stacks/common';
 import { base58CheckDecode, getPublicKeyFromPrivate } from '@stacks/encryption';
-import { STACKS_MAINNET, STACKS_TESTNET } from '@stacks/network';
+import { V2_POX_REGTEST_POX_3, setApiMocks } from '@stacks/internal';
+import { STACKS_MAINNET, STACKS_TESTNET, defaultUrlFromNetwork } from '@stacks/network';
 import {
   ClarityType,
   ReadOnlyFunctionOptions,
@@ -22,7 +28,6 @@ import {
   validateContractCall,
 } from '@stacks/transactions';
 import fetchMock from 'jest-fetch-mock';
-import { V2_POX_REGTEST_POX_3, setApiMocks } from '../../internal/src';
 import { StackingClient } from '../src';
 import { PoXAddressVersion, StackingErrors } from '../src/constants';
 import {
@@ -336,14 +341,25 @@ test('stack stx', async () => {
     validateWithAbi: true,
     network,
     senderKey: privateKey,
-    client,
+    client: expect.objectContaining({
+      baseUrl: defaultUrlFromNetwork(network),
+    }),
   };
 
   expect(fetchMock.mock.calls[0][0]).toEqual(`${HIRO_TESTNET_URL}/v2/pox`);
   expect(makeContractCall).toHaveBeenCalledTimes(1);
-  expect(makeContractCall).toHaveBeenCalledWith(expectedContractCallOptions);
+  expect(makeContractCall).toHaveBeenCalledWith(
+    expect.objectContaining(expectedContractCallOptions)
+  );
   expect(broadcastTransaction).toHaveBeenCalledTimes(1);
-  expect(broadcastTransaction).toHaveBeenCalledWith({ transaction, client });
+  expect(broadcastTransaction).toHaveBeenCalledWith(
+    expect.objectContaining({
+      transaction,
+      client: expect.objectContaining({
+        baseUrl: defaultUrlFromNetwork(network),
+      }),
+    })
+  );
   expect(stackingResults).toEqual(broadcastResponse);
   expect(isPoxAbiValid(expectedContractCallOptions)).toBe(true);
 });
@@ -408,14 +424,25 @@ test('delegate stx', async () => {
     validateWithAbi: true,
     network,
     senderKey: privateKey,
-    client,
+    client: expect.objectContaining({
+      baseUrl: defaultUrlFromNetwork(network),
+    }),
   };
 
   expect(fetchMock.mock.calls[0][0]).toEqual(`${HIRO_TESTNET_URL}/v2/pox`);
   expect(makeContractCall).toHaveBeenCalledTimes(1);
-  expect(makeContractCall).toHaveBeenCalledWith(expectedContractCallOptions);
+  expect(makeContractCall).toHaveBeenCalledWith(
+    expect.objectContaining(expectedContractCallOptions)
+  );
   expect(broadcastTransaction).toHaveBeenCalledTimes(1);
-  expect(broadcastTransaction).toHaveBeenCalledWith({ transaction, client });
+  expect(broadcastTransaction).toHaveBeenCalledWith(
+    expect.objectContaining({
+      transaction,
+      client: expect.objectContaining({
+        baseUrl: defaultUrlFromNetwork(network),
+      }),
+    })
+  );
   expect(delegateResults).toEqual(broadcastResponse);
   expect(isPoxAbiValid(expectedContractCallOptions)).toBe(true);
 });
@@ -472,14 +499,25 @@ test('delegate stx with empty optional parameters', async () => {
     validateWithAbi: true,
     network,
     senderKey: privateKey,
-    client,
+    client: expect.objectContaining({
+      baseUrl: defaultUrlFromNetwork(network),
+    }),
   };
 
   expect(fetchMock.mock.calls[0][0]).toEqual(`${HIRO_TESTNET_URL}/v2/pox`);
   expect(makeContractCall).toHaveBeenCalledTimes(1);
-  expect(makeContractCall).toHaveBeenCalledWith(expectedContractCallOptions);
+  expect(makeContractCall).toHaveBeenCalledWith(
+    expect.objectContaining(expectedContractCallOptions)
+  );
   expect(broadcastTransaction).toHaveBeenCalledTimes(1);
-  expect(broadcastTransaction).toHaveBeenCalledWith({ transaction, client });
+  expect(broadcastTransaction).toHaveBeenCalledWith(
+    expect.objectContaining({
+      transaction,
+      client: expect.objectContaining({
+        baseUrl: defaultUrlFromNetwork(network),
+      }),
+    })
+  );
   expect(delegateResults).toEqual(broadcastResponse);
   expect(isPoxAbiValid(expectedContractCallOptions)).toBe(true);
 });
@@ -555,14 +593,25 @@ test('delegate stack stx with one delegator', async () => {
     validateWithAbi: true,
     network,
     senderKey: privateKey,
-    client,
+    client: expect.objectContaining({
+      baseUrl: defaultUrlFromNetwork(network),
+    }),
   };
 
   expect(fetchMock.mock.calls[0][0]).toEqual(`${HIRO_TESTNET_URL}/v2/pox`);
   expect(makeContractCall).toHaveBeenCalledTimes(1);
-  expect(makeContractCall).toHaveBeenCalledWith(expectedContractCallOptions);
+  expect(makeContractCall).toHaveBeenCalledWith(
+    expect.objectContaining(expectedContractCallOptions)
+  );
   expect(broadcastTransaction).toHaveBeenCalledTimes(1);
-  expect(broadcastTransaction).toHaveBeenCalledWith({ transaction, client });
+  expect(broadcastTransaction).toHaveBeenCalledWith(
+    expect.objectContaining({
+      transaction,
+      client: expect.objectContaining({
+        baseUrl: defaultUrlFromNetwork(network),
+      }),
+    })
+  );
   expect(delegateResults).toEqual(broadcastResponse);
   expect(isPoxAbiValid(expectedContractCallOptions)).toBe(true);
 });
@@ -641,14 +690,25 @@ test('delegate stack stx with set nonce', async () => {
     network,
     senderKey: privateKey,
     nonce,
-    client,
+    client: expect.objectContaining({
+      baseUrl: defaultUrlFromNetwork(network),
+    }),
   };
 
   expect(fetchMock.mock.calls[0][0]).toEqual(`${HIRO_TESTNET_URL}/v2/pox`);
   expect(makeContractCall).toHaveBeenCalledTimes(1);
-  expect(makeContractCall).toHaveBeenCalledWith(expectedContractCallOptions);
+  expect(makeContractCall).toHaveBeenCalledWith(
+    expect.objectContaining(expectedContractCallOptions)
+  );
   expect(broadcastTransaction).toHaveBeenCalledTimes(1);
-  expect(broadcastTransaction).toHaveBeenCalledWith({ transaction, client });
+  expect(broadcastTransaction).toHaveBeenCalledWith(
+    expect.objectContaining({
+      transaction,
+      client: expect.objectContaining({
+        baseUrl: defaultUrlFromNetwork(network),
+      }),
+    })
+  );
   expect(delegateResults).toEqual(broadcastResponse);
   expect(isPoxAbiValid(expectedContractCallOptions)).toBe(true);
 });
@@ -704,14 +764,25 @@ test('delegator commit', async () => {
     validateWithAbi: true,
     network,
     senderKey: privateKey,
-    client,
+    client: expect.objectContaining({
+      baseUrl: defaultUrlFromNetwork(network),
+    }),
   };
 
   expect(fetchMock.mock.calls[0][0]).toEqual(`${HIRO_TESTNET_URL}/v2/pox`);
   expect(makeContractCall).toHaveBeenCalledTimes(1);
-  expect(makeContractCall).toHaveBeenCalledWith(expectedContractCallOptions);
+  expect(makeContractCall).toHaveBeenCalledWith(
+    expect.objectContaining(expectedContractCallOptions)
+  );
   expect(broadcastTransaction).toHaveBeenCalledTimes(1);
-  expect(broadcastTransaction).toHaveBeenCalledWith({ transaction, client });
+  expect(broadcastTransaction).toHaveBeenCalledWith(
+    expect.objectContaining({
+      transaction,
+      client: expect.objectContaining({
+        baseUrl: defaultUrlFromNetwork(network),
+      }),
+    })
+  );
   expect(delegateResults).toEqual(broadcastResponse);
   expect(isPoxAbiValid(expectedContractCallOptions)).toBe(true);
 });
@@ -753,14 +824,25 @@ test('revoke delegate stx', async () => {
     validateWithAbi: true,
     network,
     senderKey: privateKey,
-    client,
+    client: expect.objectContaining({
+      baseUrl: defaultUrlFromNetwork(network),
+    }),
   };
 
   expect(fetchMock.mock.calls[0][0]).toEqual(`${HIRO_TESTNET_URL}/v2/pox`);
   expect(makeContractCall).toHaveBeenCalledTimes(1);
-  expect(makeContractCall).toHaveBeenCalledWith(expectedContractCallOptions);
+  expect(makeContractCall).toHaveBeenCalledWith(
+    expect.objectContaining(expectedContractCallOptions)
+  );
   expect(broadcastTransaction).toHaveBeenCalledTimes(1);
-  expect(broadcastTransaction).toHaveBeenCalledWith({ transaction, client });
+  expect(broadcastTransaction).toHaveBeenCalledWith(
+    expect.objectContaining({
+      transaction,
+      client: expect.objectContaining({
+        baseUrl: defaultUrlFromNetwork(network),
+      }),
+    })
+  );
   expect(revokeDelegateResults).toEqual(broadcastResponse);
   expect(isPoxAbiValid(expectedContractCallOptions)).toBe(true);
 });
@@ -820,11 +902,15 @@ test('get stacking status', async () => {
     functionName: 'get-stacker-info',
     functionArgs: [standardPrincipalCV(address)],
     senderAddress: address,
-    client,
+    client: expect.objectContaining({
+      baseUrl: defaultUrlFromNetwork(network),
+    }),
   };
 
   expect(fetchCallReadOnlyFunction).toHaveBeenCalledTimes(1);
-  expect(fetchCallReadOnlyFunction).toHaveBeenCalledWith(expectedReadOnlyFunctionCallOptions);
+  expect(fetchCallReadOnlyFunction).toHaveBeenCalledWith(
+    expect.objectContaining(expectedReadOnlyFunctionCallOptions)
+  );
 
   expect(stackingStatus.stacked).toEqual(true);
   expect(stackingStatus.details.first_reward_cycle).toEqual(firstRewardCycle);
@@ -1146,8 +1232,11 @@ test('client operations with contract principal stacker', () => {
 });
 
 test('getSecondsUntilStackingDeadline', async () => {
-  const api = new StacksNodeApi({ url: 'http://localhost:3999' });
-  const client = new StackingClient({ address: '', network: STACKS_MAINNET, api });
+  const client = new StackingClient({
+    address: '',
+    network: STACKS_MAINNET,
+    client: defaultClientOpts({ baseUrl: 'http://localhost:3999' }),
+  });
 
   setApiMocks({
     '/extended/v1/info/network_block_times': `{"testnet":{"target_block_time":120},"mainnet":{"target_block_time":600}}`,

--- a/packages/stacking/tests/stacking.test.ts
+++ b/packages/stacking/tests/stacking.test.ts
@@ -336,14 +336,14 @@ test('stack stx', async () => {
     validateWithAbi: true,
     network,
     senderKey: privateKey,
-    api: client.api,
+    client,
   };
 
   expect(fetchMock.mock.calls[0][0]).toEqual(`${HIRO_TESTNET_URL}/v2/pox`);
   expect(makeContractCall).toHaveBeenCalledTimes(1);
   expect(makeContractCall).toHaveBeenCalledWith(expectedContractCallOptions);
   expect(broadcastTransaction).toHaveBeenCalledTimes(1);
-  expect(broadcastTransaction).toHaveBeenCalledWith({ transaction, api: client.api });
+  expect(broadcastTransaction).toHaveBeenCalledWith({ transaction, client });
   expect(stackingResults).toEqual(broadcastResponse);
   expect(isPoxAbiValid(expectedContractCallOptions)).toBe(true);
 });
@@ -408,14 +408,14 @@ test('delegate stx', async () => {
     validateWithAbi: true,
     network,
     senderKey: privateKey,
-    api: client.api,
+    client,
   };
 
   expect(fetchMock.mock.calls[0][0]).toEqual(`${HIRO_TESTNET_URL}/v2/pox`);
   expect(makeContractCall).toHaveBeenCalledTimes(1);
   expect(makeContractCall).toHaveBeenCalledWith(expectedContractCallOptions);
   expect(broadcastTransaction).toHaveBeenCalledTimes(1);
-  expect(broadcastTransaction).toHaveBeenCalledWith({ transaction, api: client.api });
+  expect(broadcastTransaction).toHaveBeenCalledWith({ transaction, client });
   expect(delegateResults).toEqual(broadcastResponse);
   expect(isPoxAbiValid(expectedContractCallOptions)).toBe(true);
 });
@@ -472,14 +472,14 @@ test('delegate stx with empty optional parameters', async () => {
     validateWithAbi: true,
     network,
     senderKey: privateKey,
-    api: client.api,
+    client,
   };
 
   expect(fetchMock.mock.calls[0][0]).toEqual(`${HIRO_TESTNET_URL}/v2/pox`);
   expect(makeContractCall).toHaveBeenCalledTimes(1);
   expect(makeContractCall).toHaveBeenCalledWith(expectedContractCallOptions);
   expect(broadcastTransaction).toHaveBeenCalledTimes(1);
-  expect(broadcastTransaction).toHaveBeenCalledWith({ transaction, api: client.api });
+  expect(broadcastTransaction).toHaveBeenCalledWith({ transaction, client });
   expect(delegateResults).toEqual(broadcastResponse);
   expect(isPoxAbiValid(expectedContractCallOptions)).toBe(true);
 });
@@ -555,14 +555,14 @@ test('delegate stack stx with one delegator', async () => {
     validateWithAbi: true,
     network,
     senderKey: privateKey,
-    api: client.api,
+    client,
   };
 
   expect(fetchMock.mock.calls[0][0]).toEqual(`${HIRO_TESTNET_URL}/v2/pox`);
   expect(makeContractCall).toHaveBeenCalledTimes(1);
   expect(makeContractCall).toHaveBeenCalledWith(expectedContractCallOptions);
   expect(broadcastTransaction).toHaveBeenCalledTimes(1);
-  expect(broadcastTransaction).toHaveBeenCalledWith({ transaction, api: client.api });
+  expect(broadcastTransaction).toHaveBeenCalledWith({ transaction, client });
   expect(delegateResults).toEqual(broadcastResponse);
   expect(isPoxAbiValid(expectedContractCallOptions)).toBe(true);
 });
@@ -641,14 +641,14 @@ test('delegate stack stx with set nonce', async () => {
     network,
     senderKey: privateKey,
     nonce,
-    api: client.api,
+    client,
   };
 
   expect(fetchMock.mock.calls[0][0]).toEqual(`${HIRO_TESTNET_URL}/v2/pox`);
   expect(makeContractCall).toHaveBeenCalledTimes(1);
   expect(makeContractCall).toHaveBeenCalledWith(expectedContractCallOptions);
   expect(broadcastTransaction).toHaveBeenCalledTimes(1);
-  expect(broadcastTransaction).toHaveBeenCalledWith({ transaction, api: client.api });
+  expect(broadcastTransaction).toHaveBeenCalledWith({ transaction, client });
   expect(delegateResults).toEqual(broadcastResponse);
   expect(isPoxAbiValid(expectedContractCallOptions)).toBe(true);
 });
@@ -704,14 +704,14 @@ test('delegator commit', async () => {
     validateWithAbi: true,
     network,
     senderKey: privateKey,
-    api: client.api,
+    client,
   };
 
   expect(fetchMock.mock.calls[0][0]).toEqual(`${HIRO_TESTNET_URL}/v2/pox`);
   expect(makeContractCall).toHaveBeenCalledTimes(1);
   expect(makeContractCall).toHaveBeenCalledWith(expectedContractCallOptions);
   expect(broadcastTransaction).toHaveBeenCalledTimes(1);
-  expect(broadcastTransaction).toHaveBeenCalledWith({ transaction, api: client.api });
+  expect(broadcastTransaction).toHaveBeenCalledWith({ transaction, client });
   expect(delegateResults).toEqual(broadcastResponse);
   expect(isPoxAbiValid(expectedContractCallOptions)).toBe(true);
 });
@@ -753,14 +753,14 @@ test('revoke delegate stx', async () => {
     validateWithAbi: true,
     network,
     senderKey: privateKey,
-    api: client.api,
+    client,
   };
 
   expect(fetchMock.mock.calls[0][0]).toEqual(`${HIRO_TESTNET_URL}/v2/pox`);
   expect(makeContractCall).toHaveBeenCalledTimes(1);
   expect(makeContractCall).toHaveBeenCalledWith(expectedContractCallOptions);
   expect(broadcastTransaction).toHaveBeenCalledTimes(1);
-  expect(broadcastTransaction).toHaveBeenCalledWith({ transaction, api: client.api });
+  expect(broadcastTransaction).toHaveBeenCalledWith({ transaction, client });
   expect(revokeDelegateResults).toEqual(broadcastResponse);
   expect(isPoxAbiValid(expectedContractCallOptions)).toBe(true);
 });
@@ -820,7 +820,7 @@ test('get stacking status', async () => {
     functionName: 'get-stacker-info',
     functionArgs: [standardPrincipalCV(address)],
     senderAddress: address,
-    api: client.api,
+    client,
   };
 
   expect(fetchCallReadOnlyFunction).toHaveBeenCalledTimes(1);

--- a/packages/stacking/tsconfig.build.json
+++ b/packages/stacking/tsconfig.build.json
@@ -9,9 +9,6 @@
   },
   "references": [
     {
-      "path": "../api/tsconfig.build.json"
-    },
-    {
       "path": "../common/tsconfig.build.json"
     },
     {

--- a/packages/transactions/src/builders.ts
+++ b/packages/transactions/src/builders.ts
@@ -257,7 +257,7 @@ export interface BaseContractDeployOptions {
   /** the network that the transaction will ultimately be broadcast to */
   network?: StacksNetworkName | StacksNetwork;
   /** the node/API used for estimating fee & nonce (using the `api.fetchFn` */
-  api?: ClientOpts;
+  client?: ClientOpts;
   /** the post condition mode, specifying whether or not post-conditions must fully cover all
    * transfered assets */
   postConditionMode?: PostConditionMode;
@@ -336,7 +336,7 @@ export async function makeUnsignedContractDeploy(
   };
 
   const options = Object.assign(defaultOptions, txOptions);
-  options.api = defaultClientOptsFromNetwork(options.network, txOptions.api);
+  options.client = defaultClientOptsFromNetwork(options.network, txOptions.client);
 
   const payload = createSmartContractPayload(
     options.contractName,
@@ -403,14 +403,14 @@ export async function makeUnsignedContractDeploy(
   );
 
   if (txOptions.fee === undefined || txOptions.fee === null) {
-    const fee = await fetchFeeEstimate({ transaction, client: options.api });
+    const fee = await fetchFeeEstimate({ transaction, client: options.client });
     transaction.setFee(fee);
   }
 
   if (txOptions.nonce === undefined || txOptions.nonce === null) {
     const addressVersion = network.addressVersion.singleSig;
     const address = c32address(addressVersion, transaction.auth.spendingCondition!.signer);
-    const txNonce = await fetchNonce({ address, client: options.api });
+    const txNonce = await fetchNonce({ address, client: options.client });
     transaction.setNonce(txNonce);
   }
 
@@ -627,7 +627,7 @@ export interface SponsorOptionsOpts {
   /** the Stacks blockchain network that this transaction will ultimately be broadcast to */
   network?: StacksNetworkName | StacksNetwork;
   /** the node/API used for estimating fee & nonce (using the `api.fetchFn` */
-  api?: ClientOpts;
+  client?: ClientOpts;
 }
 
 /**
@@ -655,7 +655,7 @@ export async function sponsorTransaction(
   };
 
   const options = Object.assign(defaultOptions, sponsorOptions);
-  options.api = defaultClientOptsFromNetwork(options.network, sponsorOptions.api);
+  options.client = defaultClientOptsFromNetwork(options.network, sponsorOptions.client);
 
   const network = networkFrom(options.network);
   const sponsorPubKey = privateKeyToPublic(options.sponsorPrivateKey);
@@ -683,7 +683,7 @@ export async function sponsorTransaction(
   if (sponsorOptions.sponsorNonce == null) {
     const addressVersion = network.addressVersion.singleSig;
     const address = publicKeyToAddress(addressVersion, sponsorPubKey);
-    const sponsorNonce = await fetchNonce({ address, client: options.api });
+    const sponsorNonce = await fetchNonce({ address, client: options.client });
     options.sponsorNonce = sponsorNonce;
   }
 

--- a/packages/transactions/src/utils.ts
+++ b/packages/transactions/src/utils.ts
@@ -2,18 +2,10 @@ import { ripemd160 } from '@noble/hashes/ripemd160';
 import { sha256 } from '@noble/hashes/sha256';
 import { sha512_256 } from '@noble/hashes/sha512';
 import { utils } from '@noble/secp256k1';
-import {
-  ApiOpts,
-  bytesToHex,
-  concatArray,
-  concatBytes,
-  createFetchFn,
-  utf8ToBytes,
-} from '@stacks/common';
+import { bytesToHex, concatArray, concatBytes, utf8ToBytes } from '@stacks/common';
 import { c32addressDecode } from 'c32check';
 import lodashCloneDeep from 'lodash.clonedeep';
 import { ClarityValue, deserializeCV, serializeCV } from './clarity';
-import { StacksNetwork, deriveDefaultUrl, StacksNetworkName } from '@stacks/network';
 import { ContractIdString } from './types';
 
 // Export verify as utility method for signature verification
@@ -202,21 +194,6 @@ export const validateStacksAddress = (address: string): boolean => {
   } catch (e) {
     return false;
   }
-};
-
-/** @internal */
-export const defaultApiFromNetwork = (
-  network: StacksNetworkName | StacksNetwork,
-  override?: ApiOpts
-): Required<ApiOpts> => {
-  return Object.assign(
-    {},
-    {
-      url: deriveDefaultUrl(network),
-      fetch: createFetchFn(),
-    },
-    override
-  );
 };
 
 /** @internal */

--- a/packages/transactions/tests/builder.test.ts
+++ b/packages/transactions/tests/builder.test.ts
@@ -131,7 +131,7 @@ test('API key middleware - get nonce', async () => {
   fetchMock.mockRejectOnce();
   fetchMock.mockOnce(`{"balance": "0", "nonce": "123"}`);
 
-  const fetchedNonce = await fetchNonce({ address, api });
+  const fetchedNonce = await fetchNonce({ address, client: api });
   expect(fetchedNonce).toBe(123n);
   expect(fetchMock.mock.calls.length).toEqual(2);
   expect(fetchMock.mock.calls[1][0]).toEqual(
@@ -1142,7 +1142,7 @@ test('Estimate transaction transfer fee', async () => {
   const resultEstimateFee = await fetchFeeEstimateTransaction({
     payload: bytesToHex(serializePayloadBytes(transaction.payload)),
     estimatedLength: transactionByteLength,
-    api: mainnet,
+    client: mainnet,
   });
 
   fetchMock.mockOnce(mockedResponse);
@@ -1151,7 +1151,7 @@ test('Estimate transaction transfer fee', async () => {
   const resultEstimateFee2 = await fetchFeeEstimateTransaction({
     payload: bytesToHex(serializePayloadBytes(transaction.payload)),
     estimatedLength: transactionByteLength,
-    api: testnet,
+    client: testnet,
   });
 
   expect(fetchMock.mock.calls.length).toEqual(2);
@@ -1195,7 +1195,7 @@ test('Estimate transaction fee fallback', async () => {
     functionArgs: [uintCV(100_000), principalCV(poolAddress), noneCV(), noneCV()],
     nonce: 1,
     network: STACKS_TESTNET,
-    api,
+    client: api,
   });
 
   // http://localhost:3999/v2/fees/transaction
@@ -1208,7 +1208,7 @@ test('Estimate transaction fee fallback', async () => {
   fetchMock.once('1');
 
   const testnet = { url: HIRO_TESTNET_URL };
-  const resultEstimateFee = await fetchFeeEstimate({ transaction, api: testnet });
+  const resultEstimateFee = await fetchFeeEstimate({ transaction, client: testnet });
   expect(resultEstimateFee).toBe(201n);
 
   // http://localhost:3999/v2/fees/transaction
@@ -1220,7 +1220,7 @@ test('Estimate transaction fee fallback', async () => {
   // http://localhost:3999/v2/fees/transfer
   fetchMock.once('2'); // double
 
-  const doubleRate = await fetchFeeEstimate({ transaction, api: testnet });
+  const doubleRate = await fetchFeeEstimate({ transaction, client: testnet });
   expect(doubleRate).toBe(402n);
 
   expect(fetchMock.mock.calls.length).toEqual(6);
@@ -1350,7 +1350,7 @@ test('Make STX token transfer with fetch account nonce', async () => {
   fetchMock.mockOnce(`{"balance":"0", "nonce":${nonce}}`);
   const fetchedNonce = await fetchNonce({
     address,
-    api: { url: HIRO_TESTNET_URL },
+    client: { baseUrl: HIRO_TESTNET_URL },
   });
 
   fetchMock.mockRejectOnce();
@@ -1603,7 +1603,7 @@ test('Make sponsored STX token transfer with set tx fee', async () => {
     fee,
     nonce,
     sponsored: true,
-    api,
+    client: api,
   });
 
   const sponsorOptions = {
@@ -1776,7 +1776,7 @@ test('Transaction broadcast success', async () => {
   const txid = transaction.txid();
   fetchMock.mockOnce(`"${txid}"`);
 
-  const response: TxBroadcastResult = await broadcastTransaction({ transaction, api });
+  const response: TxBroadcastResult = await broadcastTransaction({ transaction, client: api });
 
   expect(fetchMock.mock.calls.length).toEqual(1);
   expect(fetchMock.mock.calls[0][0]).toEqual(`${api.url}${BROADCAST_PATH}`);
@@ -2089,8 +2089,8 @@ describe(fetchNonce.name, () => {
     await expect(
       fetchNonce({
         address,
-        api: {
-          url: HIRO_TESTNET_URL,
+        client: {
+          baseUrl: HIRO_TESTNET_URL,
         },
       })
     ).resolves.toEqual(nonce);
@@ -2113,8 +2113,8 @@ describe(fetchNonce.name, () => {
     await expect(
       fetchNonce({
         address,
-        api: {
-          url: HIRO_TESTNET_URL,
+        client: {
+          baseUrl: HIRO_TESTNET_URL,
         },
       })
     ).resolves.toEqual(nonce);

--- a/packages/transactions/tests/fetchUtil.test.ts
+++ b/packages/transactions/tests/fetchUtil.test.ts
@@ -21,7 +21,7 @@ test('fetchFn is used in network requests', async () => {
   const txid = transaction.txid();
   fetchMock.mockOnce(`"${txid}"`);
 
-  await broadcastTransaction({ transaction, api });
+  await broadcastTransaction({ transaction, client: api });
 
   expect((fetchMock.mock.calls[0][1]?.headers as Headers)?.get('x-api-key')).toContain(apiKey);
 });

--- a/packages/wallet-sdk/src/derive.ts
+++ b/packages/wallet-sdk/src/derive.ts
@@ -8,7 +8,7 @@ import {
   STACKS_MAINNET,
   StacksNetwork,
   StacksNetworkName,
-  deriveDefaultUrl,
+  defaultUrlFromNetwork,
   networkFrom,
 } from '@stacks/network';
 import { compressPrivateKey, getAddressFromPrivateKey } from '@stacks/transactions';
@@ -181,7 +181,7 @@ const selectUsernameForAccount = async (
     network?: StacksNetwork;
   } & ApiParam
 ): Promise<{ username: string | undefined; derivationType: DerivationType }> => {
-  const api = defaultApiLike({ ...{ url: deriveDefaultUrl(opts.network) }, ...opts.api });
+  const api = defaultApiLike({ ...{ url: defaultUrlFromNetwork(opts.network) }, ...opts.api });
 
   // try to find existing usernames owned by stx derivation path
   if (opts.network) {
@@ -215,7 +215,7 @@ export const fetchUsernameForAccountByDerivationType = async (
 ): Promise<{
   username: string | undefined;
 }> => {
-  const api = defaultApiLike({ ...{ url: deriveDefaultUrl(opts.network) }, ...opts.api });
+  const api = defaultApiLike({ ...{ url: defaultUrlFromNetwork(opts.network) }, ...opts.api });
 
   // try to find existing usernames owned by given derivation path
   const selectedNetwork = opts.network ? networkFrom(opts.network) : STACKS_MAINNET;

--- a/packages/wallet-sdk/src/derive.ts
+++ b/packages/wallet-sdk/src/derive.ts
@@ -2,13 +2,13 @@
 // Secure, audited & minimal implementation of BIP32 hierarchical deterministic (HD) wallets.
 import { HDKey } from '@scure/bip32';
 import { getNameInfo } from '@stacks/auth';
-import { ApiParam, bytesToHex, defaultApiLike, utf8ToBytes } from '@stacks/common';
+import { ClientParam, bytesToHex, utf8ToBytes } from '@stacks/common';
 import { createSha2Hash } from '@stacks/encryption';
 import {
   STACKS_MAINNET,
   StacksNetwork,
   StacksNetworkName,
-  defaultUrlFromNetwork,
+  defaultClientOptsFromNetwork,
   networkFrom,
 } from '@stacks/network';
 import { compressPrivateKey, getAddressFromPrivateKey } from '@stacks/transactions';
@@ -179,22 +179,22 @@ const selectUsernameForAccount = async (
     rootNode: HDKey;
     index: number;
     network?: StacksNetwork;
-  } & ApiParam
+  } & ClientParam
 ): Promise<{ username: string | undefined; derivationType: DerivationType }> => {
-  const api = defaultApiLike({ ...{ url: defaultUrlFromNetwork(opts.network) }, ...opts.api });
+  const client = defaultClientOptsFromNetwork(opts.network, opts.client);
 
   // try to find existing usernames owned by stx derivation path
   if (opts.network) {
     const stxPrivateKey = deriveStxPrivateKey(opts);
     const address = getAddressFromPrivateKey(stxPrivateKey, opts.network);
-    let username = await fetchFirstName({ address, api });
+    let username = await fetchFirstName({ address, client });
     if (username) {
       return { username, derivationType: DerivationType.Wallet };
     } else {
       // try to find existing usernames owned by data derivation path
       const dataPrivateKey = deriveDataPrivateKey(opts);
       const address = getAddressFromPrivateKey(dataPrivateKey, opts.network);
-      username = await fetchFirstName({ address, api });
+      username = await fetchFirstName({ address, client });
       if (username) {
         return { username, derivationType: DerivationType.Data };
       }
@@ -211,17 +211,17 @@ export const fetchUsernameForAccountByDerivationType = async (
     index: number;
     derivationType: DerivationType.Wallet | DerivationType.Data;
     network?: StacksNetworkName | StacksNetwork;
-  } & ApiParam
+  } & ClientParam
 ): Promise<{
   username: string | undefined;
 }> => {
-  const api = defaultApiLike({ ...{ url: defaultUrlFromNetwork(opts.network) }, ...opts.api });
+  const client = defaultClientOptsFromNetwork(opts.network, opts.client);
 
   // try to find existing usernames owned by given derivation path
   const selectedNetwork = opts.network ? networkFrom(opts.network) : STACKS_MAINNET;
   const privateKey = derivePrivateKeyByType(opts);
   const address = getAddressFromPrivateKey(privateKey, selectedNetwork);
-  const username = await fetchFirstName({ address, api });
+  const username = await fetchFirstName({ address, client });
   return { username };
 };
 

--- a/packages/wallet-sdk/src/models/wallet.ts
+++ b/packages/wallet-sdk/src/models/wallet.ts
@@ -1,11 +1,11 @@
+import { ClientParam, defaultClientOpts } from '@stacks/common';
 import { StacksNetwork } from '@stacks/network';
 import { DerivationType, deriveStxPrivateKey, fetchUsernameForAccountByDerivationType } from '..';
 import { deriveAccount, deriveLegacyConfigPrivateKey } from '../derive';
 import { connectToGaiaHubWithConfig, getHubInfo } from '../utils';
 import { Wallet, getRootNode } from './common';
 import { fetchLegacyWalletConfig } from './legacy-wallet-config';
-import { fetchWalletConfig, updateWalletConfig, WalletConfig } from './wallet-config';
-import { ApiParam, defaultApiLike } from '@stacks/common';
+import { WalletConfig, fetchWalletConfig, updateWalletConfig } from './wallet-config';
 
 export interface LockedWallet {
   encryptedSecretKey: string;
@@ -22,13 +22,13 @@ export async function restoreWalletAccounts({
   wallet,
   gaiaHubUrl,
   network,
-  api: apiOpt,
+  client: clientOpts,
 }: {
   wallet: Wallet;
   gaiaHubUrl: string;
   network: StacksNetwork;
-} & ApiParam): Promise<Wallet> {
-  const api = defaultApiLike(apiOpt);
+} & ClientParam): Promise<Wallet> {
+  const api = defaultClientOpts(clientOpts);
 
   const hubInfo = await getHubInfo(gaiaHubUrl, api.fetch);
   const rootNode = getRootNode(wallet);

--- a/packages/wallet-sdk/src/usernames.ts
+++ b/packages/wallet-sdk/src/usernames.ts
@@ -1,13 +1,15 @@
-import { ApiParam, defaultApiLike } from '@stacks/common';
+import { ClientParam, defaultClientOpts } from '@stacks/common';
 
 export const fetchFirstName = async (
   opts: {
     address: string;
-  } & ApiParam
+  } & ClientParam
 ): Promise<string | undefined> => {
-  const api = defaultApiLike(opts.api);
+  const client = defaultClientOpts(opts.client);
   try {
-    const namesResponse = await api.fetch(`${api.url}/v1/addresses/stacks/${opts.address}`);
+    const namesResponse = await client.fetch(
+      `${client.baseUrl}/v1/addresses/stacks/${opts.address}`
+    );
     const namesJson = await namesResponse.json();
     if ((namesJson.names.length || 0) > 0) {
       return namesJson.names[0];


### PR DESCRIPTION
> This PR was published to npm with the version `6.14.1-pr.68+9f9cb5d0`
> e.g. `npm install @stacks/common@6.14.1-pr.68+9f9cb5d0 --save-exact`<!-- Sticky Header Marker -->

- undo changes introducing `StacksNodeApi`
- rename `api` to `client` to match the API blockchain client and RPC

_review_: no new functions added in `StackingClient` but reverting a previous change