### PR TITLE
ci: fix wallet-sdk repository field

### DIFF
--- a/packages/wallet-sdk/package.json
+++ b/packages/wallet-sdk/package.json
@@ -64,5 +64,9 @@
   "files": [
     "dist",
     "src"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/stx-labs/stacks.js.git"
+  }
 }


### PR DESCRIPTION
- add missing field in package.json which was failing provenanced publishing