### PR TITLE
feat: detect chainID by default for testnet networks in tx builder functions

### DIFF
--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -24,7 +24,7 @@ import {
   WalletKeyInfoResult,
 } from './derivation-path/keychain';
 import * as fixtures from './fixtures/cli.fixture';
-import { bytesToHex, ChainID } from '@stacks/common';
+import { bytesToHex } from '@stacks/common';
 
 const TEST_ABI: ClarityAbi = JSON.parse(
   readFileSync(path.join(__dirname, './abi/test-abi.json')).toString()
@@ -111,9 +111,7 @@ describe('Contract function call', () => {
     // @ts-ignore
     inquirer.prompt = jest.fn().mockResolvedValue(contractInputArg);
 
-    fetchMock.once(JSON.stringify(TEST_ABI));
-    fetchMock.once(JSON.stringify({ network_id: ChainID.Testnet }));
-    fetchMock.once('success');
+    fetchMock.once(JSON.stringify(TEST_ABI)).once('success');
 
     const txid = '0x6c764e276b500babdac6cec159667f4b68938d31eee82419473a418222af7d5d';
     const result = await contractFunctionCall(testnetNetwork, args);
@@ -134,9 +132,7 @@ describe('Contract function call', () => {
     // @ts-ignore
     inquirer.prompt = jest.fn().mockResolvedValue(contractInputArg);
 
-    fetchMock.once(JSON.stringify(TEST_ABI));
-    fetchMock.once(JSON.stringify({ network_id: ChainID.Testnet }));
-    fetchMock.once('success');
+    fetchMock.once(JSON.stringify(TEST_ABI)).once('success');
 
     const txid = '0x97f41dfa44a5833acd9ca30ffe31d7137623c0e31a5c6467daeed8e61a03f51c';
     const result = await contractFunctionCall(testnetNetwork, args);
@@ -157,9 +153,7 @@ describe('Contract function call', () => {
     // @ts-ignore
     inquirer.prompt = jest.fn().mockResolvedValue(contractInputArg);
 
-    fetchMock.once(JSON.stringify(TEST_ABI));
-    fetchMock.once(JSON.stringify({ network_id: ChainID.Testnet }));
-    fetchMock.once('success');
+    fetchMock.once(JSON.stringify(TEST_ABI)).once('success');
 
     const txid = '0x5fc468f21345c5ecaf1c007fce9630d9a79ec1945ed8652cc3c42fb542e35fe2';
     const result = await contractFunctionCall(testnetNetwork, args);
@@ -184,9 +178,7 @@ describe('Contract function call', () => {
     // @ts-ignore
     inquirer.prompt = jest.fn().mockResolvedValue(contractInputArg);
 
-    fetchMock.once(JSON.stringify(TEST_ABI));
-    fetchMock.once(JSON.stringify({ network_id: ChainID.Testnet }));
-    fetchMock.once('success');
+    fetchMock.once(JSON.stringify(TEST_ABI)).once('success');
 
     const txid = '0x94b1cfab79555b8c6725f19e4fcd6268934d905578a3e8ef7a1e542b931d3676';
     const result = await contractFunctionCall(testnetNetwork, args);
@@ -209,9 +201,7 @@ describe('Contract function call', () => {
     // @ts-ignore
     inquirer.prompt = jest.fn().mockResolvedValue(contractInputArg);
 
-    fetchMock.once(JSON.stringify(TEST_ABI));
-    fetchMock.once(JSON.stringify({ network_id: ChainID.Testnet }));
-    fetchMock.once('success');
+    fetchMock.once(JSON.stringify(TEST_ABI)).once('success');
 
     const txid = '0x6b6cd5bfb44c46a68090f0c5f659e9cc02518eafab67b0b740e1e77a55bbf284';
     const result = await contractFunctionCall(testnetNetwork, args);
@@ -296,7 +286,6 @@ describe('BNS', () => {
     fetchMock.mockOnce(mockedResponse);
     fetchMock.mockRejectOnce();
     fetchMock.mockOnce(JSON.stringify({ nonce: 1000 }));
-    fetchMock.mockOnce(JSON.stringify({ network_id: ChainID.Testnet }));
     fetchMock.mockOnce(JSON.stringify('success'));
 
     const txResult = await register(testnetNetwork, args);
@@ -317,7 +306,6 @@ describe('BNS', () => {
     fetchMock.mockOnce(mockedResponse);
     fetchMock.mockRejectOnce();
     fetchMock.mockOnce(JSON.stringify({ nonce: 1000 }));
-    fetchMock.mockOnce(JSON.stringify({ network_id: ChainID.Testnet }));
     fetchMock.mockOnce(JSON.stringify('success'));
 
     const txResult = await preorder(testnetNetwork, args);

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -24,7 +24,7 @@ import {
   WalletKeyInfoResult,
 } from './derivation-path/keychain';
 import * as fixtures from './fixtures/cli.fixture';
-import { bytesToHex } from '@stacks/common';
+import { bytesToHex, ChainID } from '@stacks/common';
 
 const TEST_ABI: ClarityAbi = JSON.parse(
   readFileSync(path.join(__dirname, './abi/test-abi.json')).toString()
@@ -111,7 +111,9 @@ describe('Contract function call', () => {
     // @ts-ignore
     inquirer.prompt = jest.fn().mockResolvedValue(contractInputArg);
 
-    fetchMock.once(JSON.stringify(TEST_ABI)).once('success');
+    fetchMock.once(JSON.stringify(TEST_ABI));
+    fetchMock.once(JSON.stringify({ network_id: ChainID.Testnet }));
+    fetchMock.once('success');
 
     const txid = '0x6c764e276b500babdac6cec159667f4b68938d31eee82419473a418222af7d5d';
     const result = await contractFunctionCall(testnetNetwork, args);
@@ -132,7 +134,9 @@ describe('Contract function call', () => {
     // @ts-ignore
     inquirer.prompt = jest.fn().mockResolvedValue(contractInputArg);
 
-    fetchMock.once(JSON.stringify(TEST_ABI)).once('success');
+    fetchMock.once(JSON.stringify(TEST_ABI));
+    fetchMock.once(JSON.stringify({ network_id: ChainID.Testnet }));
+    fetchMock.once('success');
 
     const txid = '0x97f41dfa44a5833acd9ca30ffe31d7137623c0e31a5c6467daeed8e61a03f51c';
     const result = await contractFunctionCall(testnetNetwork, args);
@@ -153,7 +157,9 @@ describe('Contract function call', () => {
     // @ts-ignore
     inquirer.prompt = jest.fn().mockResolvedValue(contractInputArg);
 
-    fetchMock.once(JSON.stringify(TEST_ABI)).once('success');
+    fetchMock.once(JSON.stringify(TEST_ABI));
+    fetchMock.once(JSON.stringify({ network_id: ChainID.Testnet }));
+    fetchMock.once('success');
 
     const txid = '0x5fc468f21345c5ecaf1c007fce9630d9a79ec1945ed8652cc3c42fb542e35fe2';
     const result = await contractFunctionCall(testnetNetwork, args);
@@ -178,7 +184,9 @@ describe('Contract function call', () => {
     // @ts-ignore
     inquirer.prompt = jest.fn().mockResolvedValue(contractInputArg);
 
-    fetchMock.once(JSON.stringify(TEST_ABI)).once('success');
+    fetchMock.once(JSON.stringify(TEST_ABI));
+    fetchMock.once(JSON.stringify({ network_id: ChainID.Testnet }));
+    fetchMock.once('success');
 
     const txid = '0x94b1cfab79555b8c6725f19e4fcd6268934d905578a3e8ef7a1e542b931d3676';
     const result = await contractFunctionCall(testnetNetwork, args);
@@ -201,7 +209,9 @@ describe('Contract function call', () => {
     // @ts-ignore
     inquirer.prompt = jest.fn().mockResolvedValue(contractInputArg);
 
-    fetchMock.once(JSON.stringify(TEST_ABI)).once('success');
+    fetchMock.once(JSON.stringify(TEST_ABI));
+    fetchMock.once(JSON.stringify({ network_id: ChainID.Testnet }));
+    fetchMock.once('success');
 
     const txid = '0x6b6cd5bfb44c46a68090f0c5f659e9cc02518eafab67b0b740e1e77a55bbf284';
     const result = await contractFunctionCall(testnetNetwork, args);
@@ -286,6 +296,7 @@ describe('BNS', () => {
     fetchMock.mockOnce(mockedResponse);
     fetchMock.mockRejectOnce();
     fetchMock.mockOnce(JSON.stringify({ nonce: 1000 }));
+    fetchMock.mockOnce(JSON.stringify({ network_id: ChainID.Testnet }));
     fetchMock.mockOnce(JSON.stringify('success'));
 
     const txResult = await register(testnetNetwork, args);
@@ -306,6 +317,7 @@ describe('BNS', () => {
     fetchMock.mockOnce(mockedResponse);
     fetchMock.mockRejectOnce();
     fetchMock.mockOnce(JSON.stringify({ nonce: 1000 }));
+    fetchMock.mockOnce(JSON.stringify({ network_id: ChainID.Testnet }));
     fetchMock.mockOnce(JSON.stringify('success'));
 
     const txResult = await preorder(testnetNetwork, args);

--- a/packages/transactions/src/builders.ts
+++ b/packages/transactions/src/builders.ts
@@ -6,6 +6,7 @@ import {
   StacksTestnet,
   FetchFn,
   createFetchFn,
+  HIRO_TESTNET_DEFAULT,
 } from '@stacks/network';
 import { c32address } from 'c32check';
 import {
@@ -138,6 +139,13 @@ export async function getNetworkChainID(network: StacksNetwork, useDefaultOnErro
     console.warn(`Error fetching network chain ID from ${url}`, error);
     return network.chainId;
   }
+}
+
+function isNetworkCustomTestnet(network: StacksNetwork) {
+  return (
+    network.version !== TransactionVersion.Mainnet &&
+    new URL(network.coreApiUrl).host !== new URL(HIRO_TESTNET_DEFAULT).host
+  );
 }
 
 /**
@@ -775,8 +783,8 @@ export async function makeUnsignedSTXTokenTransfer(
     transaction.setNonce(txNonce);
   }
 
-  // Lookup chain ID for testnet networks
-  if (network.version !== TransactionVersion.Mainnet) {
+  // Lookup chain ID for (non-primary) testnet networks
+  if (isNetworkCustomTestnet(network)) {
     transaction.chainId = await getNetworkChainID(network);
   }
 
@@ -1053,11 +1061,10 @@ export async function makeUnsignedContractDeploy(
     transaction.setNonce(txNonce);
   }
 
-  // Lookup chain ID for testnet networks
-  if (network.version !== TransactionVersion.Mainnet) {
+  // Lookup chain ID for (non-primary) testnet networks
+  if (isNetworkCustomTestnet(network)) {
     transaction.chainId = await getNetworkChainID(network);
   }
-
 
   return transaction;
 }
@@ -1272,8 +1279,8 @@ export async function makeUnsignedContractCall(
     transaction.setNonce(txNonce);
   }
 
-  // Lookup chain ID for testnet networks
-  if (network.version !== TransactionVersion.Mainnet) {
+  // Lookup chain ID for (non-primary) testnet networks
+  if (isNetworkCustomTestnet(network)) {
     transaction.chainId = await getNetworkChainID(network);
   }
 

--- a/packages/transactions/tests/builder.test.ts
+++ b/packages/transactions/tests/builder.test.ts
@@ -1,4 +1,5 @@
 import {
+  ChainID,
   PRIVATE_KEY_COMPRESSED_LENGTH,
   bytesToHex,
   bytesToUtf8,
@@ -1242,6 +1243,9 @@ test('Estimate transaction fee fallback', async () => {
   // http://localhost:3999/v2/fees/transfer
   fetchMock.once('1');
 
+  // http://localhost:3999/v2/info
+  fetchMock.once(JSON.stringify({ network_id: ChainID.Testnet }));
+
   const tx = await makeContractCall({
     senderKey: privateKey,
     contractAddress: 'ST000000000000000000002AMW42H',
@@ -1291,7 +1295,7 @@ test('Estimate transaction fee fallback', async () => {
   const doubleRate = await estimateTransactionFeeWithFallback(tx, testnet);
   expect(doubleRate).toBe(402n);
 
-  expect(fetchMock.mock.calls.length).toEqual(8);
+  expect(fetchMock.mock.calls.length).toEqual(9);
 });
 
 test('Single-sig transaction byte length must include signature', async () => {
@@ -1427,6 +1431,9 @@ test('Make STX token transfer with fetch account nonce', async () => {
   fetchMock.mockRejectOnce();
   fetchMock.mockOnce(`{"balance":"0", "nonce":${nonce}}`);
 
+  // http://localhost:3999/v2/info
+  fetchMock.once(JSON.stringify({ network_id: ChainID.Testnet }));
+
   const transaction = await makeSTXTokenTransfer({
     recipient,
     amount,
@@ -1437,9 +1444,10 @@ test('Make STX token transfer with fetch account nonce', async () => {
     anchorMode: AnchorMode.Any,
   });
 
-  expect(fetchMock.mock.calls.length).toEqual(4);
+  expect(fetchMock.mock.calls.length).toEqual(5);
   expect(fetchMock.mock.calls[1][0]).toEqual(apiUrl);
   expect(fetchMock.mock.calls[3][0]).toEqual(apiUrl);
+  expect(fetchMock.mock.calls[4][0]).toEqual(network.getInfoUrl());
   expect(fetchNonce.toString()).toEqual(nonce.toString());
   expect(transaction.auth.spendingCondition?.nonce?.toString()).toEqual(nonce.toString());
 });
@@ -1670,6 +1678,9 @@ test('Make sponsored STX token transfer with set tx fee', async () => {
   const sponsorNonce = 0;
   const sponsorFee = 500;
 
+  // http://localhost:3999/v2/info
+  fetchMock.once(JSON.stringify({ network_id: ChainID.Testnet }));
+
   const transaction = await makeSTXTokenTransfer({
     recipient,
     amount,
@@ -1695,7 +1706,7 @@ test('Make sponsored STX token transfer with set tx fee', async () => {
   const bytesReader = new BytesReader(sponsorSignedTxSerialized);
   const deserializedSponsorTx = deserializeTransaction(bytesReader);
 
-  expect(fetchMock.mock.calls.length).toEqual(0);
+  expect(fetchMock.mock.calls.length).toEqual(1);
   expect(deserializedSponsorTx.auth.spendingCondition!.nonce!.toString()).toBe(nonce.toString());
   expect(deserializedSponsorTx.auth.spendingCondition!.fee!.toString()).toBe(fee.toString());
 
@@ -1725,6 +1736,9 @@ test('Make sponsored contract deploy with sponsor fee estimate', async () => {
   const authType = AuthType.Sponsored;
   const addressHashMode = AddressHashMode.SerializeP2PKH;
 
+  // http://localhost:3999/v2/info
+  fetchMock.once(JSON.stringify({ network_id: ChainID.Testnet }));
+
   const transaction = await makeContractDeploy({
     contractName,
     codeBody,
@@ -1745,7 +1759,7 @@ test('Make sponsored contract deploy with sponsor fee estimate', async () => {
 
   const sponsorSignedTx = await sponsorTransaction(sponsorOptions);
 
-  expect(fetchMock.mock.calls.length).toEqual(0);
+  expect(fetchMock.mock.calls.length).toEqual(1);
 
   const sponsorSignedTxSerialized = sponsorSignedTx.serialize();
 
@@ -1784,6 +1798,9 @@ test('Make sponsored contract call with sponsor nonce fetch', async () => {
   const authType = AuthType.Sponsored;
   const addressHashMode = AddressHashMode.SerializeP2PKH;
 
+  // http://localhost:3999/v2/info
+  fetchMock.once(JSON.stringify({ network_id: ChainID.Testnet }));
+
   const transaction = await makeContractCall({
     contractAddress,
     contractName,
@@ -1808,8 +1825,8 @@ test('Make sponsored contract call with sponsor nonce fetch', async () => {
 
   const sponsorSignedTx = await sponsorTransaction(sponsorOptions);
 
-  expect(fetchMock.mock.calls.length).toEqual(2);
-  expect(fetchMock.mock.calls[1][0]).toEqual(network.getAccountApiUrl(sponsorAddress));
+  expect(fetchMock.mock.calls.length).toEqual(3);
+  expect(fetchMock.mock.calls[2][0]).toEqual(network.getAccountApiUrl(sponsorAddress));
 
   const sponsorSignedTxSerialized = sponsorSignedTx.serialize();
 
@@ -1883,6 +1900,9 @@ test('Transaction broadcast success with string network name', async () => {
 });
 
 test('Transaction broadcast success with network detection', async () => {
+  // http://localhost:3999/v2/info
+  fetchMock.once(JSON.stringify({ network_id: ChainID.Testnet }));
+
   const transaction = await makeSTXTokenTransfer({
     recipient: standardPrincipalCV('SP3FGQ8Z7JY9BWYZ5WM53E0M9NK7WHJF0691NZ159'),
     amount: 12345,
@@ -1898,9 +1918,9 @@ test('Transaction broadcast success with network detection', async () => {
 
   const response: TxBroadcastResult = await broadcastTransaction(transaction);
 
-  expect(fetchMock.mock.calls.length).toEqual(1);
-  expect(fetchMock.mock.calls[0][0]).toEqual(new StacksTestnet().getBroadcastApiUrl());
-  expect(fetchMock.mock.calls[0][1]?.body).toEqual(transaction.serialize());
+  expect(fetchMock.mock.calls.length).toEqual(2);
+  expect(fetchMock.mock.calls[1][0]).toEqual(new StacksTestnet().getBroadcastApiUrl());
+  expect(fetchMock.mock.calls[1][1]?.body).toEqual(transaction.serialize());
   expect(response as TxBroadcastResultOk).toEqual({ txid: 'success' });
 });
 
@@ -2018,6 +2038,9 @@ test('Make contract-call with network ABI validation', async () => {
   const abi = fs.readFileSync('./tests/abi/kv-store-abi.json').toString();
   fetchMock.mockOnce(abi);
 
+  // http://localhost:3999/v2/info
+  fetchMock.once(JSON.stringify({ network_id: ChainID.Testnet }));
+
   await makeContractCall({
     contractAddress,
     contractName,
@@ -2032,7 +2055,7 @@ test('Make contract-call with network ABI validation', async () => {
     anchorMode: AnchorMode.Any,
   });
 
-  expect(fetchMock.mock.calls.length).toEqual(1);
+  expect(fetchMock.mock.calls.length).toEqual(2);
   expect(fetchMock.mock.calls[0][0]).toEqual(network.getAbiApiUrl(contractAddress, contractName));
 });
 


### PR DESCRIPTION
> This PR was published to npm with the version `6.16.1`
> e.g. `npm install @stacks/common@6.16.1 --save-exact`<!-- Sticky Header Marker -->

Updates the transaction builder functions to make them lookup the network `chain_id` by default when constructing txs for a custom testnet network. Behavior for mainnet and for primary testnet is unchanged.

**Non-breaking**
If the `/v2/info` request fails, e.g. when constructing a tx either offline or without expecting the network RPC to be available, then by default it will fallback to using the chainID already specified in the `network` object (which is typically either the default primary testnet chainID, or a user-specified chainID).