### PR TITLE
refactor: Change getStxAddress to use network parameter

### DIFF
--- a/packages/transactions/src/keys.ts
+++ b/packages/transactions/src/keys.ts
@@ -44,9 +44,9 @@ utils.hmacSha256Sync = (key: Uint8Array, ...msgs: Uint8Array[]) => {
 export function getAddressFromPrivateKey(
   /** Private key bytes or hex string */
   privateKey: PrivateKey,
-  network?: StacksNetworkName | StacksNetwork
+  network: StacksNetworkName | StacksNetwork = 'mainnet'
 ): string {
-  network = networkFrom(network ?? STACKS_MAINNET);
+  network = networkFrom(network);
   const publicKey = privateKeyToPublic(privateKey);
   return getAddressFromPublicKey(publicKey, network);
 }
@@ -55,9 +55,9 @@ export function getAddressFromPrivateKey(
 export function getAddressFromPublicKey(
   /** Public key bytes or hex string */
   publicKey: PublicKey,
-  network?: StacksNetworkName | StacksNetwork
+  network: StacksNetworkName | StacksNetwork = 'mainnet'
 ): string {
-  network = networkFrom(network ?? STACKS_MAINNET);
+  network = networkFrom(network);
   publicKey = typeof publicKey === 'string' ? hexToBytes(publicKey) : publicKey;
   const addrVer = addressHashModeToVersion(AddressHashMode.P2PKH, network);
   const addr = addressFromVersionHash(addrVer, hashP2PKH(publicKey));

--- a/packages/wallet-sdk/src/models/account.ts
+++ b/packages/wallet-sdk/src/models/account.ts
@@ -4,13 +4,14 @@ import { HDKey } from '@scure/bip32';
 import { makeAuthResponse as _makeAuthResponse } from '@stacks/auth';
 import { bytesToHex, utf8ToBytes } from '@stacks/common';
 
+import { FetchFn, createFetchFn } from '@stacks/common';
 import {
   getPublicKeyFromPrivate,
   hashCode,
   hashSha256Sync,
   publicKeyToBtcAddress,
 } from '@stacks/encryption';
-import { createFetchFn, FetchFn } from '@stacks/common';
+import { NetworkParam, StacksNetwork, StacksNetworkName } from '@stacks/network';
 import { getAddressFromPrivateKey } from '@stacks/transactions';
 import { connectToGaiaHubWithConfig, getHubInfo, makeGaiaAssociationToken } from '../utils';
 import { Account, HARDENED_OFFSET } from './common';
@@ -20,20 +21,28 @@ import {
   fetchProfileFromUrl,
   signAndUploadProfile,
 } from './profile';
-import { STACKS_MAINNET, STACKS_TESTNET, TransactionVersion } from '@stacks/network';
 
-export const getStxAddress = ({
+export function getStxAddress(
+  account: Account,
+  network?: StacksNetworkName | StacksNetwork
+): string;
+export function getStxAddress({
   account,
-  transactionVersion = TransactionVersion.Testnet,
+  network = 'mainnet',
 }: {
   account: Account;
-  transactionVersion?: TransactionVersion;
-}): string => {
-  return getAddressFromPrivateKey(
-    account.stxPrivateKey,
-    transactionVersion == TransactionVersion.Mainnet ? STACKS_MAINNET : STACKS_TESTNET // todo: refactor for `next` wallet update
-  );
-};
+} & NetworkParam): string;
+export function getStxAddress(
+  accountOrOptions: Account | ({ account: Account } & NetworkParam),
+  network: StacksNetworkName | StacksNetwork = 'mainnet'
+): string {
+  if ('account' in accountOrOptions) {
+    const { account, network = 'mainnet' } = accountOrOptions;
+    return getAddressFromPrivateKey(account.stxPrivateKey, network);
+  }
+
+  return getAddressFromPrivateKey(accountOrOptions.stxPrivateKey, network);
+}
 
 /**
  * Get the display name of an account.
@@ -124,8 +133,8 @@ export const makeAuthResponse = async ({
     {
       ...(profile || {}),
       stxAddress: {
-        testnet: getStxAddress({ account, transactionVersion: TransactionVersion.Testnet }),
-        mainnet: getStxAddress({ account, transactionVersion: TransactionVersion.Mainnet }),
+        testnet: getStxAddress({ account, network: 'testnet' }),
+        mainnet: getStxAddress({ account, network: 'mainnet' }),
       },
       ...additionalData,
     },

--- a/packages/wallet-sdk/src/models/wallet.ts
+++ b/packages/wallet-sdk/src/models/wallet.ts
@@ -16,6 +16,7 @@ export interface LockedWallet {
  *
  * This helps provide a better UX for users, so we can keep track of accounts they've
  * created, and usernames they've used.
+ * @deprecated The usage of storing wallet related information on Gaia isn't widely used.
  */
 export async function restoreWalletAccounts({
   wallet,

--- a/packages/wallet-sdk/tests/derive-keychain.test.ts
+++ b/packages/wallet-sdk/tests/derive-keychain.test.ts
@@ -1,19 +1,19 @@
 import {
-  deriveWalletKeys,
-  deriveAccount,
-  getStxAddress,
-  deriveLegacyConfigPrivateKey,
   DerivationType,
-  selectStxDerivation,
+  deriveAccount,
+  deriveLegacyConfigPrivateKey,
+  deriveWalletKeys,
   fetchUsernameForAccountByDerivationType,
+  getStxAddress,
+  selectStxDerivation,
 } from '../src';
 // https://github.com/paulmillr/scure-bip39
 // Secure, audited & minimal implementation of BIP39 mnemonic phrases.
 import { mnemonicToSeed } from '@scure/bip39';
 
 import { HDKey } from '@scure/bip32';
+import { STACKS_MAINNET } from '@stacks/network';
 import fetchMock from 'jest-fetch-mock';
-import { STACKS_MAINNET, TransactionVersion } from '@stacks/network';
 
 const SECRET_KEY =
   'sound idle panel often situate develop unit text design antenna ' +
@@ -33,9 +33,7 @@ test('keys are serialized, and can be deserialized properly using wallet private
     salt: derived.salt,
     stxDerivationType: DerivationType.Wallet,
   });
-  expect(getStxAddress({ account, transactionVersion: TransactionVersion.Mainnet })).toEqual(
-    WALLET_ADDRESS
-  );
+  expect(getStxAddress({ account, network: 'mainnet' })).toEqual(WALLET_ADDRESS);
 });
 
 test('keys are serialized, and can be deserialized properly using data private key for stx', async () => {
@@ -49,9 +47,7 @@ test('keys are serialized, and can be deserialized properly using data private k
     salt: derived.salt,
     stxDerivationType: DerivationType.Data,
   });
-  expect(getStxAddress({ account, transactionVersion: TransactionVersion.Mainnet })).toEqual(
-    DATA_ADDRESS
-  );
+  expect(getStxAddress({ account, network: 'mainnet' })).toEqual(DATA_ADDRESS);
 });
 
 test('backwards compatible legacy config private key derivation', async () => {

--- a/packages/wallet-sdk/tests/derive.test.ts
+++ b/packages/wallet-sdk/tests/derive.test.ts
@@ -11,7 +11,7 @@ import {
 // Secure, audited & minimal implementation of BIP39 mnemonic phrases.
 import { HDKey } from '@scure/bip32';
 import { mnemonicToSeed } from '@scure/bip39';
-import { STACKS_MAINNET, TransactionVersion } from '@stacks/network';
+import { STACKS_MAINNET } from '@stacks/network';
 import fetchMock from 'jest-fetch-mock';
 
 const SECRET_KEY =
@@ -32,9 +32,7 @@ test('keys are serialized, and can be deserialized properly using wallet private
     salt: derived.salt,
     stxDerivationType: DerivationType.Wallet,
   });
-  expect(getStxAddress({ account, transactionVersion: TransactionVersion.Mainnet })).toEqual(
-    WALLET_ADDRESS
-  );
+  expect(getStxAddress({ account, network: 'mainnet' })).toEqual(WALLET_ADDRESS);
 });
 
 test('keys are serialized, and can be deserialized properly using data private key for stx', async () => {
@@ -48,9 +46,7 @@ test('keys are serialized, and can be deserialized properly using data private k
     salt: derived.salt,
     stxDerivationType: DerivationType.Data,
   });
-  expect(getStxAddress({ account, transactionVersion: TransactionVersion.Mainnet })).toEqual(
-    DATA_ADDRESS
-  );
+  expect(getStxAddress({ account, network: 'mainnet' })).toEqual(DATA_ADDRESS);
 });
 
 test('backwards compatible legacy config private key derivation', async () => {

--- a/packages/wallet-sdk/tests/generate.test.ts
+++ b/packages/wallet-sdk/tests/generate.test.ts
@@ -20,7 +20,6 @@ import {
   getGaiaAddress,
   getStxAddress,
 } from '../src';
-import { TransactionVersion } from '@stacks/network';
 
 describe(generateSecretKey, () => {
   test('generates a 24 word phrase by default', () => {
@@ -70,10 +69,10 @@ describe(generateWallet, () => {
       'a29c3e73dba79ab0f84cb792bafd65ec71f243ebe67a7ebd842ef5cdce3b21eb'
     );
 
-    expect(getStxAddress({ account, transactionVersion: TransactionVersion.Testnet })).toEqual(
+    expect(getStxAddress({ account, network: 'testnet' })).toEqual(
       'ST384CVPNDTYA0E92TKJZQTYXQHNZSWGCAH0ER64E'
     );
-    expect(getStxAddress({ account, transactionVersion: TransactionVersion.Mainnet })).toEqual(
+    expect(getStxAddress({ account, network: 'mainnet' })).toEqual(
       'SP384CVPNDTYA0E92TKJZQTYXQHNZSWGCAG7SAPVB'
     );
 


### PR DESCRIPTION
> This PR was published to npm with the version `6.14.1-pr.88+9b9cd4f3`
> e.g. `npm install @stacks/common@6.14.1-pr.88+9b9cd4f3 --save-exact`<!-- Sticky Header Marker -->

- Minor refactor to allow another method to use the network parameter