### PR TITLE
fix!: Switch to a network and client param solution

### DIFF
--- a/packages/api/src/api.ts
+++ b/packages/api/src/api.ts
@@ -1,5 +1,6 @@
 import { FetchFn, Hex, createFetchFn } from '@stacks/common';
 import {
+  NetworkParam,
   STACKS_MAINNET,
   StacksNetwork,
   StacksNetworkName,
@@ -46,11 +47,9 @@ export class StacksNodeApi {
   }: {
     /** The base API/node URL for the network fetch calls */
     baseUrl?: string;
-    /** Stacks network object (defaults to {@link STACKS_MAINNET}) */
-    network?: StacksNetworkName | StacksNetwork;
     /** An optional custom fetch function to override default behaviors */
     fetch?: FetchFn;
-  } = {}) {
+  } & NetworkParam = {}) {
     this.baseUrl = baseUrl ?? defaultUrlFromNetwork(network);
     this.fetch = fetch ?? createFetchFn();
     this.network = networkFrom(network);
@@ -67,10 +66,10 @@ export class StacksNodeApi {
    */
   broadcastTransaction = async (
     transaction: StacksTransaction,
-    attachment?: Uint8Array | string
+    attachment?: Uint8Array | string,
+    network?: StacksNetworkName | StacksNetwork
   ): Promise<TxBroadcastResult> => {
-    // todo: should we use a opts object instead of positional args here?
-    return broadcastTransaction({ transaction, attachment, client: this });
+    return broadcastTransaction({ transaction, attachment, network });
   };
 
   /**

--- a/packages/bns/src/index.ts
+++ b/packages/bns/src/index.ts
@@ -1,5 +1,5 @@
-import { ClientParam, IntegerType, PublicKey, intToBigInt, utf8ToBytes } from '@stacks/common';
-import { StacksNetwork } from '@stacks/network';
+import { IntegerType, PublicKey, intToBigInt, utf8ToBytes } from '@stacks/common';
+import { NetworkClientParam, StacksNetwork } from '@stacks/network';
 import {
   ClarityType,
   ClarityValue,
@@ -83,15 +83,12 @@ export interface BnsReadOnlyOptions {
 }
 
 async function callReadOnlyBnsFunction(
-  options: BnsReadOnlyOptions & ClientParam
+  options: BnsReadOnlyOptions & NetworkClientParam
 ): Promise<ClarityValue> {
   return fetchCallReadOnlyFunction({
+    ...options,
     contractAddress: options.network.bootAddress,
     contractName: BNS_CONTRACT_NAME,
-    functionName: options.functionName,
-    senderAddress: options.senderAddress,
-    functionArgs: options.functionArgs,
-    client: options.client,
   });
 }
 

--- a/packages/bns/tests/bns.test.ts
+++ b/packages/bns/tests/bns.test.ts
@@ -57,7 +57,7 @@ test('canRegisterName true', async () => {
       bufferCV(utf8ToBytes(fullyQualifiedName.split('.')[0])),
     ],
     senderAddress: notRandomAddress,
-    client: undefined,
+    network: STACKS_TESTNET,
   };
 
   expect(result).toEqual(true);
@@ -96,7 +96,7 @@ test('canRegisterName false', async () => {
       bufferCV(utf8ToBytes(fullyQualifiedName.split('.')[0])),
     ],
     senderAddress: notRandomAddress,
-    client: undefined,
+    network: STACKS_TESTNET,
   };
 
   expect(result).toEqual(false);
@@ -135,7 +135,7 @@ test('canRegisterName error', async () => {
       bufferCV(utf8ToBytes(fullyQualifiedName.split('.')[0])),
     ],
     senderAddress: notRandomAddress,
-    client: undefined,
+    network: STACKS_TESTNET,
   };
 
   expect(result).toEqual(false);
@@ -171,7 +171,7 @@ test('getNamespacePrice', async () => {
     functionName: bnsFunctionName,
     senderAddress: address,
     functionArgs: [bufferCVFromString(namespace)],
-    client: undefined,
+    network: STACKS_TESTNET,
   };
 
   expect(result.toString()).toEqual('10');
@@ -206,7 +206,7 @@ test('getNamespacePrice error', async () => {
     functionName: bnsFunctionName,
     senderAddress: address,
     functionArgs: [bufferCVFromString(namespace)],
-    client: undefined,
+    network: STACKS_TESTNET,
   };
 
   await expect(getNamespacePrice({ namespace, network })).rejects.toEqual(new Error('u1001'));
@@ -244,7 +244,7 @@ test('getNamePrice', async () => {
     functionName: bnsFunctionName,
     senderAddress: address,
     functionArgs: [bufferCVFromString(namespace), bufferCVFromString(name)],
-    client: undefined,
+    network: STACKS_TESTNET,
   };
 
   expect(result.toString()).toEqual('10');
@@ -281,7 +281,7 @@ test('getNamePrice error', async () => {
     functionName: bnsFunctionName,
     senderAddress: address,
     functionArgs: [bufferCVFromString(namespace), bufferCVFromString(name)],
-    client: undefined,
+    network: STACKS_TESTNET,
   };
 
   await expect(getNamePrice({ fullyQualifiedName, network })).rejects.toEqual(new Error('u2001'));

--- a/packages/common/src/fetch.ts
+++ b/packages/common/src/fetch.ts
@@ -1,7 +1,4 @@
-// Define a default request options and allow modification using getters, setters
-
-import { HIRO_MAINNET_URL } from './constants';
-
+// Define default request options and allow modification using getters, setters
 // Reference: https://developer.mozilla.org/en-US/docs/Web/API/Request/Request
 const defaultFetchOpts: RequestInit = {
   // By default referrer value will be client:origin: above reference link
@@ -55,16 +52,16 @@ export type FetchFn = (url: string, init?: RequestInit) => Promise<Response>;
  * @ignore Internally used for letting networking functions specify "API" options.
  * Should be compatible with the `client`s created by the API and RPC packages.
  */
-export type ClientOpts = {
+export interface ClientOpts {
   baseUrl?: string;
   fetch?: FetchFn;
-};
+}
 
 /** @ignore Internally used for letting networking functions specify "API" options */
-export type ClientParam = {
-  /** Optional API object (for `.url` and `.fetch`) used for API/Node, defaults to use mainnet */
+export interface ClientParam {
+  /** Optional API object (for `.baseUrl` and `.fetch`) used for API/Node, defaults to use mainnet */
   client?: ClientOpts;
-};
+}
 
 export interface RequestContext {
   fetch: FetchFn;
@@ -195,11 +192,10 @@ export function createFetchFn(...args: any[]): FetchFn {
   return fetchFn;
 }
 
-/** @ignore Creates a client-like object, which can be used without circular dependencies */
-export function defaultClientOpts(opts?: { baseUrl?: string; fetch?: FetchFn }) {
-  return {
-    // todo: do we want network here as well?
-    baseUrl: opts?.baseUrl ?? HIRO_MAINNET_URL,
-    fetch: opts?.fetch ?? createFetchFn(),
-  };
-}
+// /** @ignore Creates a client-like object, which can be used without circular dependencies */
+// export function defaultClientOpts(opts?: { baseUrl?: string; fetch?: FetchFn }) {
+//   return {
+//     baseUrl: opts?.baseUrl ?? HIRO_MAINNET_URL,
+//     fetch: opts?.fetch ?? createFetchFn(),
+//   };
+// }

--- a/packages/profile/src/profile.ts
+++ b/packages/profile/src/profile.ts
@@ -22,7 +22,9 @@ import { makeZoneFile, parseZoneFile } from 'zone-file';
 // @ts-ignore
 import * as inspector from 'schema-inspector';
 
-import { ClientParam, Logger, defaultClientOpts } from '@stacks/common';
+import { Logger } from '@stacks/common';
+import { networkFrom } from '@stacks/network';
+import { NetworkClientParam, clientFromNetwork } from '@stacks/network/src';
 import { PublicPersonProfile } from './types';
 
 const schemaDefinition: { [key: string]: any } = {
@@ -340,9 +342,10 @@ export function resolveZoneFileToProfile(
   opts: {
     zoneFile: any;
     publicKeyOrAddress: string;
-  } & ClientParam
+  } & NetworkClientParam
 ): Promise<Record<string, any>> {
-  const api = defaultClientOpts(opts.client);
+  const network = networkFrom(opts.network ?? 'mainnet');
+  const client = Object.assign({}, clientFromNetwork(network), opts.client);
 
   return new Promise((resolve, reject) => {
     let zoneFileJson = null;
@@ -367,7 +370,7 @@ export function resolveZoneFileToProfile(
     }
 
     if (tokenFileUrl) {
-      api
+      client
         .fetch(tokenFileUrl)
         .then(response => response.text())
         .then(responseText => JSON.parse(responseText))

--- a/packages/profile/src/profile.ts
+++ b/packages/profile/src/profile.ts
@@ -23,8 +23,7 @@ import { makeZoneFile, parseZoneFile } from 'zone-file';
 import * as inspector from 'schema-inspector';
 
 import { Logger } from '@stacks/common';
-import { networkFrom } from '@stacks/network';
-import { NetworkClientParam, clientFromNetwork } from '@stacks/network/src';
+import { NetworkClientParam, clientFromNetwork, networkFrom } from '@stacks/network';
 import { PublicPersonProfile } from './types';
 
 const schemaDefinition: { [key: string]: any } = {

--- a/packages/stacking/src/index.ts
+++ b/packages/stacking/src/index.ts
@@ -1,9 +1,9 @@
 import { ClientOpts, IntegerType, PrivateKey, hexToBytes, intToBigInt } from '@stacks/common';
 import {
   ChainId,
+  NetworkClientParam,
   StacksNetwork,
-  StacksNetworkName,
-  defaultClientOptsFromNetwork,
+  clientFromNetwork,
   networkFrom,
 } from '@stacks/network';
 import {
@@ -334,14 +334,10 @@ export class StackingClient {
   public client: Required<ClientOpts>;
 
   // todo: make more constructor opts optional
-  constructor(opts: {
-    address: string;
-    network: StacksNetworkName | StacksNetwork;
-    client?: ClientOpts;
-  }) {
+  constructor(opts: { address: string } & NetworkClientParam) {
     this.address = opts.address;
-    this.network = networkFrom(opts.network);
-    this.client = defaultClientOptsFromNetwork(this.network, opts.client);
+    this.network = networkFrom(opts.network ?? 'mainnet');
+    this.client = Object.assign({}, clientFromNetwork(this.network), opts.client);
   }
 
   get baseUrl() {

--- a/packages/stacking/src/utils.ts
+++ b/packages/stacking/src/utils.ts
@@ -306,7 +306,7 @@ function _poxAddressToBtcAddress_ClarityValue(
 export function poxAddressToBtcAddress(
   version: number,
   hashBytes: Uint8Array,
-  network: StacksNetworkName
+  network: StacksNetworkName // todo: allow NetworkParam in the future (minor)
 ): string;
 /**
  * Converts a PoX address to a Bitcoin address.

--- a/packages/stacking/tests/stacking-2.4.test.ts
+++ b/packages/stacking/tests/stacking-2.4.test.ts
@@ -1,4 +1,4 @@
-import { defaultClientOpts, hexToBytes } from '@stacks/common';
+import { hexToBytes } from '@stacks/common';
 import {
   MOCK_EMPTY_ACCOUNT,
   MOCK_FULL_ACCOUNT,
@@ -55,7 +55,7 @@ describe('2.4 activation', () => {
     const client = new StackingClient({
       address: '',
       network: STACKS_TESTNET,
-      client: defaultClientOpts({ baseUrl: API_URL }),
+      client: { baseUrl: API_URL },
     });
 
     const poxInfo = await client.getPoxInfo();
@@ -82,7 +82,7 @@ test('in period 3, pox-3 stacking works', async () => {
   const client = new StackingClient({
     address,
     network: STACKS_TESTNET,
-    client: defaultClientOpts({ baseUrl: API_URL }),
+    client: { baseUrl: API_URL },
   });
 
   setApiMocks({
@@ -130,7 +130,7 @@ describe('stacking eligibility', () => {
     const client = new StackingClient({
       address,
       network: STACKS_TESTNET,
-      client: defaultClientOpts({ baseUrl: API_URL }),
+      client: { baseUrl: API_URL },
     });
 
     const cycles = 1;
@@ -152,7 +152,7 @@ describe('stacking eligibility', () => {
     const client = new StackingClient({
       address,
       network: STACKS_TESTNET,
-      client: defaultClientOpts({ baseUrl: API_URL }),
+      client: { baseUrl: API_URL },
     });
 
     const cycles = 1;
@@ -176,7 +176,7 @@ describe('normal stacking', () => {
     const client = new StackingClient({
       address,
       network: STACKS_TESTNET,
-      client: defaultClientOpts({ baseUrl: API_URL }),
+      client: { baseUrl: API_URL },
     });
 
     setApiMocks({
@@ -216,7 +216,7 @@ describe('normal stacking', () => {
     const client = new StackingClient({
       address,
       network: STACKS_TESTNET,
-      client: defaultClientOpts({ baseUrl: API_URL }),
+      client: { baseUrl: API_URL },
     });
 
     setApiMocks({
@@ -274,7 +274,7 @@ describe('normal stacking', () => {
     const client = new StackingClient({
       address,
       network: STACKS_TESTNET,
-      client: defaultClientOpts({ baseUrl: API_URL }),
+      client: { baseUrl: API_URL },
     });
 
     setApiMocks({
@@ -331,7 +331,7 @@ describe('delegated stacking', () => {
     const client = new StackingClient({
       address,
       network: STACKS_TESTNET,
-      client: defaultClientOpts({ baseUrl: API_URL }),
+      client: { baseUrl: API_URL },
     });
 
     setApiMocks({
@@ -376,7 +376,7 @@ describe('delegated stacking', () => {
     const client = new StackingClient({
       address,
       network: STACKS_TESTNET,
-      client: defaultClientOpts({ baseUrl: API_URL }),
+      client: { baseUrl: API_URL },
     });
 
     setApiMocks({
@@ -420,7 +420,7 @@ describe('delegated stacking', () => {
     const client = new StackingClient({
       address,
       network: STACKS_TESTNET,
-      client: defaultClientOpts({ baseUrl: API_URL }),
+      client: { baseUrl: API_URL },
     });
     const delegatorClient = new StackingClient({
       address: delegatorAddress,
@@ -489,7 +489,7 @@ describe('delegated stacking', () => {
     const client = new StackingClient({
       address,
       network: STACKS_TESTNET,
-      client: defaultClientOpts({ baseUrl: API_URL }),
+      client: { baseUrl: API_URL },
     });
     const delegatorClient = new StackingClient({
       address: delegatorAddress,
@@ -580,7 +580,7 @@ describe('delegated stacking', () => {
     const client = new StackingClient({
       address,
       network: STACKS_TESTNET,
-      client: defaultClientOpts({ baseUrl: API_URL }),
+      client: { baseUrl: API_URL },
     });
     const delegatorClient = new StackingClient({
       address: delegatorAddress,
@@ -667,7 +667,7 @@ describe('delegated stacking', () => {
     // * The pool commits a total stacking amount (covering all of its stackers)
     //   * This is required for a pools pox-address to be "commited" into the reward-set
 
-    const client = defaultClientOpts({ baseUrl: API_URL });
+    const client = { baseUrl: API_URL };
 
     const stackerAKey = 'cb3df38053d132895220b9ce471f6b676db5b9bf0b4adefb55f2118ece2478df01';
     const stackerAAddress = 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6';
@@ -832,7 +832,7 @@ describe('delegated stacking', () => {
     // * The pool realizes the mistake and increases the amount to all of its stackers' funds
     //   * This will only work if the reward cycle anchor block hasn't been reached yet!
 
-    const clientOpts = defaultClientOpts({ baseUrl: API_URL });
+    const clientOpts = { baseUrl: API_URL };
 
     const stackerAKey = 'cb3df38053d132895220b9ce471f6b676db5b9bf0b4adefb55f2118ece2478df01';
     const stackerAAddress = 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6';
@@ -1021,7 +1021,7 @@ describe('btc addresses', () => {
       const client = new StackingClient({
         address,
         network: STACKS_TESTNET,
-        client: defaultClientOpts({ baseUrl: API_URL }),
+        client: { baseUrl: API_URL },
       });
 
       setApiMocks({

--- a/packages/stacking/tests/stacking-2.5.test.ts
+++ b/packages/stacking/tests/stacking-2.5.test.ts
@@ -1,5 +1,5 @@
 import { getPublicKeyFromPrivate, publicKeyToBtcAddress } from '@stacks/encryption';
-import { STACKS_MOCKNET } from '@stacks/network/src';
+import { STACKS_MOCKNET } from '@stacks/network';
 import { makeRandomPrivKey } from '@stacks/transactions';
 import { V2_POX_REGTEST_POX_4, setApiMocks } from '../../internal/src';
 import { StackingClient } from '../src';

--- a/packages/stacking/tests/stacking.test.ts
+++ b/packages/stacking/tests/stacking.test.ts
@@ -1,11 +1,5 @@
 import { sha256 } from '@noble/hashes/sha256';
-import {
-  HIRO_TESTNET_URL,
-  bigIntToBytes,
-  bytesToHex,
-  defaultClientOpts,
-  hexToBytes,
-} from '@stacks/common';
+import { HIRO_TESTNET_URL, bigIntToBytes, bytesToHex, hexToBytes } from '@stacks/common';
 import { base58CheckDecode, getPublicKeyFromPrivate } from '@stacks/encryption';
 import { V2_POX_REGTEST_POX_3, setApiMocks } from '@stacks/internal';
 import { STACKS_MAINNET, STACKS_TESTNET, defaultUrlFromNetwork } from '@stacks/network';
@@ -1235,7 +1229,7 @@ test('getSecondsUntilStackingDeadline', async () => {
   const client = new StackingClient({
     address: '',
     network: STACKS_MAINNET,
-    client: defaultClientOpts({ baseUrl: 'http://localhost:3999' }),
+    client: { baseUrl: 'http://localhost:3999' },
   });
 
   setApiMocks({

--- a/packages/transactions/src/transaction.ts
+++ b/packages/transactions/src/transaction.ts
@@ -351,6 +351,7 @@ export function deserializeTransaction(tx: string | Uint8Array | BytesReader) {
 
 /** @ignore */
 export function deriveNetworkFromTx(transaction: StacksTransaction) {
+  // todo: maybe add as renamed public method
   return whenTransactionVersion(transaction.version)({
     [TransactionVersion.Mainnet]: STACKS_MAINNET,
     [TransactionVersion.Testnet]: STACKS_TESTNET,

--- a/packages/transactions/src/types.ts
+++ b/packages/transactions/src/types.ts
@@ -1,4 +1,4 @@
-import { StacksNetwork, StacksNetworkName } from '@stacks/network';
+import { NetworkClientParam } from '@stacks/network';
 import { ClarityValue } from './clarity';
 
 /**
@@ -183,13 +183,11 @@ export interface FeeEstimateResponse {
  * @param {StacksNetwork} network - the Stacks blockchain network this transaction is destined for
  * @param {String} senderAddress - the c32check address of the sender
  */
-export interface ReadOnlyFunctionOptions {
+export type ReadOnlyFunctionOptions = {
   contractName: string;
   contractAddress: string;
   functionName: string;
   functionArgs: ClarityValue[];
-  /** the network that the contract which contains the function is deployed to */
-  network?: StacksNetworkName | StacksNetwork;
   /** address of the sender */
   senderAddress: string;
-}
+} & NetworkClientParam;

--- a/packages/transactions/src/wire/types.ts
+++ b/packages/transactions/src/wire/types.ts
@@ -71,7 +71,7 @@ export interface LengthPrefixedList {
 export interface AddressWire {
   readonly type: StacksWireType.Address;
   readonly version: AddressVersion;
-  readonly hash160: string;
+  readonly hash160: string; // todo: next rename to `hash` or `bytes` or `data`
 }
 
 export interface MessageSignatureWire {

--- a/packages/wallet-sdk/src/usernames.ts
+++ b/packages/wallet-sdk/src/usernames.ts
@@ -1,5 +1,4 @@
-import { clientFromNetwork, networkFrom } from '@stacks/network';
-import { NetworkClientParam } from '@stacks/network/src';
+import { NetworkClientParam, clientFromNetwork, networkFrom } from '@stacks/network';
 
 export const fetchFirstName = async (
   opts: {

--- a/packages/wallet-sdk/src/usernames.ts
+++ b/packages/wallet-sdk/src/usernames.ts
@@ -1,11 +1,13 @@
-import { ClientParam, defaultClientOpts } from '@stacks/common';
+import { clientFromNetwork, networkFrom } from '@stacks/network';
+import { NetworkClientParam } from '@stacks/network/src';
 
 export const fetchFirstName = async (
   opts: {
     address: string;
-  } & ClientParam
+  } & NetworkClientParam
 ): Promise<string | undefined> => {
-  const client = defaultClientOpts(opts.client);
+  const network = networkFrom(opts.network ?? 'mainnet');
+  const client = Object.assign({}, clientFromNetwork(network), opts.client);
   try {
     const namesResponse = await client.fetch(
       `${client.baseUrl}/v1/addresses/stacks/${opts.address}`


### PR DESCRIPTION
> This PR was published to npm with the version `6.14.1-pr.78+8cf2e30c`
> e.g. `npm install @stacks/common@6.14.1-pr.78+8cf2e30c --save-exact`<!-- Sticky Header Marker -->

- another pivot on network params

---

The previous solution had some confusing aspects. E.g when using devnet (which is only a URL, and otherwise not different from testnet)

Now, all functions that need fetch, can take a `network` param to specify which URL+fetchFn to use. All of these function ALSO take the new `client` param. But it's okay to supply `network`, `client`, both or neither. Stacks.js will default to `mainnet` or infer which network to use. This way we can easily override URL for APIs, but also create manageable `network` objects that can be passed around everywhere (what people do currently in Stacks.js code).

Want to create your custom network?
```ts
const network = {
  ...STACKS_TESTNET,
  chainId: 666,
  client: { baseUrl: "node6.org" }
}

makeSTXTokenTransfer({ network, // ...
```

Override things if you want for `client` stuff.
```ts
makeSTXTokenTransfer({
  network,
  client: { baseUrl: "node7.com" } // client overrides client in network
  // ...
```

This also makes it easier to combine network and API/RPC clients.

```ts
const client = createClient();

makeSTXTokenTransfer({
  client, // objects are mostly compatible
```

This way we always know if a function does something with it's fetching/`client` -- e.g. 
```ts
selectStxDerivation({
  network,
  // doesn't take `client` param, we know it doesn't do networking
```
