### PR TITLE
fix: Fix string parsing in signature decode

### DIFF
--- a/.github/MIGRATION.md
+++ b/.github/MIGRATION.md
@@ -308,6 +308,7 @@ This likely was a misunderstood and unused feature.
 - `AddressHashMode`: The `Serialize` prefixes were removed for brevity.
 - `makeRandomPrivKey` was renamed to `randomPrivateKey` and now returns a compressed private key.
 - `generateSecretKey` was renamed to `randomSeedPhrase`.
+- `getAesCbcOutputLength` was removed.
 
 ## Stacks.js (&lt;=4.x.x) → (5.x.x)
 

--- a/.github/MIGRATION.md
+++ b/.github/MIGRATION.md
@@ -308,7 +308,7 @@ This likely was a misunderstood and unused feature.
 - `AddressHashMode`: The `Serialize` prefixes were removed for brevity.
 - `makeRandomPrivKey` was renamed to `randomPrivateKey` and now returns a compressed private key.
 - `generateSecretKey` was renamed to `randomSeedPhrase`.
-- `getAesCbcOutputLength` was removed.
+- `nextYear`, `nextMonth`, `nextHour`, `makeUUID4`, `updateQueryStringParameter`, `getAesCbcOutputLength`, `getAPIUsageErrorMessage`, `isSameOriginAbsoluteUrl`, `isLaterVersion`, `getBase64OutputLength`, were marked as deprecated.
 
 ## Stacks.js (&lt;=4.x.x) → (5.x.x)
 

--- a/.github/MIGRATION.md
+++ b/.github/MIGRATION.md
@@ -305,6 +305,9 @@ This likely was a misunderstood and unused feature.
 
 ### Advanced: Refactorings
 
+- `encodeStructuredData` now returns a hex-encoded string instead of a Uint8Array (use `encodeStructuredDataBytes` if you need the raw bytes).
+- `decodeStructuredDataSignature` now returns a hex-encoded string instead of a Uint8Array (use `decodeStructuredDataSignatureBytes` if you need the raw bytes). Also fixes a bug that previously tried to parse input strings as UTF-8 bytes instead of hex-encoded strings.
+- `hashStructuredData` now returns a hex-encoded string instead of a Uint8Array (use `hashStructuredDataBytes` if you need the raw bytes).
 - `AddressHashMode`: The `Serialize` prefixes were removed for brevity.
 - `makeRandomPrivKey` was renamed to `randomPrivateKey` and now returns a compressed private key.
 - `generateSecretKey` was renamed to `randomSeedPhrase`.

--- a/packages/common/src/logger.ts
+++ b/packages/common/src/logger.ts
@@ -13,6 +13,7 @@ for (let index = 0; index < levels.length; index++) {
 
 /**
  * @ignore
+ * @deprecated
  */
 export class Logger {
   static error(message: string) {

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -50,6 +50,18 @@ export function megabytesToBytes(megabytes: number): number {
 }
 
 /**
+ * Calculate the AES-CBC ciphertext output byte length a given input length.
+ * AES has a fixed block size of 16-bytes regardless key size.
+ * @ignore
+ * @deprecated
+ */
+export function getAesCbcOutputLength(inputByteLength: number) {
+  // AES-CBC block mode rounds up to the next block size.
+  const cipherTextLength = (Math.floor(inputByteLength / 16) + 1) * 16;
+  return cipherTextLength;
+}
+
+/**
  * Calculate the base64 encoded string length for a given input length.
  * This is equivalent to the byte length when the string is ASCII or UTF8-8
  * encoded.

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -45,17 +45,6 @@ export function megabytesToBytes(megabytes: number): number {
 }
 
 /**
- * Calculate the AES-CBC ciphertext output byte length a given input length.
- * AES has a fixed block size of 16-bytes regardless key size.
- * @ignore
- */
-export function getAesCbcOutputLength(inputByteLength: number) {
-  // AES-CBC block mode rounds up to the next block size.
-  const cipherTextLength = (Math.floor(inputByteLength / 16) + 1) * 16;
-  return cipherTextLength;
-}
-
-/**
  * Calculate the base64 encoded string length for a given input length.
  * This is equivalent to the byte length when the string is ASCII or UTF8-8
  * encoded.

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -2,6 +2,7 @@ import { Logger } from './logger';
 
 /**
  *  @ignore
+ * @deprecated
  */
 export const BLOCKSTACK_HANDLER = 'blockstack';
 // todo: `next` get rid of all this blockstack stuff
@@ -10,6 +11,7 @@ export const BLOCKSTACK_HANDLER = 'blockstack';
  * Time
  * @private
  * @ignore
+ * @deprecated
  */
 export function nextYear() {
   return new Date(new Date().setFullYear(new Date().getFullYear() + 1));
@@ -19,6 +21,7 @@ export function nextYear() {
  * Time
  * @private
  * @ignore
+ * @deprecated
  */
 export function nextMonth() {
   return new Date(new Date().setMonth(new Date().getMonth() + 1));
@@ -28,6 +31,7 @@ export function nextMonth() {
  * Time
  * @private
  * @ignore
+ * @deprecated
  */
 export function nextHour() {
   return new Date(new Date().setHours(new Date().getHours() + 1));
@@ -36,6 +40,7 @@ export function nextHour() {
 /**
  * Converts megabytes to bytes. Returns 0 if the input is not a finite number.
  * @ignore
+ * @deprecated
  */
 export function megabytesToBytes(megabytes: number): number {
   if (!Number.isFinite(megabytes)) {
@@ -49,6 +54,7 @@ export function megabytesToBytes(megabytes: number): number {
  * This is equivalent to the byte length when the string is ASCII or UTF8-8
  * encoded.
  * @param number
+ * @deprecated
  */
 export function getBase64OutputLength(inputByteLength: number) {
   const encodedLength = Math.ceil(inputByteLength / 3) * 4;
@@ -59,8 +65,8 @@ export function getBase64OutputLength(inputByteLength: number) {
  * Query Strings
  * @private
  * @ignore
+ * @deprecated
  */
-
 export function updateQueryStringParameter(uri: string, key: string, value: string) {
   const re = new RegExp(`([?&])${key}=.*?(&|$)`, 'i');
   const separator = uri.indexOf('?') !== -1 ? '&' : '?';
@@ -78,8 +84,8 @@ export function updateQueryStringParameter(uri: string, key: string, value: stri
  * @returns {bool} iff v1 >= v2
  * @private
  * @ignore
+ * @deprecated
  */
-
 export function isLaterVersion(v1: string, v2: string) {
   if (v1 === undefined || v1 === '') {
     v1 = '0.0.0';
@@ -107,6 +113,7 @@ export function isLaterVersion(v1: string, v2: string) {
  * UUIDs
  * @private
  * @ignore
+ * @deprecated
  */
 export function makeUUID4() {
   let d = new Date().getTime();
@@ -127,6 +134,7 @@ export function makeUUID4() {
  * @return {Boolean} true if they pass the same origin check
  * @private
  * @ignore
+ * @deprecated
  */
 export function isSameOriginAbsoluteUrl(uri1: string, uri2: string) {
   try {
@@ -186,6 +194,7 @@ export function getGlobalScope(): Window {
   );
 }
 
+/** @deprecated */
 function getAPIUsageErrorMessage(
   scopeObject: unknown,
   apiName: string,
@@ -304,8 +313,18 @@ export function getGlobalObjects<K extends Extract<keyof Window, string>>(
   return result;
 }
 
+/** Different Integer representations */
 export type IntegerType = number | string | bigint | Uint8Array;
 
+/**
+ * Converts an integer-compatible value to a Uint8Array (given a byte length)
+ * @example
+ * ```ts
+ * import { intToBytes } from "@stacks/common";
+ * console.log(intToBytes(560, 4));
+ * // Uint8Array(4) [ 0, 0, 2, 48 ]
+ * ```
+ */
 export function intToBytes(value: IntegerType, byteLength: number): Uint8Array {
   return bigIntToBytes(intToBigInt(value), byteLength);
 }
@@ -376,16 +395,14 @@ export function hexToBigInt(hex: string): bigint {
 
 /**
  * Converts IntegerType to hex string
- * @ignore
  */
-export function intToHex(integer: IntegerType, lengthBytes = 8): string {
+export function intToHex(integer: IntegerType, byteLength = 8): string {
   const value = typeof integer === 'bigint' ? integer : intToBigInt(integer);
-  return value.toString(16).padStart(lengthBytes * 2, '0');
+  return value.toString(16).padStart(byteLength * 2, '0');
 }
 
 /**
  * Converts hex string to integer
- * @ignore
  */
 export function hexToInt(hex: string): number {
   return parseInt(hex, 16);

--- a/packages/encryption/src/cryptoUtils.ts
+++ b/packages/encryption/src/cryptoUtils.ts
@@ -32,11 +32,6 @@ export function isNodeCryptoAvailable<T>(
 export const NO_CRYPTO_LIB =
   'Crypto lib not found. Either the WebCrypto "crypto.subtle" or Node.js "crypto" module must be available.';
 
-export type TriplesecDecryptSignature = (
-  arg: { data: Uint8Array; key: Uint8Array },
-  cb: (err: Error | null, buff: Uint8Array | null) => void
-) => void;
-
 export interface WebCryptoLib {
   lib: SubtleCrypto;
   name: 'subtleCrypto';

--- a/packages/stacking/src/utils.ts
+++ b/packages/stacking/src/utils.ts
@@ -14,7 +14,7 @@ import {
   OptionalCV,
   TupleCV,
   bufferCV,
-  encodeStructuredData,
+  encodeStructuredDataBytes,
   signStructuredData,
   stringAsciiCV,
   tupleCV,
@@ -458,7 +458,7 @@ export function verifyPox4SignatureHash({
 }: Pox4SignatureOptions & { publicKey: string; signature: string }) {
   return verifyMessageSignatureRsv({
     message: sha256(
-      encodeStructuredData(
+      encodeStructuredDataBytes(
         pox4SignatureMessage({ topic, poxAddress, rewardCycle, period, network, maxAmount, authId })
       )
     ),

--- a/packages/stacking/tests/stacking.test.ts
+++ b/packages/stacking/tests/stacking.test.ts
@@ -15,7 +15,7 @@ import {
   SignedContractCallOptions,
   TupleCV,
   bufferCV,
-  encodeStructuredData,
+  encodeStructuredDataBytes,
   intCV,
   noneCV,
   responseErrorCV,
@@ -1317,7 +1317,7 @@ test('correctly generates pox-4 message hash', () => {
   const fixture = 'ec5b88aa81a96a6983c26cdba537a13d253425348ffc0ba6b07130869b025a2d';
 
   const hash = sha256(
-    encodeStructuredData(
+    encodeStructuredDataBytes(
       pox4SignatureMessage({
         poxAddress: poxAddress,
         topic,

--- a/packages/transactions/src/clarity/values/principalCV.ts
+++ b/packages/transactions/src/clarity/values/principalCV.ts
@@ -46,9 +46,9 @@ export function standardPrincipalCV(addressString: string): StandardPrincipalCV 
  *
  * @example
  * ```
- *  import { standardPrincipalCVFromAddress, Address  } from '@stacks/transactions';
+ *  import { standardPrincipalCVFromAddress, AddressWire  } from '@stacks/transactions';
  *
- *  const address: Address = {
+ *  const address: AddressWire = {
  *    type: 0,
  *    version: 22,
  *    hash160: 'a5d9d331000f5b79578ce56bd157f29a9056f0d6'

--- a/packages/transactions/src/clarity/values/principalCV.ts
+++ b/packages/transactions/src/clarity/values/principalCV.ts
@@ -46,9 +46,9 @@ export function standardPrincipalCV(addressString: string): StandardPrincipalCV 
  *
  * @example
  * ```
- *  import { standardPrincipalCVFromAddress, AddressWire  } from '@stacks/transactions';
+ *  import { standardPrincipalCVFromAddress, Address  } from '@stacks/transactions';
  *
- *  const address: AddressWire = {
+ *  const address: Address = {
  *    type: 0,
  *    version: 22,
  *    hash160: 'a5d9d331000f5b79578ce56bd157f29a9056f0d6'

--- a/packages/transactions/tests/keys.test.ts
+++ b/packages/transactions/tests/keys.test.ts
@@ -21,7 +21,7 @@ import {
   compressPrivateKey,
   compressPublicKey,
   createStacksPublicKey,
-  encodeStructuredData,
+  encodeStructuredDataBytes,
   getAddressFromPrivateKey,
   getAddressFromPublicKey,
   makeRandomPrivKey,
@@ -235,7 +235,7 @@ test('Retrieve public key from SIP-018 signature', () => {
   });
 
   // get expected message hex from structured data
-  const expectedMessage = encodeStructuredData({
+  const expectedMessage = encodeStructuredDataBytes({
     message: messageCV,
     domain,
   });


### PR DESCRIPTION
> This PR was published to npm with the version `6.14.1-pr.75+b2acdcaf`
> e.g. `npm install @stacks/common@6.14.1-pr.75+b2acdcaf --save-exact`<!-- Sticky Header Marker -->

- Fixes what I think is a bug, but am not sure @beguene do you remember how this was intended. Since it's a signature I'm assuming it should NOT be parsed as UTF8 ever. 🤷🏻
- Minor refactoring, comments, migrations, deprecations, etc. 