### PR TITLE
refactor: Remove unneeded deserialize overloads

### DIFF
--- a/.github/MIGRATION.md
+++ b/.github/MIGRATION.md
@@ -238,27 +238,16 @@ For easier migrating, renaming the following methods is possible to keep the pre
 - `StacksTransaction.serialize` → `StacksTransaction.serializeBytes`
 - `serializeCV` → `serializeCVBytes`
 - `serializeAddress` → `serializeAddressBytes`
-- `deserializeAddress` → `deserializeAddressBytes`
 - `serializeLPList` → `serializeLPListBytes`
-- `deserializeLPList` → `deserializeLPListBytes`
 - `serializeLPString` → `serializeLPStringBytes`
-- `deserializeLPString` → `deserializeLPStringBytes`
 - `serializePayload` → `serializePayloadBytes`
-- `deserializePayload` → `deserializePayloadBytes`
 - `serializePublicKey` → `serializePublicKeyBytes`
-- `deserializePublicKey` → `deserializePublicKeyBytes`
 - `serializeStacksMessage` → `serializeStacksMessageBytes`
-- `deserializeStacksMessage` → `deserializeStacksMessageBytes`
 - `serializeMemoString` → `serializeMemoStringBytes`
-- `deserializeMemoString` → `deserializeMemoStringBytes`
 - `serializeTransactionAuthField` → `serializeTransactionAuthFieldBytes`
-- `deserializeTransactionAuthField` → `deserializeTransactionAuthFieldBytes`
 - `serializeMessageSignature` → `serializeMessageSignatureBytes`
-- `deserializeMessageSignature` → `deserializeMessageSignatureBytes`
 - `serializePostCondition` → `serializePostConditionBytes`
-- `deserializePostCondition` → `deserializePostConditionBytes`
 - `serializeStacksMessage` → `serializeStacksWireBytes`
-- `deserializeStacksMessage` → `deserializeStacksWireBytes`
 
 ### Asset Helper Methods
 
@@ -287,7 +276,6 @@ This is only used for advanced serialization use-cases internally and should not
 - `StacksMessage` → `StacksWire`
 - `StacksMessageType` → `StacksWireType`
 - `serializeStacksMessage` → `serializeStacksWireBytes`
-- `deserializeStacksMessage` → `deserializeStacksWireBytes`
 
 More types were renamed to indicate use for serialization to _wire-format_:
 

--- a/packages/transactions/src/BytesReader.ts
+++ b/packages/transactions/src/BytesReader.ts
@@ -1,4 +1,4 @@
-import { bytesToHex, readUInt16BE, readUInt32BE, readUInt8 } from '@stacks/common';
+import { bytesToHex, hexToBytes, readUInt16BE, readUInt32BE, readUInt8 } from '@stacks/common';
 
 function createEnumChecker<T extends string, TEnumValue extends number>(enumVariable: {
   [key in T]: TEnumValue;
@@ -47,8 +47,8 @@ export class BytesReader {
   source: Uint8Array;
   consumed: number = 0;
 
-  constructor(arr: Uint8Array) {
-    this.source = arr;
+  constructor(bytes: string | Uint8Array) {
+    this.source = typeof bytes === 'string' ? hexToBytes(bytes) : bytes;
   }
 
   readBytes(length: number): Uint8Array {

--- a/packages/transactions/src/authorization.ts
+++ b/packages/transactions/src/authorization.ts
@@ -31,8 +31,8 @@ import {
   addressFromPublicKeys,
   createEmptyAddress,
   createLPList,
-  deserializeLPListBytes,
-  deserializeMessageSignatureBytes,
+  deserializeLPList,
+  deserializeMessageSignature,
   MessageSignatureWire,
   PublicKeyWire,
   serializeLPListBytes,
@@ -258,7 +258,7 @@ export function deserializeSingleSigSpendingCondition(
       'Failed to parse singlesig spending condition: incomaptible hash mode and key encoding'
     );
   }
-  const signature = deserializeMessageSignatureBytes(bytesReader);
+  const signature = deserializeMessageSignature(bytesReader);
   return {
     hashMode,
     signer,
@@ -277,7 +277,7 @@ export function deserializeMultiSigSpendingCondition(
   const nonce = BigInt('0x' + bytesToHex(bytesReader.readBytes(8)));
   const fee = BigInt('0x' + bytesToHex(bytesReader.readBytes(8)));
 
-  const fields = deserializeLPListBytes(bytesReader, StacksWireType.TransactionAuthField)
+  const fields = deserializeLPList(bytesReader, StacksWireType.TransactionAuthField)
     .values as TransactionAuthFieldWire[];
 
   let haveUncompressed = false;

--- a/packages/transactions/src/clarity/deserialize.ts
+++ b/packages/transactions/src/clarity/deserialize.ts
@@ -20,7 +20,7 @@ import {
 } from '.';
 import { BytesReader } from '../BytesReader';
 import { DeserializationError } from '../errors';
-import { deserializeAddressBytes, deserializeLPStringBytes } from '../wire';
+import { deserializeAddress, deserializeLPString } from '../wire';
 
 /**
  * Deserializes clarity value to clarity type
@@ -75,12 +75,12 @@ export function deserializeCV<T extends ClarityValue = ClarityValue>(
       return falseCV() as T;
 
     case ClarityWireType.address:
-      const sAddress = deserializeAddressBytes(bytesReader);
+      const sAddress = deserializeAddress(bytesReader);
       return standardPrincipalCVFromAddress(sAddress) as T;
 
     case ClarityWireType.contract:
-      const cAddress = deserializeAddressBytes(bytesReader);
-      const contractName = deserializeLPStringBytes(bytesReader);
+      const cAddress = deserializeAddress(bytesReader);
+      const contractName = deserializeLPString(bytesReader);
       return contractPrincipalCVFromAddress(cAddress, contractName) as T;
 
     case ClarityWireType.ok:
@@ -107,7 +107,7 @@ export function deserializeCV<T extends ClarityValue = ClarityValue>(
       const tupleLength = bytesReader.readUInt32BE();
       const tupleContents: { [key: string]: ClarityValue } = {};
       for (let i = 0; i < tupleLength; i++) {
-        const clarityName = deserializeLPStringBytes(bytesReader).content;
+        const clarityName = deserializeLPString(bytesReader).content;
         if (clarityName === undefined) {
           throw new DeserializationError('"content" is undefined');
         }

--- a/packages/transactions/tests/authorization.test.ts
+++ b/packages/transactions/tests/authorization.test.ts
@@ -458,12 +458,12 @@ test('Invalid spending conditions', () => {
     badHashModeSinglesigBytesParseable
   );
 
-  const deserializedBadHashModeSinglesigBytesParseable = deserializeSpendingCondition(
+  const deserializedBadHashModeSinglesig = deserializeSpendingCondition(
     new BytesReader(badHashModeSinglesigBytesParseableBuffer)
   );
 
   // corrupt but will parse with trailing bits
-  expect(deserializedBadHashModeSinglesigBytesParseable).toBeTruthy();
+  expect(deserializedBadHashModeSinglesig).toBeTruthy();
 
   // wrong number of public keys (too many signatures)
   // prettier-ignore

--- a/packages/transactions/tests/clarity.test.ts
+++ b/packages/transactions/tests/clarity.test.ts
@@ -1,6 +1,6 @@
 import { asciiToBytes, bytesToUtf8, concatBytes, hexToBytes, utf8ToBytes } from '@stacks/common';
 import assert from 'assert';
-import { Cl, deserializeAddressBytes } from '../src';
+import { Cl, deserializeAddress } from '../src';
 import { BytesReader } from '../src/BytesReader';
 import {
   BufferCV,
@@ -491,9 +491,7 @@ describe('Clarity Types', () => {
         0x11, 0xab, 0xab, 0xff, 0xff,
       ]);
       const bytesReader = new BytesReader(concatBytes(new Uint8Array([0x00]), addressBuffer));
-      const standardPrincipal = standardPrincipalCVFromAddress(
-        deserializeAddressBytes(bytesReader)
-      );
+      const standardPrincipal = standardPrincipalCVFromAddress(deserializeAddress(bytesReader));
       const serialized = serializeCV(standardPrincipal);
       expect(serialized).toEqual('050011deadbeef11ababffff11deadbeef11ababffff');
     });
@@ -505,9 +503,7 @@ describe('Clarity Types', () => {
       ]);
       const contractName = 'abcd';
       const bytesReader = new BytesReader(concatBytes(new Uint8Array([0x00]), addressBuffer));
-      const standardPrincipal = standardPrincipalCVFromAddress(
-        deserializeAddressBytes(bytesReader)
-      );
+      const standardPrincipal = standardPrincipalCVFromAddress(deserializeAddress(bytesReader));
       const contractPrincipal = contractPrincipalCVFromStandard(standardPrincipal, contractName);
       const serialized = serializeCV(contractPrincipal);
       expect(serialized).toEqual('060011deadbeef11ababffff11deadbeef11ababffff0461626364');

--- a/packages/transactions/tests/macros.ts
+++ b/packages/transactions/tests/macros.ts
@@ -1,7 +1,7 @@
 import {
   StacksWire,
   StacksWireType,
-  deserializeStacksWireBytes,
+  deserializeStacksWire,
   serializeStacksWireBytes,
 } from '../src';
 import { BytesReader } from '../src/BytesReader';
@@ -12,5 +12,5 @@ export function serializeDeserialize<V extends StacksWire, T extends StacksWireT
 ): V {
   const serialized = serializeStacksWireBytes(value);
   const byteReader = new BytesReader(serialized);
-  return deserializeStacksWireBytes(byteReader, type) as V;
+  return deserializeStacksWire(byteReader, type) as V;
 }

--- a/packages/transactions/tests/types.test.ts
+++ b/packages/transactions/tests/types.test.ts
@@ -13,7 +13,7 @@ import {
   createAsset,
   createLPList,
   createLPString,
-  deserializeLPListBytes,
+  deserializeLPList,
   serializeStacksWireBytes,
 } from '../src';
 import { BytesReader } from '../src/BytesReader';
@@ -51,7 +51,7 @@ test('Length prefixed list serialization and deserialization', () => {
   const serialized = serializeStacksWireBytes(lpList);
 
   const bytesReader = new BytesReader(serialized);
-  const deserialized = deserializeLPListBytes(bytesReader, StacksWireType.Address);
+  const deserialized = deserializeLPList(bytesReader, StacksWireType.Address);
 
   expect(deserialized.values.length).toBe(addressList.length);
 


### PR DESCRIPTION
> This PR was published to npm with the version `6.14.1-pr.82+695a0c7d`
> e.g. `npm install @stacks/common@6.14.1-pr.82+695a0c7d --save-exact`<!-- Sticky Header Marker -->

- reverting the Bytes overload for deserialize, since it doesn't really make sense.