### PR TITLE
docs: fix broken anchor link and stale org references in package READMEs

### DIFF
--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -93,7 +93,7 @@ userSession.signUserOut();
 
 ### Data encryption
 
-Stacks authentication also provides an easy way to encrypt the user's data. If you are using the [`@stacks/storage`](https://github.com/blockstack/stacks.js/tree/main/packages/storage) package, encryption is automatically enabled. If you would like to perform encryption outside of storage you can use the `userSession.encryptContent` and `userSession.decryptContent` methods.
+Stacks authentication also provides an easy way to encrypt the user's data. If you are using the [`@stacks/storage`](https://github.com/hirosystems/stacks.js/tree/main/packages/storage) package, encryption is automatically enabled. If you would like to perform encryption outside of storage you can use the `userSession.encryptContent` and `userSession.decryptContent` methods.
 
 ```typescript
 const message = 'My secret message';

--- a/packages/stacking/README.md
+++ b/packages/stacking/README.md
@@ -438,7 +438,7 @@ These are the methods for creating the required transactions for delegated stack
 - [Stacking in a pool](#stacking-in-a-pool)
   - [`.delegateStx` Delegate STX](#delegate-stx)
   - [`.revokeDelegateStx` Revoke delegation](#revoke-delegation)
-- [Operating a pool](#operating-a-pool)
+- [Operating a pool](#operating-a-pool--stacking-for-others)
   - [`.delegateStackStx` Stack delegated STX](#stack-delegated-stx)
   - [`.stackAggregationCommitIndexed` Commit to stacking](#commit-to-stacking)
 

--- a/packages/wallet-sdk/README.md
+++ b/packages/wallet-sdk/README.md
@@ -190,7 +190,7 @@ const authResponse = await makeAuthResponse({
 
 ### Usage with `@stacks/transactions`
 
-This library is meant to be used in conjunction with the [`@stacks/transactions`](https://github.com/blockstack/stacks.js/tree/main/packages/transactions) library for signing transactions.
+This library is meant to be used in conjunction with the [`@stacks/transactions`](https://github.com/hirosystems/stacks.js/tree/main/packages/transactions) library for signing transactions.
 
 #### Getting an account's STX address
 


### PR DESCRIPTION
### Description
This PR fixes a broken in-page anchor link and two stale cross-package links in the documentation.

1. In `packages/stacking/README.md`, the "Operating a pool" entry under the "Delegated stacking" section links to `#operating-a-pool`, but the actual heading is `### Operating a pool / Stacking for others`, whose GitHub-generated anchor is `#operating-a-pool--stacking-for-others` (this is already used correctly by the top-level TOC in the same file). The link was pointing to a non-existent anchor.

2. In `packages/auth/README.md` and `packages/wallet-sdk/README.md`, two internal cross-package links still pointed to `github.com/blockstack/stacks.js/...` (the org's name from before it was renamed to `hirosystems`/`stx-labs`). These still redirect, but are inconsistent with every other internal package link in the repo, which use the current org name. Updated for consistency.

No code or behavior changes — documentation only.

#### Breaking change?
None. This is a documentation-only change.

### Example
N/A — link/anchor fix only, no API usage changes.

---
### Checklist
- [x] Unit tested updated code paths — N/A (docs-only change, no code paths affected)
- [x] Tagged 1 of @janniks or @zone117x for review