### PR TITLE
feat: Support IntegerType for unit conversions

### DIFF
--- a/packages/transactions/src/units.ts
+++ b/packages/transactions/src/units.ts
@@ -1,3 +1,5 @@
+import { IntegerType, intToBigInt } from '@stacks/common';
+
 export const MICROSTX_IN_STX = 1_000_000;
 
 /**
@@ -9,8 +11,8 @@ export const MICROSTX_IN_STX = 1_000_000;
  * microStxToStx(1000000n); // 1n
  * ```
  */
-export function microStxToStx(amountInMicroStx: number): number {
-  return amountInMicroStx / MICROSTX_IN_STX;
+export function microStxToStx(amountInMicroStx: IntegerType): number {
+  return Number(intToBigInt(amountInMicroStx)) / MICROSTX_IN_STX;
 }
 
 /**
@@ -22,6 +24,6 @@ export function microStxToStx(amountInMicroStx: number): number {
  * stxToMicroStx(1); // 1000000
  * ```
  */
-export function stxToMicroStx(amountInStx: number): number {
-  return amountInStx * MICROSTX_IN_STX;
+export function stxToMicroStx(amountInStx: IntegerType): number {
+  return Number(intToBigInt(amountInStx)) * MICROSTX_IN_STX;
 }

--- a/packages/transactions/tests/units.test.ts
+++ b/packages/transactions/tests/units.test.ts
@@ -5,9 +5,21 @@ test(stxToMicroStx.name, () => {
   expect(stxToMicroStx(1.23)).toBe(1230000);
   expect(stxToMicroStx(0.000001)).toBe(1);
 
+  expect(stxToMicroStx('1')).toBe(1000000);
+  expect(stxToMicroStx('1.23')).toBe(1230000);
+  expect(stxToMicroStx('0.000001')).toBe(1);
+
+  expect(stxToMicroStx(1n)).toBe(1000000);
+
   expect(stxToMicroStx(-1)).toBe(-1000000);
   expect(stxToMicroStx(-2.34)).toBe(-2340000);
   expect(stxToMicroStx(-0.000001)).toBe(-1);
+
+  expect(stxToMicroStx('-1')).toBe(-1000000);
+  expect(stxToMicroStx('-2.34')).toBe(-2340000);
+  expect(stxToMicroStx('-0.000001')).toBe(-1);
+
+  expect(stxToMicroStx(-1n)).toBe(-1000000);
 });
 
 test(microStxToStx.name, () => {
@@ -15,7 +27,23 @@ test(microStxToStx.name, () => {
   expect(microStxToStx(1230000)).toBe(1.23);
   expect(microStxToStx(1)).toBe(0.000001);
 
+  expect(microStxToStx('1000000')).toBe(1);
+  expect(microStxToStx('1230000')).toBe(1.23);
+  expect(microStxToStx('1')).toBe(0.000001);
+
+  expect(microStxToStx(1000000n)).toBe(1);
+  expect(microStxToStx(1230000n)).toBe(1.23);
+  expect(microStxToStx(1n)).toBe(0.000001);
+
   expect(microStxToStx(-1000000)).toBe(-1);
   expect(microStxToStx(-2340000)).toBe(-2.34);
   expect(microStxToStx(-1)).toBe(-0.000001);
+
+  expect(microStxToStx('-1000000')).toBe(-1);
+  expect(microStxToStx('-2340000')).toBe(-2.34);
+  expect(microStxToStx('-1')).toBe(-0.000001);
+
+  expect(microStxToStx(-1000000n)).toBe(-1);
+  expect(microStxToStx(-2340000n)).toBe(-2.34);
+  expect(microStxToStx(-1n)).toBe(-0.000001);
 });


### PR DESCRIPTION
### Description

Adds support for `IntegerType` to Stacks unit converters

#### Breaking change?

No, minor

### Example

```ts
microStxToStx(1000000n)
microStxToStx('1500')
```

### Notes

Unit tests for a module that wasn't touched are failing on local. Seems these changes shouldn't break those tests though. Perhaps a local machine issue?

---

### Checklist

- [x] Unit tested updated code paths
- [x] Tagged @janniks
