### PR TITLE
fix: respect cli flags

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -867,6 +867,7 @@ async function contractFunctionCall(_network: CLINetworkAdapter, args: string[])
     const costs = await fetchFeeEstimateTransaction({
       payload: serializePayload(tx.payload),
       estimatedLength: estimateTransactionByteLength(tx),
+      network,
     });
     return costs[1].fee.toString(10);
   }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -770,6 +770,7 @@ async function contractDeploy(_network: CLINetworkAdapter, args: string[]): Prom
     return fetchFeeEstimateTransaction({
       payload: serializePayload(tx.payload),
       estimatedLength: estimateTransactionByteLength(tx),
+      network,
     }).then(costs => costs[1].fee.toString(10));
   }
 
@@ -777,7 +778,7 @@ async function contractDeploy(_network: CLINetworkAdapter, args: string[]): Prom
     return Promise.resolve(tx.serialize());
   }
 
-  return broadcastTransaction({ transaction: tx })
+  return broadcastTransaction({ transaction: tx, network })
     .then(response => {
       if (response.hasOwnProperty('error')) {
         return response;

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -97,6 +97,7 @@ import {
 
 import { gaiaAuth, gaiaConnect, gaiaUploadProfileAll, getGaiaAddressFromProfile } from './data';
 
+import { STACKS_TESTNET } from '@stacks/network';
 import { internal_parseCommaSeparated } from '@stacks/transactions';
 import {
   generateNewAccount,
@@ -1866,27 +1867,19 @@ async function preorder(_network: CLINetworkAdapter, args: string[]): Promise<st
     });
 }
 
-function faucetCall(network: CLINetworkAdapter, args: string[]): Promise<string> {
+function faucetCall(_network: CLINetworkAdapter, args: string[]): Promise<string> {
   const address = args[0];
-  // console.log(address);
 
-  // Use network configuration if available, otherwise default to testnet
-  // Since faucets only exist on testnets, we default to testnet if no custom URL is provided
-  const basePath = network.nodeAPIUrl || HIRO_TESTNET_URL;
-
-  const apiConfig = new Configuration({
-    basePath,
-  });
-
-  const faucets = new FaucetsApi(apiConfig);
-  const stacksNetwork = getStacksNetwork(network);
+  // Faucet only exists on testnet
+  const config = new Configuration({ basePath: HIRO_TESTNET_URL });
+  const faucets = new FaucetsApi(config);
 
   return faucets
     .runFaucetStx({ address })
     .then((faucetTx: any) => {
       return JSONStringify({
         txid: faucetTx.txId!,
-        transaction: generateExplorerTxPageUrl(faucetTx.txId!.replace(/^0x/, ''), stacksNetwork),
+        transaction: generateExplorerTxPageUrl(faucetTx.txId!.replace(/^0x/, ''), STACKS_TESTNET),
       });
     })
     .catch((error: any) => error.toString());

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,7 +1,7 @@
 import * as scureBip39 from '@scure/bip39';
 import { wordlist } from '@scure/bip39/wordlists/english';
 import { buildPreorderNameTx, buildRegisterNameTx } from '@stacks/bns';
-import { bytesToHex } from '@stacks/common';
+import { bytesToHex, HIRO_TESTNET_URL } from '@stacks/common';
 import {
   ACCOUNT_PATH,
   broadcastTransaction,
@@ -97,7 +97,6 @@ import {
 
 import { gaiaAuth, gaiaConnect, gaiaUploadProfileAll, getGaiaAddressFromProfile } from './data';
 
-import { defaultUrlFromNetwork, STACKS_TESTNET } from '@stacks/network';
 import { internal_parseCommaSeparated } from '@stacks/transactions';
 import {
   generateNewAccount,
@@ -363,7 +362,7 @@ async function migrateSubdomains(_network: CLINetworkAdapter, args: string[]): P
 
     console.log(`Finding subdomains for data-key address '${dataKeyAddress}'`);
     const namesResponse = await fetch(
-      `${defaultUrlFromNetwork(network)}/v1/addresses/stacks/${dataKeyAddress}`
+      `${network.client.baseUrl}/v1/addresses/stacks/${dataKeyAddress}`
     );
     const namesJson = await namesResponse.json();
 
@@ -381,7 +380,7 @@ async function migrateSubdomains(_network: CLINetworkAdapter, args: string[]): P
       // Alerts the user to any subdomains that can't be migrated to these wallet-key-derived addresses
       // Given collision with existing usernames owned by them
       const namesResponse = await fetch(
-        `${defaultUrlFromNetwork(network)}/v1/addresses/stacks/${walletKeyAddress}`
+        `${network.client.baseUrl}/v1/addresses/stacks/${walletKeyAddress}`
       );
       const existingNames = await namesResponse.json();
       if (existingNames.names?.includes(subdomain)) {
@@ -390,7 +389,7 @@ async function migrateSubdomains(_network: CLINetworkAdapter, args: string[]): P
       }
 
       // Validate user owns the subdomain
-      const nameInfo = await fetch(`${defaultUrlFromNetwork(network)}/v1/names/${subdomain}`);
+      const nameInfo = await fetch(`${network.client.baseUrl}/v1/names/${subdomain}`);
       const nameInfoJson = await nameInfo.json();
       console.log('Subdomain Info: ', nameInfoJson);
       if (nameInfoJson.address !== dataKeyAddress) {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1866,22 +1866,27 @@ async function preorder(_network: CLINetworkAdapter, args: string[]): Promise<st
     });
 }
 
-function faucetCall(_: CLINetworkAdapter, args: string[]): Promise<string> {
+function faucetCall(network: CLINetworkAdapter, args: string[]): Promise<string> {
   const address = args[0];
   // console.log(address);
 
+  // Use network configuration if available, otherwise default to testnet
+  // Since faucets only exist on testnets, we default to testnet if no custom URL is provided
+  const basePath = network.nodeAPIUrl || HIRO_TESTNET_URL;
+
   const apiConfig = new Configuration({
-    basePath: 'https://api.testnet.hiro.so',
+    basePath,
   });
 
   const faucets = new FaucetsApi(apiConfig);
+  const stacksNetwork = getStacksNetwork(network);
 
   return faucets
     .runFaucetStx({ address })
     .then((faucetTx: any) => {
       return JSONStringify({
         txid: faucetTx.txId!,
-        transaction: generateExplorerTxPageUrl(faucetTx.txId!.replace(/^0x/, ''), STACKS_TESTNET),
+        transaction: generateExplorerTxPageUrl(faucetTx.txId!.replace(/^0x/, ''), stacksNetwork),
       });
     })
     .catch((error: any) => error.toString());

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -827,26 +827,6 @@ describe('CLIMain', () => {
       expect(exitSpy).toHaveBeenCalledWith(0);
     });
 
-    test('faucet should use custom network URL with -H flag', async () => {
-      const customApiUrl = 'https://custom-faucet.example.com';
-      const address = 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM';
 
-      process.argv = ['node', 'stx', '-H', customApiUrl, 'faucet', address];
-
-      fetchMock.once(
-        JSON.stringify({
-          success: true,
-          txId: '0x94b1cfab79555b8c6725f19e4fcd6268934d905578a3e8ef7a1e542b931d3676',
-        })
-      );
-
-      CLIMain();
-      await exit;
-
-      // Verify faucet used custom API URL
-      expect(fetchMock.mock.calls[0][0]).toContain('custom-faucet.example.com');
-      expect(fetchMock.mock.calls[0][0]).toContain('/extended/v1/faucets/stx');
-      expect(exitSpy).toHaveBeenCalledWith(0);
-    });
   });
 });


### PR DESCRIPTION
> This PR was published to npm with the version `7.1.3-pr.7+a54d74ce`
> e.g. `npm install @stacks/common@7.1.3-pr.7+a54d74ce --save-exact`<!-- Sticky Header Marker -->

- Respect network flags in CLI commands

> Background: Some commands were not using the detected `network` param, which can be configured by various flags.