### PR TITLE
fix: Fix a regression from the v7.x.x update where the localnet/mock…

### DIFF
--- a/packages/cli/src/network.ts
+++ b/packages/cli/src/network.ts
@@ -3,6 +3,7 @@ import * as bitcoin from 'bitcoinjs-lib';
 import blockstack from 'blockstack';
 import { BlockstackNetwork } from 'blockstack/lib/network';
 import { CLI_CONFIG_TYPE } from './argparse';
+import { STACKS_MAINNET, STACKS_TESTNET, StacksNetwork } from '@stacks/network';
 
 export interface CLI_NETWORK_OPTS {
   consensusHash: string | null;
@@ -346,4 +347,15 @@ export function getNetwork(configData: CLI_CONFIG_TYPE, testNet: boolean): Block
 
     return network;
   }
+}
+
+/** @internal helper to convert a CLINetworkAdapter to a StacksNetwork */
+export function getStacksNetwork(network: CLINetworkAdapter): StacksNetwork {
+  const basic = network.isMainnet() ? STACKS_MAINNET : STACKS_TESTNET;
+  return {
+    ...basic,
+    client: {
+      baseUrl: network.nodeAPIUrl,
+    },
+  };
 }

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -620,4 +620,42 @@ describe('CLIMain', () => {
 
     expect(exitSpy).toHaveBeenCalledWith(0); // Expect successful exit
   });
+
+  describe('"balance" command', () => {
+    test('should call the correct endpoint and exit successfully', async () => {
+      const testAddress = 'SP2ZNGJ85ENDY6QRHQ5P2D4FXKGZWCKTB2T0Z55KS';
+      const mainnetApiUrl = 'https://api.hiro.so'; // From argparse.ts CONFIG_MAINNET_DEFAULTS
+
+      process.argv = ['node', 'stx', 'balance', testAddress];
+
+      fetchMock.once(
+        `{"balance":"0x0000000000000000000000018d4e23ec","locked":"0x00000000000000000000000000000000","unlock_height":0,"nonce":13320}`
+      );
+
+      CLIMain();
+      await exit;
+
+      expect(fetchMock.mock.calls[0][0]).toEqual(
+        `${mainnetApiUrl}/v2/accounts/${testAddress}?proof=0`
+      );
+      expect(exitSpy).toHaveBeenCalledWith(0);
+    });
+
+    test('should use testnet API URL from -t flag for balance', async () => {
+      const testAddress = 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM';
+      const testnetApiUrl = 'https://api.testnet.hiro.so'; // From argparse.ts CONFIG_TESTNET_DEFAULTS
+
+      process.argv = ['node', 'stx', '-t', 'balance', testAddress];
+
+      fetchMock.once(
+        `{"balance":"0x0000000000000000000000018d4e23ec","locked":"0x00000000000000000000000000000000","unlock_height":0,"nonce":13320}`
+      );
+
+      CLIMain();
+      await exit;
+
+      expect(fetchMock.mock.calls[0][0]).toContain(testnetApiUrl);
+      expect(exitSpy).toHaveBeenCalledWith(0);
+    });
+  });
 });

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -461,11 +461,14 @@ test('can_stack', async () => {
   );
 });
 
-describe('CLI Main', () => {
+describe('CLIMain', () => {
   let exitSpy: jest.SpyInstance;
   let exit: Promise<void>;
+  let argvBefore: string[];
 
   beforeEach(() => {
+    fetchMock.resetMocks();
+    argvBefore = [...process.argv];
     exitSpy = jest.spyOn(process, 'exit');
     exit = new Promise<void>(resolve => {
       exitSpy.mockImplementation(() => resolve());
@@ -473,6 +476,7 @@ describe('CLI Main', () => {
   });
 
   afterEach(() => {
+    process.argv = argvBefore;
     exitSpy.mockRestore();
   });
 
@@ -491,8 +495,6 @@ describe('CLI Main', () => {
     const nonce = 0;
     const privateKey = randomPrivateKey();
 
-    // Store original argv and redefine
-    const originalArgv = process.argv;
     process.argv = [
       'node',
       'stx',
@@ -518,8 +520,6 @@ describe('CLI Main', () => {
     CLIMain();
     await exit;
 
-    process.argv = originalArgv;
-
     // Call 1: ABI fetch
     expect(fetchMock.mock.calls[0][0]).toContain(customApiUrl);
     expect(fetchMock.mock.calls[0][0]).toContain(
@@ -540,8 +540,6 @@ describe('CLI Main', () => {
     const nonce = 0;
     const privateKey = randomPrivateKey();
 
-    // Store original argv and redefine
-    const originalArgv = process.argv;
     process.argv = [
       'node',
       'stx',
@@ -566,8 +564,6 @@ describe('CLI Main', () => {
     CLIMain(); // Run the main CLI entrypoint
     await exit;
 
-    process.argv = originalArgv; // Restore original argv
-
     // Verify fetch calls used the correct localnet URL
     // Call 1: ABI fetch
     expect(fetchMock.mock.calls[0][0]).toContain(localnetApiUrl);
@@ -589,8 +585,6 @@ describe('CLI Main', () => {
     const nonce = 0;
     const privateKey = randomPrivateKey();
 
-    // Store original argv and redefine
-    const originalArgv = process.argv;
     process.argv = [
       'node',
       'stx',
@@ -614,8 +608,6 @@ describe('CLI Main', () => {
 
     CLIMain(); // Run the main CLI entrypoint
     await exit;
-
-    process.argv = originalArgv; // Restore original argv
 
     // Verify fetch calls used the correct testnet URL
     // Call 1: ABI fetch


### PR DESCRIPTION
> This PR was published to npm with the version `7.0.7-pr.2+de94b530`
> e.g. `npm install @stacks/common@7.0.7-pr.2+de94b530 --save-exact`<!-- Sticky Header Marker -->

- Fixes a regression that always used testnet/mainnet when we switched to the static network object style.
- Adds tests to avoid future regressions