### PR TITLE
chore: remove unused cross-fetch dependency from network and auth

### DIFF
--- a/.changeset/quiet-networks-shrink.md
+++ b/.changeset/quiet-networks-shrink.md
@@ -1,0 +1,6 @@
+---
+"@stacks/network": patch
+"@stacks/auth": patch
+---
+
+Remove unused `cross-fetch` dependency from `@stacks/network` and `@stacks/auth`. Neither package has imported it since v7; network calls rely on the global `fetch` via `@stacks/common`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16521,13 +16521,13 @@
     },
     "packages/api": {
       "name": "@stacks/api",
-      "version": "7.5.0",
+      "version": "7.6.0",
       "license": "MIT",
       "dependencies": {
-        "@stacks/common": "^7.5.0",
-        "@stacks/network": "^7.5.0",
+        "@stacks/common": "^7.6.0",
+        "@stacks/network": "^7.6.0",
         "@stacks/stacks-blockchain-api-types": "^0.61.0",
-        "@stacks/transactions": "^7.5.0"
+        "@stacks/transactions": "^7.6.0"
       },
       "devDependencies": {
         "rimraf": "^3.0.2"
@@ -16552,15 +16552,14 @@
     },
     "packages/auth": {
       "name": "@stacks/auth",
-      "version": "7.5.0",
+      "version": "7.6.0",
       "license": "MIT",
       "dependencies": {
         "@noble/secp256k1": "1.7.1",
-        "@stacks/common": "^7.5.0",
-        "@stacks/encryption": "^7.5.0",
-        "@stacks/network": "^7.5.0",
-        "@stacks/profile": "^7.5.0",
-        "cross-fetch": "^3.1.5",
+        "@stacks/common": "^7.6.0",
+        "@stacks/encryption": "^7.6.0",
+        "@stacks/network": "^7.6.0",
+        "@stacks/profile": "^7.6.0",
         "jsontokens": "^4.0.1"
       },
       "devDependencies": {
@@ -16587,21 +16586,21 @@
     },
     "packages/bitcoin-staking": {
       "name": "@stacks/bitcoin-staking",
-      "version": "0.0.1",
+      "version": "7.6.0",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "2.2.0",
         "@noble/hashes": "2.0.1",
         "@scure/base": "2.0.0",
         "@scure/btc-signer": "2.2.0",
-        "@stacks/common": "^7.5.0",
-        "@stacks/encryption": "^7.5.0",
-        "@stacks/network": "^7.5.0",
-        "@stacks/transactions": "^7.5.0"
+        "@stacks/common": "^7.6.0",
+        "@stacks/encryption": "^7.6.0",
+        "@stacks/network": "^7.6.0",
+        "@stacks/transactions": "^7.6.0"
       },
       "devDependencies": {
         "@stacks/internal": "file:../internal",
-        "@stacks/wallet-sdk": "^7.4.0",
+        "@stacks/wallet-sdk": "^7.6.0",
         "process": "^0.11.10",
         "rimraf": "^3.0.2"
       }
@@ -16646,12 +16645,12 @@
     },
     "packages/bns": {
       "name": "@stacks/bns",
-      "version": "7.5.0",
+      "version": "7.6.0",
       "license": "MIT",
       "dependencies": {
-        "@stacks/common": "^7.5.0",
-        "@stacks/network": "^7.5.0",
-        "@stacks/transactions": "^7.5.0"
+        "@stacks/common": "^7.6.0",
+        "@stacks/network": "^7.6.0",
+        "@stacks/transactions": "^7.6.0"
       },
       "devDependencies": {
         "process": "^0.11.10",
@@ -16677,21 +16676,21 @@
     },
     "packages/cli": {
       "name": "@stacks/cli",
-      "version": "7.5.0",
+      "version": "7.6.0",
       "license": "MIT",
       "dependencies": {
         "@scure/bip32": "1.1.3",
         "@scure/bip39": "1.1.0",
-        "@stacks/auth": "^7.5.0",
+        "@stacks/auth": "^7.6.0",
         "@stacks/blockchain-api-client": "4.0.1",
-        "@stacks/bns": "^7.5.0",
-        "@stacks/common": "^7.5.0",
-        "@stacks/encryption": "^7.5.0",
-        "@stacks/network": "^7.5.0",
-        "@stacks/stacking": "^7.5.0",
-        "@stacks/storage": "^7.5.0",
-        "@stacks/transactions": "^7.5.0",
-        "@stacks/wallet-sdk": "^7.5.0",
+        "@stacks/bns": "^7.6.0",
+        "@stacks/common": "^7.6.0",
+        "@stacks/encryption": "^7.6.0",
+        "@stacks/network": "^7.6.0",
+        "@stacks/stacking": "^7.6.0",
+        "@stacks/storage": "^7.6.0",
+        "@stacks/transactions": "^7.6.0",
+        "@stacks/wallet-sdk": "^7.6.0",
         "ajv": "^6.12.6",
         "bip32": "^2.0.6",
         "bip39": "^3.0.2",
@@ -16745,7 +16744,7 @@
     },
     "packages/common": {
       "name": "@stacks/common",
-      "version": "7.5.0",
+      "version": "7.6.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^18.0.4",
@@ -16772,13 +16771,13 @@
     },
     "packages/encryption": {
       "name": "@stacks/encryption",
-      "version": "7.5.0",
+      "version": "7.6.0",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "1.1.5",
         "@noble/secp256k1": "1.7.1",
         "@scure/bip39": "1.1.0",
-        "@stacks/common": "^7.5.0",
+        "@stacks/common": "^7.6.0",
         "base64-js": "^1.5.1",
         "bs58": "^5.0.0",
         "ripemd160-min": "^0.0.6",
@@ -16786,8 +16785,8 @@
       },
       "devDependencies": {
         "@peculiar/webcrypto": "^1.1.6",
-        "@stacks/network": "^7.5.0",
-        "@stacks/transactions": "^7.5.0",
+        "@stacks/network": "^7.6.0",
+        "@stacks/transactions": "^7.6.0",
         "@types/bs58check": "^2.1.0",
         "@types/elliptic": "^6.4.12",
         "@types/node": "^18.0.4",
@@ -16821,11 +16820,11 @@
     },
     "packages/internal": {
       "name": "@stacks/internal",
-      "version": "7.5.0",
+      "version": "7.6.0",
       "devDependencies": {
         "@stacks/blockchain-api-client": "^7.12.0",
-        "@stacks/network": "^7.5.0",
-        "@stacks/stacking": "^7.5.0",
+        "@stacks/network": "^7.6.0",
+        "@stacks/stacking": "^7.6.0",
         "jest-fetch-mock": "^3.0.3"
       }
     },
@@ -16925,11 +16924,10 @@
     },
     "packages/network": {
       "name": "@stacks/network",
-      "version": "7.5.0",
+      "version": "7.6.0",
       "license": "MIT",
       "dependencies": {
-        "@stacks/common": "^7.5.0",
-        "cross-fetch": "^3.1.5"
+        "@stacks/common": "^7.6.0"
       },
       "devDependencies": {
         "process": "^0.11.10",
@@ -16955,12 +16953,12 @@
     },
     "packages/profile": {
       "name": "@stacks/profile",
-      "version": "7.5.0",
+      "version": "7.6.0",
       "license": "MIT",
       "dependencies": {
-        "@stacks/common": "^7.5.0",
-        "@stacks/network": "^7.5.0",
-        "@stacks/transactions": "^7.5.0",
+        "@stacks/common": "^7.6.0",
+        "@stacks/network": "^7.6.0",
+        "@stacks/transactions": "^7.6.0",
         "jsontokens": "^4.0.1",
         "schema-inspector": "^2.0.2",
         "zone-file": "^2.0.0-beta.3"
@@ -16990,16 +16988,16 @@
     },
     "packages/stacking": {
       "name": "@stacks/stacking",
-      "version": "7.5.0",
+      "version": "7.6.0",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "1.1.5",
         "@scure/base": "1.1.1",
-        "@stacks/common": "^7.5.0",
-        "@stacks/encryption": "^7.5.0",
-        "@stacks/network": "^7.5.0",
+        "@stacks/common": "^7.6.0",
+        "@stacks/encryption": "^7.6.0",
+        "@stacks/network": "^7.6.0",
         "@stacks/stacks-blockchain-api-types": "^0.61.0",
-        "@stacks/transactions": "^7.5.0",
+        "@stacks/transactions": "^7.6.0",
         "bs58": "^5.0.0"
       },
       "devDependencies": {
@@ -17124,18 +17122,18 @@
     },
     "packages/storage": {
       "name": "@stacks/storage",
-      "version": "7.5.0",
+      "version": "7.6.0",
       "license": "MIT",
       "dependencies": {
-        "@stacks/auth": "^7.5.0",
-        "@stacks/common": "^7.5.0",
-        "@stacks/encryption": "^7.5.0",
-        "@stacks/network": "^7.5.0",
+        "@stacks/auth": "^7.6.0",
+        "@stacks/common": "^7.6.0",
+        "@stacks/encryption": "^7.6.0",
+        "@stacks/network": "^7.6.0",
         "base64-js": "^1.5.1",
         "jsontokens": "^4.0.1"
       },
       "devDependencies": {
-        "@stacks/network": "^7.5.0",
+        "@stacks/network": "^7.6.0",
         "@types/jsdom": "^16.2.10",
         "jsdom": "^16.5.3",
         "process": "^0.11.10",
@@ -17174,18 +17172,18 @@
     },
     "packages/transactions": {
       "name": "@stacks/transactions",
-      "version": "7.5.0",
+      "version": "7.6.0",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "1.1.5",
         "@noble/secp256k1": "1.7.1",
-        "@stacks/common": "^7.5.0",
-        "@stacks/network": "^7.5.0",
+        "@stacks/common": "^7.6.0",
+        "@stacks/network": "^7.6.0",
         "c32check": "^2.0.0",
         "lodash.clonedeep": "^4.5.0"
       },
       "devDependencies": {
-        "@stacks/encryption": "^7.5.0",
+        "@stacks/encryption": "^7.6.0",
         "@types/common-tags": "^1.8.0",
         "@types/elliptic": "^6.4.12",
         "@types/lodash.clonedeep": "^4.5.6",
@@ -17214,18 +17212,18 @@
     },
     "packages/wallet-sdk": {
       "name": "@stacks/wallet-sdk",
-      "version": "7.5.0",
+      "version": "7.6.0",
       "license": "MIT",
       "dependencies": {
         "@scure/bip32": "1.1.3",
         "@scure/bip39": "1.1.0",
-        "@stacks/auth": "^7.5.0",
-        "@stacks/common": "^7.5.0",
-        "@stacks/encryption": "^7.5.0",
-        "@stacks/network": "^7.5.0",
-        "@stacks/profile": "^7.5.0",
-        "@stacks/storage": "^7.5.0",
-        "@stacks/transactions": "^7.5.0",
+        "@stacks/auth": "^7.6.0",
+        "@stacks/common": "^7.6.0",
+        "@stacks/encryption": "^7.6.0",
+        "@stacks/network": "^7.6.0",
+        "@stacks/profile": "^7.6.0",
+        "@stacks/storage": "^7.6.0",
+        "@stacks/transactions": "^7.6.0",
         "c32check": "^2.0.0",
         "jsontokens": "^4.0.1",
         "zone-file": "^2.0.0-beta.3"

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -25,7 +25,6 @@
     "@stacks/encryption": "^7.6.0",
     "@stacks/network": "^7.6.0",
     "@stacks/profile": "^7.6.0",
-    "cross-fetch": "^3.1.5",
     "jsontokens": "^4.0.1"
   },
   "devDependencies": {

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -20,8 +20,7 @@
     "typecheck:watch": "npm run typecheck -- --watch"
   },
   "dependencies": {
-    "@stacks/common": "^7.6.0",
-    "cross-fetch": "^3.1.5"
+    "@stacks/common": "^7.6.0"
   },
   "devDependencies": {
     "process": "^0.11.10",


### PR DESCRIPTION
### Description

`@stacks/network` and `@stacks/auth` have not imported `cross-fetch` since
the v7 rewrite (8ce84a38 dropped the `cross-fetch/polyfill` import). All
network calls go through `@stacks/common`'s `fetchWrapper`, which uses the
global `fetch`. Dropping the dependency removes cross-fetch, node-fetch 2.x,
whatwg-url, tr46 and webidl-conversions from every downstream install.

Also refreshes stale workspace versions in package-lock.json left over from
the last version bump.