### PR TITLE
fix: add cli contract call arg parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8955,7 +8955,6 @@
     },
     "node_modules/encoding": {
       "version": "0.1.13",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -8964,7 +8963,6 @@
     },
     "node_modules/encoding/node_modules/iconv-lite": {
       "version": "0.6.3",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {

--- a/packages/cli/src/argparse.ts
+++ b/packages/cli/src/argparse.ts
@@ -335,9 +335,15 @@ export const CLI_ARGS = {
           realtype: 'private_key',
           pattern: `${PRIVATE_KEY_PATTERN_ANY}`,
         },
+        {
+          name: 'function_args',
+          type: 'string',
+          realtype: 'string',
+          pattern: '.+',
+        },
       ],
       minItems: 6,
-      maxItems: 6,
+      maxItems: 7,
       help:
         'Call a function in a deployed Clarity smart contract.\n' +
         '\n' +
@@ -352,6 +358,12 @@ export const CLI_ARGS = {
         "       txid: '0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1'," +
         "       transaction: 'https://explorer.hiro.so/txid/0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1'" +
         '     }\n' +
+        '```\n' +
+        '\n' +
+        'You can also provide function arguments directly instead of being prompted for them:\n' +
+        '```console\n' +
+        '    $ stx call_contract_func SPBMRFRPPGCDE3F384WCJPK8PQJGZ8K9QKK7F59X contract_name' +
+        '      contract_function 1 0 "$PAYMENT" "(u100), (true), (\\"some-string\\"")\n' +
         '```\n' +
         '\n',
       group: 'Account Management',

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -98,6 +98,7 @@ import {
 import { gaiaAuth, gaiaConnect, gaiaUploadProfileAll, getGaiaAddressFromProfile } from './data';
 
 import { defaultUrlFromNetwork, STACKS_TESTNET } from '@stacks/network';
+import { internal_parseCommaSeparated } from '@stacks/transactions';
 import {
   generateNewAccount,
   generateWallet,
@@ -793,23 +794,7 @@ async function contractDeploy(_network: CLINetworkAdapter, args: string[]): Prom
 
 /** @internal */
 export function parseDirectFunctionArgs(functionArgsStr: string): ClarityValue[] {
-  return functionArgsStr
-    .split('')
-    .reduce(
-      (acc, char) => {
-        if (char === '(' || char === '{') acc.p++;
-        if (char === ')' || char === '}') acc.p--;
-        if (char === ',' && !acc.p) {
-          acc.segs.push('');
-        } else {
-          acc.segs[acc.segs.length - 1] += char;
-        }
-        return acc;
-      },
-      { p: 0, segs: [''] }
-    )
-    .segs.filter(arg => arg.trim())
-    .map(arg => Cl.parse(arg.trim()));
+  return internal_parseCommaSeparated(functionArgsStr);
 }
 
 // Get function arguments via interactive prompts

--- a/packages/cli/tests/abi/test-abi.json
+++ b/packages/cli/tests/abi/test-abi.json
@@ -69,9 +69,7 @@
     {
       "name": "test-func-buffer-argument",
       "access": "public",
-      "args": [
-        { "name": "bufferArg", "type": { "buffer": { "length": 20 } } }
-      ],
+      "args": [{ "name": "bufferArg", "type": { "buffer": { "length": 20 } } }],
       "outputs": { "type": { "response": { "ok": "bool", "error": "none" } } }
     }
   ],

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -115,7 +115,7 @@ describe('Contract function call', () => {
     const txid = '0x6c764e276b500babdac6cec159667f4b68938d31eee82419473a418222af7d5d';
     fetchMock.once(JSON.stringify(TEST_ABI)).once(txid);
 
-    const result = await contractFunctionCall(testnetNetwork, args);
+    const result = JSON.parse(await contractFunctionCall(testnetNetwork, args));
 
     expect(result.txid).toEqual(txid);
   });
@@ -136,7 +136,7 @@ describe('Contract function call', () => {
     const txid = '0x97f41dfa44a5833acd9ca30ffe31d7137623c0e31a5c6467daeed8e61a03f51c';
     fetchMock.once(JSON.stringify(TEST_ABI)).once(txid);
 
-    const result = await contractFunctionCall(testnetNetwork, args);
+    const result = JSON.parse(await contractFunctionCall(testnetNetwork, args));
 
     expect(result.txid).toEqual(txid);
   });
@@ -157,7 +157,7 @@ describe('Contract function call', () => {
     const txid = '0x5fc468f21345c5ecaf1c007fce9630d9a79ec1945ed8652cc3c42fb542e35fe2';
     fetchMock.once(JSON.stringify(TEST_ABI)).once(txid);
 
-    const result = await contractFunctionCall(testnetNetwork, args);
+    const result = JSON.parse(await contractFunctionCall(testnetNetwork, args));
 
     expect(result.txid).toEqual(txid);
   });
@@ -182,7 +182,7 @@ describe('Contract function call', () => {
     const txid = '0x94b1cfab79555b8c6725f19e4fcd6268934d905578a3e8ef7a1e542b931d3676';
     fetchMock.once(JSON.stringify(TEST_ABI)).once(txid);
 
-    const result = await contractFunctionCall(testnetNetwork, args);
+    const result = JSON.parse(await contractFunctionCall(testnetNetwork, args));
 
     expect(result.txid).toEqual(txid);
   });
@@ -205,7 +205,7 @@ describe('Contract function call', () => {
     const txid = '0x6b6cd5bfb44c46a68090f0c5f659e9cc02518eafab67b0b740e1e77a55bbf284';
     fetchMock.once(JSON.stringify(TEST_ABI)).once(txid);
 
-    const result = await contractFunctionCall(testnetNetwork, args);
+    const result = JSON.parse(await contractFunctionCall(testnetNetwork, args));
 
     expect(result.txid).toEqual(txid);
   });

--- a/packages/cli/tests/command-contract-function-call.test.ts
+++ b/packages/cli/tests/command-contract-function-call.test.ts
@@ -1,0 +1,192 @@
+import { STACKS_MAINNET, STACKS_TESTNET } from '@stacks/network';
+import { Cl, ClarityAbi, makeContractCall } from '@stacks/transactions';
+import { readFileSync } from 'fs';
+import inquirer from 'inquirer';
+import fetchMock from 'jest-fetch-mock';
+import path from 'path';
+import { CLI_CONFIG_TYPE } from '../src/argparse';
+import { parseDirectFunctionArgs, testables } from '../src/cli';
+import { CLINetworkAdapter, CLI_NETWORK_OPTS, getNetwork } from '../src/network';
+
+const { contractFunctionCall } = testables as any;
+
+const TEST_ABI: ClarityAbi = JSON.parse(
+  readFileSync(path.join(__dirname, './abi/test-abi.json')).toString()
+);
+
+fetchMock.enableMocks();
+
+const testnetNetwork = new CLINetworkAdapter(
+  getNetwork({} as CLI_CONFIG_TYPE, true),
+  {} as CLI_NETWORK_OPTS
+);
+
+describe('"contract_function_call" command', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks();
+  });
+
+  test('Should fall back to interactive prompts when no direct arguments provided', async () => {
+    const contractAddress = 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6';
+    const contractName = 'test-contract-name';
+    const functionName = 'test-func-primitive-argument';
+    const fee = '230';
+    const nonce = '3';
+    const privateKey = 'cb3df38053d132895220b9ce471f6b676db5b9bf0b4adefb55f2118ece2478df01';
+    const args = [contractAddress, contractName, functionName, fee, nonce, privateKey]; // No contract args
+
+    const contractInputArg = {
+      amount: '1000',
+      address: contractAddress,
+      exists: 'false',
+    };
+
+    // @ts-ignore
+    inquirer.prompt = jest.fn().mockResolvedValue(contractInputArg); // Mock the inquirer prompt to return our test values
+
+    fetchMock.once(JSON.stringify(TEST_ABI));
+    fetchMock.once(
+      JSON.stringify({
+        txid: '0x94b1cfab79555b8c6725f19e4fcd6268934d905578a3e8ef7a1e542b931d3676',
+      })
+    );
+
+    const expectedTx = await makeContractCall({
+      contractAddress,
+      contractName,
+      functionName,
+      functionArgs: [Cl.uint(1000), Cl.address(contractAddress), Cl.bool(false)],
+      senderKey: privateKey,
+      fee,
+      nonce,
+      network: STACKS_TESTNET,
+      postConditionMode: 'allow',
+    });
+
+    await contractFunctionCall(testnetNetwork, args);
+
+    expect(inquirer.prompt).toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0][0]).toContain(
+      `/v2/contracts/interface/${contractAddress}/${contractName}`
+    );
+
+    expect(fetchMock.mock.calls[1][0]).toContain('/v2/transactions');
+
+    const body = JSON.parse(fetchMock.mock.calls[1][1]?.body as string);
+    expect(body.tx).toBeTruthy();
+    expect(body.tx).toEqual(expectedTx.serialize());
+  });
+
+  test('Should use provided contract args when provided', async () => {
+    const contractAddress = 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6';
+    const contractName = 'test-contract-name';
+    const functionName = 'test-func-primitive-argument';
+    const fee = '230';
+    const nonce = '3';
+    const privateKey = 'cb3df38053d132895220b9ce471f6b676db5b9bf0b4adefb55f2118ece2478df01';
+    const contractArgs = [Cl.uint(1000), Cl.address(contractAddress), Cl.bool(false)]
+      .map(Cl.stringify)
+      .join(', ');
+    const args = [
+      contractAddress,
+      contractName,
+      functionName,
+      fee,
+      nonce,
+      privateKey,
+      contractArgs,
+    ];
+
+    expect(contractArgs).toEqual("u1000, 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6, false");
+
+    fetchMock.once(JSON.stringify(TEST_ABI));
+    fetchMock.once(
+      JSON.stringify({
+        txid: '0x94b1cfab79555b8c6725f19e4fcd6268934d905578a3e8ef7a1e542b931d3676',
+      })
+    );
+
+    const expectedTx = await makeContractCall({
+      contractAddress,
+      contractName,
+      functionName,
+      functionArgs: parseDirectFunctionArgs(contractArgs),
+      senderKey: privateKey,
+      fee,
+      nonce,
+      network: STACKS_TESTNET,
+      postConditionMode: 'allow',
+    });
+
+    await contractFunctionCall(testnetNetwork, args);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0][0]).toContain(
+      `/v2/contracts/interface/${contractAddress}/${contractName}`
+    );
+
+    expect(fetchMock.mock.calls[1][0]).toContain('/v2/transactions');
+
+    const body = JSON.parse(fetchMock.mock.calls[1][1]?.body as string);
+    expect(body.tx).toBeTruthy();
+    expect(body.tx).toEqual(expectedTx.serialize());
+  });
+});
+
+test('"parseDirectFunctionArgs" should work for all types with a stringify and comma join', () => {
+  const clarityValues = [
+    // Primitive types
+    Cl.uint(1000),
+    Cl.int(-42),
+    Cl.bool(true),
+    Cl.address(STACKS_MAINNET.bootAddress),
+    Cl.stringAscii('hello'),
+    Cl.stringUtf8('world 🌍'),
+    Cl.stringAscii('text, with, commas, and escapes: \\, " \\" \\", \\(, \\), \\{ \\}'),
+    Cl.stringUtf8('text (with (parentheses'),
+    Cl.stringAscii('text {with {curly braces'),
+    Cl.stringUtf8('complex )text, }with, everything}), 🌍'),
+
+    // Buffer types
+    Cl.bufferFromHex('010203'),
+    Cl.bufferFromAscii('test'),
+    Cl.bufferFromUtf8('utf8 🚀'),
+
+    // Optional types
+    Cl.some(Cl.uint(123)),
+    Cl.none(),
+
+    // Response types
+    Cl.ok(Cl.bool(true)),
+    Cl.error(Cl.uint(404)),
+
+    // Complex nested structures
+    Cl.list([
+      Cl.list([Cl.int(1), Cl.int(2), Cl.int(3)]),
+      Cl.list([
+        Cl.tuple({ x: Cl.uint(10), y: Cl.uint(20) }),
+        Cl.tuple({ x: Cl.uint(30), y: Cl.uint(40) }),
+      ]),
+    ]),
+
+    // Complex tuple with mixed types
+    Cl.tuple({
+      address: Cl.address(STACKS_MAINNET.bootAddress),
+      settings: Cl.tuple({
+        active: Cl.bool(true),
+        name: Cl.stringUtf8('test settings'),
+        values: Cl.list([Cl.uint(1), Cl.uint(2), Cl.uint(3)]),
+        metadata: Cl.some(
+          Cl.tuple({
+            version: Cl.uint(1),
+            hash: Cl.bufferFromHex('deadbeef'),
+          })
+        ),
+      }),
+    }),
+  ];
+
+  const contractArgs = clarityValues.map(Cl.stringify).join(' , ');
+  expect(parseDirectFunctionArgs(contractArgs)).toEqual(clarityValues);
+});

--- a/packages/transactions/src/clarity/index.ts
+++ b/packages/transactions/src/clarity/index.ts
@@ -24,3 +24,6 @@ export * from './types';
 
 export * from './deserialize';
 export * from './serialize';
+
+/** @ignore Meant for internal use by other Stacks.js packages. Not stable. */
+export { internal_parseCommaSeparated } from './parser';

--- a/packages/transactions/src/clarity/parser.ts
+++ b/packages/transactions/src/clarity/parser.ts
@@ -1,4 +1,4 @@
-import { Cl, ClarityValue, TupleCV } from '..';
+import { Cl, ClarityValue, ListCV, TupleCV } from '..';
 
 // COMBINATOR TYPES
 type Combinator = (str: string) => ParseResult;
@@ -193,7 +193,17 @@ function clBuffer(): Combinator {
 
 /** @ignore helper for string values, removes escaping and unescapes special characters */
 function unescape(input: string): string {
-  return input.replace(/\\\\/g, '\\').replace(/\\(.)/g, '$1');
+  // To correctly unescape sequences like \n, \t, \", \\, \uXXXX, etc.,
+  // we can leverage JSON.parse by wrapping the input string in double quotes.
+  // This ensures that all standard JSON escape sequences are handled according
+  // to the JSON specification, aligning with the test cases provided.
+  try {
+    return JSON.parse(`"${input}"`);
+  } catch (error) {
+    throw new Error(
+      `Failed to unescape string: "${input}" ${error instanceof Error ? error.message : error}`
+    );
+  }
 }
 
 function clAscii(): Combinator {

--- a/packages/transactions/src/clarity/parser.ts
+++ b/packages/transactions/src/clarity/parser.ts
@@ -327,3 +327,14 @@ export function parse(clarityValueString: string): ClarityValue {
   if (!result.success || !result.capture) throw 'Parse error'; // todo: we can add better error messages and add position tracking
   return result.capture as ClarityValue;
 }
+
+/** @ignore Meant for internal use by other Stacks.js packages. Not stable. */
+export function internal_parseCommaSeparated(clarityValueString: string): ClarityValue[] {
+  const combinator = entire(
+    greedy(1, clValue(), c => Cl.list(c as ClarityValue[]), regex(/\s*,\s*/))
+  );
+  const result = combinator(clarityValueString);
+  if (!result.success || !result.capture)
+    throw `Error trying to parse string: ${clarityValueString}`;
+  return (result.capture as ListCV<ClarityValue>).value;
+}

--- a/packages/transactions/src/clarity/prettyPrint.ts
+++ b/packages/transactions/src/clarity/prettyPrint.ts
@@ -8,6 +8,12 @@
 
 import { ClarityType, ClarityValue, ListCV, TupleCV } from '.';
 
+function escape(value: string): string {
+  // Use JSON.stringify to handle all necessary escape sequences (e.g., \n, \r, \t, \", \\, \uXXXX).
+  // JSON.stringify(value) produces a string like "\"hello\nworld\"", so we slice off the leading and trailing quotes.
+  return JSON.stringify(value).slice(1, -1);
+}
+
 function formatSpace(space: number, depth: number, end = false) {
   if (!space) return ' ';
   return `\n${' '.repeat(space * (depth - (end ? 1 : 0)))}`;
@@ -80,8 +86,8 @@ function prettyPrintWithDepth(cv: ClarityValue, space = 0, depth: number): strin
   if (cv.type === ClarityType.Int) return cv.value.toString();
   if (cv.type === ClarityType.UInt) return `u${cv.value.toString()}`;
 
-  if (cv.type === ClarityType.StringASCII) return `"${cv.value}"`;
-  if (cv.type === ClarityType.StringUTF8) return `u"${cv.value}"`;
+  if (cv.type === ClarityType.StringASCII) return `"${escape(cv.value)}"`;
+  if (cv.type === ClarityType.StringUTF8) return `u"${escape(cv.value)}"`;
 
   if (cv.type === ClarityType.PrincipalContract) return `'${cv.value}`;
   if (cv.type === ClarityType.PrincipalStandard) return `'${cv.value}`;


### PR DESCRIPTION
> This PR was published to npm with the version `7.0.7-pr.5+2d487d79`
> e.g. `npm install @stacks/common@7.0.7-pr.5+2d487d79 --save-exact`<!-- Sticky Header Marker -->

Adds a new argument to the contract call CLI feature.

Now we can pass Clarity arguments directly. e.g. `stx BLA BLA "u123, (list 1 2 3)"` where the last argument is a comma separated string of the clarity arguments of the function call.