### PR TITLE
chore: add npmrc with min release age

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7200 # 5 days in minutes


### PR DESCRIPTION
### Description

`min-release-age` of 5 days
it's trade off, less likely to pull malicious dependencies, but slower to pull patches. 3 or 5 days sounds like a solid middle ground
