### PR TITLE
fix: Make Gaia hub profile fetching and uploading in `makeAuthResponse` optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8955,7 +8955,6 @@
     },
     "node_modules/encoding": {
       "version": "0.1.13",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -8964,7 +8963,6 @@
     },
     "node_modules/encoding/node_modules/iconv-lite": {
       "version": "0.6.3",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {

--- a/packages/wallet-sdk/src/utils.ts
+++ b/packages/wallet-sdk/src/utils.ts
@@ -34,7 +34,8 @@ export const getProfileURLFromZoneFile = async (
   return;
 };
 
-interface HubInfo {
+/** @internal */
+export interface HubInfo {
   challenge_text?: string;
   read_url_prefix: string;
 }

--- a/packages/wallet-sdk/src/utils.ts
+++ b/packages/wallet-sdk/src/utils.ts
@@ -42,6 +42,8 @@ export interface HubInfo {
 
 export const getHubInfo = async (gaiaHubUrl: string, fetchFn: FetchFn = createFetchFn()) => {
   const response = await fetchFn(`${gaiaHubUrl}/hub_info`);
+  if (!response.ok) throw new Error('Failed to fetch hub info');
+
   const data: HubInfo = await response.json();
   return data;
 };

--- a/packages/wallet-sdk/tests/models/account.test.ts
+++ b/packages/wallet-sdk/tests/models/account.test.ts
@@ -152,6 +152,10 @@ describe(makeAuthResponse.name, () => {
           fetchMock.mockImplementationOnce(() => Promise.reject(new Error('Request timeout'))),
         opts: { scopes: ['read_write'] },
       },
+      {
+        mock: () => fetchMock.mockResponseOnce('Too Many Requests', { status: 429 }),
+        opts: {},
+      },
     ];
     test.each(TEST_CASES)(makeAuthResponse.name, async ({ mock, opts }) => {
       mock();

--- a/packages/wallet-sdk/tests/models/account.test.ts
+++ b/packages/wallet-sdk/tests/models/account.test.ts
@@ -26,7 +26,7 @@ test('generates the correct app private key', () => {
   expect(appPrivateKey).toEqual(expectedKey);
 });
 
-describe(makeAuthResponse, () => {
+describe(makeAuthResponse.name, () => {
   test('generates an auth response', async () => {
     const account = mockAccount;
     const appDomain = 'https://banter.pub';
@@ -127,5 +127,97 @@ describe(makeAuthResponse, () => {
     const expectedKey = '6f8b6a170f8b2ee57df5ead49b0f4c8acde05f9e1c4c6ef8223d6a42fabfa314';
     expect(appPrivateKey).toEqual(expectedKey);
     expect(payload.appPrivateKeyFromWalletSalt).toEqual(appPrivateKeyFromWalletSalt);
+  });
+
+  describe('Gaia optional functionality', () => {
+    const TEST_CASES = [
+      {
+        mock: () => fetchMock.mockRejectOnce(new Error('Network error')),
+        opts: {},
+      },
+      {
+        mock: () => fetchMock.mockResponseOnce('Internal Server Error', { status: 500 }),
+        opts: {},
+      },
+      {
+        mock: () => fetchMock.mockRejectOnce(new Error('Connection timeout')),
+        opts: { scopes: ['publish_data'] },
+      },
+      {
+        mock: () => fetchMock.mockResponseOnce('Not Found', { status: 404 }),
+        opts: { scopes: ['publish_data'] },
+      },
+      {
+        mock: () =>
+          fetchMock.mockImplementationOnce(() => Promise.reject(new Error('Request timeout'))),
+        opts: { scopes: ['read_write'] },
+      },
+    ];
+    test.each(TEST_CASES)(makeAuthResponse.name, async ({ mock, opts }) => {
+      mock();
+
+      const account = mockAccount;
+      const transitPrivateKey = makeECPrivateKey();
+      const transitPublicKey = getPublicKeyFromPrivate(transitPrivateKey);
+
+      const authResponse = await makeAuthResponse({
+        appDomain: 'https://banter.pub',
+        gaiaHubUrl,
+        transitPublicKey,
+        account,
+        ...opts,
+      });
+
+      // Common verifications
+      expect(authResponse).toBeTruthy();
+      const decoded = decodeToken(authResponse);
+      const { payload } = decoded as Decoded;
+
+      expect(payload.profile_url).toBeNull();
+      expect(payload.profile).toBeDefined();
+      expect(payload.profile.stxAddress).toBeDefined();
+      expect(payload.profile.stxAddress.testnet).toBeDefined();
+      expect(payload.profile.stxAddress.mainnet).toBeDefined();
+
+      expect(fetchMock.mock.calls.length).toEqual(1);
+    });
+
+    test('makeAuthResponse handles mixed success/failure gracefully', async () => {
+      const account = mockAccount;
+      const transitPrivateKey = makeECPrivateKey();
+      const transitPublicKey = getPublicKeyFromPrivate(transitPrivateKey);
+
+      // First call succeeds with hub info, second call (profile fetch) fails
+      fetchMock
+        .mockResponseOnce(mockGaiaHubInfo)
+        .mockResponseOnce('', { status: 404 }) // profile fetch fails
+        .mockResponseOnce(JSON.stringify({ publicUrl: 'asdf' })); // profile upload succeeds
+
+      const authResponse = await makeAuthResponse({
+        appDomain: 'https://banter.pub',
+        gaiaHubUrl,
+        transitPublicKey,
+        account,
+        scopes: ['publish_data'],
+      });
+
+      // Verify auth response is generated successfully
+      expect(authResponse).toBeTruthy();
+      const decoded = decodeToken(authResponse);
+      const { payload } = decoded as Decoded;
+
+      // Verify we get profile_url since hub info succeeded
+      expect(payload.profile_url).toEqual(
+        `https://gaia.blockstack.org/hub/${getGaiaAddress(account)}/profile.json`
+      );
+
+      // Verify profile upload was successful and profile apps were added
+      expect(payload.profile).toBeDefined();
+      expect(payload.profile.apps).toBeDefined();
+      expect(payload.profile.apps['https://banter.pub']).toBeDefined();
+
+      // Verify three fetch calls were made (hub info, profile fetch, profile upload)
+      expect(fetchMock.mock.calls.length).toEqual(3);
+    });
   });
 });


### PR DESCRIPTION
> This PR was published to npm with the version `7.1.2-pr.2+8b369f8e`
> e.g. `npm install @stacks/common@7.1.2-pr.2+8b369f8e --save-exact`<!-- Sticky Header Marker -->

- Gaia has been deprecated, but this function had a throwable path when Gaia is not reachable.
- Make the profile logic optional and still works if Gaia doesn't respond