### PR TITLE
feat(transactions): add comprehensive tests and JSDoc documentation

### DIFF
--- a/packages/transactions/src/errors.ts
+++ b/packages/transactions/src/errors.ts
@@ -1,3 +1,8 @@
+/**
+ * Base class for transaction-related errors.
+ * Provides consistent error handling and stack trace capture.
+ * @internal
+ */
 class TransactionError extends Error {
   constructor(message: string) {
     super(message);
@@ -9,12 +14,30 @@ class TransactionError extends Error {
   }
 }
 
+/**
+ * Thrown when serializing transaction data fails.
+ * This can occur due to invalid data types, malformed transaction
+ * components, or attempting to serialize incomplete transactions.
+ * @example
+ * ```ts
+ * throw new SerializationError('Invalid clarity value type');
+ * ```
+ */
 export class SerializationError extends TransactionError {
   constructor(message: string) {
     super(message);
   }
 }
 
+/**
+ * Thrown when deserializing transaction data fails.
+ * This typically indicates corrupted or invalid transaction bytes,
+ * or an attempt to deserialize malformed hex strings.
+ * @example
+ * ```ts
+ * throw new DeserializationError('Invalid transaction bytes');
+ * ```
+ */
 export class DeserializationError extends TransactionError {
   constructor(message: string) {
     super(message);
@@ -33,20 +56,43 @@ export class NoEstimateAvailableError extends TransactionError {
   }
 }
 
+/**
+ * Thrown when a feature or functionality is not yet implemented.
+ * Used to indicate planned but incomplete features in the library.
+ */
 export class NotImplementedError extends TransactionError {
   constructor(message: string) {
     super(message);
   }
 }
 
+/**
+ * Thrown when transaction signing fails.
+ * This can occur due to invalid private keys, unsupported key formats,
+ * or cryptographic operation failures.
+ * @example
+ * ```ts
+ * throw new SigningError('Invalid private key format');
+ * ```
+ */
 export class SigningError extends TransactionError {
   constructor(message: string) {
     super(message);
   }
 }
 
+/**
+ * Thrown when signature verification fails.
+ * This indicates that a signature does not match the expected
+ * public key or message digest.
+ * @example
+ * ```ts
+ * throw new VerificationError('Signature verification failed');
+ * ```
+ */
 export class VerificationError extends TransactionError {
   constructor(message: string) {
     super(message);
   }
 }
+

--- a/packages/transactions/src/utils.ts
+++ b/packages/transactions/src/utils.ts
@@ -18,15 +18,63 @@ export { verify as verifySignature } from '@noble/secp256k1';
  */
 export const randomBytes = (bytesLength?: number): Uint8Array => utils.randomBytes(bytesLength);
 
+/**
+ * Pads a hex string with a leading zero if its length is odd.
+ * Ensures the hex string has an even number of characters for proper byte representation.
+ * @param hexString - The hex string to pad
+ * @returns The padded hex string with even length
+ * @example
+ * ```ts
+ * leftPadHex('abc') // '0abc'
+ * leftPadHex('abcd') // 'abcd'
+ * ```
+ */
 export const leftPadHex = (hexString: string): string =>
   hexString.length % 2 ? `0${hexString}` : hexString;
 
+/**
+ * Left pads a hex string with zeros to reach the specified length.
+ * If the string is already longer than the target length, it is returned unchanged.
+ * @param hexString - The hex string to pad
+ * @param length - The target length of the resulting string
+ * @returns The padded hex string
+ * @example
+ * ```ts
+ * leftPadHexToLength('ab', 4) // '00ab'
+ * leftPadHexToLength('abcdef', 4) // 'abcdef' (unchanged)
+ * ```
+ */
 export const leftPadHexToLength = (hexString: string, length: number): string =>
   hexString.padStart(length, '0');
 
+/**
+ * Right pads a hex string with zeros to reach the specified length.
+ * If the string is already longer than the target length, it is returned unchanged.
+ * @param hexString - The hex string to pad
+ * @param length - The target length of the resulting string
+ * @returns The padded hex string
+ * @example
+ * ```ts
+ * rightPadHexToLength('ab', 4) // 'ab00'
+ * rightPadHexToLength('abcdef', 4) // 'abcdef' (unchanged)
+ * ```
+ */
 export const rightPadHexToLength = (hexString: string, length: number): string =>
   hexString.padEnd(length, '0');
 
+/**
+ * Checks if a string exceeds a maximum byte length when encoded as UTF-8.
+ * Useful for validating memo fields and other length-limited string inputs.
+ * @param string - The string to check
+ * @param maxLengthBytes - The maximum allowed byte length
+ * @returns true if the string exceeds the limit, false otherwise
+ * @example
+ * ```ts
+ * exceedsMaxLengthBytes('hello', 10) // false
+ * exceedsMaxLengthBytes('hello', 4) // true
+ * exceedsMaxLengthBytes('😀', 3) // true (emoji = 4 bytes)
+ * ```
+ */
 export const exceedsMaxLengthBytes = (string: string, maxLengthBytes: number): boolean =>
   string ? utf8ToBytes(string).length > maxLengthBytes : false;
 
@@ -43,6 +91,17 @@ export function omit<T, K extends keyof any>(obj: T, prop: K): Omit<T, K> {
   return clone;
 }
 
+/**
+ * Computes the HASH160 of the input, which is RIPEMD160(SHA256(input)).
+ * This is the standard hash function used for Bitcoin/Stacks addresses.
+ * @param input - The bytes to hash
+ * @returns A 20-byte (160-bit) Uint8Array hash
+ * @example
+ * ```ts
+ * const publicKey = hexToBytes('...');
+ * const addressHash = hash160(publicKey);
+ * ```
+ */
 export const hash160 = (input: Uint8Array): Uint8Array => {
   return ripemd160(sha256(input));
 };
@@ -136,6 +195,20 @@ export const hashP2WSH = (numSigs: number, pubKeys: Uint8Array[]): string => {
   return bytesToHex(redeemScriptHash);
 };
 
+/**
+ * Validates whether a string is a valid Clarity identifier name.
+ * Clarity names must start with a letter or be a single operator character,
+ * can contain letters, numbers, and certain special characters, and must be
+ * less than 128 characters in length.
+ * @param name - The name to validate
+ * @returns true if the name is a valid Clarity identifier, false otherwise
+ * @example
+ * ```ts
+ * isClarityName('my-function') // true
+ * isClarityName('get_value') // true
+ * isClarityName('123invalid') // false (starts with number)
+ * ```
+ */
 export function isClarityName(name: string) {
   const regex = /^[a-zA-Z]([a-zA-Z0-9]|[-_!?+<>=/*])*$|^[-+=/*]$|^[<>]=?$/;
   return regex.test(name) && name.length < 128;
@@ -187,6 +260,17 @@ export const parseReadOnlyResponse = (response: ReadOnlyFunctionResponse): Clari
   throw new Error(response.cause);
 };
 
+/**
+ * Validates whether a string is a valid Stacks address.
+ * Uses c32check to verify the address format and checksum.
+ * @param address - The address string to validate
+ * @returns true if the address is valid, false otherwise
+ * @example
+ * ```ts
+ * validateStacksAddress('ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM') // true
+ * validateStacksAddress('invalid-address') // false
+ * ```
+ */
 export const validateStacksAddress = (address: string): boolean => {
   try {
     c32addressDecode(address);

--- a/packages/transactions/tests/units.test.ts
+++ b/packages/transactions/tests/units.test.ts
@@ -1,21 +1,79 @@
-import { microStxToStx, stxToMicroStx } from '../src/units';
+import { microStxToStx, stxToMicroStx, MICROSTX_IN_STX } from '../src/units';
 
-test(stxToMicroStx.name, () => {
-  expect(stxToMicroStx(1)).toBe(1000000);
-  expect(stxToMicroStx(1.23)).toBe(1230000);
-  expect(stxToMicroStx(0.000001)).toBe(1);
-
-  expect(stxToMicroStx(-1)).toBe(-1000000);
-  expect(stxToMicroStx(-2.34)).toBe(-2340000);
-  expect(stxToMicroStx(-0.000001)).toBe(-1);
+describe('MICROSTX_IN_STX constant', () => {
+  test('equals 1,000,000', () => {
+    expect(MICROSTX_IN_STX).toBe(1_000_000);
+  });
 });
 
-test(microStxToStx.name, () => {
-  expect(microStxToStx(1000000)).toBe(1);
-  expect(microStxToStx(1230000)).toBe(1.23);
-  expect(microStxToStx(1)).toBe(0.000001);
+describe(stxToMicroStx.name, () => {
+  test('converts whole numbers correctly', () => {
+    expect(stxToMicroStx(1)).toBe(1000000);
+    expect(stxToMicroStx(10)).toBe(10000000);
+    expect(stxToMicroStx(100)).toBe(100000000);
+  });
 
-  expect(microStxToStx(-1000000)).toBe(-1);
-  expect(microStxToStx(-2340000)).toBe(-2.34);
-  expect(microStxToStx(-1)).toBe(-0.000001);
+  test('converts decimal values correctly', () => {
+    expect(stxToMicroStx(1.23)).toBe(1230000);
+    expect(stxToMicroStx(0.5)).toBe(500000);
+    expect(stxToMicroStx(0.000001)).toBe(1);
+  });
+
+  test('handles negative values', () => {
+    expect(stxToMicroStx(-1)).toBe(-1000000);
+    expect(stxToMicroStx(-2.34)).toBe(-2340000);
+    expect(stxToMicroStx(-0.000001)).toBe(-1);
+  });
+
+  test('handles zero', () => {
+    expect(stxToMicroStx(0)).toBe(0);
+  });
+
+  test('handles very small fractions', () => {
+    // Values smaller than 1 μSTX result in fractions
+    expect(stxToMicroStx(0.0000001)).toBe(0.1);
+    expect(stxToMicroStx(0.00000001)).toBe(0.01);
+  });
+
+  test('handles large values', () => {
+    expect(stxToMicroStx(1000000)).toBe(1000000000000);
+    expect(stxToMicroStx(21000000)).toBe(21000000000000); // 21M STX
+  });
 });
+
+describe(microStxToStx.name, () => {
+  test('converts whole numbers correctly', () => {
+    expect(microStxToStx(1000000)).toBe(1);
+    expect(microStxToStx(10000000)).toBe(10);
+    expect(microStxToStx(100000000)).toBe(100);
+  });
+
+  test('converts partial STX values correctly', () => {
+    expect(microStxToStx(1230000)).toBe(1.23);
+    expect(microStxToStx(500000)).toBe(0.5);
+    expect(microStxToStx(1)).toBe(0.000001);
+  });
+
+  test('handles negative values', () => {
+    expect(microStxToStx(-1000000)).toBe(-1);
+    expect(microStxToStx(-2340000)).toBe(-2.34);
+    expect(microStxToStx(-1)).toBe(-0.000001);
+  });
+
+  test('handles zero', () => {
+    expect(microStxToStx(0)).toBe(0);
+  });
+
+  test('handles large values', () => {
+    expect(microStxToStx(1000000000000)).toBe(1000000);
+    expect(microStxToStx(21000000000000)).toBe(21000000); // 21M STX in μSTX
+  });
+
+  test('round-trip conversion is consistent', () => {
+    const originalStx = 123.456789;
+    const microStx = stxToMicroStx(originalStx);
+    const backToStx = microStxToStx(microStx);
+    expect(backToStx).toBe(originalStx);
+  });
+});
+

--- a/packages/transactions/tests/utils.test.ts
+++ b/packages/transactions/tests/utils.test.ts
@@ -1,4 +1,19 @@
-import { validateStacksAddress } from '../src/utils';
+import { bytesToHex, utf8ToBytes } from '@stacks/common';
+import {
+  validateStacksAddress,
+  leftPadHex,
+  leftPadHexToLength,
+  rightPadHexToLength,
+  exceedsMaxLengthBytes,
+  hash160,
+  txidFromBytes,
+  isClarityName,
+  cvToHex,
+  hexToCV,
+  parseReadOnlyResponse,
+  parseContractId,
+} from '../src/utils';
+import { intCV, uintCV, trueCV, falseCV, stringAsciiCV } from '../src/clarity';
 
 describe(validateStacksAddress.name, () => {
   test('it returns true for a legit address', () => {
@@ -23,5 +38,363 @@ describe(validateStacksAddress.name, () => {
     nonsenseNotRealSillyAddresses.forEach(nonAddress =>
       expect(validateStacksAddress(nonAddress)).toBeFalsy()
     );
+  });
+
+  test('returns false for empty string', () => {
+    expect(validateStacksAddress('')).toBeFalsy();
+  });
+});
+
+describe(leftPadHex.name, () => {
+  test('pads odd-length hex strings with leading zero', () => {
+    expect(leftPadHex('a')).toBe('0a');
+    expect(leftPadHex('abc')).toBe('0abc');
+    expect(leftPadHex('12345')).toBe('012345');
+  });
+
+  test('does not modify even-length hex strings', () => {
+    expect(leftPadHex('ab')).toBe('ab');
+    expect(leftPadHex('abcd')).toBe('abcd');
+    expect(leftPadHex('123456')).toBe('123456');
+  });
+
+  test('handles empty string', () => {
+    expect(leftPadHex('')).toBe('');
+  });
+
+  test('handles single character', () => {
+    expect(leftPadHex('0')).toBe('00');
+    expect(leftPadHex('f')).toBe('0f');
+  });
+});
+
+describe(leftPadHexToLength.name, () => {
+  test('pads hex string to specified length', () => {
+    expect(leftPadHexToLength('ab', 4)).toBe('00ab');
+    expect(leftPadHexToLength('1', 8)).toBe('00000001');
+    expect(leftPadHexToLength('ff', 6)).toBe('0000ff');
+  });
+
+  test('does not truncate if string is already longer', () => {
+    expect(leftPadHexToLength('abcdef', 4)).toBe('abcdef');
+    expect(leftPadHexToLength('12345678', 2)).toBe('12345678');
+  });
+
+  test('handles exact length match', () => {
+    expect(leftPadHexToLength('abcd', 4)).toBe('abcd');
+  });
+
+  test('handles empty string', () => {
+    expect(leftPadHexToLength('', 4)).toBe('0000');
+  });
+
+  test('handles zero length', () => {
+    expect(leftPadHexToLength('abc', 0)).toBe('abc');
+  });
+});
+
+describe(rightPadHexToLength.name, () => {
+  test('pads hex string on the right to specified length', () => {
+    expect(rightPadHexToLength('ab', 4)).toBe('ab00');
+    expect(rightPadHexToLength('1', 8)).toBe('10000000');
+    expect(rightPadHexToLength('ff', 6)).toBe('ff0000');
+  });
+
+  test('does not truncate if string is already longer', () => {
+    expect(rightPadHexToLength('abcdef', 4)).toBe('abcdef');
+    expect(rightPadHexToLength('12345678', 2)).toBe('12345678');
+  });
+
+  test('handles exact length match', () => {
+    expect(rightPadHexToLength('abcd', 4)).toBe('abcd');
+  });
+
+  test('handles empty string', () => {
+    expect(rightPadHexToLength('', 4)).toBe('0000');
+  });
+});
+
+describe(exceedsMaxLengthBytes.name, () => {
+  test('returns false when string is within limit', () => {
+    expect(exceedsMaxLengthBytes('hello', 10)).toBe(false);
+    expect(exceedsMaxLengthBytes('test', 4)).toBe(false);
+    expect(exceedsMaxLengthBytes('a', 1)).toBe(false);
+  });
+
+  test('returns true when string exceeds limit', () => {
+    expect(exceedsMaxLengthBytes('hello', 4)).toBe(true);
+    expect(exceedsMaxLengthBytes('testing', 5)).toBe(true);
+  });
+
+  test('handles UTF-8 multi-byte characters correctly', () => {
+    // Emoji typically uses 4 bytes
+    expect(exceedsMaxLengthBytes('😀', 3)).toBe(true);
+    expect(exceedsMaxLengthBytes('😀', 4)).toBe(false);
+    // Chinese character typically uses 3 bytes
+    expect(exceedsMaxLengthBytes('中', 2)).toBe(true);
+    expect(exceedsMaxLengthBytes('中', 3)).toBe(false);
+  });
+
+  test('returns false for empty string', () => {
+    expect(exceedsMaxLengthBytes('', 0)).toBe(false);
+    expect(exceedsMaxLengthBytes('', 10)).toBe(false);
+  });
+
+  test('handles null/undefined gracefully', () => {
+    // @ts-expect-error testing null input
+    expect(exceedsMaxLengthBytes(null, 10)).toBe(false);
+    // @ts-expect-error testing undefined input
+    expect(exceedsMaxLengthBytes(undefined, 10)).toBe(false);
+  });
+});
+
+describe(hash160.name, () => {
+  test('produces correct RIPEMD160(SHA256(input)) hash', () => {
+    const input = utf8ToBytes('hello');
+    const result = hash160(input);
+    
+    // hash160 should return a 20-byte (160-bit) Uint8Array
+    expect(result).toBeInstanceOf(Uint8Array);
+    expect(result.length).toBe(20);
+  });
+
+  test('produces consistent results for same input', () => {
+    const input = utf8ToBytes('test');
+    const result1 = hash160(input);
+    const result2 = hash160(input);
+    
+    expect(bytesToHex(result1)).toBe(bytesToHex(result2));
+  });
+
+  test('produces different results for different inputs', () => {
+    const input1 = utf8ToBytes('hello');
+    const input2 = utf8ToBytes('world');
+    
+    expect(bytesToHex(hash160(input1))).not.toBe(bytesToHex(hash160(input2)));
+  });
+
+  test('handles empty input', () => {
+    const input = new Uint8Array(0);
+    const result = hash160(input);
+    
+    expect(result).toBeInstanceOf(Uint8Array);
+    expect(result.length).toBe(20);
+  });
+});
+
+describe(txidFromBytes.name, () => {
+  test('produces a SHA512/256 hash as hex string', () => {
+    const input = utf8ToBytes('test transaction');
+    const result = txidFromBytes(input);
+    
+    // SHA512/256 produces a 32-byte (256-bit) hash, which is 64 hex chars
+    expect(typeof result).toBe('string');
+    expect(result.length).toBe(64);
+    expect(/^[0-9a-f]+$/.test(result)).toBe(true);
+  });
+
+  test('produces consistent results for same input', () => {
+    const input = utf8ToBytes('consistent input');
+    const result1 = txidFromBytes(input);
+    const result2 = txidFromBytes(input);
+    
+    expect(result1).toBe(result2);
+  });
+
+  test('produces different results for different inputs', () => {
+    const input1 = utf8ToBytes('transaction 1');
+    const input2 = utf8ToBytes('transaction 2');
+    
+    expect(txidFromBytes(input1)).not.toBe(txidFromBytes(input2));
+  });
+
+  test('handles empty input', () => {
+    const input = new Uint8Array(0);
+    const result = txidFromBytes(input);
+    
+    expect(typeof result).toBe('string');
+    expect(result.length).toBe(64);
+  });
+});
+
+describe(isClarityName.name, () => {
+  test('returns true for valid Clarity names', () => {
+    const validNames = [
+      'hello',
+      'my-function',
+      'get_value',
+      'is-valid?',
+      'add!',
+      'less<',
+      'greater>',
+      'equals=',
+      'multiply*',
+      'divide/',
+      'add+',
+      'subtract-',
+      'compare<=',
+      'compare>=',
+      'a1b2c3',
+      'testFunction123',
+    ];
+    validNames.forEach(name => {
+      expect(isClarityName(name)).toBe(true);
+    });
+  });
+
+  test('returns false for invalid Clarity names', () => {
+    const invalidNames = [
+      '123start', // starts with number
+      '-invalid', // starts with hyphen (unless it's just "-")
+      '_underscore', // starts with underscore
+      'has space',
+      'has.dot',
+      'has@symbol',
+      'has#hash',
+      'has$dollar',
+      'has%percent',
+    ];
+    invalidNames.forEach(name => {
+      expect(isClarityName(name)).toBe(false);
+    });
+  });
+
+  test('returns false for names exceeding 127 characters', () => {
+    const longName = 'a'.repeat(128);
+    expect(isClarityName(longName)).toBe(false);
+    
+    const validLongName = 'a'.repeat(127);
+    expect(isClarityName(validLongName)).toBe(true);
+  });
+
+  test('returns true for single special character operators', () => {
+    expect(isClarityName('-')).toBe(true);
+    expect(isClarityName('+')).toBe(true);
+    expect(isClarityName('*')).toBe(true);
+    expect(isClarityName('/')).toBe(true);
+    expect(isClarityName('<')).toBe(true);
+    expect(isClarityName('>')).toBe(true);
+    expect(isClarityName('=')).toBe(true);
+    expect(isClarityName('<=')).toBe(true);
+    expect(isClarityName('>=')).toBe(true);
+  });
+
+  test('returns false for empty string', () => {
+    expect(isClarityName('')).toBe(false);
+  });
+});
+
+describe(cvToHex.name, () => {
+  test('converts integer clarity values to hex', () => {
+    const cv = intCV(10);
+    const hex = cvToHex(cv);
+    
+    expect(hex.startsWith('0x')).toBe(true);
+    expect(typeof hex).toBe('string');
+  });
+
+  test('converts unsigned integer clarity values to hex', () => {
+    const cv = uintCV(100);
+    const hex = cvToHex(cv);
+    
+    expect(hex.startsWith('0x')).toBe(true);
+  });
+
+  test('converts boolean clarity values to hex', () => {
+    const trueHex = cvToHex(trueCV());
+    const falseHex = cvToHex(falseCV());
+    
+    expect(trueHex.startsWith('0x')).toBe(true);
+    expect(falseHex.startsWith('0x')).toBe(true);
+    expect(trueHex).not.toBe(falseHex);
+  });
+
+  test('converts string clarity values to hex', () => {
+    const cv = stringAsciiCV('hello');
+    const hex = cvToHex(cv);
+    
+    expect(hex.startsWith('0x')).toBe(true);
+  });
+});
+
+describe(hexToCV.name, () => {
+  test('converts hex back to clarity value (round-trip)', () => {
+    const original = intCV(42);
+    const hex = cvToHex(original);
+    const restored = hexToCV(hex);
+    
+    expect(cvToHex(restored)).toBe(hex);
+  });
+
+  test('handles hex with 0x prefix', () => {
+    const original = uintCV(100);
+    const hex = cvToHex(original);
+    const restored = hexToCV(hex);
+    
+    expect(cvToHex(restored)).toBe(hex);
+  });
+
+  test('handles hex without 0x prefix', () => {
+    const original = trueCV();
+    const hex = cvToHex(original);
+    const hexWithoutPrefix = hex.slice(2); // Remove '0x'
+    const restored = hexToCV(hexWithoutPrefix);
+    
+    expect(cvToHex(restored)).toBe(hex);
+  });
+});
+
+describe(parseReadOnlyResponse.name, () => {
+  test('parses successful response correctly', () => {
+    const cv = intCV(123);
+    const hex = cvToHex(cv);
+    const response = { okay: true as const, result: hex };
+    
+    const result = parseReadOnlyResponse(response);
+    expect(cvToHex(result)).toBe(hex);
+  });
+
+  test('throws error for error response', () => {
+    const response = { okay: false as const, cause: 'Something went wrong' };
+    
+    expect(() => parseReadOnlyResponse(response)).toThrow('Something went wrong');
+  });
+
+  test('handles different error messages', () => {
+    const response = { okay: false as const, cause: 'Contract not found' };
+    
+    expect(() => parseReadOnlyResponse(response)).toThrow('Contract not found');
+  });
+});
+
+describe(parseContractId.name, () => {
+  test('parses valid contract identifiers', () => {
+    const [address, name] = parseContractId('ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.my-contract');
+    
+    expect(address).toBe('ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM');
+    expect(name).toBe('my-contract');
+  });
+
+  test('handles contract names with hyphens', () => {
+    const [address, name] = parseContractId('SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7.token-contract-v2');
+    
+    expect(address).toBe('SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7');
+    expect(name).toBe('token-contract-v2');
+  });
+
+  test('throws for invalid contract identifier without dot', () => {
+    expect(() => parseContractId('invalid-no-dot' as any)).toThrow('Invalid contract identifier');
+  });
+
+  test('throws for empty contract identifier', () => {
+    expect(() => parseContractId('' as any)).toThrow('Invalid contract identifier');
+  });
+
+  test('throws for contract identifier with only address', () => {
+    expect(() => parseContractId('ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.' as any)).toThrow('Invalid contract identifier');
+  });
+
+  test('throws for contract identifier with only name', () => {
+    expect(() => parseContractId('.my-contract' as any)).toThrow('Invalid contract identifier');
   });
 });


### PR DESCRIPTION
## Summary
This PR improves test coverage and documentation for the `@stacks/transactions` package.

## Changes
- **utils.test.ts**: Added 11 test suites for previously untested utility functions including `leftPadHex`, `hash160`, `isClarityName`, `cvToHex`, `hexToCV`, `parseReadOnlyResponse`, and `parseContractId`
- **utils.ts**: Added JSDoc documentation with examples for 7 utility functions
- **errors.ts**: Added JSDoc documentation to all error classes
- **units.test.ts**: Reorganized with describe blocks and added edge case tests (zero values, large values, round-trip conversions)

## Why
The `utils.test.ts` previously only tested 1 of 25+ functions. This PR significantly improves test coverage and makes the codebase more developer-friendly with better documentation.

## Testing
All existing tests continue to pass. New tests verify edge cases and expected behavior.