### PR TITLE
fix: regression in 'NoEstimateAvailable' check

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
           cache: npm
 
       - run: npm install -g npm@latest

--- a/packages/transactions/src/fetch.ts
+++ b/packages/transactions/src/fetch.ts
@@ -200,10 +200,12 @@ export async function fetchFeeEstimateTransaction({
     const body = await response.text().catch(() => '');
 
     if (body.includes('NoEstimateAvailable')) {
-      let json: { reason_data?: { message?: string} } = {};
+      let json: { reason_data?: { message?: string } } = {};
       try {
         json = JSON.parse(body);
-      } catch (err) { // ignore }
+      } catch (err) {
+        // ignore
+      }
       throw new NoEstimateAvailableError(json?.reason_data?.message ?? '');
     }
 

--- a/packages/transactions/src/fetch.ts
+++ b/packages/transactions/src/fetch.ts
@@ -197,10 +197,14 @@ export async function fetchFeeEstimateTransaction({
   const response = await client.fetch(url, options);
 
   if (!response.ok) {
-    const body = await response.json().catch(() => ({}));
+    const body = await response.text().catch(() => '');
 
-    if (body?.reason === 'NoEstimateAvailable') {
-      throw new NoEstimateAvailableError(body?.reason_data?.message ?? '');
+    if (body.includes('NoEstimateAvailable')) {
+      let json: { reason_data?: { message?: string} } = {};
+      try {
+        json = JSON.parse(body);
+      } catch (err) { // ignore }
+      throw new NoEstimateAvailableError(json?.reason_data?.message ?? '');
     }
 
     throw new Error(


### PR DESCRIPTION
> This PR was published to npm with the version `7.0.3-pr.6+dc8b1728`
> e.g. `npm install @stacks/common@7.0.3-pr.6+dc8b1728 --save-exact`<!-- Sticky Header Marker -->

The stacks-core RPC still has a bug where the `NoEstimateAvailable` response can be a plain string rather than structured json. See https://github.com/stacks-network/stacks-core/issues/4145


```
Estimator RPC endpoint failed to estimate tx ContractCall: NoEstimateAvailable
```

This PR detects `NoEstimateAvailable` when the response is a string.