### PR TITLE
feat: Add ClarityVersion `.Clarity4`

### DIFF
--- a/packages/transactions/src/builders.ts
+++ b/packages/transactions/src/builders.ts
@@ -319,7 +319,7 @@ export async function makeUnsignedContractDeploy(
     network: STACKS_MAINNET,
     postConditionMode: PostConditionMode.Deny,
     sponsored: false,
-    clarityVersion: ClarityVersion.Clarity3,
+    clarityVersion: ClarityVersion.Clarity4,
   };
 
   const options = Object.assign(defaultOptions, txOptions);

--- a/packages/transactions/src/constants.ts
+++ b/packages/transactions/src/constants.ts
@@ -47,6 +47,7 @@ export enum ClarityVersion {
   Clarity1 = 1,
   Clarity2 = 2,
   Clarity3 = 3,
+  Clarity4 = 4,
 }
 
 /**


### PR DESCRIPTION
Small change to default to Clarity4 for new contracts and allow `4` as the encoded enum.