### PR TITLE
feat(transactions): add validateContractName and validateContractId f…

### DIFF
--- a/packages/transactions/src/utils.ts
+++ b/packages/transactions/src/utils.ts
@@ -196,6 +196,33 @@ export const validateStacksAddress = (address: string): boolean => {
   }
 };
 
+/**
+ * Validates a contract name according to Clarity naming rules.
+ * @param name - The contract name to validate
+ */
+export const validateContractName = (name: string): boolean => {
+  if (!name || name.length === 0) return false;
+  return isClarityName(name);
+};
+
+/**
+ * Validates a contract identifier in the format `<address>.<contract-name>`.
+ * @param contractId - The contract identifier to validate
+ */
+export const validateContractId = (contractId: string): boolean => {
+  if (!contractId || typeof contractId !== 'string') return false;
+
+  const dotIndex = contractId.indexOf('.');
+  if (dotIndex === -1) return false;
+
+  const address = contractId.substring(0, dotIndex);
+  const name = contractId.substring(dotIndex + 1);
+
+  if (name.includes('.')) return false;
+
+  return validateStacksAddress(address) && validateContractName(name);
+};
+
 /** @ignore */
 export function parseContractId(contractId: ContractIdString) {
   const [address, name] = contractId.split('.');

--- a/packages/transactions/tests/utils.test.ts
+++ b/packages/transactions/tests/utils.test.ts
@@ -1,4 +1,4 @@
-import { validateStacksAddress } from '../src/utils';
+import { validateStacksAddress, validateContractName, validateContractId } from '../src/utils';
 
 describe(validateStacksAddress.name, () => {
   test('it returns true for a legit address', () => {
@@ -23,5 +23,55 @@ describe(validateStacksAddress.name, () => {
     nonsenseNotRealSillyAddresses.forEach(nonAddress =>
       expect(validateStacksAddress(nonAddress)).toBeFalsy()
     );
+  });
+});
+
+describe(validateContractName.name, () => {
+  test('it returns true for valid contract names', () => {
+    const validNames = [
+      'pox',
+      'my-contract',
+      'nft-trait',
+      'sip-010-ft-standard',
+      'contract123',
+      'a', // single letter is valid
+      'test_contract',
+      'is-valid?',
+    ];
+    validNames.forEach(name => expect(validateContractName(name)).toBeTruthy());
+  });
+
+  test('it returns false for invalid contract names', () => {
+    const invalidNames = [
+      '', // empty string
+      '123contract', // starts with number
+      'a'.repeat(129), // too long (max 128)
+    ];
+    invalidNames.forEach(name => expect(validateContractName(name)).toBeFalsy());
+  });
+});
+
+describe(validateContractId.name, () => {
+  test('it returns true for valid contract identifiers', () => {
+    const validContractIds = [
+      'SP000000000000000000002Q6VF78.pox',
+      'ST3J2GVMMM2R07ZFBJDWTYEYAR8FZH5WKDTFJ9AHA.my-contract',
+      'ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG.nft-trait',
+      'STVTVW5E80EET19EZ3J8W3NZKR6RHNFG58TKQGXH.sip-010-ft-standard',
+    ];
+    validContractIds.forEach(id => expect(validateContractId(id)).toBeTruthy());
+  });
+
+  test('it returns false for invalid contract identifiers', () => {
+    const invalidContractIds = [
+      'SP000000000000000000002Q6VF78', // no contract name
+      'not-an-address.contract', // invalid address
+      '.contract', // no address
+      'SP000000000000000000002Q6VF78.', // empty contract name
+      'SP000000000000000000002Q6VF78.123start', // contract name starts with number
+      'SP000000000000000000002Q6VF78.name.extra', // multiple dots
+      '', // empty string
+    ];
+    invalidContractIds.forEach(id => expect(validateContractId(id)).toBeFalsy());
   });
 });


### PR DESCRIPTION
…unctions

Adds validation functions for Stacks contract identifiers. Closes #1804
@janniks 

### Description

Added two new validation functions for Stacks contract identifiers:

- [validateContractName(name)](cci:1://file:///c:/Users/HELLO/Documents/stacks.js/packages/transactions/src/utils.ts:198:0-205:2) - Validates contract name according to Clarity rules
- [validateContractId(contractId)](cci:1://file:///c:/Users/HELLO/Documents/stacks.js/packages/transactions/src/utils.ts:207:0-223:2) - Validates full contract identifier (`address.name`)

These functions leverage the existing [isClarityName()](cci:1://file:///c:/Users/HELLO/Documents/stacks.js/packages/transactions/src/utils.ts:138:0-141:1) and [validateStacksAddress()](cci:1://file:///c:/Users/HELLO/Documents/stacks.js/packages/transactions/src/utils.ts:189:0-196:2) for consistent validation.

#### Breaking change?

None - this adds new exports without modifying existing behavior.

### Example

```typescript
import { validateContractName, validateContractId } from '@stacks/transactions';

validateContractName('my-contract');  // true
validateContractName('123invalid');   // false

validateContractId('SP000000000000000000002Q6VF78.pox');  // true
validateContractId('SP000000000000000000002Q6VF78');      // false (no contract name)
```

### Checklist

- [x] Unit tested updated code paths
- [x] Tagged 1 of @janniks or @zone117x for review

<!-- Make sure to run `npm run test` locally to find problems faster -->
