### PR TITLE
fix: Update CLI help menu entry

### DIFF
--- a/packages/cli/src/argparse.ts
+++ b/packages/cli/src/argparse.ts
@@ -363,7 +363,7 @@ export const CLI_ARGS = {
         'You can also provide function arguments directly instead of being prompted for them:\n' +
         '```console\n' +
         '    $ stx call_contract_func SPBMRFRPPGCDE3F384WCJPK8PQJGZ8K9QKK7F59X contract_name' +
-        '      contract_function 1 0 "$PAYMENT" "(u100), (true), (\\"some-string\\"")\n' +
+        '      contract_function 1 0 "$PAYMENT" \'u100, true, "some-string", { a: u"str-utf8", b: 2 }\'\n' +
         '```\n' +
         '\n',
       group: 'Account Management',


### PR DESCRIPTION
> This PR was published to npm with the version `7.1.1-pr.0+a8df8916`
> e.g. `npm install @stacks/common@7.1.1-pr.0+a8df8916 --save-exact`<!-- Sticky Header Marker -->

- Update faulty CLI manual entry