### PR TITLE
fix: Add missing post-condition conversion functions

### DIFF
--- a/packages/transactions/src/builders.ts
+++ b/packages/transactions/src/builders.ts
@@ -45,6 +45,7 @@ import {
   createLPList,
   createSmartContractPayload,
   createTokenTransferPayload,
+  deserializePostConditionWire,
 } from './wire';
 
 /** @deprecated Not used internally */
@@ -248,7 +249,7 @@ export type BaseContractDeployOptions = {
    * transfered assets */
   postConditionMode?: PostConditionModeName | PostConditionMode;
   /** a list of post conditions to add to the transaction */
-  postConditions?: PostCondition[] | PostConditionWire[];
+  postConditions?: (PostCondition | PostConditionWire | string)[];
   /** set to true if another account is sponsoring the transaction (covering the transaction fee) */
   sponsored?: boolean;
 } & NetworkClientParam;
@@ -371,6 +372,7 @@ export async function makeUnsignedContractDeploy(
     : createStandardAuth(spendingCondition);
 
   const postConditions: PostConditionWire[] = (options.postConditions ?? []).map(pc => {
+    if (typeof pc === 'string') return deserializePostConditionWire(pc);
     if (typeof pc.type === 'string') return postConditionToWire(pc);
     return pc;
   });
@@ -417,7 +419,7 @@ export type ContractCallOptions = {
    * transfered assets */
   postConditionMode?: PostConditionModeName | PostConditionMode;
   /** a list of post conditions to add to the transaction */
-  postConditions?: PostCondition[];
+  postConditions?: (PostCondition | PostConditionWire | string)[];
   /** set to true to validate that the supplied function args match those specified in
    * the published contract */
   validateWithAbi?: boolean | ClarityAbi;
@@ -521,6 +523,7 @@ export async function makeUnsignedContractCall(
     : createStandardAuth(spendingCondition);
 
   const postConditions: PostConditionWire[] = (options.postConditions ?? []).map(pc => {
+    if (typeof pc === 'string') return deserializePostConditionWire(pc);
     if (typeof pc.type === 'string') return postConditionToWire(pc);
     return pc;
   });

--- a/packages/transactions/src/pc.ts
+++ b/packages/transactions/src/pc.ts
@@ -5,11 +5,13 @@ import {
   FungiblePostCondition,
   NonFungibleComparator,
   NonFungiblePostCondition,
+  PostCondition,
   StxPostCondition,
 } from './postcondition-types';
 import { AddressString, AssetString, ContractIdString } from './types';
-import {} from './postcondition';
 import { parseContractId, validateStacksAddress } from './utils';
+import { deserializePostConditionWire } from './wire';
+import { wireToPostCondition } from './postcondition';
 
 /// `Pc.` Post Condition Builder
 //
@@ -264,6 +266,29 @@ function parseNft(nftAssetName: AssetString) {
     throw new Error(`Invalid fully-qualified nft asset name: ${nftAssetName}`);
   const [address, name] = parseContractId(principal);
   return { contractAddress: address, contractName: name, tokenName };
+}
+
+/**
+ * Deserializes a serialized post condition hex string into a post condition object
+ * @param hex - Post condition hex string
+ * @returns Deserialized post condition
+ * @example
+ * ```ts
+ * import { Pc } from '@stacks/transactions';
+ *
+ * const hex = '00021600000000000000000000000000000000000000000200000000000003e8'
+ * const postCondition = Pc.fromHex(hex);
+ * // {
+ * //   type: 'stx-postcondition',
+ * //   address: 'SP000000000000000000002Q6VF78',
+ * //   condition: 'gt',
+ * //   amount: '1000'
+ * // }
+ * ```
+ */
+export function fromHex(hex: string): PostCondition {
+  const wire = deserializePostConditionWire(hex);
+  return wireToPostCondition(wire);
 }
 
 /**

--- a/packages/transactions/tests/builder.test.ts
+++ b/packages/transactions/tests/builder.test.ts
@@ -2972,4 +2972,3 @@ describe('multi-sig', () => {
     await expect(txMismatch).rejects.toThrow();
   });
 });
-

--- a/packages/transactions/tests/builder.test.ts
+++ b/packages/transactions/tests/builder.test.ts
@@ -2052,7 +2052,7 @@ test('Make contract deploy with mixed post conditions (objects and serialized he
   expect((secondPC as STXPostConditionWire).amount).toBe(10n);
 });
 
-test('Comprehensive post condition test for contract call and deploy', async () => {
+test('Make contract transactions with multiple post condition formats', async () => {
   // Common test variables
   const senderKey = 'e494f188c2d35887531ba474c433b1e41fadd8eb824aca983447fd4bb8b277a801';
   const fee = 0;
@@ -2972,3 +2972,4 @@ describe('multi-sig', () => {
     await expect(txMismatch).rejects.toThrow();
   });
 });
+

--- a/packages/transactions/tests/pc.test.ts
+++ b/packages/transactions/tests/pc.test.ts
@@ -417,4 +417,20 @@ describe('pc -- post condition builder', () => {
       });
     });
   });
+
+  describe('fromHex function', () => {
+    test('deserializes hex string to post condition object', () => {
+      const hex = '00021600000000000000000000000000000000000000000200000000000003e8';
+      const postCondition = Pc.fromHex(hex);
+
+      const expectedPostCondition: StxPostCondition = {
+        type: 'stx-postcondition',
+        address: 'SP000000000000000000002Q6VF78',
+        condition: 'gt',
+        amount: '1000',
+      };
+
+      expect(postCondition).toEqual(expectedPostCondition);
+    });
+  });
 });


### PR DESCRIPTION
> This PR was published to npm with the version `7.0.5-pr.3+5beb8cef`
> e.g. `npm install @stacks/common@7.0.5-pr.3+5beb8cef --save-exact`<!-- Sticky Header Marker -->

- adds a few new functions to make deserializing post conditions easier.