### PR TITLE
fix(transactions): allow wire format in contract calls

### DIFF
--- a/packages/transactions/src/builders.ts
+++ b/packages/transactions/src/builders.ts
@@ -417,7 +417,7 @@ export type ContractCallOptions = {
    * transfered assets */
   postConditionMode?: PostConditionModeName | PostConditionMode;
   /** a list of post conditions to add to the transaction */
-  postConditions?: PostCondition[];
+  postConditions?: PostCondition[] | PostConditionWire[];
   /** set to true to validate that the supplied function args match those specified in
    * the published contract */
   validateWithAbi?: boolean | ClarityAbi;


### PR DESCRIPTION
Noticed that different types are accepted for PC between contract call/contract deploy. Running into issue refactoring Leather that the wire format isn't accepted