### PR TITLE
feat: Add originator post-condition mode and maybe-sent condition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -3308,7 +3307,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4737,7 +4735,6 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -5564,7 +5561,6 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -5768,7 +5764,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
       "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -5944,7 +5939,6 @@
       "integrity": "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
         "@typescript-eslint/scope-manager": "6.21.0",
@@ -5981,7 +5975,6 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -6738,7 +6731,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8038,7 +8030,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -10293,6 +10284,29 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -11138,7 +11152,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -11195,7 +11208,6 @@
       "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -11339,7 +11351,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -12465,8 +12476,7 @@
       "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.16.11.tgz",
       "integrity": "sha512-LaI+KaX2NFkfn1ZGHoKCmcfv7yrZsC3b8NtWsTVQeHkq4F27vI5igUuO53sxqDEa2gNQMHFPmpojDw/1zmUK7w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fresh": {
       "version": "0.5.2",
@@ -13822,7 +13832,6 @@
       "integrity": "sha512-FHCCztTkHoV9mdBsHpocLpdTAfh956ZQcIkWQxxS0U5HT53vtrcuYdQneEJKH6xILaLNzXVl2Cvwtoy8XNN0AA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "fp-ts": "^2.5.0"
       }
@@ -14673,7 +14682,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -16201,7 +16209,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -18603,7 +18610,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@napi-rs/wasm-runtime": "0.2.4",
         "@yarnpkg/lockfile": "^1.1.0",
@@ -19997,7 +20003,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -20346,7 +20351,6 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -21789,7 +21793,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -23324,7 +23327,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -23593,7 +23595,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -23965,7 +23966,6 @@
       "integrity": "sha512-ahJ6Cpcvxwaxfu4KtjA8qZNqS43wYt6JL27wYiIgl1vd38WW/KWX11YuAeZhuz9v+ttrutSsgK+XO1CjL1kA3w==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "lunr": "^2.3.9",
         "marked": "^4.3.0",
@@ -24004,7 +24004,6 @@
       "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -24116,7 +24115,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "napi-postinstall": "^0.3.0"
       },
@@ -24448,7 +24446,6 @@
       "integrity": "sha512-7h/weGm9d/ywQ6qzJ+Xy+r9n/3qgp/thalBbpOi5i223dPXKi04IBtqPN9nTd+jBc7QKfvDbaBnFipYp4sJAUQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -24538,7 +24535,6 @@
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",
@@ -24849,7 +24845,6 @@
       "resolved": "https://registry.npmjs.org/winston/-/winston-3.18.3.tgz",
       "integrity": "sha512-NoBZauFNNWENgsnC9YpgyYwOVrl2m58PpQ8lNHjV3kosGs7KJ7Npk9pCUE+WJlawVSe8mykWDKWFSVfs3QO9ww==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@colors/colors": "^1.6.0",
         "@dabh/diagnostics": "^2.0.8",

--- a/packages/transactions/src/constants.ts
+++ b/packages/transactions/src/constants.ts
@@ -103,7 +103,14 @@ export enum PostConditionMode {
   Allow = 0x01,
   /** `Deny` — Do not allow unspecified transfers */
   Deny = 0x02,
-  /** `Originator` — Deny for the transaction origin, Allow for everyone else (SIP-040) */
+  /**
+   * `Originator` (SIP-040) — Deny for the transaction origin, Allow for everyone else
+   *
+   * **⚠︎ Attention**: Enabled with [Epoch 3.4](https://forum.stacks.org/t/clarity-5-and-epoch-3-4/18659)
+   *
+   * @see [SIP-039](https://github.com/stacksgov/sips/pull/256/changes)
+   * @see [SIP-040](https://github.com/stacksgov/sips/pull/257/changes)
+   */
   Originator = 0x03,
 }
 
@@ -185,7 +192,14 @@ export enum FungibleConditionCode {
 export enum NonFungibleConditionCode {
   Sends = 0x10,
   DoesNotSend = 0x11,
-  /** `MaybeSent` — The NFT may or may not be sent; always passes (SIP-040) */
+  /**
+   * `MaybeSent` (SIP-040) — The NFT may or may not be sent; always passes
+   *
+   * **⚠︎ Attention**: Enabled with [Epoch 3.4](https://forum.stacks.org/t/clarity-5-and-epoch-3-4/18659)
+   *
+   * @see [SIP-039](https://github.com/stacksgov/sips/pull/256/changes)
+   * @see [SIP-040](https://github.com/stacksgov/sips/pull/257/changes)
+   */
   MaybeSent = 0x12,
 }
 

--- a/packages/transactions/src/constants.ts
+++ b/packages/transactions/src/constants.ts
@@ -103,6 +103,8 @@ export enum PostConditionMode {
   Allow = 0x01,
   /** `Deny` — Do not allow unspecified transfers */
   Deny = 0x02,
+  /** `Originator` — Deny for the transaction origin, Allow for everyone else (SIP-040) */
+  Originator = 0x03,
 }
 
 /**
@@ -183,6 +185,8 @@ export enum FungibleConditionCode {
 export enum NonFungibleConditionCode {
   Sends = 0x10,
   DoesNotSend = 0x11,
+  /** `MaybeSent` — The NFT may or may not be sent; always passes (SIP-040) */
+  MaybeSent = 0x12,
 }
 
 /**

--- a/packages/transactions/src/pc.ts
+++ b/packages/transactions/src/pc.ts
@@ -166,6 +166,15 @@ class PartialPcWithPrincipal {
   willNotSendAsset() {
     return new PartialPcNftWithCode(this.address, 'not-sent');
   }
+
+  /**
+   * ### NFT Post Condition
+   * A post-condition where the NFT `NonFungibleConditionCode.MaybeSent` (may or may not be sent).
+   * Finalize with the chained `.nft(…)` method.
+   */
+  willMaybeSendAsset() {
+    return new PartialPcNftWithCode(this.address, 'maybe-sent');
+  }
 }
 
 /**

--- a/packages/transactions/src/pc.ts
+++ b/packages/transactions/src/pc.ts
@@ -171,6 +171,11 @@ class PartialPcWithPrincipal {
    * ### NFT Post Condition
    * A post-condition where the NFT `NonFungibleConditionCode.MaybeSent` (may or may not be sent).
    * Finalize with the chained `.nft(…)` method.
+   *
+   * **⚠︎ Attention**: Enabled with [Epoch 3.4](https://forum.stacks.org/t/clarity-5-and-epoch-3-4/18659)
+   *
+   * @see [SIP-039](https://github.com/stacksgov/sips/pull/256/changes)
+   * @see [SIP-040](https://github.com/stacksgov/sips/pull/257/changes)
    */
   willMaybeSendAsset() {
     return new PartialPcNftWithCode(this.address, 'maybe-sent');

--- a/packages/transactions/src/postcondition-types.ts
+++ b/packages/transactions/src/postcondition-types.ts
@@ -25,7 +25,7 @@ export type FungiblePostCondition = {
   amount: string | bigint | number;
 };
 
-export type NonFungibleComparator = 'sent' | 'not-sent';
+export type NonFungibleComparator = 'sent' | 'not-sent' | 'maybe-sent';
 
 export type NonFungiblePostCondition = {
   type: 'nft-postcondition';
@@ -41,4 +41,4 @@ export type NonFungiblePostCondition = {
 
 export type PostCondition = StxPostCondition | FungiblePostCondition | NonFungiblePostCondition;
 
-export type PostConditionModeName = 'allow' | 'deny';
+export type PostConditionModeName = 'allow' | 'deny' | 'originator';

--- a/packages/transactions/src/postcondition-types.ts
+++ b/packages/transactions/src/postcondition-types.ts
@@ -25,6 +25,18 @@ export type FungiblePostCondition = {
   amount: string | bigint | number;
 };
 
+/**
+ * The type of non-fungible token post-condition comparison.
+ *
+ * - `sent`: The NFT MUST have been sent by the principal.
+ * - `not-sent`: The NFT MUST NOT have been sent by the principal.
+ * - `maybe-sent`: The NFT may or may not have been sent by the principal.
+ *
+ * **⚠︎ Attention**: `maybe-sent` is only enabled starting with [Epoch 3.4](https://forum.stacks.org/t/clarity-5-and-epoch-3-4/18659)
+ *
+ * @see [SIP-039](https://github.com/stacksgov/sips/pull/256/changes)
+ * @see [SIP-040](https://github.com/stacksgov/sips/pull/257/changes)
+ */
 export type NonFungibleComparator = 'sent' | 'not-sent' | 'maybe-sent';
 
 export type NonFungiblePostCondition = {
@@ -41,4 +53,17 @@ export type NonFungiblePostCondition = {
 
 export type PostCondition = StxPostCondition | FungiblePostCondition | NonFungiblePostCondition;
 
+/**
+ * Describes how unspecified asset transfers are handled in a transaction:
+ * - `'allow'`: Allow unspecified asset transfers.
+ * - `'deny'`: Do not allow unspecified asset transfers.
+ * - `'originator'`: Deny unspecified asset transfers for the transaction origin, allow for others (e.g. smart contracts).
+ *
+ * **Note**: Specified post-conditions are always checked, regardless of _mode_.
+ *
+ * **⚠︎ Attention**: `originator` is only enabled starting with [Epoch 3.4](https://forum.stacks.org/t/clarity-5-and-epoch-3-4/18659)
+ *
+ * @see {@link https://github.com/stacksgov/sips/pull/256/changes SIP-039}
+ * @see {@link https://github.com/stacksgov/sips/pull/257/changes SIP-040}
+ */
 export type PostConditionModeName = 'allow' | 'deny' | 'originator';

--- a/packages/transactions/src/postcondition.ts
+++ b/packages/transactions/src/postcondition.ts
@@ -47,6 +47,7 @@ enum PostConditionCodeWireType {
 
   sent = NonFungibleConditionCode.Sends,
   'not-sent' = NonFungibleConditionCode.DoesNotSend,
+  'maybe-sent' = NonFungibleConditionCode.MaybeSent,
 }
 
 export function postConditionToWire(postcondition: PostCondition): PostConditionWire {
@@ -178,6 +179,7 @@ export function postConditionModeFrom(
   if (typeof mode === 'number') return mode;
   if (mode === 'allow') return PostConditionMode.Allow;
   if (mode === 'deny') return PostConditionMode.Deny;
+  if (mode === 'originator') return PostConditionMode.Originator;
   throw new Error(`Invalid post condition mode: ${mode}`);
 }
 

--- a/packages/transactions/tests/builder.test.ts
+++ b/packages/transactions/tests/builder.test.ts
@@ -2971,3 +2971,26 @@ describe('multi-sig', () => {
     await expect(txMismatch).rejects.toThrow();
   });
 });
+
+test('Build transaction with originator post-condition mode', async () => {
+  const senderKey = 'edf9aee84d9b7abc145504dde6726c64f369d37ee34ded868fabd876c26570bc01';
+  const publicKey = privateKeyToPublic(senderKey);
+
+  const transaction = await makeUnsignedContractCall({
+    contractAddress: 'SP3FGQ8Z7JY9BWYZ5WM53E0M9NK7WHJF0691NZ159',
+    contractName: 'test-contract',
+    functionName: 'test-function',
+    functionArgs: [],
+    publicKey,
+    fee: 0,
+    nonce: 0,
+    network: STACKS_TESTNET,
+    postConditionMode: 'originator',
+  });
+
+  const serialized = transaction.serializeBytes();
+  const deserializedTx = deserializeTransaction(new BytesReader(serialized));
+
+  expect(deserializedTx.postConditionMode).toBe(PostConditionMode.Originator);
+  expect(deserializedTx.postConditionMode).toBe(0x03);
+});

--- a/packages/transactions/tests/pc.test.ts
+++ b/packages/transactions/tests/pc.test.ts
@@ -242,6 +242,20 @@ describe('pc -- post condition builder', () => {
         } as NonFungiblePostCondition;
         expect(pc).toEqual(postCondition);
       });
+
+      test('will maybe send nft', () => {
+        const pc = Pc.principal(STANDARD_ADDRESS)
+          .willMaybeSendAsset()
+          .nft(`${NFT_CONTRACT_ADDRESS}.${NFT_CONTRACT_NAME}`, NFT_TOKEN_NAME, NFT_ASSET_ID);
+        const postCondition = {
+          type: 'nft-postcondition',
+          address: STANDARD_ADDRESS,
+          condition: 'maybe-sent',
+          asset: `${NFT_CONTRACT_ADDRESS}.${NFT_CONTRACT_NAME}::${NFT_TOKEN_NAME}`,
+          assetId: NFT_ASSET_ID,
+        } as NonFungiblePostCondition;
+        expect(pc).toEqual(postCondition);
+      });
     });
   });
 
@@ -403,6 +417,20 @@ describe('pc -- post condition builder', () => {
         } as NonFungiblePostCondition;
         expect(pc).toEqual(postCondition);
       });
+
+      test('will maybe send nft', () => {
+        const pc = Pc.principal(`${CONTRACT_ADDRESS}.${CONTRACT_NAME}`)
+          .willMaybeSendAsset()
+          .nft(`${NFT_CONTRACT_ADDRESS}.${NFT_CONTRACT_NAME}`, NFT_TOKEN_NAME, NFT_ASSET_ID);
+        const postCondition = {
+          type: 'nft-postcondition',
+          address: `${CONTRACT_ADDRESS}.${CONTRACT_NAME}`,
+          condition: 'maybe-sent',
+          asset: `${NFT_CONTRACT_ADDRESS}.${NFT_CONTRACT_NAME}::${NFT_TOKEN_NAME}`,
+          assetId: NFT_ASSET_ID,
+        } as NonFungiblePostCondition;
+        expect(pc).toEqual(postCondition);
+      });
     });
   });
 
@@ -414,6 +442,19 @@ describe('pc -- post condition builder', () => {
         address: 'origin',
         condition: 'eq',
         amount: '12345',
+      });
+    });
+
+    test('origin will maybe send nft', () => {
+      const pc = Pc.origin()
+        .willMaybeSendAsset()
+        .nft(`${NFT_CONTRACT_ADDRESS}.${NFT_CONTRACT_NAME}`, NFT_TOKEN_NAME, NFT_ASSET_ID);
+      expect(pc).toEqual({
+        type: 'nft-postcondition',
+        address: 'origin',
+        condition: 'maybe-sent',
+        asset: `${NFT_CONTRACT_ADDRESS}.${NFT_CONTRACT_NAME}::${NFT_TOKEN_NAME}`,
+        assetId: NFT_ASSET_ID,
       });
     });
   });

--- a/packages/transactions/tests/postcondition.test.ts
+++ b/packages/transactions/tests/postcondition.test.ts
@@ -13,12 +13,14 @@ import { BufferCV, bufferCVFromString } from '../src/clarity';
 import {
   FungibleConditionCode,
   NonFungibleConditionCode,
+  PostConditionMode,
   PostConditionPrincipalId,
   PostConditionType,
 } from '../src/constants';
 import {
   conditionByteToType,
   conditionTypeToByte,
+  postConditionModeFrom,
   postConditionToHex,
   postConditionToWire,
   wireToPostCondition,
@@ -131,6 +133,44 @@ test('Non-fungible post condition serialization and deserialization', () => {
   expect(bytesToUtf8(hexToBytes((deserialized.assetName as BufferCV).value))).toEqual(nftAssetName);
 });
 
+test('Non-fungible post condition with maybe-sent serialization and deserialization', () => {
+  const postConditionType = PostConditionType.NonFungible;
+
+  const address = 'SP2JXKMSH007NPYAQHKJPQMAQYAD90NQGTVJVQ02B';
+  const contractName = 'contract-name';
+
+  const conditionCode = NonFungibleConditionCode.MaybeSent;
+
+  const assetAddress = 'SP2ZP4GJDZJ1FDHTQ963F0292PE9J9752TZJ68F21';
+  const assetContractName = 'contract_name';
+  const assetName = 'asset_name';
+
+  const nftAssetName = 'nft_asset_name';
+
+  const postCondition = postConditionToWire({
+    type: 'nft-postcondition',
+    address: `${address}.${contractName}`,
+    condition: 'maybe-sent',
+    asset: `${assetAddress}.${assetContractName}::${assetName}`,
+    assetId: bufferCVFromString(nftAssetName),
+  });
+
+  const deserialized = serializeDeserialize(
+    postCondition,
+    StacksWireType.PostCondition
+  ) as NonFungiblePostConditionWire;
+  expect(deserialized.conditionType).toBe(postConditionType);
+  expect(deserialized.principal.prefix).toBe(PostConditionPrincipalId.Contract);
+  if (!('address' in deserialized.principal)) throw TypeError;
+  expect(addressToString(deserialized.principal.address)).toBe(address);
+  expect((deserialized.principal as ContractPrincipalWire).contractName.content).toBe(contractName);
+  expect(deserialized.conditionCode).toBe(conditionCode);
+  expect(addressToString(deserialized.asset.address)).toBe(assetAddress);
+  expect(deserialized.asset.contractName.content).toBe(assetContractName);
+  expect(deserialized.asset.assetName.content).toBe(assetName);
+  expect(bytesToUtf8(hexToBytes((deserialized.assetName as BufferCV).value))).toEqual(nftAssetName);
+});
+
 test('Non-fungible post condition with string IDs serialization and deserialization', () => {
   const postConditionType = PostConditionType.NonFungible;
 
@@ -202,11 +242,40 @@ describe(postConditionToHex.name, () => {
       expected:
         '02021a164247d6f2b425ac5771423ae6c80c754f7172b01a164247d6f2b425ac5771423ae6c80c754f7172b005746f6b656e03746f6b010000000000000000000000000000002011',
     },
+    {
+      repr: {
+        type: 'nft-postcondition',
+        address: 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6',
+        condition: 'maybe-sent',
+        asset: 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6.token::tok',
+        assetId: Cl.uint(32),
+      } as const,
+      expected:
+        '02021a164247d6f2b425ac5771423ae6c80c754f7172b01a164247d6f2b425ac5771423ae6c80c754f7172b005746f6b656e03746f6b010000000000000000000000000000002012',
+    },
   ];
 
   test.each(TEST_CASES)('postConditionToHex %p', ({ repr, expected }) => {
     const hex = postConditionToHex(repr);
     expect(hex).toBe(expected);
+  });
+});
+
+describe('postConditionModeFrom', () => {
+  test('converts originator string to PostConditionMode.Originator', () => {
+    expect(postConditionModeFrom('originator')).toBe(PostConditionMode.Originator);
+  });
+
+  test('converts allow string to PostConditionMode.Allow', () => {
+    expect(postConditionModeFrom('allow')).toBe(PostConditionMode.Allow);
+  });
+
+  test('converts deny string to PostConditionMode.Deny', () => {
+    expect(postConditionModeFrom('deny')).toBe(PostConditionMode.Deny);
+  });
+
+  test('passes through numeric enum values', () => {
+    expect(postConditionModeFrom(PostConditionMode.Originator)).toBe(PostConditionMode.Originator);
   });
 });
 
@@ -322,6 +391,7 @@ describe('conditionTypeToByte', () => {
   const nonFungibleTestCases = [
     { name: 'sent', expectedCode: NonFungibleConditionCode.Sends },
     { name: 'not-sent', expectedCode: NonFungibleConditionCode.DoesNotSend },
+    { name: 'maybe-sent', expectedCode: NonFungibleConditionCode.MaybeSent },
   ] as const;
 
   test.each(fungibleTestCases)(
@@ -353,6 +423,7 @@ describe('conditionBytesToType', () => {
   const nonFungibleTestCases = [
     { code: NonFungibleConditionCode.Sends, expectedName: 'sent' },
     { code: NonFungibleConditionCode.DoesNotSend, expectedName: 'not-sent' },
+    { code: NonFungibleConditionCode.MaybeSent, expectedName: 'maybe-sent' },
   ] as const;
 
   test.each(fungibleTestCases)(
@@ -559,5 +630,80 @@ describe('post-condition amount u64 validation', () => {
         })
       ).toThrow();
     });
+  });
+});
+
+describe('SIP-040 stacks-core test vectors', () => {
+  test('Vector 1: Originator mode + STX SentEq post-condition', () => {
+    const txHex =
+      '80800000000400143e543243dfcd8c02a12ad7ea371bd07bc91df90000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003030000000100010100000000000003e801047465737400000009286f6b207472756529';
+    const tx = deserializeTransaction(txHex);
+    expect(tx.postConditionMode).toBe(PostConditionMode.Originator);
+    expect(tx.postConditions.values).toHaveLength(1);
+    const pc = wireToPostCondition(tx.postConditions.values[0]);
+    expect(pc.type).toBe('stx-postcondition');
+    expect(pc.address).toBe('origin');
+    expect(pc.condition).toBe('eq');
+    expect((pc as StxPostCondition).amount).toBe('1000');
+  });
+
+  test('Vector 2: Originator mode + Fungible SentGe post-condition', () => {
+    const txHex =
+      '80800000000400143e543243dfcd8c02a12ad7ea371bd07bc91df900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000030300000001010101aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0d746573742d636f6e747261637408746573742d6e667403000000000000138801047465737400000009286f6b207472756529';
+    const tx = deserializeTransaction(txHex);
+    expect(tx.postConditionMode).toBe(PostConditionMode.Originator);
+    const pc = wireToPostCondition(tx.postConditions.values[0]);
+    expect(pc.type).toBe('ft-postcondition');
+    expect(pc.address).toBe('origin');
+    expect(pc.condition).toBe('gte');
+  });
+
+  test('Vector 3: Originator mode + NFT MaybeSent post-condition', () => {
+    const txHex =
+      '80800000000400143e543243dfcd8c02a12ad7ea371bd07bc91df900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000030300000001020101aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0d746573742d636f6e747261637408746573742d6e667401000000000000000000000000000000011201047465737400000009286f6b207472756529';
+    const tx = deserializeTransaction(txHex);
+    expect(tx.postConditionMode).toBe(PostConditionMode.Originator);
+    const pc = wireToPostCondition(tx.postConditions.values[0]);
+    expect(pc.type).toBe('nft-postcondition');
+    expect(pc.address).toBe('origin');
+    expect(pc.condition).toBe('maybe-sent');
+  });
+
+  test('Vector 4: Deny mode + NFT MaybeSent post-condition', () => {
+    const txHex =
+      '80800000000400143e543243dfcd8c02a12ad7ea371bd07bc91df900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000030200000001020101aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0d746573742d636f6e747261637408746573742d6e667401000000000000000000000000000000011201047465737400000009286f6b207472756529';
+    const tx = deserializeTransaction(txHex);
+    expect(tx.postConditionMode).toBe(PostConditionMode.Deny);
+    const pc = wireToPostCondition(tx.postConditions.values[0]);
+    expect(pc.type).toBe('nft-postcondition');
+    expect(pc.condition).toBe('maybe-sent');
+  });
+
+  test('Vector 5: Originator mode + multiple post-conditions (STX + NFT MaybeSent)', () => {
+    const txHex =
+      '80800000000400143e543243dfcd8c02a12ad7ea371bd07bc91df90000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003030000000200010500000000000007d0020101aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0d746573742d636f6e747261637408746573742d6e6674010000000000000000000000000000002a1201047465737400000009286f6b207472756529';
+    const tx = deserializeTransaction(txHex);
+    expect(tx.postConditionMode).toBe(PostConditionMode.Originator);
+    expect(tx.postConditions.values).toHaveLength(2);
+    const pc0 = wireToPostCondition(tx.postConditions.values[0]);
+    expect(pc0.type).toBe('stx-postcondition');
+    expect(pc0.address).toBe('origin');
+    expect(pc0.condition).toBe('lte');
+    expect((pc0 as StxPostCondition).amount).toBe('2000');
+    const pc1 = wireToPostCondition(tx.postConditions.values[1]);
+    expect(pc1.type).toBe('nft-postcondition');
+    expect(pc1.address).toBe('origin');
+    expect(pc1.condition).toBe('maybe-sent');
+  });
+
+  test('Vector 6: Standalone MaybeSent NFT post-condition bytes', () => {
+    const hex =
+      '020101aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0d746573742d636f6e747261637408746573742d6e6674010000000000000000000000000000000112';
+    const pc = Pc.fromHex(hex);
+    expect(pc.type).toBe('nft-postcondition');
+    expect(pc.condition).toBe('maybe-sent');
+    if (pc.type === 'nft-postcondition') {
+      expect(pc.assetId).toEqual(Cl.uint(1));
+    }
   });
 });


### PR DESCRIPTION
## Summary                                                                                                                                                     
                                                                                                                                                              
Add SIP-040 post-condition support for Epoch 3.4:                                                                                                           
                                                                                                                                                              
  - PostConditionMode.Originator (0x03) — Deny semantics for the tx origin's assets, Allow for everyone else
  - NonFungibleConditionCode.MaybeSent (0x12) — NFT condition that always passes; useful when a transfer is optional                                          
  - New Pc.willMaybeSendAsset() builder method and 'originator' post-condition mode string  

---

- adds `originator` str enum mode
- adds `maybe-sent` str enum condition

See also:
   * [SIP-039](https://github.com/stacksgov/sips/pull/256/changes)
   * [SIP-040](https://github.com/stacksgov/sips/pull/257/changes)