### PR TITLE
fixed typo in fetch.test.ts variable name

### DIFF
--- a/packages/common/tests/fetch.test.ts
+++ b/packages/common/tests/fetch.test.ts
@@ -2,9 +2,9 @@ import fetchMock from 'jest-fetch-mock';
 import { fetchWrapper, getFetchOptions, setFetchOptions } from '../src/fetch';
 
 test('Verify fetch private options', async () => {
-  const defaultOptioins = getFetchOptions();
+  const defaultOptions = getFetchOptions();
 
-  expect(defaultOptioins).toEqual({
+  expect(defaultOptions).toEqual({
     referrerPolicy: 'origin',
     headers: {
       'x-hiro-product': 'stacksjs',


### PR DESCRIPTION
### Description

Fixed a typo in `packages/common/tests/fetch.test.ts`. The variable `defaultOptioins` was misspelled and has been corrected to `defaultOptions`.

Closes #1764

#### Breaking change?

No

### Checklist

- [x] Unit tested updated code paths
- [x] Tagged 1 of @janniks or @zone117x for review