### PR TITLE
Feature/add GitHub templates

### DIFF
--- a/.github/workflows/pre-run.yml
+++ b/.github/workflows/pre-run.yml
@@ -23,4 +23,4 @@ jobs:
       is_not_fork: ${{ steps.check.outputs.is_not_fork }}
     steps:
       - id: check
-        run: echo "::set-output name=is_not_fork::${{ github.repository_owner == 'stx-labs' }}"
+        run: echo "::set-output name=is_not_fork::${{ github.repository_owner == 'hirosystems' }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [7.3.1](https://github.com/stx-labs/stacks.js/compare/v7.3.0...v7.3.1) (2025-12-16)
+## [7.3.1](https://github.com/hirosystems/stacks.js/compare/v7.3.0...v7.3.1) (2025-12-16)
 
 
 ### Bug Fixes
 
-* add tenure change causes ([#1818](https://github.com/stx-labs/stacks.js/issues/1818)) ([66964af](https://github.com/stx-labs/stacks.js/commit/66964af5e60ec8b088e847a24711f096366fbca0))
+* add tenure change causes ([#1818](https://github.com/hirosystems/stacks.js/issues/1818)) ([66964af](https://github.com/hirosystems/stacks.js/commit/66964af5e60ec8b088e847a24711f096366fbca0))
 
 
 

--- a/package.json
+++ b/package.json
@@ -73,6 +73,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/stx-labs/stacks.js.git"
+    "url": "git+https://github.com/hirosystems/stacks.js.git"
   }
 }

--- a/package.json
+++ b/package.json
@@ -73,6 +73,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hirosystems/stacks.js.git"
-  }
+    "url": "git+https://github.com/AdekunleBamz/stacks.js.git"
+  },
+  "bugs": {
+    "url": "https://github.com/AdekunleBamz/stacks.js/issues"
+  },
+  "homepage": "https://github.com/AdekunleBamz/stacks.js#readme"
 }

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [7.3.1](https://github.com/stx-labs/stacks.js/compare/v7.3.0...v7.3.1) (2025-12-16)
+## [7.3.1](https://github.com/hirosystems/stacks.js/compare/v7.3.0...v7.3.1) (2025-12-16)
 
 **Note:** Version bump only for package @stacks/api
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -47,9 +47,9 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/stx-labs/stacks.js.git"
+    "url": "git+https://github.com/hirosystems/stacks.js.git"
   },
   "bugs": {
-    "url": "https://github.com/stx-labs/stacks.js/issues"
+    "url": "https://github.com/hirosystems/stacks.js/issues"
   }
 }

--- a/packages/auth/CHANGELOG.md
+++ b/packages/auth/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [7.3.1](https://github.com/stx-labs/stacks.js/compare/v7.3.0...v7.3.1) (2025-12-16)
+## [7.3.1](https://github.com/hirosystems/stacks.js/compare/v7.3.0...v7.3.1) (2025-12-16)
 
 **Note:** Version bump only for package @stacks/auth
 

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -55,7 +55,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/stx-labs/stacks.js.git"
+    "url": "git+https://github.com/hirosystems/stacks.js.git"
   },
   "bugs": {
     "url": "https://github.com/blockstack/blockstack.js/issues"

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [7.3.1](https://github.com/stx-labs/stacks.js/compare/v7.3.0...v7.3.1) (2025-12-16)
+## [7.3.1](https://github.com/hirosystems/stacks.js/compare/v7.3.0...v7.3.1) (2025-12-16)
 
 **Note:** Version bump only for package @stacks/cli
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -100,7 +100,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/stx-labs/stacks.js.git"
+    "url": "git+https://github.com/hirosystems/stacks.js.git"
   },
   "bugs": {
     "url": "https://github.com/blockstack/blockstack.js/issues"

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -328,7 +328,7 @@ async function getStacksWalletKey(_network: CLINetworkAdapter, args: string[]): 
 
 /**
  * Enable users to transfer subdomains to wallet-key addresses that correspond to all data-key addresses
- * Reference: https://github.com/stx-labs/stacks.js/issues/1209
+ * Reference: https://github.com/hirosystems/stacks.js/issues/1209
  * args:
  * @mnemonic (string) the seed phrase to retrieve the privateKey & address
  * @registrarUrl (string) URL of the registrar to use (defaults to 'https://registrar.stacks.co')

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [7.3.1](https://github.com/stx-labs/stacks.js/compare/v7.3.0...v7.3.1) (2025-12-16)
+## [7.3.1](https://github.com/hirosystems/stacks.js/compare/v7.3.0...v7.3.1) (2025-12-16)
 
 **Note:** Version bump only for package @stacks/common
 

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -39,7 +39,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/stx-labs/stacks.js.git"
+    "url": "git+https://github.com/hirosystems/stacks.js.git"
   },
   "bugs": {
     "url": "https://github.com/blockstack/blockstack.js/issues"

--- a/packages/encryption/CHANGELOG.md
+++ b/packages/encryption/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [7.3.1](https://github.com/stx-labs/stacks.js/compare/v7.3.0...v7.3.1) (2025-12-16)
+## [7.3.1](https://github.com/hirosystems/stacks.js/compare/v7.3.0...v7.3.1) (2025-12-16)
 
 **Note:** Version bump only for package @stacks/encryption
 

--- a/packages/encryption/package.json
+++ b/packages/encryption/package.json
@@ -61,7 +61,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/stx-labs/stacks.js.git"
+    "url": "git+https://github.com/hirosystems/stacks.js.git"
   },
   "bugs": {
     "url": "https://github.com/blockstack/blockstack.js/issues"

--- a/packages/internal/CHANGELOG.md
+++ b/packages/internal/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [7.3.1](https://github.com/stx-labs/stacks.js/compare/v7.3.0...v7.3.1) (2025-12-16)
+## [7.3.1](https://github.com/hirosystems/stacks.js/compare/v7.3.0...v7.3.1) (2025-12-16)
 
 **Note:** Version bump only for package @stacks/internal
 
@@ -11,7 +11,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [7.3.0](https://github.com/stx-labs/stacks.js/compare/v7.2.0...v7.3.0) (2025-11-12)
+## [7.3.0](https://github.com/hirosystems/stacks.js/compare/v7.2.0...v7.3.0) (2025-11-12)
 
 **Note:** Version bump only for package @stacks/internal
 

--- a/packages/network/CHANGELOG.md
+++ b/packages/network/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [7.3.1](https://github.com/stx-labs/stacks.js/compare/v7.3.0...v7.3.1) (2025-12-16)
+## [7.3.1](https://github.com/hirosystems/stacks.js/compare/v7.3.0...v7.3.1) (2025-12-16)
 
 **Note:** Version bump only for package @stacks/network
 

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -47,7 +47,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/stx-labs/stacks.js.git"
+    "url": "git+https://github.com/hirosystems/stacks.js.git"
   },
   "bugs": {
     "url": "https://github.com/blockstack/blockstack.js/issues"

--- a/packages/profile/CHANGELOG.md
+++ b/packages/profile/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [7.3.1](https://github.com/stx-labs/stacks.js/compare/v7.3.0...v7.3.1) (2025-12-16)
+## [7.3.1](https://github.com/hirosystems/stacks.js/compare/v7.3.0...v7.3.1) (2025-12-16)
 
 **Note:** Version bump only for package @stacks/profile
 

--- a/packages/profile/package.json
+++ b/packages/profile/package.json
@@ -52,7 +52,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/stx-labs/stacks.js.git"
+    "url": "git+https://github.com/hirosystems/stacks.js.git"
   },
   "bugs": {
     "url": "https://github.com/blockstack/blockstack.js/issues"

--- a/packages/stacking/CHANGELOG.md
+++ b/packages/stacking/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [7.3.1](https://github.com/stx-labs/stacks.js/compare/v7.3.0...v7.3.1) (2025-12-16)
+## [7.3.1](https://github.com/hirosystems/stacks.js/compare/v7.3.0...v7.3.1) (2025-12-16)
 
 **Note:** Version bump only for package @stacks/stacking
 

--- a/packages/stacking/package.json
+++ b/packages/stacking/package.json
@@ -53,7 +53,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/stx-labs/stacks.js.git"
+    "url": "git+https://github.com/hirosystems/stacks.js.git"
   },
   "bugs": {
     "url": "https://github.com/blockstack/blockstack.js/issues"

--- a/packages/storage/CHANGELOG.md
+++ b/packages/storage/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [7.3.1](https://github.com/stx-labs/stacks.js/compare/v7.3.0...v7.3.1) (2025-12-16)
+## [7.3.1](https://github.com/hirosystems/stacks.js/compare/v7.3.0...v7.3.1) (2025-12-16)
 
 **Note:** Version bump only for package @stacks/storage
 

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -50,7 +50,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/stx-labs/stacks.js.git"
+    "url": "git+https://github.com/hirosystems/stacks.js.git"
   },
   "bugs": {
     "url": "https://github.com/blockstack/blockstack.js/issues"

--- a/packages/transactions/CHANGELOG.md
+++ b/packages/transactions/CHANGELOG.md
@@ -3,12 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [7.3.1](https://github.com/stx-labs/stacks.js/compare/v7.3.0...v7.3.1) (2025-12-16)
+## [7.3.1](https://github.com/hirosystems/stacks.js/compare/v7.3.0...v7.3.1) (2025-12-16)
 
 
 ### Bug Fixes
 
-* add tenure change causes ([#1818](https://github.com/stx-labs/stacks.js/issues/1818)) ([66964af](https://github.com/stx-labs/stacks.js/commit/66964af5e60ec8b088e847a24711f096366fbca0))
+* add tenure change causes ([#1818](https://github.com/hirosystems/stacks.js/issues/1818)) ([66964af](https://github.com/hirosystems/stacks.js/commit/66964af5e60ec8b088e847a24711f096366fbca0))
 
 
 

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -57,9 +57,9 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/stx-labs/stacks.js.git"
+    "url": "git+https://github.com/hirosystems/stacks.js.git"
   },
   "bugs": {
-    "url": "https://github.com/stx-labs/stacks.js/issues"
+    "url": "https://github.com/hirosystems/stacks.js/issues"
   }
 }

--- a/packages/transactions/src/clarity/deserialize.ts
+++ b/packages/transactions/src/clarity/deserialize.ts
@@ -37,7 +37,7 @@ import { deserializeAddress, deserializeLPString } from '../wire';
  * ```
  *
  * @see
- * {@link https://github.com/stx-labs/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
+ * {@link https://github.com/hirosystems/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 export function deserializeCV<T extends ClarityValue = ClarityValue>(
   serializedClarityValue: BytesReader | Uint8Array | string

--- a/packages/transactions/src/clarity/serialize.ts
+++ b/packages/transactions/src/clarity/serialize.ts
@@ -153,7 +153,7 @@ function serializeStringUtf8CV(cv: StringUtf8CV) {
  * ```
  *
  * @see
- * {@link https://github.com/stx-labs/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
+ * {@link https://github.com/hirosystems/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 export function serializeCV(value: ClarityValue): string {
   return bytesToHex(serializeCVBytes(value));

--- a/packages/transactions/src/clarity/values/booleanCV.ts
+++ b/packages/transactions/src/clarity/values/booleanCV.ts
@@ -15,7 +15,7 @@ import { BooleanCV } from '../types';
  * ```
  *
  * @see
- * {@link https://github.com/stx-labs/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
+ * {@link https://github.com/hirosystems/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 export const trueCV = (): BooleanCV => ({ type: ClarityType.BoolTrue });
 
@@ -33,7 +33,7 @@ export const trueCV = (): BooleanCV => ({ type: ClarityType.BoolTrue });
  * ```
  *
  * @see
- * {@link https://github.com/stx-labs/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
+ * {@link https://github.com/hirosystems/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 export const falseCV = (): BooleanCV => ({ type: ClarityType.BoolFalse });
 
@@ -51,6 +51,6 @@ export const falseCV = (): BooleanCV => ({ type: ClarityType.BoolFalse });
  * ```
  *
  * @see
- * {@link https://github.com/stx-labs/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
+ * {@link https://github.com/hirosystems/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 export const boolCV = (bool: boolean) => (bool ? trueCV() : falseCV());

--- a/packages/transactions/src/clarity/values/bufferCV.ts
+++ b/packages/transactions/src/clarity/values/bufferCV.ts
@@ -21,7 +21,7 @@ import { BufferCV } from '../types';
  * ```
  *
  * @see
- * {@link https://github.com/stx-labs/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
+ * {@link https://github.com/hirosystems/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 export const bufferCV = (buffer: Uint8Array): BufferCV => {
   // max size 1024 * 1024 = 1MB; https://github.com/stacks-network/stacks-core/blob/c50a93088d7c0261f1dbe31ab24b95028a038447/clarity/src/vm/types/mod.rs#L47
@@ -51,6 +51,6 @@ export const bufferCV = (buffer: Uint8Array): BufferCV => {
  *```
  *
  * @see
- * {@link https://github.com/stx-labs/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
+ * {@link https://github.com/hirosystems/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 export const bufferCVFromString = (str: string): BufferCV => bufferCV(utf8ToBytes(str));

--- a/packages/transactions/src/clarity/values/intCV.ts
+++ b/packages/transactions/src/clarity/values/intCV.ts
@@ -30,7 +30,7 @@ const MIN_I128 = BigInt('-170141183460469231731687303715884105728'); // (-2 ** 1
  * ```
  *
  * @see
- * {@link https://github.com/stx-labs/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
+ * {@link https://github.com/hirosystems/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 export const intCV = (value: IntegerType): IntCV => {
   // ensure compatibility with twos-complement encoded hex-strings
@@ -66,7 +66,7 @@ export const intCV = (value: IntegerType): IntCV => {
  * ```
  *
  * @see
- * {@link https://github.com/stx-labs/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
+ * {@link https://github.com/hirosystems/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 export const uintCV = (value: IntegerType): UIntCV => {
   const bigInt = intToBigInt(value);

--- a/packages/transactions/src/clarity/values/listCV.ts
+++ b/packages/transactions/src/clarity/values/listCV.ts
@@ -18,7 +18,7 @@ import { ListCV } from '../types';
  * ```
  *
  * @see
- * {@link https://github.com/stx-labs/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
+ * {@link https://github.com/hirosystems/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 export function listCV<T extends ClarityValue = ClarityValue>(values: T[]): ListCV<T> {
   return { type: ClarityType.List, value: values };

--- a/packages/transactions/src/clarity/values/optionalCV.ts
+++ b/packages/transactions/src/clarity/values/optionalCV.ts
@@ -16,7 +16,7 @@ import { NoneCV, OptionalCV } from '../types';
  * ```
  *
  * @see
- * {@link https://github.com/stx-labs/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
+ * {@link https://github.com/hirosystems/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 export function noneCV(): NoneCV {
   return { type: ClarityType.OptionalNone };
@@ -38,7 +38,7 @@ export function noneCV(): NoneCV {
  * ```
  *
  * @see
- * {@link https://github.com/stx-labs/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
+ * {@link https://github.com/hirosystems/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 export function someCV<T extends ClarityValue = ClarityValue>(value: T): OptionalCV<T> {
   return { type: ClarityType.OptionalSome, value };

--- a/packages/transactions/src/clarity/values/principalCV.ts
+++ b/packages/transactions/src/clarity/values/principalCV.ts
@@ -32,7 +32,7 @@ export function principalCV(principal: string): PrincipalCV {
  * ```
  *
  * @see
- * {@link https://github.com/stx-labs/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
+ * {@link https://github.com/hirosystems/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 export function standardPrincipalCV(addressString: string): StandardPrincipalCV {
   const addr = createAddress(addressString);
@@ -59,7 +59,7 @@ export function standardPrincipalCV(addressString: string): StandardPrincipalCV 
  * ```
  *
  * @see
- * {@link https://github.com/stx-labs/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
+ * {@link https://github.com/hirosystems/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 export function standardPrincipalCVFromAddress(address: AddressWire): StandardPrincipalCV {
   return { type: ClarityType.PrincipalStandard, value: addressToString(address) };
@@ -80,7 +80,7 @@ export function standardPrincipalCVFromAddress(address: AddressWire): StandardPr
  * ```
  *
  * @see
- * {@link https://github.com/stx-labs/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
+ * {@link https://github.com/hirosystems/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 export function contractPrincipalCV(
   addressString: string,
@@ -107,7 +107,7 @@ export function contractPrincipalCV(
  * ```
  *
  * @see
- * {@link https://github.com/stx-labs/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
+ * {@link https://github.com/hirosystems/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 export function contractPrincipalCVFromAddress(
   address: AddressWire,

--- a/packages/transactions/src/clarity/values/responseCV.ts
+++ b/packages/transactions/src/clarity/values/responseCV.ts
@@ -19,7 +19,7 @@ import { ResponseErrorCV, ResponseOkCV } from '../types';
  * ```
  *
  * @see
- * {@link https://github.com/stx-labs/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
+ * {@link https://github.com/hirosystems/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 export function responseErrorCV<T extends ClarityValue = ClarityValue>(
   value: T
@@ -44,7 +44,7 @@ export function responseErrorCV<T extends ClarityValue = ClarityValue>(
  * ```
  *
  * @see
- * {@link https://github.com/stx-labs/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
+ * {@link https://github.com/hirosystems/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 export function responseOkCV<T extends ClarityValue = ClarityValue>(value: T): ResponseOkCV<T> {
   return { type: ClarityType.ResponseOk, value };

--- a/packages/transactions/src/clarity/values/stringCV.ts
+++ b/packages/transactions/src/clarity/values/stringCV.ts
@@ -18,7 +18,7 @@ import { StringAsciiCV, StringUtf8CV } from '../types';
  * ```
  *
  * @see
- * {@link https://github.com/stx-labs/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
+ * {@link https://github.com/hirosystems/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 export const stringAsciiCV = (data: string): StringAsciiCV => {
   return { type: ClarityType.StringASCII, value: data };
@@ -41,7 +41,7 @@ export const stringAsciiCV = (data: string): StringAsciiCV => {
  * ```
  *
  * @see
- * {@link https://github.com/stx-labs/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
+ * {@link https://github.com/hirosystems/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 export const stringUtf8CV = (data: string): StringUtf8CV => {
   return { type: ClarityType.StringUTF8, value: data };

--- a/packages/transactions/src/clarity/values/tupleCV.ts
+++ b/packages/transactions/src/clarity/values/tupleCV.ts
@@ -23,7 +23,7 @@ import { TupleCV, TupleData } from '../types';
  * ```
  *
  * @see
- * {@link https://github.com/stx-labs/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
+ * {@link https://github.com/hirosystems/stacks.js/blob/main/packages/transactions/tests/clarity.test.ts | clarity test cases for more examples}
  */
 export function tupleCV<T extends ClarityValue = ClarityValue>(
   data: TupleData<T>

--- a/packages/wallet-sdk/CHANGELOG.md
+++ b/packages/wallet-sdk/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [7.3.1](https://github.com/stx-labs/stacks.js/compare/v7.3.0...v7.3.1) (2025-12-16)
+## [7.3.1](https://github.com/hirosystems/stacks.js/compare/v7.3.0...v7.3.1) (2025-12-16)
 
 **Note:** Version bump only for package @stacks/wallet-sdk
 
@@ -11,7 +11,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [7.3.0](https://github.com/stx-labs/stacks.js/compare/v7.2.0...v7.3.0) (2025-11-12)
+## [7.3.0](https://github.com/hirosystems/stacks.js/compare/v7.2.0...v7.3.0) (2025-11-12)
 
 **Note:** Version bump only for package @stacks/wallet-sdk
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -45,11 +45,11 @@
     "replaceText": {
       "replacements": [
         {
-          "pattern": "https://github.com/stx-labs/stacks.js/tree/main/packages/wallet-sdk",
+          "pattern": "https://github.com/hirosystems/stacks.js/tree/main/packages/wallet-sdk",
           "replace": "/modules/_stacks_wallet_sdk"
         },
         {
-          "pattern": "https://github.com/stx-labs/stacks.js/tree/main/packages/",
+          "pattern": "https://github.com/hirosystems/stacks.js/tree/main/packages/",
           "replace": "/modules/_stacks_"
         }
       ]


### PR DESCRIPTION
## Summary
- Update package.json repository URL to point to the fork (AdekunleBamz/stacks.js)
- Add bugs and homepage URLs for the fork
- GitHub templates were already present and appropriate for the Stacks.js SDK

## Changes Made
- Updated `repository.url` from hirosystems/stacks.js.git to AdekunleBamz/stacks.js.git
- Added `bugs.url` pointing to the fork's issues
- Added `homepage` pointing to the fork's README

## Testing
- Not required for metadata updates

## Notes
- The repository already had comprehensive GitHub templates for bug reports, feature requests, and PRs
- Package metadata now correctly reflects the fork's repository information