### PR TITLE
feat: consolidate `contract` param in tx builders

### DIFF
--- a/packages/transactions/src/builders.ts
+++ b/packages/transactions/src/builders.ts
@@ -84,7 +84,7 @@ export type SignedMultiSigOptions = UnsignedMultiSigOptions & {
 export type TokenTransferOptions = {
   /** the address of the recipient of the token transfer */
   recipient: string | PrincipalCV;
-  /** the amount to be transfered in microstacks */
+  /** the amount to be transferred in microstacks */
   amount: IntegerType;
   /** the transaction fee in microstacks */
   fee?: IntegerType;

--- a/packages/transactions/src/builders.ts
+++ b/packages/transactions/src/builders.ts
@@ -256,18 +256,11 @@ export type ContractDeployParams = {
   sponsored?: boolean;
 } & NetworkClientParam;
 
-export interface UnsignedContractDeployParams extends ContractDeployParams {
-  /** a hex string of the public key of the transaction sender */
-  publicKey: PublicKey;
-}
+export type UnsignedContractDeployParams = ContractDeployParams &
+  ({ publicKey: PublicKey } | UnsignedMultiSigOptions);
 
-export interface SignedContractDeployParams extends ContractDeployParams {
-  senderKey: PrivateKey;
-}
-
-export type UnsignedMultiSigContractDeployParams = ContractDeployParams & UnsignedMultiSigOptions;
-
-export type SignedMultiSigContractDeployParams = ContractDeployParams & SignedMultiSigOptions;
+export type SignedContractDeployParams = ContractDeployParams &
+  ({ senderKey: PrivateKey } | SignedMultiSigOptions);
 
 /**
  * Contract deploy transaction options (legacy shape).
@@ -306,35 +299,22 @@ export interface SignedContractDeployOptions extends BaseContractDeployOptions {
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface ContractDeployOptions extends SignedContractDeployOptions {}
 
-/** @deprecated Use {@link UnsignedMultiSigContractDeployParams} instead. */
+/** @deprecated Use {@link UnsignedContractDeployParams} instead. */
 export type UnsignedMultiSigContractDeployOptions = BaseContractDeployOptions &
   UnsignedMultiSigOptions;
 
-/** @deprecated Use {@link SignedMultiSigContractDeployParams} instead. */
+/** @deprecated Use {@link SignedContractDeployParams} instead. */
 export type SignedMultiSigContractDeployOptions = BaseContractDeployOptions & SignedMultiSigOptions;
 
-/**
- * If the preferred `name`/`clarityCode` fields are present, renames them to
- * the legacy `contractName`/`codeBody` shape used internally. All other
- * properties pass through untouched.
- * @internal
- */
-function toLegacyContractDeployOptions<T extends object>(
-  opts: T
-): T & { contractName: string; codeBody: string } {
-  const o = opts as { name?: string; clarityCode?: string };
-  if (!o.name && !o.clarityCode) return opts as T & { contractName: string; codeBody: string };
-  const { name, clarityCode, ...rest } = opts as T & {
-    name?: string;
-    clarityCode?: string;
-    contractName?: string;
-    codeBody?: string;
-  };
-  return {
-    ...(rest as T),
-    contractName: name ?? rest.contractName!,
-    codeBody: clarityCode ?? rest.codeBody!,
-  };
+/** @internal If both shapes are provided, `name`/`clarityCode` take precedence. */
+function toLegacyContractDeployOptions<
+  T extends { name: string; clarityCode: string } | { contractName: string; codeBody: string },
+>(opts: T): T & { contractName: string; codeBody: string } {
+  if ('name' in opts) {
+    const o = opts as T & { name: string; clarityCode: string };
+    return { ...opts, contractName: o.name, codeBody: o.clarityCode };
+  }
+  return opts as T & { contractName: string; codeBody: string };
 }
 
 /**
@@ -349,7 +329,7 @@ function toLegacyContractDeployOptions<T extends object>(
  * @return {StacksTransactionWire}
  */
 export async function makeContractDeploy(
-  txOptions: SignedContractDeployParams | SignedMultiSigContractDeployParams
+  txOptions: SignedContractDeployParams
 ): Promise<StacksTransactionWire>;
 /** @deprecated Use {@link SignedContractDeployParams} with `name` and `clarityCode` fields. */
 export async function makeContractDeploy(
@@ -358,7 +338,6 @@ export async function makeContractDeploy(
 export async function makeContractDeploy(
   _txOptions:
     | SignedContractDeployParams
-    | SignedMultiSigContractDeployParams
     | SignedContractDeployOptions
     | SignedMultiSigContractDeployOptions
 ): Promise<StacksTransactionWire> {
@@ -398,7 +377,7 @@ export async function makeContractDeploy(
  * (with `contractName` and `codeBody`).
  */
 export async function makeUnsignedContractDeploy(
-  txOptions: UnsignedContractDeployParams | UnsignedMultiSigContractDeployParams
+  txOptions: UnsignedContractDeployParams
 ): Promise<StacksTransactionWire>;
 /** @deprecated Use {@link UnsignedContractDeployParams} with `name` and `clarityCode` fields. */
 export async function makeUnsignedContractDeploy(
@@ -407,7 +386,6 @@ export async function makeUnsignedContractDeploy(
 export async function makeUnsignedContractDeploy(
   _txOptions:
     | UnsignedContractDeployParams
-    | UnsignedMultiSigContractDeployParams
     | UnsignedContractDeployOptions
     | UnsignedMultiSigContractDeployOptions
 ): Promise<StacksTransactionWire> {
@@ -525,17 +503,11 @@ export type ContractCallParams = {
   sponsored?: boolean;
 } & NetworkClientParam;
 
-export interface UnsignedContractCallParams extends ContractCallParams {
-  publicKey: PublicKey;
-}
+export type UnsignedContractCallParams = ContractCallParams &
+  ({ publicKey: PublicKey } | UnsignedMultiSigOptions);
 
-export interface SignedContractCallParams extends ContractCallParams {
-  senderKey: PrivateKey;
-}
-
-export type UnsignedMultiSigContractCallParams = ContractCallParams & UnsignedMultiSigOptions;
-
-export type SignedMultiSigContractCallParams = ContractCallParams & SignedMultiSigOptions;
+export type SignedContractCallParams = ContractCallParams &
+  ({ senderKey: PrivateKey } | SignedMultiSigOptions);
 
 /**
  * Contract function call transaction options (legacy shape, split contract identifier).
@@ -573,25 +545,23 @@ export interface SignedContractCallOptions extends ContractCallOptions {
   senderKey: PublicKey;
 }
 
-/** @deprecated Use {@link UnsignedMultiSigContractCallParams} instead. */
+/** @deprecated Use {@link UnsignedContractCallParams} instead. */
 export type UnsignedMultiSigContractCallOptions = ContractCallOptions & UnsignedMultiSigOptions;
 
-/** @deprecated Use {@link SignedMultiSigContractCallParams} instead. */
+/** @deprecated Use {@link SignedContractCallParams} instead. */
 export type SignedMultiSigContractCallOptions = ContractCallOptions & SignedMultiSigOptions;
 
-/**
- * If the combined `contract` field is present, splits it into the legacy
- * `contractAddress` + `contractName` shape used internally. All other
- * properties pass through untouched.
- * @internal
- */
-function toLegacyContractCallOptions<T extends object>(
-  opts: T
-): T & { contractAddress: string; contractName: string } {
-  const o = opts as { contract?: ContractIdString };
-  if (!o.contract) return opts as T & { contractAddress: string; contractName: string };
-  const [contractAddress, contractName] = parseContractId(o.contract);
-  return { ...opts, contractAddress, contractName };
+/** @internal If both shapes are provided, `contract` takes precedence over `contractAddress`/`contractName`. */
+function toLegacyContractCallOptions<
+  T extends { contract: ContractIdString } | { contractAddress: string; contractName: string },
+>(opts: T): T & { contractAddress: string; contractName: string } {
+  if ('contract' in opts) {
+    const [contractAddress, contractName] = parseContractId(
+      (opts as { contract: ContractIdString }).contract
+    );
+    return { ...opts, contractAddress, contractName };
+  }
+  return opts as T & { contractAddress: string; contractName: string };
 }
 
 /**
@@ -605,7 +575,7 @@ function toLegacyContractCallOptions<T extends object>(
  * @returns {Promise<StacksTransactionWire>}
  */
 export async function makeUnsignedContractCall(
-  txOptions: UnsignedContractCallParams | UnsignedMultiSigContractCallParams
+  txOptions: UnsignedContractCallParams
 ): Promise<StacksTransactionWire>;
 /** @deprecated Use {@link UnsignedContractCallParams} with the combined `contract` field. */
 export async function makeUnsignedContractCall(
@@ -614,7 +584,6 @@ export async function makeUnsignedContractCall(
 export async function makeUnsignedContractCall(
   _txOptions:
     | UnsignedContractCallParams
-    | UnsignedMultiSigContractCallParams
     | UnsignedContractCallOptions
     | UnsignedMultiSigContractCallOptions
 ): Promise<StacksTransactionWire> {
@@ -736,7 +705,7 @@ export async function makeUnsignedContractCall(
  * @return {StacksTransactionWire}
  */
 export async function makeContractCall(
-  txOptions: SignedContractCallParams | SignedMultiSigContractCallParams
+  txOptions: SignedContractCallParams
 ): Promise<StacksTransactionWire>;
 /** @deprecated Use {@link SignedContractCallParams} with the combined `contract` field. */
 export async function makeContractCall(
@@ -745,7 +714,6 @@ export async function makeContractCall(
 export async function makeContractCall(
   _txOptions:
     | SignedContractCallParams
-    | SignedMultiSigContractCallParams
     | SignedContractCallOptions
     | SignedMultiSigContractCallOptions
 ): Promise<StacksTransactionWire> {

--- a/packages/transactions/src/builders.ts
+++ b/packages/transactions/src/builders.ts
@@ -36,7 +36,8 @@ import { postConditionModeFrom, postConditionToWire } from './postcondition';
 import { PostCondition, PostConditionModeName } from './postcondition-types';
 import { TransactionSigner } from './signer';
 import { StacksTransactionWire, deriveNetworkFromTx } from './transaction';
-import { omit } from './utils';
+import { ContractIdString } from './types';
+import { omit, parseContractId } from './utils';
 import {
   PostConditionWire,
   addressFromPublicKeys,
@@ -234,7 +235,43 @@ export async function makeSTXTokenTransfer(
 }
 
 /**
- * Contract deploy transaction options
+ * Contract deploy transaction options (preferred shape).
+ */
+export type ContractDeployParams = {
+  clarityVersion?: ClarityVersion;
+  /** the name of the contract to deploy */
+  name: string;
+  /** the Clarity code to be deployed */
+  clarityCode: string;
+  /** transaction fee in microstacks */
+  fee?: IntegerType;
+  /** the transaction nonce, which must be increased monotonically with each new transaction */
+  nonce?: IntegerType;
+  /** the post condition mode, specifying whether or not post-conditions must fully cover all
+   * transfered assets */
+  postConditionMode?: PostConditionModeName | PostConditionMode;
+  /** a list of post conditions to add to the transaction */
+  postConditions?: (PostCondition | PostConditionWire | string)[];
+  /** set to true if another account is sponsoring the transaction (covering the transaction fee) */
+  sponsored?: boolean;
+} & NetworkClientParam;
+
+export interface UnsignedContractDeployParams extends ContractDeployParams {
+  /** a hex string of the public key of the transaction sender */
+  publicKey: PublicKey;
+}
+
+export interface SignedContractDeployParams extends ContractDeployParams {
+  senderKey: PrivateKey;
+}
+
+export type UnsignedMultiSigContractDeployParams = ContractDeployParams & UnsignedMultiSigOptions;
+
+export type SignedMultiSigContractDeployParams = ContractDeployParams & SignedMultiSigOptions;
+
+/**
+ * Contract deploy transaction options (legacy shape).
+ * @deprecated Use {@link ContractDeployParams} with `name` and `clarityCode` fields instead.
  */
 export type BaseContractDeployOptions = {
   clarityVersion?: ClarityVersion;
@@ -254,36 +291,78 @@ export type BaseContractDeployOptions = {
   sponsored?: boolean;
 } & NetworkClientParam;
 
+/** @deprecated Use {@link UnsignedContractDeployParams} instead. */
 export interface UnsignedContractDeployOptions extends BaseContractDeployOptions {
   /** a hex string of the public key of the transaction sender */
   publicKey: PublicKey;
 }
 
+/** @deprecated Use {@link SignedContractDeployParams} instead. */
 export interface SignedContractDeployOptions extends BaseContractDeployOptions {
   senderKey: PrivateKey;
 }
 
-/** @deprecated Use {@link SignedContractDeployOptions} or {@link UnsignedContractDeployOptions} instead. */
+/** @deprecated Use {@link SignedContractDeployParams} or {@link UnsignedContractDeployParams} instead. */
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface ContractDeployOptions extends SignedContractDeployOptions {}
 
+/** @deprecated Use {@link UnsignedMultiSigContractDeployParams} instead. */
 export type UnsignedMultiSigContractDeployOptions = BaseContractDeployOptions &
   UnsignedMultiSigOptions;
 
+/** @deprecated Use {@link SignedMultiSigContractDeployParams} instead. */
 export type SignedMultiSigContractDeployOptions = BaseContractDeployOptions & SignedMultiSigOptions;
 
 /**
- * Generates a Clarity smart contract deploy transaction
+ * If the preferred `name`/`clarityCode` fields are present, renames them to
+ * the legacy `contractName`/`codeBody` shape used internally. All other
+ * properties pass through untouched.
+ * @internal
+ */
+function toLegacyContractDeployOptions<T extends object>(
+  opts: T
+): T & { contractName: string; codeBody: string } {
+  const o = opts as { name?: string; clarityCode?: string };
+  if (!o.name && !o.clarityCode) return opts as T & { contractName: string; codeBody: string };
+  const { name, clarityCode, ...rest } = opts as T & {
+    name?: string;
+    clarityCode?: string;
+    contractName?: string;
+    codeBody?: string;
+  };
+  return {
+    ...(rest as T),
+    contractName: name ?? rest.contractName!,
+    codeBody: clarityCode ?? rest.codeBody!,
+  };
+}
+
+/**
+ * Generates a Clarity smart contract deploy transaction.
  *
- * @param {SignedContractDeployOptions | SignedMultiSigContractDeployOptions} txOptions - an options object for the contract deploy
+ * Accepts either the preferred {@link ContractDeployParams} shape (with `name`
+ * and `clarityCode`) or the legacy {@link BaseContractDeployOptions} shape
+ * (with `contractName` and `codeBody`).
  *
  * Returns a signed Stacks smart contract deploy transaction.
  *
  * @return {StacksTransactionWire}
  */
 export async function makeContractDeploy(
+  txOptions: SignedContractDeployParams | SignedMultiSigContractDeployParams
+): Promise<StacksTransactionWire>;
+/** @deprecated Use {@link SignedContractDeployParams} with `name` and `clarityCode` fields. */
+export async function makeContractDeploy(
   txOptions: SignedContractDeployOptions | SignedMultiSigContractDeployOptions
+): Promise<StacksTransactionWire>;
+export async function makeContractDeploy(
+  _txOptions:
+    | SignedContractDeployParams
+    | SignedMultiSigContractDeployParams
+    | SignedContractDeployOptions
+    | SignedMultiSigContractDeployOptions
 ): Promise<StacksTransactionWire> {
+  const txOptions = toLegacyContractDeployOptions(_txOptions);
   if ('senderKey' in txOptions) {
     // single-sig
     const publicKey = privateKeyToPublic(txOptions.senderKey);
@@ -311,9 +390,28 @@ export async function makeContractDeploy(
   }
 }
 
+/**
+ * Generates an unsigned Clarity smart contract deploy transaction.
+ *
+ * Accepts either the preferred {@link ContractDeployParams} shape (with `name`
+ * and `clarityCode`) or the legacy {@link BaseContractDeployOptions} shape
+ * (with `contractName` and `codeBody`).
+ */
+export async function makeUnsignedContractDeploy(
+  txOptions: UnsignedContractDeployParams | UnsignedMultiSigContractDeployParams
+): Promise<StacksTransactionWire>;
+/** @deprecated Use {@link UnsignedContractDeployParams} with `name` and `clarityCode` fields. */
 export async function makeUnsignedContractDeploy(
   txOptions: UnsignedContractDeployOptions | UnsignedMultiSigContractDeployOptions
+): Promise<StacksTransactionWire>;
+export async function makeUnsignedContractDeploy(
+  _txOptions:
+    | UnsignedContractDeployParams
+    | UnsignedMultiSigContractDeployParams
+    | UnsignedContractDeployOptions
+    | UnsignedMultiSigContractDeployOptions
 ): Promise<StacksTransactionWire> {
+  const txOptions = toLegacyContractDeployOptions(_txOptions);
   const defaultOptions = {
     fee: BigInt(0),
     nonce: BigInt(0),
@@ -404,7 +502,44 @@ export async function makeUnsignedContractDeploy(
 }
 
 /**
- * Contract function call transaction options
+ * Contract function call transaction options (preferred shape).
+ */
+export type ContractCallParams = {
+  /** the fully-qualified contract identifier as `<address>.<name>` */
+  contract: ContractIdString;
+  functionName: string;
+  functionArgs: ClarityValue[];
+  /** transaction fee in microstacks */
+  fee?: IntegerType;
+  /** the transaction nonce, which must be increased monotonically with each new transaction */
+  nonce?: IntegerType;
+  /** the post condition mode, specifying whether or not post-conditions must fully cover all
+   * transfered assets */
+  postConditionMode?: PostConditionModeName | PostConditionMode;
+  /** a list of post conditions to add to the transaction */
+  postConditions?: (PostCondition | PostConditionWire | string)[];
+  /** set to true to validate that the supplied function args match those specified in
+   * the published contract */
+  validateWithAbi?: boolean | ClarityAbi;
+  /** set to true if another account is sponsoring the transaction (covering the transaction fee) */
+  sponsored?: boolean;
+} & NetworkClientParam;
+
+export interface UnsignedContractCallParams extends ContractCallParams {
+  publicKey: PublicKey;
+}
+
+export interface SignedContractCallParams extends ContractCallParams {
+  senderKey: PrivateKey;
+}
+
+export type UnsignedMultiSigContractCallParams = ContractCallParams & UnsignedMultiSigOptions;
+
+export type SignedMultiSigContractCallParams = ContractCallParams & SignedMultiSigOptions;
+
+/**
+ * Contract function call transaction options (legacy shape, split contract identifier).
+ * @deprecated Use {@link ContractCallParams} with the combined `contract` field instead.
  */
 export type ContractCallOptions = {
   /** the Stacks address of the contract */
@@ -428,28 +563,62 @@ export type ContractCallOptions = {
   sponsored?: boolean;
 } & NetworkClientParam;
 
+/** @deprecated Use {@link UnsignedContractCallParams} instead. */
 export interface UnsignedContractCallOptions extends ContractCallOptions {
   publicKey: PrivateKey;
 }
 
+/** @deprecated Use {@link SignedContractCallParams} instead. */
 export interface SignedContractCallOptions extends ContractCallOptions {
   senderKey: PublicKey;
 }
 
+/** @deprecated Use {@link UnsignedMultiSigContractCallParams} instead. */
 export type UnsignedMultiSigContractCallOptions = ContractCallOptions & UnsignedMultiSigOptions;
 
+/** @deprecated Use {@link SignedMultiSigContractCallParams} instead. */
 export type SignedMultiSigContractCallOptions = ContractCallOptions & SignedMultiSigOptions;
 
 /**
- * Generates an unsigned Clarity smart contract function call transaction
+ * If the combined `contract` field is present, splits it into the legacy
+ * `contractAddress` + `contractName` shape used internally. All other
+ * properties pass through untouched.
+ * @internal
+ */
+function toLegacyContractCallOptions<T extends object>(
+  opts: T
+): T & { contractAddress: string; contractName: string } {
+  const o = opts as { contract?: ContractIdString };
+  if (!o.contract) return opts as T & { contractAddress: string; contractName: string };
+  const [contractAddress, contractName] = parseContractId(o.contract);
+  return { ...opts, contractAddress, contractName };
+}
+
+/**
+ * Generates an unsigned Clarity smart contract function call transaction.
  *
- * @param {UnsignedContractCallOptions | UnsignedMultiSigContractCallOptions} txOptions - an options object for the contract call
+ * Accepts either the preferred {@link ContractCallParams} shape (with the
+ * combined `contract: "<address>.<name>"` field) or the legacy
+ * {@link ContractCallOptions} shape (with split `contractAddress` and
+ * `contractName` fields).
  *
  * @returns {Promise<StacksTransactionWire>}
  */
 export async function makeUnsignedContractCall(
+  txOptions: UnsignedContractCallParams | UnsignedMultiSigContractCallParams
+): Promise<StacksTransactionWire>;
+/** @deprecated Use {@link UnsignedContractCallParams} with the combined `contract` field. */
+export async function makeUnsignedContractCall(
   txOptions: UnsignedContractCallOptions | UnsignedMultiSigContractCallOptions
+): Promise<StacksTransactionWire>;
+export async function makeUnsignedContractCall(
+  _txOptions:
+    | UnsignedContractCallParams
+    | UnsignedMultiSigContractCallParams
+    | UnsignedContractCallOptions
+    | UnsignedMultiSigContractCallOptions
 ): Promise<StacksTransactionWire> {
+  const txOptions = toLegacyContractCallOptions(_txOptions);
   const defaultOptions = {
     fee: BigInt(0),
     nonce: BigInt(0),
@@ -555,17 +724,32 @@ export async function makeUnsignedContractCall(
 }
 
 /**
- * Generates a Clarity smart contract function call transaction
+ * Generates a Clarity smart contract function call transaction.
  *
- * @param {SignedContractCallOptions | SignedMultiSigContractCallOptions} txOptions - an options object for the contract function call
+ * Accepts either the preferred {@link ContractCallParams} shape (with the
+ * combined `contract: "<address>.<name>"` field) or the legacy
+ * {@link ContractCallOptions} shape (with split `contractAddress` and
+ * `contractName` fields).
  *
  * Returns a signed Stacks smart contract function call transaction.
  *
  * @return {StacksTransactionWire}
  */
 export async function makeContractCall(
+  txOptions: SignedContractCallParams | SignedMultiSigContractCallParams
+): Promise<StacksTransactionWire>;
+/** @deprecated Use {@link SignedContractCallParams} with the combined `contract` field. */
+export async function makeContractCall(
   txOptions: SignedContractCallOptions | SignedMultiSigContractCallOptions
+): Promise<StacksTransactionWire>;
+export async function makeContractCall(
+  _txOptions:
+    | SignedContractCallParams
+    | SignedMultiSigContractCallParams
+    | SignedContractCallOptions
+    | SignedMultiSigContractCallOptions
 ): Promise<StacksTransactionWire> {
+  const txOptions = toLegacyContractCallOptions(_txOptions);
   if ('senderKey' in txOptions) {
     // single-sig
     const publicKey = privateKeyToPublic(txOptions.senderKey);

--- a/packages/transactions/src/builders.ts
+++ b/packages/transactions/src/builders.ts
@@ -248,7 +248,7 @@ type PreferredContractDeployOptions = {
   /** the transaction nonce, which must be increased monotonically with each new transaction */
   nonce?: IntegerType;
   /** the post condition mode, specifying whether or not post-conditions must fully cover all
-   * transfered assets */
+   * transferred assets */
   postConditionMode?: PostConditionModeName | PostConditionMode;
   /** a list of post conditions to add to the transaction */
   postConditions?: (PostCondition | PostConditionWire | string)[];
@@ -276,7 +276,7 @@ type LegacyContractDeployOptions = {
   /** the transaction nonce, which must be increased monotonically with each new transaction */
   nonce?: IntegerType;
   /** the post condition mode, specifying whether or not post-conditions must fully cover all
-   * transfered assets */
+   * transferred assets */
   postConditionMode?: PostConditionModeName | PostConditionMode;
   /** a list of post conditions to add to the transaction */
   postConditions?: (PostCondition | PostConditionWire | string)[];
@@ -487,7 +487,7 @@ type PreferredContractCallOptions = {
   /** the transaction nonce, which must be increased monotonically with each new transaction */
   nonce?: IntegerType;
   /** the post condition mode, specifying whether or not post-conditions must fully cover all
-   * transfered assets */
+   * transferred assets */
   postConditionMode?: PostConditionModeName | PostConditionMode;
   /** a list of post conditions to add to the transaction */
   postConditions?: (PostCondition | PostConditionWire | string)[];
@@ -519,7 +519,7 @@ type LegacyContractCallOptions = {
   /** the transaction nonce, which must be increased monotonically with each new transaction */
   nonce?: IntegerType;
   /** the post condition mode, specifying whether or not post-conditions must fully cover all
-   * transfered assets */
+   * transferred assets */
   postConditionMode?: PostConditionModeName | PostConditionMode;
   /** a list of post conditions to add to the transaction */
   postConditions?: (PostCondition | PostConditionWire | string)[];

--- a/packages/transactions/src/builders.ts
+++ b/packages/transactions/src/builders.ts
@@ -553,11 +553,11 @@ type PreferredSignedMultiSigContractCallOptions = PreferredContractCallOptions &
   SignedMultiSigOptions;
 
 type LegacyUnsignedSingleSigContractCallOptions = LegacyContractCallOptions & {
-  publicKey: PrivateKey;
+  publicKey: PublicKey;
 };
 
 type LegacySignedSingleSigContractCallOptions = LegacyContractCallOptions & {
-  senderKey: PublicKey;
+  senderKey: PrivateKey;
 };
 
 export type UnsignedContractCallOptions =

--- a/packages/transactions/src/builders.ts
+++ b/packages/transactions/src/builders.ts
@@ -284,36 +284,51 @@ type LegacyContractDeployOptions = {
   sponsored?: boolean;
 } & NetworkClientParam;
 
-export type ContractDeployOptions = PreferredContractDeployOptions | LegacyContractDeployOptions;
-
 type LegacyUnsignedContractDeployOptions = LegacyContractDeployOptions &
   ({ publicKey: PublicKey } | UnsignedMultiSigOptions);
 
 type LegacySignedContractDeployOptions = LegacyContractDeployOptions &
   ({ senderKey: PrivateKey } | SignedMultiSigOptions);
 
+type PreferredUnsignedMultiSigContractDeployOptions = PreferredContractDeployOptions &
+  UnsignedMultiSigOptions;
+
+type PreferredSignedMultiSigContractDeployOptions = PreferredContractDeployOptions &
+  SignedMultiSigOptions;
+
+type PreferredUnsignedSingleSigContractDeployOptions = PreferredContractDeployOptions & {
+  publicKey: PublicKey;
+};
+
+type PreferredSignedSingleSigContractDeployOptions = PreferredContractDeployOptions & {
+  senderKey: PrivateKey;
+};
+
+type LegacyUnsignedSingleSigContractDeployOptions = LegacyContractDeployOptions & {
+  publicKey: PublicKey;
+};
+
+type LegacySignedSingleSigContractDeployOptions = LegacyContractDeployOptions & {
+  senderKey: PrivateKey;
+};
+
+export type ContractDeployOptions = SignedContractDeployOptions;
+
 export type UnsignedContractDeployOptions =
-  | PreferredUnsignedContractDeployOptions
-  | LegacyUnsignedContractDeployOptions;
+  | PreferredUnsignedSingleSigContractDeployOptions
+  | LegacyUnsignedSingleSigContractDeployOptions;
 
 export type SignedContractDeployOptions =
-  | PreferredSignedContractDeployOptions
-  | LegacySignedContractDeployOptions;
+  | PreferredSignedSingleSigContractDeployOptions
+  | LegacySignedSingleSigContractDeployOptions;
 
-/**
- * @deprecated Use {@link ContractDeployOptions} instead.
- */
-export type ContractDeployParams = PreferredContractDeployOptions;
+export type UnsignedMultiSigContractDeployOptions =
+  | PreferredUnsignedMultiSigContractDeployOptions
+  | (LegacyContractDeployOptions & UnsignedMultiSigOptions);
 
-/**
- * @deprecated Use {@link UnsignedContractDeployOptions} instead.
- */
-export type UnsignedContractDeployParams = UnsignedContractDeployOptions;
-
-/**
- * @deprecated Use {@link SignedContractDeployOptions} instead.
- */
-export type SignedContractDeployParams = SignedContractDeployOptions;
+export type SignedMultiSigContractDeployOptions =
+  | PreferredSignedMultiSigContractDeployOptions
+  | (LegacyContractDeployOptions & SignedMultiSigOptions);
 
 /** @internal If both shapes are provided, `name`/`clarityCode` take precedence. */
 function toLegacyContractDeployOptions<
@@ -329,9 +344,8 @@ function toLegacyContractDeployOptions<
 /**
  * Generates a Clarity smart contract deploy transaction.
  *
- * Accepts either the preferred {@link ContractDeployOptions} shape (with `name`
- * and `clarityCode`) or the legacy {@link LegacyContractDeployOptions} shape
- * (with `contractName` and `codeBody`).
+ * Accepts either `name`/`clarityCode` or the legacy `contractName`/`codeBody`
+ * fields.
  *
  * Returns a signed Stacks smart contract deploy transaction.
  *
@@ -374,9 +388,8 @@ export async function makeContractDeploy(
 /**
  * Generates an unsigned Clarity smart contract deploy transaction.
  *
- * Accepts either the preferred {@link ContractDeployOptions} shape (with `name`
- * and `clarityCode`) or the legacy {@link LegacyContractDeployOptions} shape
- * (with `contractName` and `codeBody`).
+ * Accepts either `name`/`clarityCode` or the legacy `contractName`/`codeBody`
+ * fields.
  */
 export async function makeUnsignedContractDeploy(
   txOptions: UnsignedContractDeployOptions
@@ -498,15 +511,8 @@ type PreferredContractCallOptions = {
   sponsored?: boolean;
 } & NetworkClientParam;
 
-type PreferredUnsignedContractCallOptions = PreferredContractCallOptions &
-  ({ publicKey: PublicKey } | UnsignedMultiSigOptions);
-
-type PreferredSignedContractCallOptions = PreferredContractCallOptions &
-  ({ senderKey: PrivateKey } | SignedMultiSigOptions);
-
 /**
  * Contract function call transaction options (legacy shape, split contract identifier).
- * @deprecated Use {@link ContractCallOptions} with the combined `contract` field instead.
  */
 type LegacyContractCallOptions = {
   /** the Stacks address of the contract */
@@ -532,34 +538,43 @@ type LegacyContractCallOptions = {
 
 export type ContractCallOptions = PreferredContractCallOptions | LegacyContractCallOptions;
 
-type LegacyUnsignedContractCallOptions = LegacyContractCallOptions &
-  ({ publicKey: PrivateKey } | UnsignedMultiSigOptions);
+type PreferredUnsignedSingleSigContractCallOptions = PreferredContractCallOptions & {
+  publicKey: PublicKey;
+};
 
-type LegacySignedContractCallOptions = LegacyContractCallOptions &
-  ({ senderKey: PublicKey } | SignedMultiSigOptions);
+type PreferredSignedSingleSigContractCallOptions = PreferredContractCallOptions & {
+  senderKey: PrivateKey;
+};
+
+type PreferredUnsignedMultiSigContractCallOptions = PreferredContractCallOptions &
+  UnsignedMultiSigOptions;
+
+type PreferredSignedMultiSigContractCallOptions = PreferredContractCallOptions &
+  SignedMultiSigOptions;
+
+type LegacyUnsignedSingleSigContractCallOptions = LegacyContractCallOptions & {
+  publicKey: PrivateKey;
+};
+
+type LegacySignedSingleSigContractCallOptions = LegacyContractCallOptions & {
+  senderKey: PublicKey;
+};
 
 export type UnsignedContractCallOptions =
-  | PreferredUnsignedContractCallOptions
-  | LegacyUnsignedContractCallOptions;
+  | PreferredUnsignedSingleSigContractCallOptions
+  | LegacyUnsignedSingleSigContractCallOptions;
 
 export type SignedContractCallOptions =
-  | PreferredSignedContractCallOptions
-  | LegacySignedContractCallOptions;
+  | PreferredSignedSingleSigContractCallOptions
+  | LegacySignedSingleSigContractCallOptions;
 
-/**
- * @deprecated Use {@link ContractCallOptions} instead.
- */
-export type ContractCallParams = PreferredContractCallOptions;
+export type UnsignedMultiSigContractCallOptions =
+  | PreferredUnsignedMultiSigContractCallOptions
+  | (LegacyContractCallOptions & UnsignedMultiSigOptions);
 
-/**
- * @deprecated Use {@link UnsignedContractCallOptions} instead.
- */
-export type UnsignedContractCallParams = UnsignedContractCallOptions;
-
-/**
- * @deprecated Use {@link SignedContractCallOptions} instead.
- */
-export type SignedContractCallParams = SignedContractCallOptions;
+export type SignedMultiSigContractCallOptions =
+  | PreferredSignedMultiSigContractCallOptions
+  | (LegacyContractCallOptions & SignedMultiSigOptions);
 
 /** @internal If both shapes are provided, `contract` takes precedence over `contractAddress`/`contractName`. */
 function toLegacyContractCallOptions<
@@ -577,10 +592,8 @@ function toLegacyContractCallOptions<
 /**
  * Generates an unsigned Clarity smart contract function call transaction.
  *
- * Accepts either the preferred {@link ContractCallOptions} shape (with the
- * combined `contract: "<address>.<name>"` field) or the legacy
- * {@link LegacyContractCallOptions} shape (with split `contractAddress` and
- * `contractName` fields).
+ * Accepts either `contract: "<address>.<name>"` or the legacy split
+ * `contractAddress` and `contractName` fields.
  *
  * @returns {Promise<StacksTransactionWire>}
  */
@@ -698,10 +711,8 @@ export async function makeUnsignedContractCall(
 /**
  * Generates a Clarity smart contract function call transaction.
  *
- * Accepts either the preferred {@link ContractCallOptions} shape (with the
- * combined `contract: "<address>.<name>"` field) or the legacy
- * {@link LegacyContractCallOptions} shape (with split `contractAddress` and
- * `contractName` fields).
+ * Accepts either `contract: "<address>.<name>"` or the legacy split
+ * `contractAddress` and `contractName` fields.
  *
  * Returns a signed Stacks smart contract function call transaction.
  *

--- a/packages/transactions/src/builders.ts
+++ b/packages/transactions/src/builders.ts
@@ -237,7 +237,7 @@ export async function makeSTXTokenTransfer(
 /**
  * Contract deploy transaction options (preferred shape).
  */
-export type ContractDeployParams = {
+type PreferredContractDeployOptions = {
   clarityVersion?: ClarityVersion;
   /** the name of the contract to deploy */
   name: string;
@@ -256,17 +256,17 @@ export type ContractDeployParams = {
   sponsored?: boolean;
 } & NetworkClientParam;
 
-export type UnsignedContractDeployParams = ContractDeployParams &
+type PreferredUnsignedContractDeployOptions = PreferredContractDeployOptions &
   ({ publicKey: PublicKey } | UnsignedMultiSigOptions);
 
-export type SignedContractDeployParams = ContractDeployParams &
+type PreferredSignedContractDeployOptions = PreferredContractDeployOptions &
   ({ senderKey: PrivateKey } | SignedMultiSigOptions);
 
 /**
  * Contract deploy transaction options (legacy shape).
- * @deprecated Use {@link ContractDeployParams} with `name` and `clarityCode` fields instead.
+ * @deprecated Use {@link ContractDeployOptions} with `name` and `clarityCode` fields instead.
  */
-export type BaseContractDeployOptions = {
+type LegacyContractDeployOptions = {
   clarityVersion?: ClarityVersion;
   contractName: string;
   /** the Clarity code to be deployed */
@@ -284,27 +284,36 @@ export type BaseContractDeployOptions = {
   sponsored?: boolean;
 } & NetworkClientParam;
 
-/** @deprecated Use {@link UnsignedContractDeployParams} instead. */
-export interface UnsignedContractDeployOptions extends BaseContractDeployOptions {
-  /** a hex string of the public key of the transaction sender */
-  publicKey: PublicKey;
-}
+export type ContractDeployOptions = PreferredContractDeployOptions | LegacyContractDeployOptions;
 
-/** @deprecated Use {@link SignedContractDeployParams} instead. */
-export interface SignedContractDeployOptions extends BaseContractDeployOptions {
-  senderKey: PrivateKey;
-}
+type LegacyUnsignedContractDeployOptions = LegacyContractDeployOptions &
+  ({ publicKey: PublicKey } | UnsignedMultiSigOptions);
 
-/** @deprecated Use {@link SignedContractDeployParams} or {@link UnsignedContractDeployParams} instead. */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface ContractDeployOptions extends SignedContractDeployOptions {}
+type LegacySignedContractDeployOptions = LegacyContractDeployOptions &
+  ({ senderKey: PrivateKey } | SignedMultiSigOptions);
 
-/** @deprecated Use {@link UnsignedContractDeployParams} instead. */
-export type UnsignedMultiSigContractDeployOptions = BaseContractDeployOptions &
-  UnsignedMultiSigOptions;
+export type UnsignedContractDeployOptions =
+  | PreferredUnsignedContractDeployOptions
+  | LegacyUnsignedContractDeployOptions;
 
-/** @deprecated Use {@link SignedContractDeployParams} instead. */
-export type SignedMultiSigContractDeployOptions = BaseContractDeployOptions & SignedMultiSigOptions;
+export type SignedContractDeployOptions =
+  | PreferredSignedContractDeployOptions
+  | LegacySignedContractDeployOptions;
+
+/**
+ * @deprecated Use {@link ContractDeployOptions} instead.
+ */
+export type ContractDeployParams = PreferredContractDeployOptions;
+
+/**
+ * @deprecated Use {@link UnsignedContractDeployOptions} instead.
+ */
+export type UnsignedContractDeployParams = UnsignedContractDeployOptions;
+
+/**
+ * @deprecated Use {@link SignedContractDeployOptions} instead.
+ */
+export type SignedContractDeployParams = SignedContractDeployOptions;
 
 /** @internal If both shapes are provided, `name`/`clarityCode` take precedence. */
 function toLegacyContractDeployOptions<
@@ -320,8 +329,8 @@ function toLegacyContractDeployOptions<
 /**
  * Generates a Clarity smart contract deploy transaction.
  *
- * Accepts either the preferred {@link ContractDeployParams} shape (with `name`
- * and `clarityCode`) or the legacy {@link BaseContractDeployOptions} shape
+ * Accepts either the preferred {@link ContractDeployOptions} shape (with `name`
+ * and `clarityCode`) or the legacy {@link LegacyContractDeployOptions} shape
  * (with `contractName` and `codeBody`).
  *
  * Returns a signed Stacks smart contract deploy transaction.
@@ -329,17 +338,10 @@ function toLegacyContractDeployOptions<
  * @return {StacksTransactionWire}
  */
 export async function makeContractDeploy(
-  txOptions: SignedContractDeployParams
-): Promise<StacksTransactionWire>;
-/** @deprecated Use {@link SignedContractDeployParams} with `name` and `clarityCode` fields. */
-export async function makeContractDeploy(
-  txOptions: SignedContractDeployOptions | SignedMultiSigContractDeployOptions
+  txOptions: SignedContractDeployOptions
 ): Promise<StacksTransactionWire>;
 export async function makeContractDeploy(
-  _txOptions:
-    | SignedContractDeployParams
-    | SignedContractDeployOptions
-    | SignedMultiSigContractDeployOptions
+  _txOptions: SignedContractDeployOptions
 ): Promise<StacksTransactionWire> {
   const txOptions = toLegacyContractDeployOptions(_txOptions);
   if ('senderKey' in txOptions) {
@@ -372,22 +374,15 @@ export async function makeContractDeploy(
 /**
  * Generates an unsigned Clarity smart contract deploy transaction.
  *
- * Accepts either the preferred {@link ContractDeployParams} shape (with `name`
- * and `clarityCode`) or the legacy {@link BaseContractDeployOptions} shape
+ * Accepts either the preferred {@link ContractDeployOptions} shape (with `name`
+ * and `clarityCode`) or the legacy {@link LegacyContractDeployOptions} shape
  * (with `contractName` and `codeBody`).
  */
 export async function makeUnsignedContractDeploy(
-  txOptions: UnsignedContractDeployParams
-): Promise<StacksTransactionWire>;
-/** @deprecated Use {@link UnsignedContractDeployParams} with `name` and `clarityCode` fields. */
-export async function makeUnsignedContractDeploy(
-  txOptions: UnsignedContractDeployOptions | UnsignedMultiSigContractDeployOptions
+  txOptions: UnsignedContractDeployOptions
 ): Promise<StacksTransactionWire>;
 export async function makeUnsignedContractDeploy(
-  _txOptions:
-    | UnsignedContractDeployParams
-    | UnsignedContractDeployOptions
-    | UnsignedMultiSigContractDeployOptions
+  _txOptions: UnsignedContractDeployOptions
 ): Promise<StacksTransactionWire> {
   const txOptions = toLegacyContractDeployOptions(_txOptions);
   const defaultOptions = {
@@ -482,7 +477,7 @@ export async function makeUnsignedContractDeploy(
 /**
  * Contract function call transaction options (preferred shape).
  */
-export type ContractCallParams = {
+type PreferredContractCallOptions = {
   /** the fully-qualified contract identifier as `<address>.<name>` */
   contract: ContractIdString;
   functionName: string;
@@ -503,17 +498,17 @@ export type ContractCallParams = {
   sponsored?: boolean;
 } & NetworkClientParam;
 
-export type UnsignedContractCallParams = ContractCallParams &
+type PreferredUnsignedContractCallOptions = PreferredContractCallOptions &
   ({ publicKey: PublicKey } | UnsignedMultiSigOptions);
 
-export type SignedContractCallParams = ContractCallParams &
+type PreferredSignedContractCallOptions = PreferredContractCallOptions &
   ({ senderKey: PrivateKey } | SignedMultiSigOptions);
 
 /**
  * Contract function call transaction options (legacy shape, split contract identifier).
- * @deprecated Use {@link ContractCallParams} with the combined `contract` field instead.
+ * @deprecated Use {@link ContractCallOptions} with the combined `contract` field instead.
  */
-export type ContractCallOptions = {
+type LegacyContractCallOptions = {
   /** the Stacks address of the contract */
   contractAddress: string;
   contractName: string;
@@ -535,21 +530,36 @@ export type ContractCallOptions = {
   sponsored?: boolean;
 } & NetworkClientParam;
 
-/** @deprecated Use {@link UnsignedContractCallParams} instead. */
-export interface UnsignedContractCallOptions extends ContractCallOptions {
-  publicKey: PrivateKey;
-}
+export type ContractCallOptions = PreferredContractCallOptions | LegacyContractCallOptions;
 
-/** @deprecated Use {@link SignedContractCallParams} instead. */
-export interface SignedContractCallOptions extends ContractCallOptions {
-  senderKey: PublicKey;
-}
+type LegacyUnsignedContractCallOptions = LegacyContractCallOptions &
+  ({ publicKey: PrivateKey } | UnsignedMultiSigOptions);
 
-/** @deprecated Use {@link UnsignedContractCallParams} instead. */
-export type UnsignedMultiSigContractCallOptions = ContractCallOptions & UnsignedMultiSigOptions;
+type LegacySignedContractCallOptions = LegacyContractCallOptions &
+  ({ senderKey: PublicKey } | SignedMultiSigOptions);
 
-/** @deprecated Use {@link SignedContractCallParams} instead. */
-export type SignedMultiSigContractCallOptions = ContractCallOptions & SignedMultiSigOptions;
+export type UnsignedContractCallOptions =
+  | PreferredUnsignedContractCallOptions
+  | LegacyUnsignedContractCallOptions;
+
+export type SignedContractCallOptions =
+  | PreferredSignedContractCallOptions
+  | LegacySignedContractCallOptions;
+
+/**
+ * @deprecated Use {@link ContractCallOptions} instead.
+ */
+export type ContractCallParams = PreferredContractCallOptions;
+
+/**
+ * @deprecated Use {@link UnsignedContractCallOptions} instead.
+ */
+export type UnsignedContractCallParams = UnsignedContractCallOptions;
+
+/**
+ * @deprecated Use {@link SignedContractCallOptions} instead.
+ */
+export type SignedContractCallParams = SignedContractCallOptions;
 
 /** @internal If both shapes are provided, `contract` takes precedence over `contractAddress`/`contractName`. */
 function toLegacyContractCallOptions<
@@ -567,25 +577,18 @@ function toLegacyContractCallOptions<
 /**
  * Generates an unsigned Clarity smart contract function call transaction.
  *
- * Accepts either the preferred {@link ContractCallParams} shape (with the
+ * Accepts either the preferred {@link ContractCallOptions} shape (with the
  * combined `contract: "<address>.<name>"` field) or the legacy
- * {@link ContractCallOptions} shape (with split `contractAddress` and
+ * {@link LegacyContractCallOptions} shape (with split `contractAddress` and
  * `contractName` fields).
  *
  * @returns {Promise<StacksTransactionWire>}
  */
 export async function makeUnsignedContractCall(
-  txOptions: UnsignedContractCallParams
-): Promise<StacksTransactionWire>;
-/** @deprecated Use {@link UnsignedContractCallParams} with the combined `contract` field. */
-export async function makeUnsignedContractCall(
-  txOptions: UnsignedContractCallOptions | UnsignedMultiSigContractCallOptions
+  txOptions: UnsignedContractCallOptions
 ): Promise<StacksTransactionWire>;
 export async function makeUnsignedContractCall(
-  _txOptions:
-    | UnsignedContractCallParams
-    | UnsignedContractCallOptions
-    | UnsignedMultiSigContractCallOptions
+  _txOptions: UnsignedContractCallOptions
 ): Promise<StacksTransactionWire> {
   const txOptions = toLegacyContractCallOptions(_txOptions);
   const defaultOptions = {
@@ -695,9 +698,9 @@ export async function makeUnsignedContractCall(
 /**
  * Generates a Clarity smart contract function call transaction.
  *
- * Accepts either the preferred {@link ContractCallParams} shape (with the
+ * Accepts either the preferred {@link ContractCallOptions} shape (with the
  * combined `contract: "<address>.<name>"` field) or the legacy
- * {@link ContractCallOptions} shape (with split `contractAddress` and
+ * {@link LegacyContractCallOptions} shape (with split `contractAddress` and
  * `contractName` fields).
  *
  * Returns a signed Stacks smart contract function call transaction.
@@ -705,17 +708,10 @@ export async function makeUnsignedContractCall(
  * @return {StacksTransactionWire}
  */
 export async function makeContractCall(
-  txOptions: SignedContractCallParams
-): Promise<StacksTransactionWire>;
-/** @deprecated Use {@link SignedContractCallParams} with the combined `contract` field. */
-export async function makeContractCall(
-  txOptions: SignedContractCallOptions | SignedMultiSigContractCallOptions
+  txOptions: SignedContractCallOptions
 ): Promise<StacksTransactionWire>;
 export async function makeContractCall(
-  _txOptions:
-    | SignedContractCallParams
-    | SignedContractCallOptions
-    | SignedMultiSigContractCallOptions
+  _txOptions: SignedContractCallOptions
 ): Promise<StacksTransactionWire> {
   const txOptions = toLegacyContractCallOptions(_txOptions);
   if ('senderKey' in txOptions) {

--- a/packages/transactions/src/fetch.ts
+++ b/packages/transactions/src/fetch.ts
@@ -286,8 +286,8 @@ export async function fetchAbi({
  * Calls a function as read-only from a contract interface.
  * It is not necessary that the function is defined as read-only in the contract
  *
- * @return Returns an object with a status bool (okay) and a result string that
- * is a serialized clarity value in hex format.
+ * @return A promise that resolves to the parsed Clarity value returned by the
+ * read-only function call.
  */
 export async function fetchCallReadOnlyFunction(
   opts: ReadOnlyFunctionOptions

--- a/packages/transactions/src/fetch.ts
+++ b/packages/transactions/src/fetch.ts
@@ -9,13 +9,14 @@ import {
   estimateTransactionByteLength,
 } from './transaction';
 import {
+  ContractIdString,
   FeeEstimateResponse,
   FeeEstimation,
   TxBroadcastResult,
   TxBroadcastResultOk,
   TxBroadcastResultRejected,
 } from './types';
-import { cvToHex, parseReadOnlyResponse } from './utils';
+import { cvToHex, parseContractId, parseReadOnlyResponse } from './utils';
 import { serializePayloadBytes } from './wire';
 
 export const BROADCAST_PATH = '/v2/transactions';
@@ -284,8 +285,11 @@ export async function fetchAbi({
 /**
  * Calls a function as read-only from a contract interface.
  * It is not necessary that the function is defined as read-only in the contract
- * @param opts.contractName - The contract name
- * @param opts.contractAddress - The contract address
+ *
+ * Accepts either the preferred `contract: "<address>.<name>"` combined
+ * identifier, or the legacy split `contractAddress` + `contractName` fields.
+ *
+ * @param opts.contract - The fully-qualified contract identifier (`<address>.<name>`)
  * @param opts.functionName - The contract function name
  * @param opts.functionArgs - The contract function arguments
  * @param opts.senderAddress - The address of the (simulated) sender
@@ -293,22 +297,28 @@ export async function fetchAbi({
  * @return Returns an object with a status bool (okay) and a result string that
  * is a serialized clarity value in hex format.
  */
-export async function fetchCallReadOnlyFunction({
-  contractName,
-  contractAddress,
-  functionName,
-  functionArgs,
-  senderAddress,
-  network = 'mainnet',
-  client: _client,
-}: {
-  contractName: string;
-  contractAddress: string;
-  functionName: string;
-  functionArgs: ClarityValue[];
-  /** address of the sender */
-  senderAddress: string;
-} & NetworkClientParam): Promise<ClarityValue> {
+export async function fetchCallReadOnlyFunction(
+  opts: (
+    | {
+        /** the fully-qualified contract identifier as `<address>.<name>` */
+        contract: ContractIdString;
+      }
+    | {
+        /** @deprecated Use `contract` instead. */
+        contractName: string;
+        /** @deprecated Use `contract` instead. */
+        contractAddress: string;
+      }
+  ) & {
+    functionName: string;
+    functionArgs: ClarityValue[];
+    /** address of the sender */
+    senderAddress: string;
+  } & NetworkClientParam
+): Promise<ClarityValue> {
+  const [contractAddress, contractName] =
+    'contract' in opts ? parseContractId(opts.contract) : [opts.contractAddress, opts.contractName];
+  const { functionName, functionArgs, senderAddress, network = 'mainnet', client: _client } = opts;
   const json = {
     sender: senderAddress,
     arguments: functionArgs.map(arg => cvToHex(arg)),

--- a/packages/transactions/src/fetch.ts
+++ b/packages/transactions/src/fetch.ts
@@ -9,9 +9,10 @@ import {
   estimateTransactionByteLength,
 } from './transaction';
 import {
-  ContractIdString,
   FeeEstimateResponse,
   FeeEstimation,
+  ReadOnlyFunctionOptions,
+  ReadOnlyFunctionParams,
   TxBroadcastResult,
   TxBroadcastResultOk,
   TxBroadcastResultRejected,
@@ -286,35 +287,11 @@ export async function fetchAbi({
  * Calls a function as read-only from a contract interface.
  * It is not necessary that the function is defined as read-only in the contract
  *
- * Accepts either the preferred `contract: "<address>.<name>"` combined
- * identifier, or the legacy split `contractAddress` + `contractName` fields.
- *
- * @param opts.contract - The fully-qualified contract identifier (`<address>.<name>`)
- * @param opts.functionName - The contract function name
- * @param opts.functionArgs - The contract function arguments
- * @param opts.senderAddress - The address of the (simulated) sender
- * @param opts.api - Optional API info (`.url` & `.fetch`) used for fetch call
  * @return Returns an object with a status bool (okay) and a result string that
  * is a serialized clarity value in hex format.
  */
 export async function fetchCallReadOnlyFunction(
-  opts: (
-    | {
-        /** the fully-qualified contract identifier as `<address>.<name>` */
-        contract: ContractIdString;
-      }
-    | {
-        /** @deprecated Use `contract` instead. */
-        contractName: string;
-        /** @deprecated Use `contract` instead. */
-        contractAddress: string;
-      }
-  ) & {
-    functionName: string;
-    functionArgs: ClarityValue[];
-    /** address of the sender */
-    senderAddress: string;
-  } & NetworkClientParam
+  opts: ReadOnlyFunctionParams | ReadOnlyFunctionOptions
 ): Promise<ClarityValue> {
   const [contractAddress, contractName] =
     'contract' in opts ? parseContractId(opts.contract) : [opts.contractAddress, opts.contractName];

--- a/packages/transactions/src/fetch.ts
+++ b/packages/transactions/src/fetch.ts
@@ -12,7 +12,6 @@ import {
   FeeEstimateResponse,
   FeeEstimation,
   ReadOnlyFunctionOptions,
-  ReadOnlyFunctionParams,
   TxBroadcastResult,
   TxBroadcastResultOk,
   TxBroadcastResultRejected,
@@ -291,7 +290,7 @@ export async function fetchAbi({
  * is a serialized clarity value in hex format.
  */
 export async function fetchCallReadOnlyFunction(
-  opts: ReadOnlyFunctionParams | ReadOnlyFunctionOptions
+  opts: ReadOnlyFunctionOptions
 ): Promise<ClarityValue> {
   const [contractAddress, contractName] =
     'contract' in opts ? parseContractId(opts.contract) : [opts.contractAddress, opts.contractName];

--- a/packages/transactions/src/types.ts
+++ b/packages/transactions/src/types.ts
@@ -183,6 +183,19 @@ export interface FeeEstimateResponse {
  * @param {StacksNetwork} network - the Stacks blockchain network this transaction is destined for
  * @param {String} senderAddress - the c32check address of the sender
  */
+/**
+ * Options for a read-only contract function call (preferred shape).
+ */
+export type ReadOnlyFunctionParams = {
+  /** the fully-qualified contract identifier as `<address>.<name>` */
+  contract: ContractIdString;
+  functionName: string;
+  functionArgs: ClarityValue[];
+  /** address of the sender */
+  senderAddress: string;
+} & NetworkClientParam;
+
+/** @deprecated Use {@link ReadOnlyFunctionParams} with the combined `contract` field instead. */
 export type ReadOnlyFunctionOptions = {
   contractName: string;
   contractAddress: string;

--- a/packages/transactions/src/types.ts
+++ b/packages/transactions/src/types.ts
@@ -174,16 +174,6 @@ export interface FeeEstimateResponse {
 }
 
 /**
- * Read only function options
- *
- * @param {String} contractAddress - the c32check address of the contract
- * @param {String} contractName - the contract name
- * @param {String} functionName - name of the function to be called
- * @param {[ClarityValue]} functionArgs - an array of Clarity values as arguments to the function call
- * @param {StacksNetwork} network - the Stacks blockchain network this transaction is destined for
- * @param {String} senderAddress - the c32check address of the sender
- */
-/**
  * Options for a read-only contract function call (preferred shape).
  */
 export type ReadOnlyFunctionParams = {

--- a/packages/transactions/src/types.ts
+++ b/packages/transactions/src/types.ts
@@ -176,7 +176,7 @@ export interface FeeEstimateResponse {
 /**
  * Options for a read-only contract function call (preferred shape).
  */
-export type ReadOnlyFunctionParams = {
+export type PreferredReadOnlyFunctionOptions = {
   /** the fully-qualified contract identifier as `<address>.<name>` */
   contract: ContractIdString;
   functionName: string;
@@ -185,8 +185,8 @@ export type ReadOnlyFunctionParams = {
   senderAddress: string;
 } & NetworkClientParam;
 
-/** @deprecated Use {@link ReadOnlyFunctionParams} with the combined `contract` field instead. */
-export type ReadOnlyFunctionOptions = {
+/** @deprecated Use {@link ReadOnlyFunctionOptions} with the combined `contract` field instead. */
+export type LegacyReadOnlyFunctionOptions = {
   contractName: string;
   contractAddress: string;
   functionName: string;
@@ -194,3 +194,10 @@ export type ReadOnlyFunctionOptions = {
   /** address of the sender */
   senderAddress: string;
 } & NetworkClientParam;
+
+export type ReadOnlyFunctionOptions =
+  | PreferredReadOnlyFunctionOptions
+  | LegacyReadOnlyFunctionOptions;
+
+/** @deprecated Use {@link ReadOnlyFunctionOptions} instead. */
+export type ReadOnlyFunctionParams = PreferredReadOnlyFunctionOptions;

--- a/packages/transactions/src/types.ts
+++ b/packages/transactions/src/types.ts
@@ -176,7 +176,7 @@ export interface FeeEstimateResponse {
 /**
  * Options for a read-only contract function call (preferred shape).
  */
-export type PreferredReadOnlyFunctionOptions = {
+type PreferredReadOnlyFunctionOptions = {
   /** the fully-qualified contract identifier as `<address>.<name>` */
   contract: ContractIdString;
   functionName: string;
@@ -185,8 +185,7 @@ export type PreferredReadOnlyFunctionOptions = {
   senderAddress: string;
 } & NetworkClientParam;
 
-/** @deprecated Use {@link ReadOnlyFunctionOptions} with the combined `contract` field instead. */
-export type LegacyReadOnlyFunctionOptions = {
+type LegacyReadOnlyFunctionOptions = {
   contractName: string;
   contractAddress: string;
   functionName: string;
@@ -198,6 +197,3 @@ export type LegacyReadOnlyFunctionOptions = {
 export type ReadOnlyFunctionOptions =
   | PreferredReadOnlyFunctionOptions
   | LegacyReadOnlyFunctionOptions;
-
-/** @deprecated Use {@link ReadOnlyFunctionOptions} instead. */
-export type ReadOnlyFunctionParams = PreferredReadOnlyFunctionOptions;

--- a/packages/transactions/src/utils.ts
+++ b/packages/transactions/src/utils.ts
@@ -198,7 +198,11 @@ export const validateStacksAddress = (address: string): boolean => {
 
 /** @ignore */
 export function parseContractId(contractId: ContractIdString) {
-  const [address, name] = contractId.split('.');
-  if (!address || !name) throw new Error(`Invalid contract identifier: ${contractId}`);
-  return [address, name];
+  const segments = contractId.split('.');
+  if (segments.length !== 2 || !segments[0] || !segments[1]) {
+    throw new Error(
+      `Invalid contract identifier "${contractId}". Expected format "<address>.<name>".`
+    );
+  }
+  return segments as [string, string];
 }

--- a/packages/transactions/tests/builder.test.ts
+++ b/packages/transactions/tests/builder.test.ts
@@ -3116,7 +3116,7 @@ describe('Preferred param shapes', () => {
     expect(unified.serialize()).toBe(legacy.serialize());
   });
 
-  test('makeContractDeploy with empty-string `name` still normalizes', async () => {
+  test('makeUnsignedContractDeploy with empty-string `name` still normalizes', async () => {
     const publicKey = '03ef788b3830c00abe8f64f62dc32fc863bc0b2cafeb073b6c8e1c7657d9c2c3ab';
     const codeBody = '(+ 1 1)';
 

--- a/packages/transactions/tests/builder.test.ts
+++ b/packages/transactions/tests/builder.test.ts
@@ -2995,8 +2995,8 @@ test('Build transaction with originator post-condition mode', async () => {
   expect(deserializedTx.postConditionMode).toBe(0x03);
 });
 
-describe('Unified param shapes', () => {
-  test('makeContractCall accepts combined `contract` field and matches legacy shape', async () => {
+describe('Preferred param shapes', () => {
+  test('makeContractCall with `contract` produces identical serialization', async () => {
     const contractAddress = 'ST3KC0MTNW34S1ZXD36JYKFD3JJMWA01M55DSJ4JE';
     const contractName = 'kv-store';
     const functionName = 'get-value';
@@ -3028,7 +3028,7 @@ describe('Unified param shapes', () => {
     expect(() => unified.verifyOrigin()).not.toThrow();
   });
 
-  test('makeUnsignedContractCall accepts combined `contract` field and matches legacy shape', async () => {
+  test('makeUnsignedContractCall with `contract` produces identical serialization', async () => {
     const contractAddress = 'ST3KC0MTNW34S1ZXD36JYKFD3JJMWA01M55DSJ4JE';
     const contractName = 'kv-store';
     const functionName = 'get-value';
@@ -3059,7 +3059,7 @@ describe('Unified param shapes', () => {
     expect(unified.serialize()).toBe(legacy.serialize());
   });
 
-  test('makeContractDeploy accepts `name`/`clarityCode` and matches legacy shape', async () => {
+  test('makeContractDeploy with `name`/`clarityCode` produces identical serialization', async () => {
     const contractName = 'kv-store';
     const codeBody = fs.readFileSync('./tests/contracts/kv-store.clar').toString();
     const senderKey = 'e494f188c2d35887531ba474c433b1e41fadd8eb824aca983447fd4bb8b277a801';
@@ -3088,7 +3088,7 @@ describe('Unified param shapes', () => {
     expect(() => unified.verifyOrigin()).not.toThrow();
   });
 
-  test('makeUnsignedContractDeploy accepts `name`/`clarityCode` and matches legacy shape', async () => {
+  test('makeUnsignedContractDeploy with `name`/`clarityCode` produces identical serialization', async () => {
     const contractName = 'kv-store';
     const codeBody = fs.readFileSync('./tests/contracts/kv-store.clar').toString();
     const publicKey = '03ef788b3830c00abe8f64f62dc32fc863bc0b2cafeb073b6c8e1c7657d9c2c3ab';
@@ -3114,5 +3114,64 @@ describe('Unified param shapes', () => {
     });
 
     expect(unified.serialize()).toBe(legacy.serialize());
+  });
+
+  test('makeContractDeploy with empty-string `name` still normalizes', async () => {
+    const publicKey = '03ef788b3830c00abe8f64f62dc32fc863bc0b2cafeb073b6c8e1c7657d9c2c3ab';
+    const codeBody = '(+ 1 1)';
+
+    const tx = await makeUnsignedContractDeploy({
+      name: '',
+      clarityCode: codeBody,
+      publicKey,
+      fee: 0,
+      nonce: 0,
+      network: STACKS_TESTNET,
+    });
+
+    // Empty name is allowed by the builder (validated downstream);
+    // the key is that normalization still ran (contractName is set, not undefined).
+    const legacyTx = await makeUnsignedContractDeploy({
+      contractName: '',
+      codeBody,
+      publicKey,
+      fee: 0,
+      nonce: 0,
+      network: STACKS_TESTNET,
+    });
+
+    expect(tx.serialize()).toBe(legacyTx.serialize());
+  });
+
+  test('fetchCallReadOnlyFunction accepts `contract` field', async () => {
+    const contractAddress = 'ST000000000000000000002AMW42H';
+    const contractName = 'pox';
+    const functionName = 'is-pox-active';
+    const senderAddress = contractAddress;
+    const mockResult = '0x03';
+
+    const apiUrl = `${HIRO_MAINNET_URL}/v2/contracts/call-read/${contractAddress}/${contractName}/is-pox-active`;
+    fetchMock.mockOnce(JSON.stringify({ okay: true, result: mockResult }));
+
+    const result1 = await fetchCallReadOnlyFunction({
+      contract: `${contractAddress}.${contractName}`,
+      functionName,
+      functionArgs: [],
+      senderAddress,
+    });
+
+    expect(fetchMock.mock.calls[0][0]).toContain(apiUrl);
+
+    fetchMock.mockOnce(JSON.stringify({ okay: true, result: mockResult }));
+
+    const result2 = await fetchCallReadOnlyFunction({
+      contractAddress,
+      contractName,
+      functionName,
+      functionArgs: [],
+      senderAddress,
+    });
+
+    expect(result1).toEqual(result2);
   });
 });

--- a/packages/transactions/tests/builder.test.ts
+++ b/packages/transactions/tests/builder.test.ts
@@ -2994,3 +2994,125 @@ test('Build transaction with originator post-condition mode', async () => {
   expect(deserializedTx.postConditionMode).toBe(PostConditionMode.Originator);
   expect(deserializedTx.postConditionMode).toBe(0x03);
 });
+
+describe('Unified param shapes', () => {
+  test('makeContractCall accepts combined `contract` field and matches legacy shape', async () => {
+    const contractAddress = 'ST3KC0MTNW34S1ZXD36JYKFD3JJMWA01M55DSJ4JE';
+    const contractName = 'kv-store';
+    const functionName = 'get-value';
+    const functionArgs = [bufferCV(utf8ToBytes('foo'))];
+    const senderKey = 'e494f188c2d35887531ba474c433b1e41fadd8eb824aca983447fd4bb8b277a801';
+
+    const legacy = await makeContractCall({
+      contractAddress,
+      contractName,
+      functionName,
+      functionArgs,
+      senderKey,
+      fee: 0,
+      nonce: 1,
+      network: STACKS_TESTNET,
+    });
+
+    const unified = await makeContractCall({
+      contract: `${contractAddress}.${contractName}`,
+      functionName,
+      functionArgs,
+      senderKey,
+      fee: 0,
+      nonce: 1,
+      network: STACKS_TESTNET,
+    });
+
+    expect(unified.serialize()).toBe(legacy.serialize());
+    expect(() => unified.verifyOrigin()).not.toThrow();
+  });
+
+  test('makeUnsignedContractCall accepts combined `contract` field and matches legacy shape', async () => {
+    const contractAddress = 'ST3KC0MTNW34S1ZXD36JYKFD3JJMWA01M55DSJ4JE';
+    const contractName = 'kv-store';
+    const functionName = 'get-value';
+    const functionArgs = [bufferCV(utf8ToBytes('foo'))];
+    const publicKey = '03ef788b3830c00abe8f64f62dc32fc863bc0b2cafeb073b6c8e1c7657d9c2c3ab';
+
+    const legacy = await makeUnsignedContractCall({
+      contractAddress,
+      contractName,
+      functionName,
+      functionArgs,
+      publicKey,
+      fee: 0,
+      nonce: 1,
+      network: STACKS_TESTNET,
+    });
+
+    const unified = await makeUnsignedContractCall({
+      contract: `${contractAddress}.${contractName}`,
+      functionName,
+      functionArgs,
+      publicKey,
+      fee: 0,
+      nonce: 1,
+      network: STACKS_TESTNET,
+    });
+
+    expect(unified.serialize()).toBe(legacy.serialize());
+  });
+
+  test('makeContractDeploy accepts `name`/`clarityCode` and matches legacy shape', async () => {
+    const contractName = 'kv-store';
+    const codeBody = fs.readFileSync('./tests/contracts/kv-store.clar').toString();
+    const senderKey = 'e494f188c2d35887531ba474c433b1e41fadd8eb824aca983447fd4bb8b277a801';
+
+    const legacy = await makeContractDeploy({
+      contractName,
+      codeBody,
+      senderKey,
+      fee: 0,
+      nonce: 0,
+      network: STACKS_TESTNET,
+      clarityVersion: ClarityVersion.Clarity2,
+    });
+
+    const unified = await makeContractDeploy({
+      name: contractName,
+      clarityCode: codeBody,
+      senderKey,
+      fee: 0,
+      nonce: 0,
+      network: STACKS_TESTNET,
+      clarityVersion: ClarityVersion.Clarity2,
+    });
+
+    expect(unified.serialize()).toBe(legacy.serialize());
+    expect(() => unified.verifyOrigin()).not.toThrow();
+  });
+
+  test('makeUnsignedContractDeploy accepts `name`/`clarityCode` and matches legacy shape', async () => {
+    const contractName = 'kv-store';
+    const codeBody = fs.readFileSync('./tests/contracts/kv-store.clar').toString();
+    const publicKey = '03ef788b3830c00abe8f64f62dc32fc863bc0b2cafeb073b6c8e1c7657d9c2c3ab';
+
+    const legacy = await makeUnsignedContractDeploy({
+      contractName,
+      codeBody,
+      publicKey,
+      fee: 0,
+      nonce: 0,
+      network: STACKS_TESTNET,
+      clarityVersion: ClarityVersion.Clarity2,
+    });
+
+    const unified = await makeUnsignedContractDeploy({
+      name: contractName,
+      clarityCode: codeBody,
+      publicKey,
+      fee: 0,
+      nonce: 0,
+      network: STACKS_TESTNET,
+      clarityVersion: ClarityVersion.Clarity2,
+    });
+
+    expect(unified.serialize()).toBe(legacy.serialize());
+  });
+});


### PR DESCRIPTION
🚧 wip

## Consolidate `contract` field
- Add preferred builder params for contract calls and deploys so callers can pass `contract: "<address>.<name>"` and deploy code as `name` plus `clarityCode`.
- Extend `fetchCallReadOnlyFunction` with the same unified `contract` field for read-only calls.
- Keep the legacy split fields working by normalizing both shapes internally, with the new fields taking precedence when both are present.
- Add regression tests that prove the new shapes serialize identically to the legacy inputs for signed and unsigned transactions.

### Why
This matches `@stacks/connect` and makes the transaction API easier to compose without breaking existing callers that still use the older option shapes. Users already think about addresses (even contract addresses) as single strings.

### Example
```ts
await makeContractCall({
  contract: 'ST3KC0MTNW34S1ZXD36JYKFD3JJMWA01M55DSJ4JE.kv-store',
  functionName: 'get-value',
  functionArgs: [bufferCV(utf8ToBytes('foo'))],
  senderKey,
  network: STACKS_TESTNET,
});
```

### Compatibility
Legacy `contractAddress`/`contractName` and `contractName`/`codeBody` inputs remain supported but are now deprecated in favor of the unified shapes.
