### PR TITLE
refactor!: Update Cl.serialize to return string instead of bytes

### DIFF
--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -76,14 +76,14 @@ describe('decode_cv', () => {
 
   test('Should decode from hex to repr', async () => {
     const list = Cl.list([1, 2, 3].map(Cl.int));
-    const serialized = bytesToHex(Cl.serialize(list));
+    const serialized = Cl.serialize(list);
     const result = await decodeCV(mainnetNetwork, [serialized, 'repr']);
     expect(result).toEqual('(list 1 2 3)');
   });
 
   test('Should decode from hex to pretty print', async () => {
     const list = Cl.list([1, 2, 3].map(Cl.int));
-    const serialized = bytesToHex(Cl.serialize(list));
+    const serialized = Cl.serialize(list);
     const result = await decodeCV(mainnetNetwork, [serialized, 'pretty']);
     expect(result).toEqual('(list\n  1\n  2\n  3\n)');
   });

--- a/packages/transactions/src/cl.ts
+++ b/packages/transactions/src/cl.ts
@@ -9,7 +9,7 @@ import {
   noneCV,
   responseErrorCV,
   responseOkCV,
-  serializeCVBytes,
+  serializeCV,
   someCV,
   standardPrincipalCV,
   stringAsciiCV,
@@ -270,7 +270,7 @@ export const tuple = tupleCV;
 /**
  * `Cl.serialize` — Serializes a Clarity JS object to the equivalent hex-encoded representation
  *
- * Alias for {@link serializeCVBytes}
+ * Alias for {@link serializeCV}
  * @example
  * ```
  * import { Cl } from '@stacks/transactions';
@@ -278,7 +278,7 @@ export const tuple = tupleCV;
  * ```
  * @see {@link deserialize}
  */
-export const serialize = serializeCVBytes;
+export const serialize = serializeCV;
 /**
  * `Cl.deserialize` — Deserializes a hex string to the equivalent Clarity JS object
  *

--- a/packages/transactions/src/clarity/serialize.ts
+++ b/packages/transactions/src/clarity/serialize.ts
@@ -158,6 +158,7 @@ function serializeStringUtf8CV(cv: StringUtf8CV) {
 export function serializeCV(value: ClarityValue): string {
   return bytesToHex(serializeCVBytes(value));
 }
+
 /** @ignore */
 export function serializeCVBytes(value: ClarityValue): Uint8Array {
   switch (value.type) {


### PR DESCRIPTION
> This PR was published to npm with the version `6.14.1-pr.89+5155caff`
> e.g. `npm install @stacks/common@6.14.1-pr.89+5155caff --save-exact`<!-- Sticky Header Marker -->

- Update Cl.serialize to return string instead of bytes