### PR TITLE
fix: allow read-only headers in fetch

### DIFF
--- a/packages/network/src/fetch.ts
+++ b/packages/network/src/fetch.ts
@@ -108,9 +108,11 @@ export function createApiKeyMiddleware({
       const reqUrl = new URL(context.url);
       if (!hostMatches(reqUrl.host, host)) return; // Skip middleware if host does not match pattern
 
-      const headers = new Headers(context.init.headers);
+      const headers =
+        context.init.headers instanceof Headers
+          ? context.init.headers
+          : (context.init.headers = new Headers(context.init.headers));
       headers.set(httpHeader, apiKey);
-      context.init.headers = headers;
     },
   };
 }


### PR DESCRIPTION
> This PR was published to npm with the version `6.16.1`
> e.g. `npm install @stacks/common@6.16.1 --save-exact`<!-- Sticky Header Marker -->

> This fixes a bug where in some instances the headers property is a read-only getter and cannot be re-assigned.

Taken from the other PR

Closes #1737