### PR TITLE
ci: trigger version workflow on changeset-only pushes

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -13,8 +13,6 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - '**.md'
 
 permissions:
   contents: write


### PR DESCRIPTION
Drop the `paths-ignore: **.md` filter from the version workflow. Changeset files are Markdown, so the filter silently skipped changeset-only pushes to main (e.g. 45b71da) and never opened/refreshed the version PR. The changesets action no-ops when there are no changesets, so running on docs-only pushes is harmless.
